### PR TITLE
Bug 1333016 - Add token flag to the `oc login`

### DIFF
--- a/app/scripts/controllers/create/nextSteps.js
+++ b/app/scripts/controllers/create/nextSteps.js
@@ -9,7 +9,7 @@
  * Controller of the openshiftConsole
  */
 angular.module("openshiftConsole")
-  .controller("NextStepsController", function($scope, $http, $routeParams, DataService, $q, $location, TaskList, $parse, Navigate, $filter, imageObjectRefFilter, failureObjectNameFilter, ProjectsService) {
+  .controller("NextStepsController", function($scope, $http, AuthService, $routeParams, DataService, $q, $location, TaskList, $parse, Navigate, $filter, imageObjectRefFilter, failureObjectNameFilter, ProjectsService) {
     var displayNameFilter = $filter('displayName');
     var watches = [];
 
@@ -17,6 +17,14 @@ angular.module("openshiftConsole")
     $scope.alerts = [];
     $scope.loginBaseUrl = DataService.openshiftAPIBaseUrl();
     $scope.buildConfigs = {};
+
+    AuthService.withUser();
+    $scope.sessionToken = AuthService.UserStore().getToken();
+    $scope.showSessionToken = false;
+
+    $scope.toggleShowSessionToken = function() {
+      $scope.showSessionToken = !$scope.showSessionToken;
+    };
 
     $scope.projectName = $routeParams.project;
     var imageName = $routeParams.imageName;

--- a/app/scripts/directives/popups.js
+++ b/app/scripts/directives/popups.js
@@ -104,4 +104,13 @@ angular.module('openshiftConsole')
       },
       templateUrl: 'views/directives/_warnings-popover.html'
     };
+  })
+  .directive('tokenWarning', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        showSessionToken: '='
+      },
+      template: '<div ng-show="showSessionToken" class="alert alert-warning"><span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span><strong>A token is a form of a password.</strong>Do not share your API token.</div>'
+    };
   });

--- a/app/views/command-line.html
+++ b/app/views/command-line.html
@@ -33,19 +33,10 @@
                   </p>
                   <p>
                     After downloading and installing it, you can start by logging in using<span ng-if="sessionToken"> this current session token</span>:
-                    <div class="code prettyprint ng-binding" ng-if="sessionToken">
-                      oc login {{loginBaseURL}} --token=<span ng-show="showSessionToken">{{sessionToken}}</span><a href="#" ng-click="toggleShowSessionToken()" ng-show="!showSessionToken">...click to show token...</a>
-                    </div>
-                    <pre class="code prettyprint ng-binding" ng-if="!sessionToken">
-                      oc login {{loginBaseURL}}
-                    </pre>
+                    <pre class="code prettyprint">oc login {{loginBaseURL}} <span ng-if="sessionToken">--token=<span ng-show="showSessionToken">{{sessionToken}}</span><a href="#" ng-click="toggleShowSessionToken()" ng-show="!showSessionToken">...click to show token...</a></span></pre>
                   </p>
 
-                  <div ng-show="showSessionToken" class="alert alert-warning">
-                    <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
-                    <strong>A token is a form of a password.</strong>
-                    Do not share your API token.
-                  </div>
+                  <token-warning show-session-token='showSessionToken'></token-warning>
 
                   <p>After you login to your account you will get a list of projects that you can switch between:
                      <pre class="code prettyprint">oc project <i>project-name</i></pre>

--- a/app/views/create/next-steps.html
+++ b/app/views/create/next-steps.html
@@ -45,11 +45,12 @@
                 <h2>Things you can do</h2>
                 <p>Go to the <a href="project/{{projectName}}/overview">overview page</a> to see more details about this project. Make sure you don't already have <a href="project/{{projectName}}/browse/services">services</a>, <a href="project/{{projectName}}/browse/builds">build configs</a>, <a href="project/{{projectName}}/browse/deployments">deployment configs</a>, or other resources with the same names you are trying to create. Refer to the <a target="_blank" href="{{'new_app' | helpLink}}">documentation for creating new applications</a> for more information.</p>
                 <h3>Command line tools</h3>
-                <p>You may want to use the <code>oc</code> command line tool to help with troubleshooting. After <a target="_blank" href="command-line">downloading and installing</a> it, you can log in, switch to this particular project, and try some commands :</p>
+                <p>You may want to use the <code>oc</code> command line tool to help with troubleshooting. After <a target="_blank" href="command-line">downloading and installing</a> it, you can log in <span ng-if="sessionToken">using current session token</span>, switch to this particular project, and try some commands :</p>
 
-                <pre class="code prettyprint">oc login {{loginBaseUrl}}
+                <pre class="code prettyprint">oc login {{loginBaseUrl}} <span ng-if="sessionToken">--token=<span ng-show="showSessionToken">{{sessionToken}}</span><a href="#" ng-click="toggleShowSessionToken()" ng-show="!showSessionToken">...click to show token...</a></span>
 oc project {{projectName}}
 oc logs -h</pre>
+                <token-warning show-session-token="showSessionToken"></token-warning>
 
                 <p>For more information about the command line tools, check the <a target="_blank" href="{{'cli' | helpLink}}">CLI Reference</a> and <a target="_blank" href="{{'basic_cli_operations' | helpLink}}">Basic CLI Operations</a>.</p>
               </div>
@@ -59,14 +60,17 @@ oc logs -h</pre>
                 <p>The web console is convenient, but if you need deeper control you may want to try our command line tools.</p>
 
                 <h3>Command line tools</h3>
-                <p><a target="_blank" href="command-line">Download and install</a> the <code>oc</code> command line tool. After that, you can start by logging in, switching to this particular project, and displaying an overview of it, by doing:</p>
+                <p><a target="_blank" href="command-line">Download and install</a> the <code>oc</code> command line tool. After that, you can start by logging in <span ng-if="sessionToken">using current session token</span>, switching to this particular project, and displaying an overview of it, by doing:</p>
 
-                <pre class="code prettyprint">oc login {{loginBaseUrl}}
+                <pre class="code prettyprint">oc login {{loginBaseUrl}} <span ng-if="sessionToken">--token=<span ng-show="showSessionToken">{{sessionToken}}</span><a href="#" ng-click="toggleShowSessionToken()" ng-show="!showSessionToken">...click to show token...</a></span>
 oc project {{projectName}}
 oc status</pre>
+                <token-warning show-session-token="showSessionToken"></token-warning>
 
                 <p>For more information about the command line tools, check the <a target="_blank" href="{{'cli' | helpLink}}">CLI Reference</a> and <a target="_blank" href="{{'basic_cli_operations' | helpLink}}">Basic CLI Operations</a>.</p>
               </div>
+
+
 
               <div ng-if="createdBuildConfig" class="col-md-6">
                 <h2>Making code changes</h2>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4336,31 +4336,33 @@ null !== a && (b.debug("Generated resource definition:", a), d.push(a));
 }), w(d, a.projectName, a).then(x, y);
 };
 }));
-} ]), angular.module("openshiftConsole").controller("NextStepsController", [ "$scope", "$http", "$routeParams", "DataService", "$q", "$location", "TaskList", "$parse", "Navigate", "$filter", "imageObjectRefFilter", "failureObjectNameFilter", "ProjectsService", function(a, b, c, d, e, f, g, h, i, j, k, l, m) {
-function n() {
-return t && s;
-}
+} ]), angular.module("openshiftConsole").controller("NextStepsController", [ "$scope", "$http", "AuthService", "$routeParams", "DataService", "$q", "$location", "TaskList", "$parse", "Navigate", "$filter", "imageObjectRefFilter", "failureObjectNameFilter", "ProjectsService", function(a, b, c, d, e, f, g, h, i, j, k, l, m, n) {
 function o() {
-return q && r && s;
+return u && t;
 }
-var p = (j("displayName"), []);
-a.emptyMessage = "Loading...", a.alerts = [], a.loginBaseUrl = d.openshiftAPIBaseUrl(), a.buildConfigs = {}, a.projectName = c.project;
-var q = c.imageName, r = c.imageTag, s = c.namespace;
-a.fromSampleRepo = c.fromSample;
-var t = c.name, u = "";
-u = o() ? "project/" + a.projectName + "/create/fromimage?imageName=" + q + "&imageTag=" + r + "&namespace=" + s + "&name=" + t :"project/" + a.projectName + "/create/fromtemplate?name=" + t + "&namespace=" + s, a.breadcrumbs = [ {
+function p() {
+return r && s && t;
+}
+var q = (k("displayName"), []);
+a.emptyMessage = "Loading...", a.alerts = [], a.loginBaseUrl = e.openshiftAPIBaseUrl(), a.buildConfigs = {}, c.withUser(), a.sessionToken = c.UserStore().getToken(), a.showSessionToken = !1, a.toggleShowSessionToken = function() {
+a.showSessionToken = !a.showSessionToken;
+}, a.projectName = d.project;
+var r = d.imageName, s = d.imageTag, t = d.namespace;
+a.fromSampleRepo = d.fromSample;
+var u = d.name, v = "";
+v = p() ? "project/" + a.projectName + "/create/fromimage?imageName=" + r + "&imageTag=" + s + "&namespace=" + t + "&name=" + u :"project/" + a.projectName + "/create/fromtemplate?name=" + u + "&namespace=" + t, a.breadcrumbs = [ {
 title:a.projectName,
 link:"project/" + a.projectName
 }, {
 title:"Add to Project",
 link:"project/" + a.projectName + "/create"
 }, {
-title:t,
-link:u
+title:u,
+link:v
 }, {
 title:"Next Steps"
-} ], m.get(c.project).then(_.spread(function(b, e) {
-function g(a) {
+} ], n.get(d.project).then(_.spread(function(b, c) {
+function f(a) {
 var b = [];
 return angular.forEach(a, function(a) {
 a.hasErrors && b.push(a);
@@ -4372,8 +4374,8 @@ return angular.forEach(a, function(a) {
 "completed" !== a.status && b.push(a);
 }), b;
 }
-return a.project = b, a.breadcrumbs[0].title = j("displayName")(b), t && (n(c) || o(c)) ? (p.push(d.watch("buildconfigs", e, function(b) {
-a.buildConfigs = b.by("metadata.name"), a.createdBuildConfig = a.buildConfigs[t], Logger.log("buildconfigs (subscribe)", a.buildConfigs);
+return a.project = b, a.breadcrumbs[0].title = k("displayName")(b), u && (o(d) || p(d)) ? (q.push(e.watch("buildconfigs", c, function(b) {
+a.buildConfigs = b.by("metadata.name"), a.createdBuildConfig = a.buildConfigs[u], Logger.log("buildconfigs (subscribe)", a.buildConfigs);
 })), a.createdBuildConfigWithGitHubTrigger = function() {
 return _.some(_.get(a, "createdBuildConfig.spec.triggers"), {
 type:"GitHub"
@@ -4383,12 +4385,12 @@ return _.some(_.get(a, "createdBuildConfig.spec.triggers"), {
 type:"ConfigChange"
 });
 }, a.allTasksSuccessful = function(a) {
-return !h(a).length && !g(a).length;
-}, a.erroredTasks = g, a.pendingTasks = h, a.goBack = function() {
-o() ? f.path("project/" + encodeURIComponent(this.projectName) + "/create/fromimage") :f.path("project/" + encodeURIComponent(this.projectName) + "/create/fromtemplate");
+return !h(a).length && !f(a).length;
+}, a.erroredTasks = f, a.pendingTasks = h, a.goBack = function() {
+p() ? g.path("project/" + encodeURIComponent(this.projectName) + "/create/fromimage") :g.path("project/" + encodeURIComponent(this.projectName) + "/create/fromtemplate");
 }, void a.$on("$destroy", function() {
-d.unwatchAll(p);
-})) :void i.toProjectOverview(a.projectName);
+e.unwatchAll(q);
+})) :void j.toProjectOverview(a.projectName);
 }));
 } ]), angular.module("openshiftConsole").controller("NewFromTemplateController", [ "$scope", "$http", "$routeParams", "DataService", "AlertMessageService", "ProjectsService", "$q", "$location", "TaskList", "$parse", "Navigate", "$filter", "imageObjectRefFilter", "failureObjectNameFilter", "CachedTemplateService", function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) {
 var p = c.name, q = c.namespace || "";
@@ -6152,7 +6154,15 @@ b.$watch("route", c, !0), b.$watch("service", c, !0), b.$watch("warnings", c, !0
 },
 templateUrl:"views/directives/_warnings-popover.html"
 };
-} ]), angular.module("openshiftConsole").directive("takeFocus", [ "$timeout", function(a) {
+} ]).directive("tokenWarning", function() {
+return {
+restrict:"E",
+scope:{
+showSessionToken:"="
+},
+template:'<div ng-show="showSessionToken" class="alert alert-warning"><span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span><strong>A token is a form of a password.</strong>Do not share your API token.</div>'
+};
+}), angular.module("openshiftConsole").directive("takeFocus", [ "$timeout", function(a) {
 return {
 restrict:"A",
 link:function(b, c) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3205,18 +3205,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "<p>\n" +
     "After downloading and installing it, you can start by logging in using<span ng-if=\"sessionToken\"> this current session token</span>:\n" +
-    "<div class=\"code prettyprint ng-binding\" ng-if=\"sessionToken\">\n" +
-    "oc login {{loginBaseURL}} --token=<span ng-show=\"showSessionToken\">{{sessionToken}}</span><a href=\"#\" ng-click=\"toggleShowSessionToken()\" ng-show=\"!showSessionToken\">...click to show token...</a>\n" +
-    "</div>\n" +
-    "<pre class=\"code prettyprint ng-binding\" ng-if=\"!sessionToken\">\n" +
-    "                      oc login {{loginBaseURL}}\n" +
-    "                    </pre>\n" +
+    "<pre class=\"code prettyprint\">oc login {{loginBaseURL}} <span ng-if=\"sessionToken\">--token=<span ng-show=\"showSessionToken\">{{sessionToken}}</span><a href=\"#\" ng-click=\"toggleShowSessionToken()\" ng-show=\"!showSessionToken\">...click to show token...</a></span></pre>\n" +
     "</p>\n" +
-    "<div ng-show=\"showSessionToken\" class=\"alert alert-warning\">\n" +
-    "<span class=\"pficon pficon-warning-triangle-o\" aria-hidden=\"true\"></span>\n" +
-    "<strong>A token is a form of a password.</strong>\n" +
-    "Do not share your API token.\n" +
-    "</div>\n" +
+    "<token-warning show-session-token=\"showSessionToken\"></token-warning>\n" +
     "<p>After you login to your account you will get a list of projects that you can switch between:\n" +
     "<pre class=\"code prettyprint\">oc project <i>project-name</i></pre>\n" +
     "</p>\n" +
@@ -3771,20 +3762,22 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<h2>Things you can do</h2>\n" +
     "<p>Go to the <a href=\"project/{{projectName}}/overview\">overview page</a> to see more details about this project. Make sure you don't already have <a href=\"project/{{projectName}}/browse/services\">services</a>, <a href=\"project/{{projectName}}/browse/builds\">build configs</a>, <a href=\"project/{{projectName}}/browse/deployments\">deployment configs</a>, or other resources with the same names you are trying to create. Refer to the <a target=\"_blank\" href=\"{{'new_app' | helpLink}}\">documentation for creating new applications</a> for more information.</p>\n" +
     "<h3>Command line tools</h3>\n" +
-    "<p>You may want to use the <code>oc</code> command line tool to help with troubleshooting. After <a target=\"_blank\" href=\"command-line\">downloading and installing</a> it, you can log in, switch to this particular project, and try some commands :</p>\n" +
-    "<pre class=\"code prettyprint\">oc login {{loginBaseUrl}}\n" +
+    "<p>You may want to use the <code>oc</code> command line tool to help with troubleshooting. After <a target=\"_blank\" href=\"command-line\">downloading and installing</a> it, you can log in <span ng-if=\"sessionToken\">using current session token</span>, switch to this particular project, and try some commands :</p>\n" +
+    "<pre class=\"code prettyprint\">oc login {{loginBaseUrl}} <span ng-if=\"sessionToken\">--token=<span ng-show=\"showSessionToken\">{{sessionToken}}</span><a href=\"#\" ng-click=\"toggleShowSessionToken()\" ng-show=\"!showSessionToken\">...click to show token...</a></span>\n" +
     "oc project {{projectName}}\n" +
     "oc logs -h</pre>\n" +
+    "<token-warning show-session-token=\"showSessionToken\"></token-warning>\n" +
     "<p>For more information about the command line tools, check the <a target=\"_blank\" href=\"{{'cli' | helpLink}}\">CLI Reference</a> and <a target=\"_blank\" href=\"{{'basic_cli_operations' | helpLink}}\">Basic CLI Operations</a>.</p>\n" +
     "</div>\n" +
     "<div ng-if=\"allTasksSuccessful(tasks())\" ng-class=\"createdBuildConfigWithGitHubTrigger() ? 'col-md-6' : 'col-md-12'\">\n" +
     "<h2>Manage your app</h2>\n" +
     "<p>The web console is convenient, but if you need deeper control you may want to try our command line tools.</p>\n" +
     "<h3>Command line tools</h3>\n" +
-    "<p><a target=\"_blank\" href=\"command-line\">Download and install</a> the <code>oc</code> command line tool. After that, you can start by logging in, switching to this particular project, and displaying an overview of it, by doing:</p>\n" +
-    "<pre class=\"code prettyprint\">oc login {{loginBaseUrl}}\n" +
+    "<p><a target=\"_blank\" href=\"command-line\">Download and install</a> the <code>oc</code> command line tool. After that, you can start by logging in <span ng-if=\"sessionToken\">using current session token</span>, switching to this particular project, and displaying an overview of it, by doing:</p>\n" +
+    "<pre class=\"code prettyprint\">oc login {{loginBaseUrl}} <span ng-if=\"sessionToken\">--token=<span ng-show=\"showSessionToken\">{{sessionToken}}</span><a href=\"#\" ng-click=\"toggleShowSessionToken()\" ng-show=\"!showSessionToken\">...click to show token...</a></span>\n" +
     "oc project {{projectName}}\n" +
     "oc status</pre>\n" +
+    "<token-warning show-session-token=\"showSessionToken\"></token-warning>\n" +
     "<p>For more information about the command line tools, check the <a target=\"_blank\" href=\"{{'cli' | helpLink}}\">CLI Reference</a> and <a target=\"_blank\" href=\"{{'basic_cli_operations' | helpLink}}\">Basic CLI Operations</a>.</p>\n" +
     "</div>\n" +
     "<div ng-if=\"createdBuildConfig\" class=\"col-md-6\">\n" +


### PR DESCRIPTION
Adding the `--token` flag to the `oc login` command that is recommended after project is created. After revealing the token a warning will show under the commands, same as the one in the Command Line Tools.
For that I've created a separate to make the code DRYer.
Attaching the screens:
With webhook trigger:
![screenshot](https://cloud.githubusercontent.com/assets/1668218/15503342/ba411752-21b9-11e6-8fd5-e89839b384ab.png)
![screenshot-1](https://cloud.githubusercontent.com/assets/1668218/15503346/bd6b8d86-21b9-11e6-93b1-5b716355223e.png)

Without the trigger:
![screenshot-2](https://cloud.githubusercontent.com/assets/1668218/15503354/c5565a9e-21b9-11e6-8bab-d7a2312b9413.png)
![screenshot-3](https://cloud.githubusercontent.com/assets/1668218/15503356/c6f0cf38-21b9-11e6-9672-a5c02a8cb105.png)

Also refactored a bit the `command-line.html` but without any visual changes.

@spadgett PTAL
