### PR TITLE
Tweak to debounce delay on osc-key-values clean check

### DIFF
--- a/app/scripts/directives/oscKeyValues.js
+++ b/app/scripts/directives/oscKeyValues.js
@@ -146,7 +146,7 @@ angular.module("openshiftConsole")
               $scope.clean.isClean.$setValidity('isClean', true);
             }
           });
-        }, 100);
+        }, 200);
 
         // returns a new function bound to the set of DOM nodes provided as an array.
         // allows us to treat the osc-key-values directive as a single node on blur
@@ -173,6 +173,7 @@ angular.module("openshiftConsole")
           checkCommitted();
           isClean();
         };
+
         $scope.allowDelete = function(value){
           if ($scope.preventEmpty && (Object.keys($scope.entries).length === 1)) {
             return false;
@@ -185,6 +186,7 @@ angular.module("openshiftConsole")
           }
           return true;
         };
+
         $scope.addEntry = function() {
           if($scope.key && $scope.value){
             var readonly = $scope.readonlyKeys.split(",");
@@ -202,6 +204,7 @@ angular.module("openshiftConsole")
             focusElem.focus();
           }
         };
+
         $scope.deleteEntry = function(key) {
           if ($scope.entries[key]) {
             delete $scope.entries[key];
@@ -209,6 +212,7 @@ angular.module("openshiftConsole")
             $scope.form.$setDirty();
           }
         };
+
         $scope.setErrorText = function(keyTitle) {
           if (keyTitle === 'path') {
             return "absolute path";

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5659,7 +5659,7 @@ d() ? a.showCommmitWarning = !0 :a.showCommmitWarning = !1;
 a.$applyAsync(function() {
 a.key ? a.clean.isClean.$setValidity("isClean", !1) :a.value ? a.clean.isClean.$setValidity("isClean", !1) :a.clean.isClean.$setValidity("isClean", !0);
 });
-}, 100), g = function(b) {
+}, 200), g = function(b) {
 return function(c) {
 a.$applyAsync(function() {
 _.includes(b, document.activeElement) || (e(), f());


### PR DESCRIPTION
@jwforres increased the debounce just a bit, found at `100` it might not catch the first key entry but works consistently at `200`.