### PR TITLE
Issue 73 - Delete Confirmation Modal Auto-focus

### DIFF
--- a/app/views/modals/delete-resource.html
+++ b/app/views/modals/delete-resource.html
@@ -17,7 +17,8 @@
               class="form-control input-lg"
               autocorrect="off"
               autocapitalize="off"
-              spellcheck="false">
+              spellcheck="false"
+              autofocus>
         </p>
       </div>
 

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6316,7 +6316,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p>Type the name of the {{typeDisplayName || (kind | humanizeKind)}} to confirm.</p>\n" +
     "<p>\n" +
     "<label class=\"sr-only\" for=\"resource-to-delete\">{{typeDisplayName || (kind | humanizeKind)}} to delete</label>\n" +
-    "<input ng-model=\"confirmName\" id=\"resource-to-delete\" type=\"text\" class=\"form-control input-lg\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck>\n" +
+    "<input ng-model=\"confirmName\" id=\"resource-to-delete\" type=\"text\" class=\"form-control input-lg\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck autofocus>\n" +
     "</p>\n" +
     "</div>\n" +
     "\n" +


### PR DESCRIPTION
Delete confirmation input now gets autofocus on display as stated in #73 

Fixes #73 