### PR TITLE
Improve overview loading / get started check

### DIFF
--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -24,6 +24,7 @@ angular.module('openshiftConsole')
     // scope variables are inherited by overview-service-group and overview-service directives.
     $scope.projectName = $routeParams.project;
     $scope.renderOptions = $scope.renderOptions || {};
+    $scope.renderOptions.showLoading = true;
     $scope.renderOptions.showGetStarted = false;
 
     $scope.alerts = $scope.alerts || {};
@@ -266,13 +267,18 @@ angular.module('openshiftConsole')
 
     // Show the "Get Started" message if the project is empty.
     var updateShowGetStarted = function() {
+      // Check if there is any data visible in the overview.
       var projectEmpty =
         _.isEmpty(services) &&
         _.isEmpty(pods) &&
         _.isEmpty(deployments) &&
         _.isEmpty(deploymentConfigs);
 
-      $scope.renderOptions.showGetStarted = projectEmpty;
+      // Check if we've loaded everything we show on the overview.
+      var loaded = services && pods && deployments && deploymentConfigs;
+
+      $scope.renderOptions.showGetStarted = loaded && projectEmpty;
+      $scope.renderOptions.showLoading = !loaded && projectEmpty;
     };
 
     ProjectsService

--- a/app/views/overview.html
+++ b/app/views/overview.html
@@ -26,8 +26,7 @@
                   </p>
                 </div>
               </div>
-              <div ng-if="((services | hashSize) === 0 && (deploymentConfigsByService[''] | hashSize) === 0 && (monopodsByService[''] | hashSize) === 0) && !renderOptions.showGetStarted"
-                   class="loading-message">
+              <div ng-if="renderOptions.showLoading" class="loading-message">
                 Loading...
               </div>
               <div ng-repeat="service in services" ng-if="!isChildService(service) && (service.metadata.labels.app || routesByService[service.metadata.name].length || childServicesByParent[service.metadata.name].length)">
@@ -44,7 +43,7 @@
               </div>
 
               <!-- Unserviced DCs, RCs, and pods -->
-              <div >
+              <div>
                 <overview-service-group
                   ng-if="(monopodsByService[''] | hashSize) > 0 || (deploymentConfigsByService[''] | hashSize) > 0 || (deploymentsByService[''] | hashSize) > 0">
                 </overview-service-group>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2725,7 +2725,7 @@ f.unwatchAll(k), n();
 });
 }));
 } ]), angular.module("openshiftConsole").controller("OverviewController", [ "$filter", "$routeParams", "$scope", "AlertMessageService", "BuildsService", "DataService", "DeploymentsService", "Logger", "PodsService", "ProjectsService", "RoutesService", "ServicesService", function(a, b, c, d, e, f, g, h, i, j, k, l) {
-c.projectName = b.project, c.renderOptions = c.renderOptions || {}, c.renderOptions.showGetStarted = !1, c.alerts = c.alerts || {}, d.getAlerts().forEach(function(a) {
+c.projectName = b.project, c.renderOptions = c.renderOptions || {}, c.renderOptions.showLoading = !0, c.renderOptions.showGetStarted = !1, c.alerts = c.alerts || {}, d.getAlerts().forEach(function(a) {
 c.alerts[a.name] = a.data;
 }), d.clearAlerts();
 var m, n, o, p, q, r, s, t, u, v, w = [], x = a("isJenkinsPipelineStrategy"), y = a("annotation"), z = a("label"), A = a("imageObjectRef"), B = a("isRecentDeployment"), C = function() {
@@ -2812,8 +2812,8 @@ s && (c.recentPipelinesByDC = {}, c.recentBuildsByOutputImage = {}, _.each(s, fu
 return R(a) ? x(a) ? void Q(a) :void O(a) :void 0;
 }));
 }, T = function() {
-var a = _.isEmpty(n) && _.isEmpty(q) && _.isEmpty(p) && _.isEmpty(o);
-c.renderOptions.showGetStarted = a;
+var a = _.isEmpty(n) && _.isEmpty(q) && _.isEmpty(p) && _.isEmpty(o), b = n && q && p && o;
+c.renderOptions.showGetStarted = b && a, c.renderOptions.showLoading = !b && a;
 };
 j.get(b.project).then(_.spread(function(a, b) {
 c.project = a, w.push(f.watch("pods", b, function(a) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6597,7 +6597,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-if=\"((services | hashSize) === 0 && (deploymentConfigsByService[''] | hashSize) === 0 && (monopodsByService[''] | hashSize) === 0) && !renderOptions.showGetStarted\" class=\"loading-message\">\n" +
+    "<div ng-if=\"renderOptions.showLoading\" class=\"loading-message\">\n" +
     "Loading...\n" +
     "</div>\n" +
     "<div ng-repeat=\"service in services\" ng-if=\"!isChildService(service) && (service.metadata.labels.app || routesByService[service.metadata.name].length || childServicesByParent[service.metadata.name].length)\">\n" +


### PR DESCRIPTION
Fixes a problem where the get started message can flicker briefly if the first type that loads is empty.

@jwforres PTAL