### PR TITLE
Fix bug 1333118, ensure key,value committed before allowing parent forms to submit.

### DIFF
--- a/app/scripts/directives/oscKeyValues.js
+++ b/app/scripts/directives/oscKeyValues.js
@@ -19,51 +19,6 @@ angular.module("openshiftConsole")
       }
     };
   })
-  .controller("KeyValuesController", function($scope){
-    var added = {};
-    $scope.allowDelete = function(value){
-      if ($scope.preventEmpty && (Object.keys($scope.entries).length === 1)) {
-        return false;
-      }
-      if($scope.deletePolicy === "never") {
-        return false;
-      }
-      if($scope.deletePolicy === "added"){
-        return added[value] !== undefined;
-      }
-      return true;
-    };
-    $scope.addEntry = function() {
-      if($scope.key && $scope.value){
-        var readonly = $scope.readonlyKeys.split(",");
-        if(readonly.indexOf($scope.key) !== -1){
-          return;
-        }
-        added[$scope.key] = "";
-        $scope.entries[$scope.key] = $scope.value;
-        $scope.key = null;
-        $scope.value = null;
-        $scope.form.$setPristine();
-        $scope.form.$setUntouched();
-      }
-    };
-    $scope.deleteEntry = function(key) {
-      if ($scope.entries[key]) {
-        delete $scope.entries[key];
-        delete added[key];
-        $scope.form.$setDirty();
-      }
-    };
-    $scope.setErrorText = function(keyTitle) {
-      if (keyTitle === 'path') {
-        return "absolute path";
-      } else if (keyTitle === 'label') {
-        return "label";
-      } else {
-        return "key";
-      }
-    };
-  })
   .directive("oscInputValidator", function(){
 
     var validators = {
@@ -162,10 +117,124 @@ angular.module("openshiftConsole")
         readonlyKeys: "@",
         keyValidationTooltip: "@",
         valueValidationTooltip: "@",
-        preventEmpty: "=?",
+        preventEmpty: "=?"
       },
       controller: function($scope){
+        var focusElem;
+        var added = {};
+        var isUncommitted = function() {
+          return (!!$scope.key) || (!!$scope.value);
+        };
+        var checkCommitted = function() {
+          if(isUncommitted()) {
+            $scope.showCommmitWarning = true;
+          } else {
+            $scope.showCommmitWarning = false;
+          }
+        };
+        // checks if the key,value inputs have any text value.
+        // if so, sets the form name="clean" to an 'invalid' state, which will
+        // invalidate any parent form up the chain.  This should result in an
+        // inability to submit that form until the user commits the new key-value pair.
+        var isClean = _.debounce(function() {
+          $scope.$applyAsync(function() {
+            if(!!$scope.key) {
+              $scope.clean.isClean.$setValidity('isClean', false);
+            } else if(!!$scope.value) {
+              $scope.clean.isClean.$setValidity('isClean', false);
+            } else {
+              $scope.clean.isClean.$setValidity('isClean', true);
+            }
+          });
+        }, 100);
+
+        // returns a new function bound to the set of DOM nodes provided as an array.
+        // allows us to treat the osc-key-values directive as a single node on blur
+        // events, though it is actually made up of a number of nodes.  If any of the
+        // provided nodes is the document.activeElement, we know the osc-key-values
+        // directive as a whole still has focus. When the document.activeElement no
+        // longer matches a child node, we can test to see if there are uncommitted
+        // values left in the osc-key-values directive & notify the user if so.
+        var onBlur = function(nodes) {
+          return function(evt) {
+            $scope.$applyAsync(function() {
+              if(!_.includes(nodes, document.activeElement)) {
+                checkCommitted();
+                isClean();
+              }
+            });
+          };
+        };
+        $scope.isClean = isClean;
+
+        $scope.clear = function() {
+          $scope.key = '';
+          $scope.value = '';
+          checkCommitted();
+          isClean();
+        };
+        $scope.allowDelete = function(value){
+          if ($scope.preventEmpty && (Object.keys($scope.entries).length === 1)) {
+            return false;
+          }
+          if($scope.deletePolicy === "never") {
+            return false;
+          }
+          if($scope.deletePolicy === "added"){
+            return added[value] !== undefined;
+          }
+          return true;
+        };
+        $scope.addEntry = function() {
+          if($scope.key && $scope.value){
+            var readonly = $scope.readonlyKeys.split(",");
+            if(readonly.indexOf($scope.key) !== -1){
+              return;
+            }
+            added[$scope.key] = "";
+            $scope.entries[$scope.key] = $scope.value;
+            $scope.key = null;
+            $scope.value = null;
+            $scope.form.$setPristine();
+            $scope.form.$setUntouched();
+            checkCommitted();
+            isClean();
+            focusElem.focus();
+          }
+        };
+        $scope.deleteEntry = function(key) {
+          if ($scope.entries[key]) {
+            delete $scope.entries[key];
+            delete added[key];
+            $scope.form.$setDirty();
+          }
+        };
+        $scope.setErrorText = function(keyTitle) {
+          if (keyTitle === 'path') {
+            return "absolute path";
+          } else if (keyTitle === 'label') {
+            return "label";
+          } else {
+            return "key";
+          }
+        };
+
         this.scope = $scope;
+
+        this.init = function(keyInput, valInput, submitBtn) {
+          var nodes = [keyInput[0], valInput[0], submitBtn[0]];
+          var boundBlur = onBlur(nodes);
+          focusElem = keyInput;
+          keyInput.on('blur', boundBlur);
+          valInput.on('blur', boundBlur);
+          submitBtn.on('blur', boundBlur);
+
+          $scope.$on('$destroy', function() {
+            keyInput.off('blur', boundBlur);
+            valInput.off('blur', boundBlur);
+            submitBtn.off('blur', boundBlur);
+          });
+        };
       },
       templateUrl: "views/directives/osc-key-values.html",
       compile: function(element, attrs){
@@ -185,6 +254,15 @@ angular.module("openshiftConsole")
         if(!attrs.readonlyKeys){
           attrs.readonlyKeys = "";
         }
+        return {
+          post: function($scope, $elem, $attrs, ctrl) {
+            ctrl.init(
+                $elem.find('input[name="key"]'),
+                $elem.find('input[name="value"]'),
+                $elem.find('a.add-key-value')
+              );
+          }
+        };
       }
     };
   });

--- a/app/views/directives/osc-key-values.html
+++ b/app/views/directives/osc-key-values.html
@@ -1,4 +1,8 @@
-<div ng-controller="KeyValuesController" class="labels">
+<ng-form hidden name="clean">
+  <input name="isClean" ng-model="keyValuesClean">
+</ng-form>
+
+<div class="labels">
     <div class="form-inline labels-edit" ng-show="editable">
       <ng-form class="edit-label" name="form" novalidate>
 
@@ -21,7 +25,8 @@
               spellcheck="false"
               osc-input-validator="key"
               osc-unique="entries"
-              on-enter="form.$valid && addEntry()">
+              on-enter="form.$valid && addEntry()"
+              ng-keyup="isClean()">
           </div>
 
           <div
@@ -39,18 +44,25 @@
               autocapitalize="off"
               spellcheck="false"
               osc-input-validator="value"
-              on-enter="form.$valid && addEntry()">
+              on-enter="form.$valid && addEntry()"
+              ng-keyup="isClean()">
           </div>
           <!-- We need to replace button tag with a link tag cause we are embedding this directive into different forms (BC edit
           form, from image form) and in order to be able to submit the top level form with hitting Enter key we needed to replace buttons with links.
           Based on: https://docs.angularjs.org/api/ng/directive/form#submitting-a-form-and-preventing-the-default-action -->
-          <a class="btn btn-default"
+          <a class="btn btn-default add-key-value"
             href=""
             role="button"
             ng-click="addEntry()"
             ng-disabled="form.$invalid || !key || !value">
             Add
           </a>
+        </div>
+
+        <div ng-if="showCommmitWarning" class="has-error">
+          <span class="help-block">
+            Please add or <a href="" ng-click="clear()">clear</a> this {{(keyTitle || 'key') | lowercase}}-{{(valueTitle || 'value') | lowercase}} pair
+          </span>
         </div>
 
         <div row class="has-error" ng-show="form.key.$error.oscUnique">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5594,21 +5594,6 @@ a.value = a.originalValue, a.editing = !1;
 }, a.update = function(b, c, d) {
 c && (d[b] = c, a.editing = !1);
 };
-} ]).controller("KeyValuesController", [ "$scope", function(a) {
-var b = {};
-a.allowDelete = function(c) {
-return a.preventEmpty && 1 === Object.keys(a.entries).length ? !1 :"never" === a.deletePolicy ? !1 :"added" === a.deletePolicy ? void 0 !== b[c] :!0;
-}, a.addEntry = function() {
-if (a.key && a.value) {
-var c = a.readonlyKeys.split(",");
-if (-1 !== c.indexOf(a.key)) return;
-b[a.key] = "", a.entries[a.key] = a.value, a.key = null, a.value = null, a.form.$setPristine(), a.form.$setUntouched();
-}
-}, a.deleteEntry = function(c) {
-a.entries[c] && (delete a.entries[c], delete b[c], a.form.$setDirty());
-}, a.setErrorText = function(a) {
-return "path" === a ? "absolute path" :"label" === a ? "label" :"key";
-};
 } ]).directive("oscInputValidator", function() {
 var a = {
 always:function(a, b) {
@@ -5668,11 +5653,49 @@ valueValidationTooltip:"@",
 preventEmpty:"=?"
 },
 controller:[ "$scope", function(a) {
-this.scope = a;
+var b, c = {}, d = function() {
+return !!a.key || !!a.value;
+}, e = function() {
+d() ? a.showCommmitWarning = !0 :a.showCommmitWarning = !1;
+}, f = _.debounce(function() {
+a.$applyAsync(function() {
+a.key ? a.clean.isClean.$setValidity("isClean", !1) :a.value ? a.clean.isClean.$setValidity("isClean", !1) :a.clean.isClean.$setValidity("isClean", !0);
+});
+}, 100), g = function(b) {
+return function(c) {
+a.$applyAsync(function() {
+_.includes(b, document.activeElement) || (e(), f());
+});
+};
+};
+a.isClean = f, a.clear = function() {
+a.key = "", a.value = "", e(), f();
+}, a.allowDelete = function(b) {
+return a.preventEmpty && 1 === Object.keys(a.entries).length ? !1 :"never" === a.deletePolicy ? !1 :"added" === a.deletePolicy ? void 0 !== c[b] :!0;
+}, a.addEntry = function() {
+if (a.key && a.value) {
+var d = a.readonlyKeys.split(",");
+if (-1 !== d.indexOf(a.key)) return;
+c[a.key] = "", a.entries[a.key] = a.value, a.key = null, a.value = null, a.form.$setPristine(), a.form.$setUntouched(), e(), f(), b.focus();
+}
+}, a.deleteEntry = function(b) {
+a.entries[b] && (delete a.entries[b], delete c[b], a.form.$setDirty());
+}, a.setErrorText = function(a) {
+return "path" === a ? "absolute path" :"label" === a ? "label" :"key";
+}, this.scope = a, this.init = function(c, d, e) {
+var f = [ c[0], d[0], e[0] ], h = g(f);
+b = c, c.on("blur", h), d.on("blur", h), e.on("blur", h), a.$on("$destroy", function() {
+c.off("blur", h), d.off("blur", h), e.off("blur", h);
+});
+};
 } ],
 templateUrl:"views/directives/osc-key-values.html",
 compile:function(a, b) {
-b.delimiter || (b.delimiter = ":"), b.keyTitle || (b.keyTitle = "Name"), b.valueTitle || (b.valueTitle = "Value"), b.editable && "true" !== b.editable ? b.editable = !1 :b.editable = !0, b.keyValidator || (b.keyValidator = "always"), b.valueValidator || (b.valueValidator = "always"), -1 === [ "always", "added", "none" ].indexOf(b.deletePolicy) && (b.deletePolicy = "always"), b.readonlyKeys || (b.readonlyKeys = "");
+return b.delimiter || (b.delimiter = ":"), b.keyTitle || (b.keyTitle = "Name"), b.valueTitle || (b.valueTitle = "Value"), b.editable && "true" !== b.editable ? b.editable = !1 :b.editable = !0, b.keyValidator || (b.keyValidator = "always"), b.valueValidator || (b.valueValidator = "always"), -1 === [ "always", "added", "none" ].indexOf(b.deletePolicy) && (b.deletePolicy = "always"), b.readonlyKeys || (b.readonlyKeys = ""), {
+post:function(a, b, c, d) {
+d.init(b.find('input[name="key"]'), b.find('input[name="value"]'), b.find("a.add-key-value"));
+}
+};
 }
 };
 }), angular.module("openshiftConsole").directive("oscRouting", function() {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4939,20 +4939,28 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/directives/osc-key-values.html',
-    "<div ng-controller=\"KeyValuesController\" class=\"labels\">\n" +
+    "<ng-form hidden name=\"clean\">\n" +
+    "<input name=\"isClean\" ng-model=\"keyValuesClean\">\n" +
+    "</ng-form>\n" +
+    "<div class=\"labels\">\n" +
     "<div class=\"form-inline labels-edit\" ng-show=\"editable\">\n" +
     "<ng-form class=\"edit-label\" name=\"form\" novalidate>\n" +
     "<div row cross-axis=\"start\">\n" +
     "<div flex grow=\"5\" shrink=\"5\" class=\"form-group\" ng-class=\"{'has-error': form.key.$error.oscKeyValid}\" style=\"margin-right: 10px\">\n" +
-    "<input class=\"form-control\" type=\"text\" name=\"key\" ng-attr-placeholder=\"{{keyTitle}}\" ng-model=\"key\" ng-model-options=\"{ debounce: 200 }\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck osc-input-validator=\"key\" osc-unique=\"entries\" on-enter=\"form.$valid && addEntry()\">\n" +
+    "<input class=\"form-control\" type=\"text\" name=\"key\" ng-attr-placeholder=\"{{keyTitle}}\" ng-model=\"key\" ng-model-options=\"{ debounce: 200 }\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck osc-input-validator=\"key\" osc-unique=\"entries\" on-enter=\"form.$valid && addEntry()\" ng-keyup=\"isClean()\">\n" +
     "</div>\n" +
     "<div flex grow=\"5\" shrink=\"5\" class=\"form-group\" ng-class=\"{'has-error': form.value.$error.oscValueValid}\" style=\"margin-right: 10px\">\n" +
-    "<input class=\"form-control\" type=\"text\" name=\"value\" ng-attr-placeholder=\"{{valueTitle}}\" ng-model=\"value\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck osc-input-validator=\"value\" on-enter=\"form.$valid && addEntry()\">\n" +
+    "<input class=\"form-control\" type=\"text\" name=\"value\" ng-attr-placeholder=\"{{valueTitle}}\" ng-model=\"value\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck osc-input-validator=\"value\" on-enter=\"form.$valid && addEntry()\" ng-keyup=\"isClean()\">\n" +
     "</div>\n" +
     "\n" +
-    "<a class=\"btn btn-default\" href=\"\" role=\"button\" ng-click=\"addEntry()\" ng-disabled=\"form.$invalid || !key || !value\">\n" +
+    "<a class=\"btn btn-default add-key-value\" href=\"\" role=\"button\" ng-click=\"addEntry()\" ng-disabled=\"form.$invalid || !key || !value\">\n" +
     "Add\n" +
     "</a>\n" +
+    "</div>\n" +
+    "<div ng-if=\"showCommmitWarning\" class=\"has-error\">\n" +
+    "<span class=\"help-block\">\n" +
+    "Please add or <a href=\"\" ng-click=\"clear()\">clear</a> this {{(keyTitle || 'key') | lowercase}}-{{(valueTitle || 'value') | lowercase}} pair\n" +
+    "</span>\n" +
     "</div>\n" +
     "<div row class=\"has-error\" ng-show=\"form.key.$error.oscUnique\">\n" +
     "<span class=\"help-block\">\n" +

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "karma": "0.12.23",
     "karma-coverage": "0.2.6",
     "karma-jasmine": "0.1.5",
+    "karma-ng-html2js-preprocessor": "1.0.0",
     "karma-phantomjs-launcher": "0.1.4",
     "less": "2.6.1",
     "load-grunt-tasks": "0.4.0",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -56,6 +56,7 @@ module.exports = function(config) {
       "bower_components/ui-select/dist/select.js",
       'app/config.js',
       'app/scripts/**/*.js',
+      'app/views/directives/**/*.html',
       //'test/mock/**/*.js',
       'test/spec/spec-helper.js',
       'test/spec/fixtures/api-discovery.js',
@@ -83,6 +84,7 @@ module.exports = function(config) {
     // Which plugins to enable
     plugins: [
       'karma-phantomjs-launcher',
+      'karma-ng-html2js-preprocessor',
       'karma-jasmine',
       'karma-coverage'
     ],
@@ -108,7 +110,15 @@ module.exports = function(config) {
       // source files, that you wanna generate coverage for
       // do not include tests or libraries
       // (these files will be instrumented by Istanbul)
-      'app/**/*.js': ['coverage']
+      'app/**/*.js': ['coverage'],
+      'app/views/directives/**/*.html': ['ng-html2js']
+    },
+
+    ngHtml2JsPreprocessor: {
+      moduleName: 'openshiftConsoleTemplates',
+      cacheIdFromPath: function(filepath) {
+        return filepath.replace('app/', '');
+      },
     },
 
     reporters: ['progress', 'coverage'],
@@ -118,6 +128,6 @@ module.exports = function(config) {
         {type: 'json', dir:'test/coverage/'},
         {type: 'text-summary', dir:'test/coverage/'}
       ]
-    }    
+    }
   });
 };


### PR DESCRIPTION
Nixed the prev solution, presenting new:

- link function passes DOM elements to controller once rendered
- blur events used to check against `document.activeElement` to see if an `osc-key-values` child is active
- show message when user leaves `osc-key-values` with uncommitted changes
- eliminates secondary controller & assimilates it into the main directive controller to simplify access to `$scope` vars
- when uncommitted key-value pairs exist, osc-key-values remains valid, HOWEVER it will invalidate the parent form, ensuring it is not submitted until the user decides to keep or discard all key-value pairs.


@jwforres @spadgett thoughts?