### PR TITLE
[WIP] Show what triggered a build

### DIFF
--- a/app/scripts/controllers/build.js
+++ b/app/scripts/controllers/build.js
@@ -14,6 +14,7 @@ angular.module('openshiftConsole')
     $scope.buildConfigName = $routeParams.buildconfig;
     $scope.builds = {};
     $scope.alerts = {};
+    $scope.showSecret = false;
     $scope.renderOptions = {
       hideFilterWidget: true
     };
@@ -132,6 +133,10 @@ angular.module('openshiftConsole')
 
           updateCanBuild();
         }));
+
+        $scope.toggleSecret = function() {
+          $scope.showSecret = true;
+        };
 
         $scope.cancelBuild = function() {
           BuildsService.cancelBuild($scope.build, $scope.buildConfigName, context, $scope);

--- a/app/styles/_components.less
+++ b/app/styles/_components.less
@@ -186,10 +186,6 @@
     span[data-icon] {
       color: #888;
     }
-    .hash {
-      font-family: @font-family-monospace;
-      font-size: (@font-size-base - 1);
-    }
     .pod-template-build {
       .word-break();
     }
@@ -200,6 +196,11 @@
       }
     }
   }
+}
+
+.hash {
+  font-family: @font-family-monospace;
+  font-size: (@font-size-base - 1);
 }
 
 // so that .word-break() on children works

--- a/app/views/_webhook-trigger-cause.html
+++ b/app/views/_webhook-trigger-cause.html
@@ -1,0 +1,18 @@
+{{trigger.message === 'GitHub WebHook' ? 'GitHub webhook' : 'Generic webhook'}}:
+<span ng-if="trigger.githubWebHook.revision || trigger.genericWebHook.revision"> {{trigger.githubWebHook.revision.git.message || trigger.genericWebHook.revision.git.message}}</span>
+<osc-git-link
+  ng-if="trigger.githubWebHook.revision || trigger.genericWebHook.revision"
+  class="hash"
+  uri="build.spec.source.git.uri"
+  commit="trigger.githubWebHook.revision.git.commit || trigger.genericWebHook.revision.git.commit">{{trigger.githubWebHook.revision.git.commit || trigger.genericWebHook.revision.git.commit | limitTo:7}}
+</osc-git-link>
+<span ng-if="trigger.githubWebHook.revision || trigger.genericWebHook.revision">
+  authored by {{trigger.githubWebHook.revision.git.author.name || trigger.genericWebHook.revision.git.author.name}},
+</span>
+<span ng-if="trigger.genericWebHook && !trigger.genericWebHook.revision">
+  no revision information,
+</span>
+<a href="" ng-if="!showSecret" ng-click="toggleSecret()"> show obfuscated secret</a>
+<span ng-if="showSecret">
+  {{trigger.githubWebHook.secret || trigger.genericWebHook.secret}}
+</span>

--- a/app/views/browse/_build-details.html
+++ b/app/views/browse/_build-details.html
@@ -34,6 +34,26 @@
             </span>
           </span>
         </dd>
+        <div ng-if='build.spec.triggeredBy.length'>
+          <dt>Triggered by:</dt>
+          <dd>
+            <div ng-repeat="trigger in build.spec.triggeredBy">
+              <div ng-switch="trigger.message">
+                <span ng-switch-when="Manually triggered">Manual build</span>
+                <span ng-switch-when="GitHub WebHook">
+                  <ng-include src=" 'views/_webhook-trigger-cause.html' "></ng-include>
+                </span>
+                <span ng-switch-when="Generic WebHook">
+                  <ng-include src=" 'views/_webhook-trigger-cause.html' "></ng-include>
+                </span>
+                <span ng-switch-when="Image change">
+                  {{trigger.message}} for {{trigger.imageChangeBuild.fromRef.name}}
+                </span>
+                <span ng-switch-default>{{trigger.message}}</span>
+              </div>
+            </div>
+          </dd>
+        </div>
       </dl>
       <h3>Configuration <span class="small" ng-if="buildConfigName">created from <a href="{{buildConfigName | navigateResourceURL : 'BuildConfig' : build.metadata.namespace}}">{{buildConfigName}}</a></span></h3>
       <dl class="dl-horizontal left">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3004,7 +3004,7 @@ c.unwatchAll(j);
 });
 }));
 } ]), angular.module("openshiftConsole").controller("BuildController", [ "$scope", "$routeParams", "DataService", "ProjectsService", "BuildsService", "$filter", function(a, b, c, d, e, f) {
-a.projectName = b.project, a.build = null, a.buildConfig = null, a.buildConfigName = b.buildconfig, a.builds = {}, a.alerts = {}, a.renderOptions = {
+a.projectName = b.project, a.build = null, a.buildConfig = null, a.buildConfigName = b.buildconfig, a.builds = {}, a.alerts = {}, a.showSecret = !1, a.renderOptions = {
 hideFilterWidget:!0
 }, a.breadcrumbs = [ {
 title:"Builds",
@@ -3049,7 +3049,9 @@ c.metadata.labels && c.metadata.labels.buildconfig === b.buildconfig && (a.build
 });
 var g, h;
 e && (g = e.metadata.labels.buildconfig, h = e.metadata.name), i();
-})), a.cancelBuild = function() {
+})), a.toggleSecret = function() {
+a.showSecret = !0;
+}, a.cancelBuild = function() {
 e.cancelBuild(a.build, a.buildConfigName, j, a);
 }, a.cloneBuild = function() {
 var b = _.get(a, "build.metadata.name");

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -867,6 +867,23 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/_webhook-trigger-cause.html',
+    "{{trigger.message === 'GitHub WebHook' ? 'GitHub webhook' : 'Generic webhook'}}: <span ng-if=\"trigger.githubWebHook.revision || trigger.genericWebHook.revision\"> {{trigger.githubWebHook.revision.git.message || trigger.genericWebHook.revision.git.message}}</span>\n" +
+    "<osc-git-link ng-if=\"trigger.githubWebHook.revision || trigger.genericWebHook.revision\" class=\"hash\" uri=\"build.spec.source.git.uri\" commit=\"trigger.githubWebHook.revision.git.commit || trigger.genericWebHook.revision.git.commit\">{{trigger.githubWebHook.revision.git.commit || trigger.genericWebHook.revision.git.commit | limitTo:7}}\n" +
+    "</osc-git-link>\n" +
+    "<span ng-if=\"trigger.githubWebHook.revision || trigger.genericWebHook.revision\">\n" +
+    "authored by {{trigger.githubWebHook.revision.git.author.name || trigger.genericWebHook.revision.git.author.name}},\n" +
+    "</span>\n" +
+    "<span ng-if=\"trigger.genericWebHook && !trigger.genericWebHook.revision\">\n" +
+    "no revision information,\n" +
+    "</span>\n" +
+    "<a href=\"\" ng-if=\"!showSecret\" ng-click=\"toggleSecret()\"> show obfuscated secret</a>\n" +
+    "<span ng-if=\"showSecret\">\n" +
+    "{{trigger.githubWebHook.secret || trigger.genericWebHook.secret}}\n" +
+    "</span>"
+  );
+
+
   $templateCache.put('views/about.html',
     "<default-header class=\"top-header\"></default-header>\n" +
     "<div class=\"wrap no-sidebar\">\n" +
@@ -1098,6 +1115,26 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</span>\n" +
     "</dd>\n" +
+    "<div ng-if=\"build.spec.triggeredBy.length\">\n" +
+    "<dt>Triggered by:</dt>\n" +
+    "<dd>\n" +
+    "<div ng-repeat=\"trigger in build.spec.triggeredBy\">\n" +
+    "<div ng-switch=\"trigger.message\">\n" +
+    "<span ng-switch-when=\"Manually triggered\">Manual build</span>\n" +
+    "<span ng-switch-when=\"GitHub WebHook\">\n" +
+    "<ng-include src=\" 'views/_webhook-trigger-cause.html' \"></ng-include>\n" +
+    "</span>\n" +
+    "<span ng-switch-when=\"Generic WebHook\">\n" +
+    "<ng-include src=\" 'views/_webhook-trigger-cause.html' \"></ng-include>\n" +
+    "</span>\n" +
+    "<span ng-switch-when=\"Image change\">\n" +
+    "{{trigger.message}} for {{trigger.imageChangeBuild.fromRef.name}}\n" +
+    "</span>\n" +
+    "<span ng-switch-default>{{trigger.message}}</span>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</dd>\n" +
+    "</div>\n" +
     "</dl>\n" +
     "<h3>Configuration <span class=\"small\" ng-if=\"buildConfigName\">created from <a href=\"{{buildConfigName | navigateResourceURL : 'BuildConfig' : build.metadata.namespace}}\">{{buildConfigName}}</a></span></h3>\n" +
     "<dl class=\"dl-horizontal left\">\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3204,7 +3204,7 @@ to{transform:rotate(359deg)}
 .components.components-group .connector{display:inline-block;position:absolute;top:48%;left:-5px}
 .components.components-group .connector i{color:#ccc;-webkit-transform:rotate(137deg);-ms-transform:rotate(137deg);-o-transform:rotate(137deg);transform:rotate(137deg);font-size:9px;position:absolute}
 .components.components-group .connector:before{content:'\f111';font:normal normal normal 6px/1 FontAwesome;display:inline-block;color:#fff;position:absolute;left:2px;top:1px}
-.environment-variables.table.table-bordered>tbody>tr>td:last-child .env-var-value,.modal-resource-edit .editor,.pod-template-block .pod-template .hash{font-family:Menlo,Monaco,Consolas,monospace}
+.environment-variables.table.table-bordered>tbody>tr>td:last-child .env-var-value,.hash,.modal-resource-edit .editor{font-family:Menlo,Monaco,Consolas,monospace}
 .components .components-panel{background-color:#fff;border:1px solid #ddd;position:relative}
 .components .components-panel.deployment-block.none,.components .components-panel.service.none{background-color:transparent}
 @media (min-width:768px){.components.components-group .osc-object-active .connector i{color:#00a8e1}
@@ -3243,10 +3243,10 @@ to{transform:rotate(359deg)}
 .pod-template-block .component-label{font-size:11px;padding:0 10px 4px 0;text-transform:uppercase}
 .pod-template-block .pod-template [row]{border-left:3px solid #eee;padding:2px 0 0 2px}
 .pod-template-block .pod-template .fa,.pod-template-block .pod-template .pficon,.pod-template-block .pod-template span[data-icon]{color:#888}
-.pod-template-block .pod-template .hash{font-size:12px}
 .pod-template-block .pod-template .pod-template-build{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .pod-template-block .pod-template .pod-template-key{font-weight:700}
 .components .pod-template-block .pod-template .pod-template-key{font-weight:600}
+.hash{font-size:12px}
 .pod-template-container{margin:0 0 20px}
 .components .pod-template-container{margin-bottom:0}
 .pod-container-terminal{margin-top:15px;margin-bottom:15px}


### PR DESCRIPTION
The browse page of a build will now show what caused it, in the `Status` section. All new builds objects are going to carry the array of objects that cause the build to trigger when https://github.com/openshift/origin/pull/7518 will get merged. 
Triggers will be:
- Image change
- Build Configuration change
- Generic WebHook
- Github WebHook
- Triggered Manually

All old builds will have `triggeredBy` array empty which will display in web-console as `unknown`

Screens:
![screenshot-7](https://cloud.githubusercontent.com/assets/1668218/15609060/10ac5960-241e-11e6-9fbf-ece74ccdf982.png)
![screenshot-6](https://cloud.githubusercontent.com/assets/1668218/15609067/166a0d66-241e-11e6-9e9e-80dc92be2eff.png)
![screenshot-5](https://cloud.githubusercontent.com/assets/1668218/15609072/1928ba66-241e-11e6-9245-e325133d0d6a.png)


