### PR TITLE
Fix bug 1285658: adding labels and envs is tricky

### DIFF
--- a/app/scripts/directives/oscKeyValues.js
+++ b/app/scripts/directives/oscKeyValues.js
@@ -33,6 +33,22 @@ angular.module("openshiftConsole")
       }
       return true;
     };
+
+    // checks if the key,value inputs have any text value.
+    // if so, sets the form name="clean" to an 'invalid' state, which will
+    // invalidate any parent form up the chain.  This should result in an
+    // inability to submit that form until the user commits the new key-value pair.
+    $scope.isClean = _.debounce(function() {
+      $scope.$apply(function() {
+        if(!!$scope.key) {
+          $scope.clean.isClean.$setValidity('isClean', false);
+        } else if(!!$scope.value) {
+          $scope.clean.isClean.$setValidity('isClean', false);
+        } else {
+          $scope.clean.isClean.$setValidity('isClean', true);
+        }
+      });
+    }, 50);
     $scope.addEntry = function() {
       if($scope.key && $scope.value){
         var readonly = $scope.readonlyKeys.split(",");
@@ -45,6 +61,7 @@ angular.module("openshiftConsole")
         $scope.value = null;
         $scope.form.$setPristine();
         $scope.form.$setUntouched();
+        $scope.isClean();
       }
     };
     $scope.deleteEntry = function(key) {

--- a/app/scripts/directives/oscKeyValues.js
+++ b/app/scripts/directives/oscKeyValues.js
@@ -19,7 +19,7 @@ angular.module("openshiftConsole")
       }
     };
   })
-  .controller("KeyValuesController", function($scope){
+  .controller("KeyValuesController", function($scope, $timeout){
     var added = {};
     $scope.allowDelete = function(value){
       if ($scope.preventEmpty && (Object.keys($scope.entries).length === 1)) {
@@ -34,12 +34,25 @@ angular.module("openshiftConsole")
       return true;
     };
 
+    // add/remove 'must commit' message.
+    $scope.onBlur = function() {
+      $timeout(function() {
+        if(!!$scope.key) {
+          $scope.reminder = true;
+        } else if(!!$scope.value) {
+          $scope.reminder = true;
+        } else {
+          $scope.reminder = false;
+        }
+      }, 100);
+    };
+
     // checks if the key,value inputs have any text value.
     // if so, sets the form name="clean" to an 'invalid' state, which will
     // invalidate any parent form up the chain.  This should result in an
     // inability to submit that form until the user commits the new key-value pair.
     $scope.isClean = _.debounce(function() {
-      $scope.$apply(function() {
+      $scope.$applyAsync(function() {
         if(!!$scope.key) {
           $scope.clean.isClean.$setValidity('isClean', false);
         } else if(!!$scope.value) {
@@ -62,6 +75,7 @@ angular.module("openshiftConsole")
         $scope.form.$setPristine();
         $scope.form.$setUntouched();
         $scope.isClean();
+        $scope.onBlur();
       }
     };
     $scope.deleteEntry = function(key) {

--- a/app/views/directives/osc-key-values.html
+++ b/app/views/directives/osc-key-values.html
@@ -1,3 +1,9 @@
+<!-- a hidden input to let parent forms know they are "invalid" if the user is
+     in the midst of editing one of the key-value pairs (and form should NOT submit) -->
+<ng-form hidden name="clean">
+  <input name="isClean" ng-model="keyValuesClean"></input>
+</ng-form>
+
 <div ng-controller="KeyValuesController" class="labels">
     <div class="form-inline labels-edit" ng-show="editable">
       <ng-form class="edit-label" name="form" novalidate>
@@ -15,12 +21,12 @@
               name="key"
               ng-attr-placeholder="{{keyTitle}}"
               ng-model="key"
-              ng-model-options="{ debounce: 200 }"
               autocorrect="off"
               autocapitalize="off"
               spellcheck="false"
               osc-input-validator="key"
               osc-unique="entries"
+              ng-keyup="isClean()"
               on-enter="form.$valid && addEntry()">
           </div>
 
@@ -39,6 +45,7 @@
               autocapitalize="off"
               spellcheck="false"
               osc-input-validator="value"
+              ng-keyup="isClean()"
               on-enter="form.$valid && addEntry()">
           </div>
           <!-- We need to replace button tag with a link tag cause we are embedding this directive into different forms (BC edit

--- a/app/views/directives/osc-key-values.html
+++ b/app/views/directives/osc-key-values.html
@@ -8,7 +8,6 @@
     <div class="form-inline labels-edit" ng-show="editable">
       <ng-form class="edit-label" name="form" novalidate>
 
-
         <div row cross-axis="start">
           <div
             flex grow="5" shrink="5"
@@ -27,6 +26,7 @@
               osc-input-validator="key"
               osc-unique="entries"
               ng-keyup="isClean()"
+              ng-blur="onBlur()"
               on-enter="form.$valid && addEntry()">
           </div>
 
@@ -46,6 +46,7 @@
               spellcheck="false"
               osc-input-validator="value"
               ng-keyup="isClean()"
+              ng-blur="onBlur()"
               on-enter="form.$valid && addEntry()">
           </div>
           <!-- We need to replace button tag with a link tag cause we are embedding this directive into different forms (BC edit
@@ -55,9 +56,13 @@
             href=""
             role="button"
             ng-click="addEntry()"
+            ng-blur="onBlur()"
             ng-disabled="form.$invalid || !key || !value">
             Add
           </a>
+        </div>
+        <div ng-show="reminder" style="color: red;">
+          Press 'add' to commit
         </div>
 
         <div row class="has-error" ng-show="form.key.$error.oscUnique">


### PR DESCRIPTION
Fix bug 1333118, ensure key,value committed before allowing parent forms to submit.

Simplest fix essentially:
- adds a separate hidden form with its own `<input>` used only as a proxy validation
- if either key or value inputs have any value at all, the hidden form will be set to 'invalid', which will bubble up and invalidate parent forms, ensuring user has to make a decision to submit the new key-value pair before submitting the larger form.
- ensures existing validation on the key-value form continues to work as before


```html
<!-- separate hidden form, allows key-value inputs to use normal validation but bubble up an 'invalid' to parent forms if any values are detected -->
<ng-form hidden name="clean">
  <input name="isClean" ng-model="keyValuesClean"></input>
</ng-form>
```

Screenshots of the various states:
![screen shot 2016-05-16 at 12 56 26 pm](https://cloud.githubusercontent.com/assets/280512/15296970/d3230654-1b65-11e6-9d28-8e2a86ce6e14.png)
![screen shot 2016-05-16 at 12 56 31 pm](https://cloud.githubusercontent.com/assets/280512/15296941/b3d2253c-1b65-11e6-9693-7e7dc4233f8d.png)
![screen shot 2016-05-16 at 12 56 36 pm](https://cloud.githubusercontent.com/assets/280512/15296943/b3d7cc58-1b65-11e6-9a8b-bc5325666181.png)
![screen shot 2016-05-16 at 12 56 45 pm](https://cloud.githubusercontent.com/assets/280512/15296944/b3d806e6-1b65-11e6-9ec4-bcd3b2b31613.png)
![screen shot 2016-05-16 at 12 56 40 pm](https://cloud.githubusercontent.com/assets/280512/15296942/b3d66d86-1b65-11e6-8c9f-31bcf20d31d6.png)

@jwforres @spadgett for review!
