### PR TITLE
Bug 1333118 - Make for CLI tools a standalone help page

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -215,6 +215,7 @@
         <script src="scripts/controllers/modals/confirmReplaceModal.js"></script>
         <script src="scripts/controllers/modals/processTemplateModal.js"></script>
         <script src="scripts/controllers/about.js"></script>
+        <script src="scripts/controllers/commandLine.js"></script>
         <script src="scripts/directives/date.js"></script>
         <script src="scripts/directives/deleteLink.js"></script>
         <script src="scripts/directives/editLink.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -269,6 +269,10 @@ angular
         templateUrl: 'views/about.html',
         controller: 'AboutController'
       })
+      .when('/command-line', {
+        templateUrl: 'views/command-line.html',
+        controller: 'CommandLineController'
+      })
       .when('/oauth', {
         templateUrl: 'views/util/oauth.html',
         controller: 'OAuthController'

--- a/app/scripts/controllers/about.js
+++ b/app/scripts/controllers/about.js
@@ -7,7 +7,7 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('AboutController', function ($scope, DataService, AuthService, Constants) {
+  .controller('AboutController', function ($scope, AuthService, Constants) {
     AuthService.withUser();
     
     $scope.version = {
@@ -16,8 +16,4 @@ angular.module('openshiftConsole')
         kubernetes: Constants.VERSION.kubernetes,
       },
     };
-    $scope.cliDownloadURL = Constants.CLI;
-    $scope.cliDownloadURLPresent = $scope.cliDownloadURL && !_.isEmpty($scope.cliDownloadURL);
-    $scope.loginBaseURL = DataService.openshiftAPIBaseUrl();
-    $scope.sessionToken = AuthService.UserStore().getToken();
   });

--- a/app/scripts/controllers/commandLine.js
+++ b/app/scripts/controllers/commandLine.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:CommandLineController
+ * @description
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('CommandLineController', function ($scope, DataService, AuthService, Constants) {
+    AuthService.withUser();
+
+    $scope.cliDownloadURL = Constants.CLI;
+    $scope.cliDownloadURLPresent = $scope.cliDownloadURL && !_.isEmpty($scope.cliDownloadURL);
+    $scope.loginBaseURL = DataService.openshiftAPIBaseUrl();
+    $scope.sessionToken = AuthService.UserStore().getToken();
+    $scope.showSessionToken = false;
+
+    $scope.toggleShowSessionToken = function() {
+      $scope.showSessionToken = !$scope.showSessionToken;
+    };
+  });

--- a/app/scripts/extensions/nav/dropdownMobile.js
+++ b/app/scripts/extensions/nav/dropdownMobile.js
@@ -24,6 +24,15 @@ angular.module('openshiftConsole')
           ].join('')
         }, {
           type: 'dom',
+          node: [
+            '<li>',
+              '<a href="command-line">',
+                '<span class="fa fa-terminal" aria-hidden="true"></span> Command Line Tools',
+              '</a>',
+            '</li>'
+          ].join('')
+        }, {
+          type: 'dom',
           node: _.template([
             '<li>',
               '<a href="logout">',

--- a/app/scripts/extensions/nav/helpDropdown.js
+++ b/app/scripts/extensions/nav/helpDropdown.js
@@ -14,6 +14,10 @@ angular.module('openshiftConsole')
           {
             type: 'dom',
             node: '<li><a href="about">About</a></li>'
+          },
+          {
+            type: 'dom',
+            node: '<li><a href="command-line">Command Line Tools</a></li>'
           }
         ];
       });

--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -432,7 +432,8 @@ label.checkbox {
   text-align: right;
 }
 
-.about {
+.about,
+.command-line {
   .about-icon {
     img {
       width: 100%;

--- a/app/views/about.html
+++ b/app/views/about.html
@@ -29,35 +29,11 @@
                         <dd>{{version.master.kubernetes || 'unknown'}}</dd>
                       </dl>
 
-                      <h2 id="cli">Command Line Tools</h2>
-                      <p>
-                        With the OpenShift command line interface (CLI), you can create applications and manage OpenShift projects from a terminal.
-                        <span ng-if="cliDownloadURLPresent">
-                          You can download the <code>oc</code> client tool using the links below. For more information about downloading and installing it, please refer to the <a href="{{'get_started_cli' | helpLink}}">Get Started with the CLI</a> documentation.
-                        </span>
-                        <span ng-if="!cliDownloadURLPresent">
-                          Refer to the <a href="{{'get_started_cli' | helpLink}}">Get Started with the CLI</a> documentation for instructions about downloading and installing the <code>oc</code> client tool.
-                        </span>
-                        <div ng-if="cliDownloadURLPresent">
-                          <label class="cli-download-label">Download <code>oc</code>:</label>
-                          <div ng-repeat="(key, value) in cliDownloadURL">
-                            <a href="{{value}}" class="cli-download-link">
-                              {{key}}
-                              <i class="fa fa-external-link"></i>
-                            </a>
-                          </div>
-                        </div>
+                      <p>The <a target="_blank" href="{{'welcome' | helpLink}}">documentation</a> contains information and guides to help you learn about OpenShift and start exploring its features. From getting started with creating your first application, to trying out more advanced build and deployment techniques, it provides what you need to set up and manage your OpenShift environment as an application developer.</p>
+
+                      <p>With the OpenShift command line interface (CLI), you can create applications and manage OpenShift projects from a terminal. To get started using the CLI you will need to <a target="_blank" href="command-line">download it and login</a>. For more information about the command line tools, check the <a target="_blank" href="{{'cli' | helpLink}}">CLI Reference</a> and <a target="_blank" href="{{'basic_cli_operations' | helpLink}}">Basic CLI Operations</a>.
                       </p>
-                      <p>
-                        After downloading and installing it, you can start by logging in using<span ng-if="sessionToken"> this current session token</span>:
-                        <div class="code prettyprint ng-binding" ng-if="sessionToken">
-                          oc login {{loginBaseURL}} --token=<span ng-show="showSessionToken">{{sessionToken}}</span><a href="#" ng-click="showSessionToken = !showSessionToken" ng-show="!showSessionToken">...click to show token...</a>
-                        </div>
-                        <pre class="code prettyprint ng-binding" ng-if="!sessionToken">
-        oc login {{loginBaseURL}}
-        </pre>
-                      </p>
-                      <p>For other information about the command line tools, check the <a target="_blank" href="{{'cli' | helpLink}}">CLI Reference</a> and <a target="_blank" href="{{'basic_cli_operations' | helpLink}}">Basic CLI Operations</a>.</p>
+
                     </div>
                   </div>
                 </div>

--- a/app/views/command-line.html
+++ b/app/views/command-line.html
@@ -1,0 +1,71 @@
+<default-header class="top-header"></default-header>
+<div class="wrap no-sidebar">
+  <div class="sidebar-left collapse navbar-collapse navbar-collapse-2">
+    <navbar-utility-mobile></navbar-utility-mobile>
+  </div>
+  <div class="middle">
+    <!-- Middle section -->
+    <div class="middle-section surface-shaded">
+      <div class="middle-container has-scroll">
+        <div class="middle-content">
+          <div class="container surface-shaded gutter-top">
+            <div class="row">
+              <div class="col-md-12">
+                <div class="command-line">
+                  <h1 id="cli">Command Line Tools</h1>
+                  <p>
+                    With the OpenShift command line interface (CLI), you can create applications and manage OpenShift projects from a terminal.
+                    <span ng-if="cliDownloadURLPresent">
+                      You can download the <code>oc</code> client tool using the links below. For more information about downloading and installing it, please refer to the <a href="{{'get_started_cli' | helpLink}}">Get Started with the CLI</a> documentation.
+                    </span>
+                    <span ng-if="!cliDownloadURLPresent">
+                      Refer to the <a href="{{'get_started_cli' | helpLink}}">Get Started with the CLI</a> documentation for instructions about downloading and installing the <code>oc</code> client tool.
+                    </span>
+                    <div ng-if="cliDownloadURLPresent">
+                      <label class="cli-download-label">Download <code>oc</code>:</label>
+                      <div ng-repeat="(key, value) in cliDownloadURL">
+                        <a href="{{value}}" class="cli-download-link">
+                          {{key}}
+                          <i class="fa fa-external-link"></i>
+                        </a>
+                      </div>
+                    </div>
+                  </p>
+                  <p>
+                    After downloading and installing it, you can start by logging in using<span ng-if="sessionToken"> this current session token</span>:
+                    <div class="code prettyprint ng-binding" ng-if="sessionToken">
+                      oc login {{loginBaseURL}} --token=<span ng-show="showSessionToken">{{sessionToken}}</span><a href="#" ng-click="toggleShowSessionToken()" ng-show="!showSessionToken">...click to show token...</a>
+                    </div>
+                    <pre class="code prettyprint ng-binding" ng-if="!sessionToken">
+                      oc login {{loginBaseURL}}
+                    </pre>
+                  </p>
+
+                  <div ng-show="showSessionToken" class="alert alert-warning">
+                    <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
+                    <strong>A token is a form of a password.</strong>
+                    Do not share your API token.
+                  </div>
+
+                  <p>After you login to your account you will get a list of projects that you can switch between:
+                     <pre class="code prettyprint">oc project <i>project-name</i></pre>
+                  </p>
+
+                  <p>If you do not have any existing projects, you can create one:
+                     <pre class="code prettyprint">oc new-project <i>project-name</i></pre>
+                  </p>
+
+                  <p>To show a high level overview of the current project:
+                     <pre class="code prettyprint">oc status</pre>
+                  </p>
+
+                  <p>For other information about the command line tools, check the <a target="_blank" href="{{'cli' | helpLink}}">CLI Reference</a> and <a target="_blank" href="{{'basic_cli_operations' | helpLink}}">Basic CLI Operations</a>.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div><!-- /middle-content -->
+      </div><!-- /middle-container -->
+    </div><!-- /middle-section -->
+  </div><!-- /middle -->
+</div><!-- /wrap -->

--- a/app/views/create/next-steps.html
+++ b/app/views/create/next-steps.html
@@ -45,7 +45,7 @@
                 <h2>Things you can do</h2>
                 <p>Go to the <a href="project/{{projectName}}/overview">overview page</a> to see more details about this project. Make sure you don't already have <a href="project/{{projectName}}/browse/services">services</a>, <a href="project/{{projectName}}/browse/builds">build configs</a>, <a href="project/{{projectName}}/browse/deployments">deployment configs</a>, or other resources with the same names you are trying to create. Refer to the <a target="_blank" href="{{'new_app' | helpLink}}">documentation for creating new applications</a> for more information.</p>
                 <h3>Command line tools</h3>
-                <p>You may want to use the <code>oc</code> command line tool to help with troubleshooting. After <a target="_blank" href="about#cli">downloading and installing</a> it, you can log in, switch to this particular project, and try some commands :</p>
+                <p>You may want to use the <code>oc</code> command line tool to help with troubleshooting. After <a target="_blank" href="command-line">downloading and installing</a> it, you can log in, switch to this particular project, and try some commands :</p>
 
                 <pre class="code prettyprint">oc login {{loginBaseUrl}}
 oc project {{projectName}}
@@ -59,7 +59,7 @@ oc logs -h</pre>
                 <p>The web console is convenient, but if you need deeper control you may want to try our command line tools.</p>
 
                 <h3>Command line tools</h3>
-                <p><a target="_blank" href="about#cli">Download and install</a> the <code>oc</code> command line tool. After that, you can start by logging in, switching to this particular project, and displaying an overview of it, by doing:</p>
+                <p><a target="_blank" href="command-line">Download and install</a> the <code>oc</code> command line tool. After that, you can start by logging in, switching to this particular project, and displaying an overview of it, by doing:</p>
 
                 <pre class="code prettyprint">oc login {{loginBaseUrl}}
 oc project {{projectName}}

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -170,6 +170,9 @@ controller:"EditHealthChecksController"
 }).when("/about", {
 templateUrl:"views/about.html",
 controller:"AboutController"
+}).when("/command-line", {
+templateUrl:"views/command-line.html",
+controller:"CommandLineController"
 }).when("/oauth", {
 templateUrl:"views/util/oauth.html",
 controller:"OAuthController"
@@ -4879,13 +4882,17 @@ b.close("create");
 }, a.cancel = function() {
 b.dismiss("cancel");
 };
-} ]), angular.module("openshiftConsole").controller("AboutController", [ "$scope", "DataService", "AuthService", "Constants", function(a, b, c, d) {
-c.withUser(), a.version = {
+} ]), angular.module("openshiftConsole").controller("AboutController", [ "$scope", "AuthService", "Constants", function(a, b, c) {
+b.withUser(), a.version = {
 master:{
-openshift:d.VERSION.openshift,
-kubernetes:d.VERSION.kubernetes
+openshift:c.VERSION.openshift,
+kubernetes:c.VERSION.kubernetes
 }
-}, a.cliDownloadURL = d.CLI, a.cliDownloadURLPresent = a.cliDownloadURL && !_.isEmpty(a.cliDownloadURL), a.loginBaseURL = b.openshiftAPIBaseUrl(), a.sessionToken = c.UserStore().getToken();
+};
+} ]), angular.module("openshiftConsole").controller("CommandLineController", [ "$scope", "DataService", "AuthService", "Constants", function(a, b, c, d) {
+c.withUser(), a.cliDownloadURL = d.CLI, a.cliDownloadURLPresent = a.cliDownloadURL && !_.isEmpty(a.cliDownloadURL), a.loginBaseURL = b.openshiftAPIBaseUrl(), a.sessionToken = c.UserStore().getToken(), a.showSessionToken = !1, a.toggleShowSessionToken = function() {
+a.showSessionToken = !a.showSessionToken;
+};
 } ]), angular.module("openshiftConsole").directive("relativeTimestamp", function() {
 return {
 restrict:"E",
@@ -8309,6 +8316,9 @@ node:'<li><a href="https://docs.openshift.org/latest/welcome/index.html">Documen
 }, {
 type:"dom",
 node:'<li><a href="about">About</a></li>'
+}, {
+type:"dom",
+node:'<li><a href="command-line">Command Line Tools</a></li>'
 } ];
 });
 } ]), angular.module("openshiftConsole").run([ "extensionRegistry", function(a) {
@@ -8326,6 +8336,9 @@ node:[ "<li>", '<a href="https://docs.openshift.org/latest/welcome/index.html">'
 }, {
 type:"dom",
 node:[ "<li>", '<a href="about">', '<span class="pficon pficon-info fa-fw" aria-hidden="true"></span> About', "</a>", "</li>" ].join("")
+}, {
+type:"dom",
+node:[ "<li>", '<a href="command-line">', '<span class="fa fa-terminal" aria-hidden="true"></span> Command Line Tools', "</a>", "</li>" ].join("")
 }, {
 type:"dom",
 node:_.template([ "<li>", '<a href="logout">', '<span class="pficon pficon-user fa-fw" aria-hidden="true"></span>', 'Log out <span class="username"><%= userName %></span>', "</a>", "</li>" ].join(""))({

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -897,35 +897,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt>Kubernetes Master:</dt>\n" +
     "<dd>{{version.master.kubernetes || 'unknown'}}</dd>\n" +
     "</dl>\n" +
-    "<h2 id=\"cli\">Command Line Tools</h2>\n" +
-    "<p>\n" +
-    "With the OpenShift command line interface (CLI), you can create applications and manage OpenShift projects from a terminal.\n" +
-    "<span ng-if=\"cliDownloadURLPresent\">\n" +
-    "You can download the <code>oc</code> client tool using the links below. For more information about downloading and installing it, please refer to the <a href=\"{{'get_started_cli' | helpLink}}\">Get Started with the CLI</a> documentation.\n" +
-    "</span>\n" +
-    "<span ng-if=\"!cliDownloadURLPresent\">\n" +
-    "Refer to the <a href=\"{{'get_started_cli' | helpLink}}\">Get Started with the CLI</a> documentation for instructions about downloading and installing the <code>oc</code> client tool.\n" +
-    "</span>\n" +
-    "<div ng-if=\"cliDownloadURLPresent\">\n" +
-    "<label class=\"cli-download-label\">Download <code>oc</code>:</label>\n" +
-    "<div ng-repeat=\"(key, value) in cliDownloadURL\">\n" +
-    "<a href=\"{{value}}\" class=\"cli-download-link\">\n" +
-    "{{key}}\n" +
-    "<i class=\"fa fa-external-link\"></i>\n" +
-    "</a>\n" +
-    "</div>\n" +
-    "</div>\n" +
+    "<p>The <a target=\"_blank\" href=\"{{'welcome' | helpLink}}\">documentation</a> contains information and guides to help you learn about OpenShift and start exploring its features. From getting started with creating your first application, to trying out more advanced build and deployment techniques, it provides what you need to set up and manage your OpenShift environment as an application developer.</p>\n" +
+    "<p>With the OpenShift command line interface (CLI), you can create applications and manage OpenShift projects from a terminal. To get started using the CLI you will need to <a target=\"_blank\" href=\"command-line\">download it and login</a>. For more information about the command line tools, check the <a target=\"_blank\" href=\"{{'cli' | helpLink}}\">CLI Reference</a> and <a target=\"_blank\" href=\"{{'basic_cli_operations' | helpLink}}\">Basic CLI Operations</a>.\n" +
     "</p>\n" +
-    "<p>\n" +
-    "After downloading and installing it, you can start by logging in using<span ng-if=\"sessionToken\"> this current session token</span>:\n" +
-    "<div class=\"code prettyprint ng-binding\" ng-if=\"sessionToken\">\n" +
-    "oc login {{loginBaseURL}} --token=<span ng-show=\"showSessionToken\">{{sessionToken}}</span><a href=\"#\" ng-click=\"showSessionToken = !showSessionToken\" ng-show=\"!showSessionToken\">...click to show token...</a>\n" +
-    "</div>\n" +
-    "<pre class=\"code prettyprint ng-binding\" ng-if=\"!sessionToken\">\n" +
-    "        oc login {{loginBaseURL}}\n" +
-    "        </pre>\n" +
-    "</p>\n" +
-    "<p>For other information about the command line tools, check the <a target=\"_blank\" href=\"{{'cli' | helpLink}}\">CLI Reference</a> and <a target=\"_blank\" href=\"{{'basic_cli_operations' | helpLink}}\">Basic CLI Operations</a>.</p>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -3184,6 +3158,76 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/command-line.html',
+    "<default-header class=\"top-header\"></default-header>\n" +
+    "<div class=\"wrap no-sidebar\">\n" +
+    "<div class=\"sidebar-left collapse navbar-collapse navbar-collapse-2\">\n" +
+    "<navbar-utility-mobile></navbar-utility-mobile>\n" +
+    "</div>\n" +
+    "<div class=\"middle\">\n" +
+    "\n" +
+    "<div class=\"middle-section surface-shaded\">\n" +
+    "<div class=\"middle-container has-scroll\">\n" +
+    "<div class=\"middle-content\">\n" +
+    "<div class=\"container surface-shaded gutter-top\">\n" +
+    "<div class=\"row\">\n" +
+    "<div class=\"col-md-12\">\n" +
+    "<div class=\"command-line\">\n" +
+    "<h1 id=\"cli\">Command Line Tools</h1>\n" +
+    "<p>\n" +
+    "With the OpenShift command line interface (CLI), you can create applications and manage OpenShift projects from a terminal.\n" +
+    "<span ng-if=\"cliDownloadURLPresent\">\n" +
+    "You can download the <code>oc</code> client tool using the links below. For more information about downloading and installing it, please refer to the <a href=\"{{'get_started_cli' | helpLink}}\">Get Started with the CLI</a> documentation.\n" +
+    "</span>\n" +
+    "<span ng-if=\"!cliDownloadURLPresent\">\n" +
+    "Refer to the <a href=\"{{'get_started_cli' | helpLink}}\">Get Started with the CLI</a> documentation for instructions about downloading and installing the <code>oc</code> client tool.\n" +
+    "</span>\n" +
+    "<div ng-if=\"cliDownloadURLPresent\">\n" +
+    "<label class=\"cli-download-label\">Download <code>oc</code>:</label>\n" +
+    "<div ng-repeat=\"(key, value) in cliDownloadURL\">\n" +
+    "<a href=\"{{value}}\" class=\"cli-download-link\">\n" +
+    "{{key}}\n" +
+    "<i class=\"fa fa-external-link\"></i>\n" +
+    "</a>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</p>\n" +
+    "<p>\n" +
+    "After downloading and installing it, you can start by logging in using<span ng-if=\"sessionToken\"> this current session token</span>:\n" +
+    "<div class=\"code prettyprint ng-binding\" ng-if=\"sessionToken\">\n" +
+    "oc login {{loginBaseURL}} --token=<span ng-show=\"showSessionToken\">{{sessionToken}}</span><a href=\"#\" ng-click=\"toggleShowSessionToken()\" ng-show=\"!showSessionToken\">...click to show token...</a>\n" +
+    "</div>\n" +
+    "<pre class=\"code prettyprint ng-binding\" ng-if=\"!sessionToken\">\n" +
+    "                      oc login {{loginBaseURL}}\n" +
+    "                    </pre>\n" +
+    "</p>\n" +
+    "<div ng-show=\"showSessionToken\" class=\"alert alert-warning\">\n" +
+    "<span class=\"pficon pficon-warning-triangle-o\" aria-hidden=\"true\"></span>\n" +
+    "<strong>A token is a form of a password.</strong>\n" +
+    "Do not share your API token.\n" +
+    "</div>\n" +
+    "<p>After you login to your account you will get a list of projects that you can switch between:\n" +
+    "<pre class=\"code prettyprint\">oc project <i>project-name</i></pre>\n" +
+    "</p>\n" +
+    "<p>If you do not have any existing projects, you can create one:\n" +
+    "<pre class=\"code prettyprint\">oc new-project <i>project-name</i></pre>\n" +
+    "</p>\n" +
+    "<p>To show a high level overview of the current project:\n" +
+    "<pre class=\"code prettyprint\">oc status</pre>\n" +
+    "</p>\n" +
+    "<p>For other information about the command line tools, check the <a target=\"_blank\" href=\"{{'cli' | helpLink}}\">CLI Reference</a> and <a target=\"_blank\" href=\"{{'basic_cli_operations' | helpLink}}\">Basic CLI Operations</a>.</p>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>"
+  );
+
+
   $templateCache.put('views/create-project.html',
     "<default-header class=\"top-header\"></default-header>\n" +
     "<div class=\"wrap no-sidebar\">\n" +
@@ -3716,7 +3760,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<h2>Things you can do</h2>\n" +
     "<p>Go to the <a href=\"project/{{projectName}}/overview\">overview page</a> to see more details about this project. Make sure you don't already have <a href=\"project/{{projectName}}/browse/services\">services</a>, <a href=\"project/{{projectName}}/browse/builds\">build configs</a>, <a href=\"project/{{projectName}}/browse/deployments\">deployment configs</a>, or other resources with the same names you are trying to create. Refer to the <a target=\"_blank\" href=\"{{'new_app' | helpLink}}\">documentation for creating new applications</a> for more information.</p>\n" +
     "<h3>Command line tools</h3>\n" +
-    "<p>You may want to use the <code>oc</code> command line tool to help with troubleshooting. After <a target=\"_blank\" href=\"about#cli\">downloading and installing</a> it, you can log in, switch to this particular project, and try some commands :</p>\n" +
+    "<p>You may want to use the <code>oc</code> command line tool to help with troubleshooting. After <a target=\"_blank\" href=\"command-line\">downloading and installing</a> it, you can log in, switch to this particular project, and try some commands :</p>\n" +
     "<pre class=\"code prettyprint\">oc login {{loginBaseUrl}}\n" +
     "oc project {{projectName}}\n" +
     "oc logs -h</pre>\n" +
@@ -3726,7 +3770,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<h2>Manage your app</h2>\n" +
     "<p>The web console is convenient, but if you need deeper control you may want to try our command line tools.</p>\n" +
     "<h3>Command line tools</h3>\n" +
-    "<p><a target=\"_blank\" href=\"about#cli\">Download and install</a> the <code>oc</code> command line tool. After that, you can start by logging in, switching to this particular project, and displaying an overview of it, by doing:</p>\n" +
+    "<p><a target=\"_blank\" href=\"command-line\">Download and install</a> the <code>oc</code> command line tool. After that, you can start by logging in, switching to this particular project, and displaying an overview of it, by doing:</p>\n" +
     "<pre class=\"code prettyprint\">oc login {{loginBaseUrl}}\n" +
     "oc project {{projectName}}\n" +
     "oc status</pre>\n" +

--- a/dist/scripts/vendor.js
+++ b/dist/scripts/vendor.js
@@ -38867,9 +38867,15 @@ return this || ("undefined" != typeof window ? window :global);
 "function" == typeof define && define.amd ? define([ "base1/angular", "base1/term" ], b) :b(a.angular, a.Terminal);
 }(this, function(a, b) {
 "use strict";
+function c(a) {
+return window.btoa(window.unescape(encodeURIComponent(a)));
+}
+function d(a) {
+return decodeURIComponent(window.escape(window.atob(a)));
+}
 try {
 a.module("kubernetesUI");
-} catch (c) {
+} catch (e) {
 a.module("kubernetesUI", []);
 }
 return a.module("kubernetesUI").provider("kubernetesContainerSocket", function() {
@@ -38885,7 +38891,7 @@ return 0 === a.indexOf("/") && (a = "http:" === window.location.protocol ? "ws:/
 }, c.$get = [ "$injector", function(a) {
 return b(a, c.WebSocketFactory);
 } ];
-}).directive("kubernetesContainerTerminal", [ "$q", "kubernetesContainerSocket", function(c, d) {
+}).directive("kubernetesContainerTerminal", [ "$q", "kubernetesContainerSocket", function(e, f) {
 return {
 restrict:"E",
 scope:{
@@ -38895,62 +38901,63 @@ command:"@",
 prevent:"=",
 rows:"=",
 cols:"=",
-screenKeys:"="
+screenKeys:"=",
+autofocus:"=?"
 },
-link:function(e, f, g) {
-function h() {
+link:function(g, h, i) {
+function j() {
 function a(a) {
-!a && j && (a = "Could not connect to the container. Do you have sufficient privileges?"), a || (a = "disconnected"), j || (a = "\r\n" + a), o.write("[31m" + a + "[m\r\n"), e.$apply(i);
+!a && j && (a = "Could not connect to the container. Do you have sufficient privileges?"), a || (a = "disconnected"), j || (a = "\r\n" + a), q.write("[31m" + a + "[m\r\n"), g.$apply(k);
 }
-i(), o.reset();
-var b = "", f = e.pod();
-b += f.metadata ? f.metadata.selfLink :f, b += "/exec", -1 === b.indexOf("?") && (b += "?"), b += "stdout=1&stdin=1&stderr=1&tty=1";
-var g = e.container ? e.container() :null;
-g && (b += "&container=" + encodeURIComponent(g));
-var h = e.command;
-h || (h = [ "/bin/sh", "-i" ]), "string" == typeof h && (h = [ h ]), h.forEach(function(a) {
+k(), q.reset();
+var b = "", c = g.pod();
+b += c.metadata ? c.metadata.selfLink :c, b += "/exec", -1 === b.indexOf("?") && (b += "?"), b += "stdout=1&stdin=1&stderr=1&tty=1";
+var h = g.container ? g.container() :null;
+h && (b += "&container=" + encodeURIComponent(h));
+var i = g.command;
+i || (i = [ "/bin/sh", "-i" ]), "string" == typeof i && (i = [ i ]), i.forEach(function(a) {
 b += "&command=" + encodeURIComponent(a);
 });
 var j = !0;
-k.removeClass("hidden"), l.addClass("hidden"), c.when(d(b, "base64.channel.k8s.io"), function(b) {
-n = b, n.onopen = function(a) {
-m = window.setInterval(function() {
-n.send("0");
+m.removeClass("hidden"), n.addClass("hidden"), e.when(f(b, "base64.channel.k8s.io"), function(b) {
+p = b, p.onopen = function(a) {
+o = window.setInterval(function() {
+p.send("0");
 }, 3e4);
-}, n.onmessage = function(a) {
+}, p.onmessage = function(a) {
 var b = a.data.slice(1);
 switch (a.data[0]) {
 case "1":
 case "2":
 case "3":
-o.write(window.atob(b));
+q.write(d(b));
 }
-j && (j = !1, k.addClass("hidden"), l.addClass("hidden"), o.cursorHidden = !1, o.showCursor(), o.refresh(o.y, o.y));
-}, n.onclose = function(b) {
+j && (j = !1, m.addClass("hidden"), n.addClass("hidden"), q.cursorHidden = !1, q.showCursor(), q.refresh(q.y, q.y), g.autofocus && q.element && q.element.focus());
+}, p.onclose = function(b) {
 a(b.reason);
 };
 }, function(b) {
 a(b.message);
 });
 }
-function i() {
-k.addClass("hidden"), l.removeClass("hidden"), o && (o.cursorHidden = !0, o.refresh(o.x, o.y)), n && (n.onopen = n.onmessage = n.onerror = n.onclose = null, n.readyState < 2 && n.close(), n = null), window.clearInterval(m), m = null;
+function k() {
+m.addClass("hidden"), n.removeClass("hidden"), q && (q.cursorHidden = !0, q.refresh(q.x, q.y)), p && (p.onopen = p.onmessage = p.onerror = p.onclose = null, p.readyState < 2 && p.close(), p = null), window.clearInterval(o), o = null;
 }
-var j = a.element("<div class='terminal-wrapper'>");
-f.append(j);
-var k = a.element("<div class='spinner spinner-white hidden'>"), l = a.element("<button class='btn btn-default fa fa-refresh'>");
-l.on("click", h).attr("title", "Connect"), f.append(a.element("<div class='terminal-actions'>").append(k).append(l));
-var m = null, n = null, o = new b({
-cols:e.cols || 80,
-rows:e.rows || 24,
-screenKeys:e.screenKeys || !0
+var l = a.element("<div class='terminal-wrapper'>");
+h.append(l);
+var m = a.element("<div class='spinner spinner-white hidden'>"), n = a.element("<button class='btn btn-default fa fa-refresh'>");
+n.on("click", j).attr("title", "Connect"), h.append(a.element("<div class='terminal-actions'>").append(m).append(n));
+var o = null, p = null, q = new b({
+cols:g.cols || 80,
+rows:g.rows || 24,
+screenKeys:g.screenKeys || !0
 });
-j.empty(), o.open(j[0]), o.cursorHidden = !0, o.refresh(o.x, o.y), o.on("data", function(a) {
-n && 1 === n.readyState && n.send("0" + window.btoa(a));
-}), e.$watch("prevent", function(a) {
-a || h();
-}), e.$on("$destroy", function() {
-o && o.destroy(), i();
+l.empty(), q.open(l[0]), q.cursorHidden = !0, q.refresh(q.x, q.y), q.on("data", function(a) {
+p && 1 === p.readyState && p.send("0" + c(a));
+}), g.$watch("prevent", function(a) {
+a || j();
+}), g.$on("$destroy", function() {
+q && q.destroy(), k();
 });
 }
 };

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3381,7 +3381,7 @@ label.checkbox{font-weight:400}
 .add-to-project .catalog-header-left{padding-right:10px}
 .add-to-project .catalog-legend{padding-left:15px}
 }
-.about .about-icon img,.catalog .tile-image,.catalog .tile-template,.osc-form .flow{width:100%}
+.about .about-icon img,.catalog .tile-image,.catalog .tile-template,.command-line .about-icon img,.osc-form .flow{width:100%}
 @media (min-width:992px){.add-to-project .catalog-header-left{padding-right:15px}
 }
 .drag-and-drop-zone{position:absolute;border-width:3px;visibility:hidden}


### PR DESCRIPTION
I've split the About page which contained also info about CLI tools into two separate pages `About` and `Command Line Tools`

About page:
![screenshot-13](https://cloud.githubusercontent.com/assets/1668218/15180229/928d94da-1780-11e6-9ffb-c712357f032a.png)

Command Line page with updated dropdown:
![screenshot-16](https://cloud.githubusercontent.com/assets/1668218/15180313/0f16c260-1781-11e6-950a-4beed679225b.png)

Mobile version of the dropdown:
![screenshot-15](https://cloud.githubusercontent.com/assets/1668218/15180243/a59a9f6e-1780-11e6-8c8e-6512c389d314.png)

Will add bindata after review :)