### PR TITLE
Fixes Issue #91 - Build-configs URL Tab Navigation

### DIFF
--- a/app/scripts/controllers/buildConfig.js
+++ b/app/scripts/controllers/buildConfig.js
@@ -36,6 +36,12 @@ angular.module('openshiftConsole')
       editor.$blockScrolling = Infinity;
     };
 
+    // Check for a ?tab=<name> query param to allow linking directly to a tab.
+    if ($routeParams.tab) {
+      $scope.selectedTab = {};
+      $scope.selectedTab[$routeParams.tab] = true;
+    }
+
     var orderByDate = $filter('orderObjectsByDate');
     var watches = [];
 

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -68,7 +68,7 @@
             <div class="row" ng-if="loaded">
               <div class="col-md-12" ng-class="{ 'hide-tabs' : !buildConfig }">
                 <uib-tabset>
-                  <uib-tab>
+                  <uib-tab active="selectedTab.summary">
                     <uib-tab-heading>Summary</uib-tab-heading>
 
                     <!-- If unfilteredBuilds is undefined, the builds are still loading. -->
@@ -189,7 +189,7 @@
                       </div>
                     </div>
                   </uib-tab>
-                  <uib-tab ng-if="buildConfig">
+                  <uib-tab active="selectedTab.configuration" ng-if="buildConfig">
                     <uib-tab-heading>Configuration</uib-tab-heading>
                       <div class="resource-details">
                         <div class="row">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3375,7 +3375,7 @@ a.alerts[b.name] = b.data;
 }), h.clearAlerts(), a.aceLoaded = function(a) {
 var b = a.getSession();
 b.setOption("tabSize", 2), b.setOption("useSoftTabs", !0), a.$blockScrolling = 1 / 0;
-};
+}, b.tab && (a.selectedTab = {}, a.selectedTab[b.tab] = !0);
 var i = f("orderObjectsByDate"), j = [];
 d.get(b.project).then(_.spread(function(d, h) {
 function k() {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1393,7 +1393,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"row\" ng-if=\"loaded\">\n" +
     "<div class=\"col-md-12\" ng-class=\"{ 'hide-tabs' : !buildConfig }\">\n" +
     "<uib-tabset>\n" +
-    "<uib-tab>\n" +
+    "<uib-tab active=\"selectedTab.summary\">\n" +
     "<uib-tab-heading>Summary</uib-tab-heading>\n" +
     "\n" +
     "<div ng-if=\"!unfilteredBuilds\" class=\"gutter-bottom\">Loading...</div>\n" +
@@ -1505,7 +1505,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</uib-tab>\n" +
-    "<uib-tab ng-if=\"buildConfig\">\n" +
+    "<uib-tab active=\"selectedTab.configuration\" ng-if=\"buildConfig\">\n" +
     "<uib-tab-heading>Configuration</uib-tab-heading>\n" +
     "<div class=\"resource-details\">\n" +
     "<div class=\"row\">\n" +


### PR DESCRIPTION
Fixes #91 

Can now use ?tab=summary, ?tab=configuration, and ?tab=environment to navigate around the build-configs page.

@benjaminapetersen 