### PR TITLE
Remove relative Jenkins build URL workaround

### DIFF
--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -870,23 +870,7 @@ angular.module('openshiftConsole')
   })
   .filter('jenkinsBuildURL', function(annotationFilter, jenkinsLogURLFilter) {
     return function(build) {
-      var relativeBuildURL = annotationFilter(build, 'jenkinsBuildURL');
-      if (!relativeBuildURL) {
-        return null;
-      }
-
-      // We expect a relative URL, but if it is absolute, just return it.
-      if (URI(relativeBuildURL).is('absolute')) {
-        return relativeBuildURL;
-      }
-
-      // Use the log URL to determine the base URL of Jenkins since the build URL is relative.
-      var logURL = jenkinsLogURLFilter(build);
-      if (!logURL) {
-        return null;
-      }
-
-      return URI(logURL).path(relativeBuildURL).toString();
+      return annotationFilter(build, 'jenkinsBuildURL');
     };
   })
   .filter('buildLogURL', function(isJenkinsPipelineStrategyFilter,

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8507,12 +8507,8 @@ var d = a(b, "jenkinsLogURL");
 return !d || c ? d :d.replace(/\/consoleText$/, "/console");
 };
 } ]).filter("jenkinsBuildURL", [ "annotationFilter", "jenkinsLogURLFilter", function(a, b) {
-return function(c) {
-var d = a(c, "jenkinsBuildURL");
-if (!d) return null;
-if (URI(d).is("absolute")) return d;
-var e = b(c);
-return e ? URI(e).path(d).toString() :null;
+return function(b) {
+return a(b, "jenkinsBuildURL");
 };
 } ]).filter("buildLogURL", [ "isJenkinsPipelineStrategyFilter", "jenkinsLogURLFilter", "navigateResourceURLFilter", function(a, b, c) {
 return function(d) {


### PR DESCRIPTION
The workaround is no longer needed since the sync plugin now sets an absolute URL. See https://github.com/fabric8io/openshift-jenkins-sync-plugin/pull/86

@jwforres PTAL