### PR TITLE
Simplify some overview logic

### DIFF
--- a/app/scripts/directives/overviewService.js
+++ b/app/scripts/directives/overviewService.js
@@ -49,7 +49,7 @@ angular.module('openshiftConsole')
           }
 
           var deploymentVersion = parseInt(annotation(deployment, 'deploymentVersion'));
-          return _.find($scope.deploymentConfigs, function(dc) {
+          return _.some($scope.deploymentConfigs, function(dc) {
             return dc.metadata.name === dcName && dc.status.latestVersion === deploymentVersion;
           });
         };
@@ -82,7 +82,13 @@ angular.module('openshiftConsole')
           return hpaByRC[rcName];
         };
 
-        $scope.isScalableDeployment = DeploymentsService.isScalable;
+        $scope.isScalableDeployment = function(deployment) {
+          return DeploymentsService.isScalable(deployment,
+                                               $scope.deploymentConfigs,
+                                               $scope.hpaByDc,
+                                               $scope.hpaByRc,
+                                               $scope.scalableDeploymentByConfig);
+        };
       }
     };
   });

--- a/app/scripts/services/builds.js
+++ b/app/scripts/services/builds.js
@@ -115,5 +115,39 @@ angular.module("openshiftConsole")
       return true;
     };
 
+    var annotation = $filter('annotation');
+    BuildsService.prototype.usesDeploymentConfigs = function(buildConfig) {
+      var uses = annotation(buildConfig, 'pipeline.alpha.openshift.io/uses');
+      if (!uses) {
+        return [];
+      }
+
+      try {
+        uses = JSON.parse(uses);
+      } catch(e) {
+        Logger.warn('Could not parse "pipeline.alpha.openshift.io/uses" annotation', e);
+        return;
+      }
+
+      var depoymentConfigs = [];
+      _.each(uses, function(resource) {
+        if (!resource.name) {
+          return;
+        }
+
+        if (resource.namespace && resource.namespace !== _.get(buildConfig, 'metadata.namespace')) {
+          return;
+        }
+
+        if (resource.kind !== 'DeploymentConfig') {
+          return;
+        }
+
+        depoymentConfigs.push(resource.name);
+      });
+
+      return depoymentConfigs;
+    };
+
     return new BuildsService();
   });

--- a/app/views/_overview-service.html
+++ b/app/views/_overview-service.html
@@ -46,7 +46,7 @@
               pods="podsByDeployment[deployment.metadata.name]"
               hpa="getHPA(deployment.metadata.name, dcName)"
               limit-ranges="limitRanges"
-              scalable="isScalableDeployment(deployment, deploymentConfigs, hpaByDc, hpaByRc, scalableDeploymentByConfig)"
+              scalable="isScalableDeployment(deployment)"
               alerts="alerts">
           </deployment-donut>
         </div>
@@ -125,7 +125,7 @@
                 pods="podsByDeployment[deployment.metadata.name]"
                 hpa="getHPA(deployment.metadata.name, dcName)"
                 limit-ranges="limitRanges"
-                scalable="isScalableDeployment(deployment, deploymentConfigs, hpaByDc, hpaByRc, scalableDeploymentByConfig)"
+                scalable="isScalableDeployment(deployment)"
                 alerts="alerts">
             </deployment-donut>
           </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -287,7 +287,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div row class=\"deployment-body\">\n" +
     "\n" +
     "<div column class=\"overview-donut\" ng-repeat=\"deployment in deployments | orderObjectsByDate : true track by (deployment | uid)\" ng-class=\"{ latest: isDeploymentLatest(deployment) }\" ng-if=\"!activeDeploymentByConfig[dcName] || !(isDeploymentLatest(deployment) && ((deployment | deploymentStatus) == 'Cancelled' || (deployment | deploymentStatus) == 'Failed'))\">\n" +
-    "<deployment-donut rc=\"deployment\" deployment-config=\"deploymentConfigs[dcName]\" pods=\"podsByDeployment[deployment.metadata.name]\" hpa=\"getHPA(deployment.metadata.name, dcName)\" limit-ranges=\"limitRanges\" scalable=\"isScalableDeployment(deployment, deploymentConfigs, hpaByDc, hpaByRc, scalableDeploymentByConfig)\" alerts=\"alerts\">\n" +
+    "<deployment-donut rc=\"deployment\" deployment-config=\"deploymentConfigs[dcName]\" pods=\"podsByDeployment[deployment.metadata.name]\" hpa=\"getHPA(deployment.metadata.name, dcName)\" limit-ranges=\"limitRanges\" scalable=\"isScalableDeployment(deployment)\" alerts=\"alerts\">\n" +
     "</deployment-donut>\n" +
     "</div>\n" +
     "\n" +
@@ -355,7 +355,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div row class=\"deployment-body\">\n" +
     "\n" +
     "<div column class=\"overview-donut\" ng-class=\"{ latest: isDeploymentLatest(deployment) }\">\n" +
-    "<deployment-donut rc=\"deployment\" deployment-config=\"deploymentConfigs[dcName]\" pods=\"podsByDeployment[deployment.metadata.name]\" hpa=\"getHPA(deployment.metadata.name, dcName)\" limit-ranges=\"limitRanges\" scalable=\"isScalableDeployment(deployment, deploymentConfigs, hpaByDc, hpaByRc, scalableDeploymentByConfig)\" alerts=\"alerts\">\n" +
+    "<deployment-donut rc=\"deployment\" deployment-config=\"deploymentConfigs[dcName]\" pods=\"podsByDeployment[deployment.metadata.name]\" hpa=\"getHPA(deployment.metadata.name, dcName)\" limit-ranges=\"limitRanges\" scalable=\"isScalableDeployment(deployment)\" alerts=\"alerts\">\n" +
     "</deployment-donut>\n" +
     "</div>\n" +
     "\n" +


### PR DESCRIPTION
Move handling of the `pipeline.alpha.openshift.io/uses` annotation into BuildsService and clean up the logic for grouping builds in OverviewController. Also remove `$scope.pipelinesByDeployment`, which was no longer used.

@jwforres PTAL