### PR TITLE
Fixes bug 1333101 - switch to longer date format

### DIFF
--- a/app/views/browse/_build-details.html
+++ b/app/views/browse/_build-details.html
@@ -16,7 +16,7 @@
         <dd>
           <span ng-if="build.status.startTimestamp">
             <relative-timestamp timestamp="build.status.startTimestamp"></relative-timestamp>
-            <span><span class="text-muted">&ndash;</span> {{build.status.startTimestamp | date : 'short'}}</span>
+            <span><span class="text-muted">&ndash;</span> {{build.status.startTimestamp | date : 'MMM dd, yyyy h:m a'}} </span>
           </span>
           <span ng-if="!build.status.startTimestamp"><em>not started</em></span>
         </dd>

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -177,7 +177,6 @@
                             </td>
                             <td data-title="Created">
                               <relative-timestamp timestamp="build.metadata.creationTimestamp"></relative-timestamp>
-                              <span>- {{build.metadata.creationTimestamp | date : 'short'}}</span>
                             </td>
                           </tr>
                         </tbody>

--- a/app/views/builds.html
+++ b/app/views/builds.html
@@ -92,7 +92,6 @@
                     </td>
                     <td data-title="Created">
                       <relative-timestamp timestamp="build.metadata.creationTimestamp"></relative-timestamp>
-                      <span>- {{build.metadata.creationTimestamp | date : 'short'}}</span>
                     </td>
                     <td data-title="Type">{{build.spec.strategy.type | startCase}}</td>
                     <td data-title="Source" class="word-break-all">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1023,7 +1023,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dd>\n" +
     "<span ng-if=\"build.status.startTimestamp\">\n" +
     "<relative-timestamp timestamp=\"build.status.startTimestamp\"></relative-timestamp>\n" +
-    "<span><span class=\"text-muted\">&ndash;</span> {{build.status.startTimestamp | date : 'short'}}</span>\n" +
+    "<span><span class=\"text-muted\">&ndash;</span> {{build.status.startTimestamp | date : 'MMM dd, yyyy h:m a'}} </span>\n" +
     "</span>\n" +
     "<span ng-if=\"!build.status.startTimestamp\"><em>not started</em></span>\n" +
     "</dd>\n" +
@@ -1445,7 +1445,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</td>\n" +
     "<td data-title=\"Created\">\n" +
     "<relative-timestamp timestamp=\"build.metadata.creationTimestamp\"></relative-timestamp>\n" +
-    "<span>- {{build.metadata.creationTimestamp | date : 'short'}}</span>\n" +
     "</td>\n" +
     "</tr>\n" +
     "</tbody>\n" +
@@ -2988,7 +2987,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</td>\n" +
     "<td data-title=\"Created\">\n" +
     "<relative-timestamp timestamp=\"build.metadata.creationTimestamp\"></relative-timestamp>\n" +
-    "<span>- {{build.metadata.creationTimestamp | date : 'short'}}</span>\n" +
     "</td>\n" +
     "<td data-title=\"Type\">{{build.spec.strategy.type | startCase}}</td>\n" +
     "<td data-title=\"Source\" class=\"word-break-all\">\n" +


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1333101

In all build tables, the 'Created' column no longer states the date of creation. Instead it only states how long ago the build was created.

When viewing the build details for a specific build, the date format for the 'Started' status has been changed to the format MMM dd, yyyy followed by hh:mm AM/PM.