### PR TITLE
Make Jenkinsfile path a link when possible

### DIFF
--- a/app/views/browse/_build-details.html
+++ b/app/views/browse/_build-details.html
@@ -76,7 +76,14 @@
         <dt ng-if-start="build.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath">
           Jenkinsfile Path:
         </dt>
-        <dd ng-if-end>{{buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}</dd>
+        <dd ng-if-end>
+          <span ng-if="build | jenkinsfileLink">
+            <a ng-href="{{build | jenkinsfileLink}}">{{build.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}</a>
+          </span>
+          <span ng-if="!(build | jenkinsfileLink)">
+            {{build.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}
+          </span>
+        </dd>
         <dt ng-if-start="build.spec.strategy.jenkinsPipelineStrategy.jenkinsfile">
           Jenkinsfile:
         </dt>

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -252,7 +252,12 @@
                                 <div ng-if="buildConfig | isJenkinsPipelineStrategy">
                                   <div ng-if="buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath">
                                     <dt>Jenkinsfile Path:</dt>
-                                    <dd>{{buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}</dd>
+                                    <dd ng-if="buildConfig | jenkinsfileLink">
+                                      <a ng-href="{{buildConfig | jenkinsfileLink}}">{{buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}</a>
+                                    </dd>
+                                    <dd ng-if="!(buildConfig | jenkinsfileLink)">
+                                      {{buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}
+                                    </dd>
                                   </div>
                                   <div ng-if="buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile">
                                     <dt>Jenkinsfile:</dt><dd></dd>

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "angular-route": "1.3.20",
     "angular-bootstrap": "0.14.3",
     "angular-patternfly": "3.3.0",
-    "uri.js": "1.17.1",
+    "uri.js": "1.18.0",
     "moment": "2.10.6",
     "moment-timezone": "0.5.3",
     "patternfly": "3.3.0",

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8547,6 +8547,16 @@ if (a(d)) return b(d);
 var e = c(d);
 return e ? new URI(e).addSearch("tab", "logs").toString() :null;
 };
+} ]).filter("jenkinsfileLink", [ "isJenkinsPipelineStrategyFilter", "githubLinkFilter", function(a, b) {
+return function(c) {
+if (!a(c) || _.has(c, "spec.strategy.jenkinsPipelineStrategy.jenkinsfile")) return "";
+var d = _.get(c, "spec.source.git.uri");
+if (!d) return "";
+var e = _.get(c, "spec.source.git.ref"), f = _.get(c, "spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath", "Jenkinsfile"), g = _.get(c, "spec.source.contextDir");
+g && (f = URI.joinPaths(g, f).path());
+var h = b(d, e, f);
+return URI(h).is("url") ? h :"";
+};
 } ]).filter("pipelineStageComplete", function() {
 return function(a) {
 return a ? -1 !== _.indexOf([ "ABORTED", "FAILED", "SUCCESS" ], a.status) :!1;

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1104,7 +1104,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt ng-if-start=\"build.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath\">\n" +
     "Jenkinsfile Path:\n" +
     "</dt>\n" +
-    "<dd ng-if-end>{{buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}</dd>\n" +
+    "<dd ng-if-end>\n" +
+    "<span ng-if=\"build | jenkinsfileLink\">\n" +
+    "<a ng-href=\"{{build | jenkinsfileLink}}\">{{build.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}</a>\n" +
+    "</span>\n" +
+    "<span ng-if=\"!(build | jenkinsfileLink)\">\n" +
+    "{{build.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}\n" +
+    "</span>\n" +
+    "</dd>\n" +
     "<dt ng-if-start=\"build.spec.strategy.jenkinsPipelineStrategy.jenkinsfile\">\n" +
     "Jenkinsfile:\n" +
     "</dt>\n" +
@@ -1561,7 +1568,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"buildConfig | isJenkinsPipelineStrategy\">\n" +
     "<div ng-if=\"buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath\">\n" +
     "<dt>Jenkinsfile Path:</dt>\n" +
-    "<dd>{{buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}</dd>\n" +
+    "<dd ng-if=\"buildConfig | jenkinsfileLink\">\n" +
+    "<a ng-href=\"{{buildConfig | jenkinsfileLink}}\">{{buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}</a>\n" +
+    "</dd>\n" +
+    "<dd ng-if=\"!(buildConfig | jenkinsfileLink)\">\n" +
+    "{{buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}\n" +
+    "</dd>\n" +
     "</div>\n" +
     "<div ng-if=\"buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile\">\n" +
     "<dt>Jenkinsfile:</dt><dd></dd>\n" +


### PR DESCRIPTION
If source repo is a GitHub repo, make the Jenkinsfile Path value a link so it's easy to see the contents of the Jenkinsfile. For non-GitHub repositories, fall back to just showing the path as before.

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/16271592/aad13bc4-3868-11e6-9f95-42bbd95930ba.png)

@jwforres PTAL
@bparees CC