### PR TITLE
Container terminal selector Review

### DIFF
--- a/app/views/browse/pod.html
+++ b/app/views/browse/pod.html
@@ -99,11 +99,11 @@
                       </span>
 
                       <select
-                          id="selectLogContainer"
-                          ng-if="pod.spec.containers.length > 1"
-                          ng-model="logOptions.container"
-                          ng-options="container.name as container.name for container in pod.spec.containers"
-                          ng-init="logOptions.container = pod.spec.containers[0].name">
+                        id="selectLogContainer"
+                        ng-if="pod.spec.containers.length > 1"
+                        ng-model="logOptions.container"
+                        ng-options="container.name as container.name for container in pod.spec.containers"
+                        ng-init="logOptions.container = pod.spec.containers[0].name">
                       </select>
 
                       <span ng-if="containerStateReason || containerStatusKey">
@@ -119,24 +119,68 @@
                     </log-viewer>
                   </uib-tab>
 
-                  <uib-tab active="selectedTab.terminal"
+                  <uib-tab
+                    active="selectedTab.terminal"
                     select="terminalTabWasSelected = true"
                     ng-init="containers = pod.status.containerStatuses"
-                    ng-if="containersRunning(pod.status.containerStatuses) > 0 && ('pods/exec' | canI : 'get')">
-                    <uib-tab-heading>Terminal</uib-tab-heading>
-                    <div>
-                      <span class="pficon pficon-info" aria-hidden="true"></span>
-                      When you navigate away from this pod, any processes running
-                      in these terminals will quit.
-                    </div>
-                    <div class="pod-container-terminal"
-                      ng-repeat="container in containers | orderBy:'name' track by container.name"
-                      ng-if="container.state.running">
-                      <h3 ng-if="containers.length > 1">{{container.name}}</h3>
-                      <kubernetes-container-terminal pod="pod" container="container.name"
-                        prevent="!terminalTabWasSelected">
-                      </kubernetes-container-terminal>
-                    </div>
+                    ng-if="containersRunning(pod.status.containerStatuses) > 0">
+                      <uib-tab-heading>Terminal</uib-tab-heading>
+
+                      <div class="mar-bottom-md">
+                        <span class="pficon pficon-info" aria-hidden="true"></span>
+                        When you navigate away from this pod, any open terminal connections will be closed.
+                        This will kill any foreground processes you started from the terminal.
+                      </div>
+
+                      <div class="mar-left-xl mar-bottom-lg">
+                        <div class="row">
+                          <div class="pad-left-none pad-bottom-lg col-xs-4 col-lg-3">
+                            <ui-select
+                              ng-model="selectedTerminalContainer"
+                              on-select="onTerminalSelectChange(selectedTerminalContainer)"
+                              class="mar-left-none pad-left-none pad-right-none">
+                             <ui-select-match
+                                class="truncate"
+                                placeholder="Container Name">
+                                  <span class="pad-left-md">
+                                    {{selectedTerminalContainer.containerName}}
+                                  </span>
+                              </ui-select-match>
+                              <ui-select-choices
+                                repeat="term in containerTerminals | filter: $select.search"
+                                ui-disable-choice="(term.containerState !== 'running') && !term.isUsed">
+                                <div row>
+                                  <span ng-bind-html="term.containerName | highlight: $select.search">
+                                  </span>
+                                  <span flex></span>
+                                  <span
+                                    ng-if="term.isUsed && (term.containerState === 'running')"
+                                    ng-class="{'text-muted' : (term.status === 'disconnected')}">
+                                      {{term.status}}
+                                  </span>
+                                  <span
+                                    ng-if="term.containerState !== 'running'"
+                                    ng-class="{'text-muted' : !term.isUsed}">
+                                      {{term.containerState}}
+                                  </span>
+                                </div>
+                              </ui-select-choices>
+                            </ui-select>
+                          </div>
+                        </div>
+
+                        <div class="row" ng-repeat="term in containerTerminals">
+                          <kubernetes-container-terminal
+                            prevent="!terminalTabWasSelected"
+                            ng-if="term.isUsed"
+                            ng-show="term.isVisible"
+                            pod="pod"
+                            container="term.containerName"
+                            status="term.status"
+                            >
+                          </kubernetes-container-terminal>
+                        </div>
+                      </div>
     	            </uib-tab>
 
                   <uib-tab active="selectedTab.events" ng-if="'events' | canI : 'watch'">

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "messenger": "1.4.1",
     "kubernetes-label-selector": "1.0.1",
     "kubernetes-topology-graph": "0.0.23",
-    "kubernetes-container-terminal": "0.0.13",
+    "kubernetes-container-terminal": "0.0.14",
     "openshift-object-describer": "1.1.2",
     "layout.attrs": "2.1.0",
     "bootstrap-hover-dropdown": "2.1.3",

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2909,15 +2909,46 @@ containerEndTime:_.get(c, [ d, "finishedAt" ])
 });
 }
 };
+a.onTerminalSelectChange = function(b) {
+_.each(a.containerTerminals, function(a) {
+a.isVisible = !1;
+}), b.isVisible = !0, b.isUsed = !0;
+};
+var n = function(a) {
+var b = _.get(a, "state", {});
+return _.head(_.keys(b));
+}, o = function() {
+var b = [];
+_.each(a.pod.spec.containers, function(c) {
+var d = _.find(a.pod.status.containerStatuses, {
+name:c.name
+}), e = n(d);
+b.push({
+containerName:c.name,
+isVisible:!1,
+isUsed:!1,
+containerState:e
+});
+});
+var c = _.head(b);
+return c.isVisible = !0, c.isUsed = !0, a.selectedTerminalContainer = c, b;
+}, p = function(b) {
+_.each(b, function(b) {
+var c = _.find(a.pod.status.containerStatuses, {
+name:b.containerName
+}), d = n(c);
+b.containerState = d;
+});
+};
 j.get(c.project).then(_.spread(function(d, h) {
 a.project = d, a.projectContext = h, f.get("pods", c.pod, h).then(function(b) {
 a.loaded = !0, a.pod = b, l(b), m();
 var d = {};
-d[b.metadata.name] = b, g.fetchReferencedImageStreamImages(d, a.imagesByDockerReference, a.imageStreamImageRefByDockerReference, h), k.push(f.watchObject("pods", c.pod, h, function(b, c) {
+d[b.metadata.name] = b, g.fetchReferencedImageStreamImages(d, a.imagesByDockerReference, a.imageStreamImageRefByDockerReference, h), a.containerTerminals = o(), k.push(f.watchObject("pods", c.pod, h, function(b, c) {
 "DELETED" === c && (a.alerts.deleted = {
 type:"warning",
 message:"This pod has been deleted."
-}), a.pod = b, l(b), m();
+}), a.pod = b, l(b), m(), p(a.containerTerminals);
 }));
 }, function(c) {
 a.loaded = !0, a.alerts.load = {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2488,16 +2488,41 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</log-viewer>\n" +
     "</uib-tab>\n" +
-    "<uib-tab active=\"selectedTab.terminal\" select=\"terminalTabWasSelected = true\" ng-init=\"containers = pod.status.containerStatuses\" ng-if=\"containersRunning(pod.status.containerStatuses) > 0 && ('pods/exec' | canI : 'get')\">\n" +
+    "<uib-tab active=\"selectedTab.terminal\" select=\"terminalTabWasSelected = true\" ng-init=\"containers = pod.status.containerStatuses\" ng-if=\"containersRunning(pod.status.containerStatuses) > 0\">\n" +
     "<uib-tab-heading>Terminal</uib-tab-heading>\n" +
-    "<div>\n" +
+    "<div class=\"mar-bottom-md\">\n" +
     "<span class=\"pficon pficon-info\" aria-hidden=\"true\"></span>\n" +
-    "When you navigate away from this pod, any processes running in these terminals will quit.\n" +
+    "When you navigate away from this pod, any open terminal connections will be closed. This will kill any foreground processes you started from the terminal.\n" +
     "</div>\n" +
-    "<div class=\"pod-container-terminal\" ng-repeat=\"container in containers | orderBy:'name' track by container.name\" ng-if=\"container.state.running\">\n" +
-    "<h3 ng-if=\"containers.length > 1\">{{container.name}}</h3>\n" +
-    "<kubernetes-container-terminal pod=\"pod\" container=\"container.name\" prevent=\"!terminalTabWasSelected\">\n" +
+    "<div class=\"mar-left-xl mar-bottom-lg\">\n" +
+    "<div class=\"row\">\n" +
+    "<div class=\"pad-left-none pad-bottom-lg col-xs-4 col-lg-3\">\n" +
+    "<ui-select ng-model=\"selectedTerminalContainer\" on-select=\"onTerminalSelectChange(selectedTerminalContainer)\" class=\"mar-left-none pad-left-none pad-right-none\">\n" +
+    "<ui-select-match class=\"truncate\" placeholder=\"Container Name\">\n" +
+    "<span class=\"pad-left-md\">\n" +
+    "{{selectedTerminalContainer.containerName}}\n" +
+    "</span>\n" +
+    "</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"term in containerTerminals | filter: $select.search\" ui-disable-choice=\"(term.containerState !== 'running') && !term.isUsed\">\n" +
+    "<div row>\n" +
+    "<span ng-bind-html=\"term.containerName | highlight: $select.search\">\n" +
+    "</span>\n" +
+    "<span flex></span>\n" +
+    "<span ng-if=\"term.isUsed && (term.containerState === 'running')\" ng-class=\"{'text-muted' : (term.status === 'disconnected')}\">\n" +
+    "{{term.status}}\n" +
+    "</span>\n" +
+    "<span ng-if=\"term.containerState !== 'running'\" ng-class=\"{'text-muted' : !term.isUsed}\">\n" +
+    "{{term.containerState}}\n" +
+    "</span>\n" +
+    "</div>\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"row\" ng-repeat=\"term in containerTerminals\">\n" +
+    "<kubernetes-container-terminal prevent=\"!terminalTabWasSelected\" ng-if=\"term.isUsed\" ng-show=\"term.isVisible\" pod=\"pod\" container=\"term.containerName\" status=\"term.status\">\n" +
     "</kubernetes-container-terminal>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</uib-tab>\n" +
     "<uib-tab active=\"selectedTab.events\" ng-if=\"'events' | canI : 'watch'\">\n" +

--- a/dist/scripts/vendor.js
+++ b/dist/scripts/vendor.js
@@ -41214,12 +41214,13 @@ prevent:"=",
 rows:"=",
 cols:"=",
 screenKeys:"=",
-autofocus:"=?"
+autofocus:"=?",
+status:"="
 },
 link:function(g, h, i) {
 function j() {
 function a(a) {
-!a && j && (a = "Could not connect to the container. Do you have sufficient privileges?"), a || (a = "disconnected"), j || (a = "\r\n" + a), q.write("[31m" + a + "[m\r\n"), g.$apply(k);
+!a && j && (a = "Could not connect to the container. Do you have sufficient privileges?"), a || (a = "disconnected"), j || (a = "\r\n" + a), q.write("[31m" + a + "[m\r\n"), g.status = "disconnected", g.$apply(k);
 }
 k(), q.reset();
 var b = "", c = g.pod();
@@ -41246,15 +41247,16 @@ q.write(d(b));
 }
 j && (j = !1, m.addClass("hidden"), n.addClass("hidden"), q.cursorHidden = !1, q.showCursor(), q.refresh(q.y, q.y), g.autofocus && q.element && q.element.focus());
 }, p.onclose = function(b) {
-a(b.reason);
+g.status = "disconnected", a(b.reason);
 };
 }, function(b) {
 a(b.message);
-});
+}), g.status = "connected";
 }
 function k() {
-m.addClass("hidden"), n.removeClass("hidden"), q && (q.cursorHidden = !0, q.refresh(q.x, q.y)), p && (p.onopen = p.onmessage = p.onerror = p.onclose = null, p.readyState < 2 && p.close(), p = null), window.clearInterval(o), o = null;
+g.status = "disconnected", m.addClass("hidden"), n.removeClass("hidden"), q && (q.cursorHidden = !0, q.refresh(q.x, q.y)), p && (p.onopen = p.onmessage = p.onerror = p.onclose = null, p.readyState < 2 && p.close(), p = null), window.clearInterval(o), o = null;
 }
+g.status = "disconnected";
 var l = a.element("<div class='terminal-wrapper'>");
 h.append(l);
 var m = a.element("<div class='spinner spinner-white hidden'>"), n = a.element("<button class='btn btn-default fa fa-refresh'>");


### PR DESCRIPTION
Initial style/functional review of the Container Terminal selector dropdown feature. Functionality is roughly 90% done. The remaining 10% rests on effective testing of crashing containers and disconnecting terminals. Currently, the 'died' value for a terminal is only set when a terminal from the current set is missing from the future (read: updated) set of terminals. Currently the only way for a dead terminal to become alive (not dead) is for it to appear in the next updated list of terminals, not from the client restarting/refreshing the terminal via the reconnect button in the terminal window. The final implementation will take connection and status data directly from the containers to which the terminals are directly connecting.

@benjaminapetersen 