### PR TITLE
Round network metrics to one decimal place

### DIFF
--- a/app/scripts/directives/metrics.js
+++ b/app/scripts/directives/metrics.js
@@ -35,7 +35,8 @@ angular.module('openshiftConsole')
             return value;
           }
 
-          return value / 1024;
+          // Round to one decimal place
+          return _.round(value / 1024, 1);
         }
 
         scope.uniqueID = _.uniqueId('metrics-chart-');

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -6461,7 +6461,7 @@ function i(a) {
 return a ? a / 1048576 :a;
 }
 function j(a) {
-return a ? a / 1024 :a;
+return a ? _.round(a / 1024, 1) :a;
 }
 function k(a) {
 if (!h.pod) return null;


### PR DESCRIPTION
Round network metrics to one decimal place to avoid values like "0.007 KiB/s".

![screen shot 2016-05-26 at 7 38 58 pm](https://cloud.githubusercontent.com/assets/1167259/15593398/c61f5ffe-2379-11e6-8c2f-fd2a73837176.png)

@jwforres PTAL