### PR TITLE
Bug 1333172 - differ between route hostname and navigation within the console

### DIFF
--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -314,8 +314,11 @@ angular.module('openshiftConsole')
         return url;
     };
   })
-  .filter('routeLabel', function(routeHostFilter) {
+  .filter('routeLabel', function(routeHostFilter, routeWebURLFilter, isWebRouteFilter) {
     return function(route, host) {
+      if (isWebRouteFilter(route)) {
+        return routeWebURLFilter(route, host);
+      }
       var label = (host || routeHostFilter(route));
       if (route.spec.path) {
         label += route.spec.path;

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7501,10 +7501,11 @@ return function(b, c) {
 var d = b.spec.tls && "" !== b.spec.tls.tlsTerminationType ? "https" :"http", e = d + "://" + (c || a(b));
 return b.spec.path && (e += b.spec.path), e;
 };
-} ]).filter("routeLabel", [ "routeHostFilter", function(a) {
-return function(b, c) {
-var d = c || a(b);
-return b.spec.path && (d += b.spec.path), d || "<unknown host>";
+} ]).filter("routeLabel", [ "routeHostFilter", "routeWebURLFilter", "isWebRouteFilter", function(a, b, c) {
+return function(d, e) {
+if (c(d)) return b(d, e);
+var f = e || a(d);
+return d.spec.path && (f += d.spec.path), f || "<unknown host>";
 };
 } ]).filter("parameterPlaceholder", function() {
 return function(a) {


### PR DESCRIPTION
Making difference between route hostname and navigation within the console more obvious, by prepending the `pficon-route` icon before the exposed route link.

Screen prepending the icon(which I like more then the appending one):
![screenshot-11](https://cloud.githubusercontent.com/assets/1668218/15177827/7ab873c4-1772-11e6-99cb-d5a70f6f6880.png)


Screen appending the icon:
![screenshot-12](https://cloud.githubusercontent.com/assets/1668218/15177840/8653a348-1772-11e6-9da3-067d72284e47.png)

Also I've created a standalone class for the icon `font-size` since by default it will take the size of `h2` style which is 19px and that seems to be too big for the icon.

@liggitt suggested we use the `fa-external-link` icon instead the `pficon-route` as original was suggested:
![screenshot-17](https://cloud.githubusercontent.com/assets/1668218/15187100/14d35a5a-17a0-11e6-914a-66a948cbfd4f.png)


@jwforres PTAL