### PR TITLE
Align text to left in the Action td at the other-resources page for mobile

### DIFF
--- a/app/views/other-resources.html
+++ b/app/views/other-resources.html
@@ -47,11 +47,12 @@
                     <td data-title="Labels">
                       <em ng-if="(resource.metadata.labels | hashSize) === 0">none</em>
                       <labels labels="resource.metadata.labels" clickable="true" kind="{{kindSelector.selected.kind | kindToResource : true }}" project-name="{{resource.metadata.namespace}}" limit="3" filter-current-page="true"></labels></td>
-                    <td data-title="Actions" class="text-right">
+                    <td data-title="Actions" class="text-xs-left text-right">
                       <span uib-dropdown>
-                        <a uib-dropdown-toggle id="{{resource.metadata.name}}_actions" href="" class="actions-dropdown-kebab">
-                          <i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span>
-                        </a>
+                        <button type="button" class="dropdown-toggle btn btn-default" data-toggle="dropdown">
+                          Actions
+                          <span class="caret"></span>
+                        </button>
                         <ul class="uib-dropdown-menu dropdown-menu-right" aria-labelledby="{{resource.metadata.name}}_actions">
                           <li>
                               <edit-link

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6741,11 +6741,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<td data-title=\"Labels\">\n" +
     "<em ng-if=\"(resource.metadata.labels | hashSize) === 0\">none</em>\n" +
     "<labels labels=\"resource.metadata.labels\" clickable=\"true\" kind=\"{{kindSelector.selected.kind | kindToResource : true }}\" project-name=\"{{resource.metadata.namespace}}\" limit=\"3\" filter-current-page=\"true\"></labels></td>\n" +
-    "<td data-title=\"Actions\" class=\"text-right\">\n" +
+    "<td data-title=\"Actions\" class=\"text-xs-left text-right\">\n" +
     "<span uib-dropdown>\n" +
-    "<a uib-dropdown-toggle id=\"{{resource.metadata.name}}_actions\" href=\"\" class=\"actions-dropdown-kebab\">\n" +
-    "<i class=\"fa fa-ellipsis-v\"></i><span class=\"sr-only\">Actions</span>\n" +
-    "</a>\n" +
+    "<button type=\"button\" class=\"dropdown-toggle btn btn-default\" data-toggle=\"dropdown\">\n" +
+    "Actions\n" +
+    "<span class=\"caret\"></span>\n" +
+    "</button>\n" +
     "<ul class=\"uib-dropdown-menu dropdown-menu-right\" aria-labelledby=\"{{resource.metadata.name}}_actions\">\n" +
     "<li>\n" +
     "<edit-link resource=\"resource\" kind=\"{{kindSelector.selected.kind}}\" alerts=\"alerts\" success=\"loadKind\">\n" +


### PR DESCRIPTION
Fixing small bug where on the other-resources page for the mobile the Action column text was align to right.
Screen of the issue:
![screenshot-8](https://cloud.githubusercontent.com/assets/1668218/16299643/9def00de-393b-11e6-978d-924e2cc19da0.png)

After fix:
![screenshot-7](https://cloud.githubusercontent.com/assets/1668218/16299645/a326e1a2-393b-11e6-8ff1-87ddedf88e26.png)

@jwforres @spadgett PTAL

