### PR TITLE
Update repo name and version in bower.json and package.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
-  "name": "assets",
-  "version": "0.0.0",
+  "name": "origin-web-console",
+  "version": "1.3.0-alpha",
   "dependencies": {
     "angular": "1.3.8",
     "json3": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "assets",
-  "version": "0.0.0",
+  "name": "origin-web-console",
+  "version": "1.3.0-alpha",
   "dependencies": {},
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently:
```
"name": "assets"
"version": "0.0.0"
```
Suggesting:
```
"name": "origin-web-console"
"version": "1.3.0"
```
To match the repo name & the current version of origin when we broke off.

@jwforres @spadgett 