### PR TITLE
Display template message

### DIFF
--- a/app/scripts/controllers/create/nextSteps.js
+++ b/app/scripts/controllers/create/nextSteps.js
@@ -9,7 +9,7 @@
  * Controller of the openshiftConsole
  */
 angular.module("openshiftConsole")
-  .controller("NextStepsController", function($scope, $http, $routeParams, DataService, $q, $location, ProcessedParametersService, TaskList, $parse, Navigate, $filter, imageObjectRefFilter, failureObjectNameFilter, ProjectsService) {
+  .controller("NextStepsController", function($scope, $http, $routeParams, DataService, $q, $location, ProcessedTemplateService, TaskList, $parse, Navigate, $filter, imageObjectRefFilter, failureObjectNameFilter, ProjectsService) {
     var displayNameFilter = $filter('displayName');
     var watches = [];
 
@@ -51,8 +51,10 @@ angular.module("openshiftConsole")
       }
     ];
 
-    $scope.parameters = ProcessedParametersService.getParams();
-    ProcessedParametersService.clearParams();
+    var processedTemplateData = ProcessedTemplateService.getTemplateData();
+    $scope.parameters = processedTemplateData.params;
+    $scope.templateMessage = processedTemplateData.message;
+    ProcessedTemplateService.clearTemplateData();
 
     ProjectsService
       .get($routeParams.project)

--- a/app/scripts/controllers/newfromtemplate.js
+++ b/app/scripts/controllers/newfromtemplate.js
@@ -9,7 +9,7 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('NewFromTemplateController', function ($scope, $http, $routeParams, DataService, ProcessedParametersService, AlertMessageService, ProjectsService, $q, $location, TaskList, $parse, Navigate, $filter, imageObjectRefFilter, failureObjectNameFilter, CachedTemplateService) {
+  .controller('NewFromTemplateController', function ($scope, $http, $routeParams, DataService, ProcessedTemplateService, AlertMessageService, ProjectsService, $q, $location, TaskList, $parse, Navigate, $filter, imageObjectRefFilter, failureObjectNameFilter, CachedTemplateService) {
 
 
     var name = $routeParams.name;
@@ -142,9 +142,8 @@ angular.module('openshiftConsole')
                 failure: "Failed to create " + $scope.templateDisplayName() + " in project " + $scope.projectDisplayName()
               };
 
-              if (!_.isEmpty(config.parameters)) {
-                ProcessedParametersService.setParams(config.parameters, $scope.template.parameters);
-              }
+              // Cache template parameters and message so they can be displayed in the nexSteps page
+              ProcessedTemplateService.setTemplateData(config.parameters, $scope.template.parameters, config.message);
 
               var helpLinks = getHelpLinks($scope.template);
               TaskList.clear();

--- a/app/scripts/services/templates.js
+++ b/app/scripts/services/templates.js
@@ -16,35 +16,42 @@ angular.module("openshiftConsole")
       }
     };
 
-  }).service("ProcessedParametersService", function(){
-
-    var params = {
-      all: [],
-      generated: []
+  }).service("ProcessedTemplateService", function(){
+    
+    var cleanTemplateData = function() {
+      return {
+        params: {
+          all: [],
+          generated: []
+        },
+        message: null
+      };
     };
 
+    var templateData = cleanTemplateData();
+
     return {
-      setParams: function(allParameters, generatedParametersName) {
+      setTemplateData: function(allParameters, generatedParametersName, msg) {
         _.each(allParameters, function(param) {
-          params.all.push({
+          templateData.params.all.push({
             name: param.name,
             value: param.value
           });
         });
         _.each(generatedParametersName, function(param) {
           if (!param.value) {
-            params.generated.push(param.name);
+            templateData.params.generated.push(param.name);
           }
         });
+        if (msg) {
+          templateData.message = msg;
+        }
       },
-      getParams: function() {
-        return params;
+      getTemplateData: function() {
+        return templateData;
       },
-      clearParams: function() {
-        params = {
-          all: [],
-          generated: []
-        };
+      clearTemplateData: function() {
+        templateData = cleanTemplateData();
       }
     };
   });

--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -696,6 +696,21 @@ label.checkbox {
   margin-left: 3px;
 }
 
+.template-message {
+  .pficon-info {
+    float: left;
+    font-size: 18px;
+    margin-right: 6px;
+    color: #31708f;
+  }
+  background-color: #d9edf7;
+  border-color: #31708f;
+  border-width: 1px;
+  color: black;
+  border-style: solid;
+  padding: 21px;
+}
+
 .resource-description {
   .word-break();
   .pre-wrap();

--- a/app/views/create/next-steps.html
+++ b/app/views/create/next-steps.html
@@ -40,6 +40,11 @@
               </div>
             </div>
 
+            <div class="template-message" ng-if="templateMessage.length">
+              <span class="pficon pficon-info" aria-hidden="true"></span>
+              <div class="resource-description" ng-bind-html="templateMessage | linky"></div>
+            </div>
+
             <div class="row" ng-controller="TasksController">
               <div ng-if="!pendingTasks(tasks()).length && erroredTasks(tasks()).length" class="col-md-12">
                 <h2>Things you can do</h2>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2606,30 +2606,32 @@ clearTemplate:function() {
 a = null;
 }
 };
-}).service("ProcessedParametersService", function() {
-var a = {
-all:[],
-generated:[]
-};
+}).service("ProcessedTemplateService", function() {
+var a = function() {
 return {
-setParams:function(b, c) {
-_.each(b, function(b) {
-a.all.push({
-name:b.name,
-value:b.value
-});
-}), _.each(c, function(b) {
-b.value || a.generated.push(b.name);
-});
-},
-getParams:function() {
-return a;
-},
-clearParams:function() {
-a = {
+params:{
 all:[],
 generated:[]
+},
+message:null
 };
+}, b = a();
+return {
+setTemplateData:function(a, c, d) {
+_.each(a, function(a) {
+b.params.all.push({
+name:a.name,
+value:a.value
+});
+}), _.each(c, function(a) {
+a.value || b.params.generated.push(a.name);
+}), d && (b.message = d);
+},
+getTemplateData:function() {
+return b;
+},
+clearTemplateData:function() {
+b = a();
 }
 };
 }), angular.module("openshiftConsole").factory("ServicesService", [ "$filter", "DataService", function(a, b) {
@@ -4944,7 +4946,7 @@ null !== a && (b.debug("Generated resource definition:", a), d.push(a));
 }), w(d, a.projectName, a).then(x, y);
 };
 }));
-} ]), angular.module("openshiftConsole").controller("NextStepsController", [ "$scope", "$http", "$routeParams", "DataService", "$q", "$location", "ProcessedParametersService", "TaskList", "$parse", "Navigate", "$filter", "imageObjectRefFilter", "failureObjectNameFilter", "ProjectsService", function(a, b, c, d, e, f, g, h, i, j, k, l, m, n) {
+} ]), angular.module("openshiftConsole").controller("NextStepsController", [ "$scope", "$http", "$routeParams", "DataService", "$q", "$location", "ProcessedTemplateService", "TaskList", "$parse", "Navigate", "$filter", "imageObjectRefFilter", "failureObjectNameFilter", "ProjectsService", function(a, b, c, d, e, f, g, h, i, j, k, l, m, n) {
 function o() {
 return u && t;
 }
@@ -4967,7 +4969,9 @@ title:u,
 link:v
 }, {
 title:"Next Steps"
-} ], a.parameters = g.getParams(), g.clearParams(), n.get(c.project).then(_.spread(function(b, c) {
+} ];
+var w = g.getTemplateData();
+a.parameters = w.params, a.templateMessage = w.message, g.clearTemplateData(), n.get(c.project).then(_.spread(function(b, c) {
 function e(a) {
 var b = [];
 return angular.forEach(a, function(a) {
@@ -4998,7 +5002,7 @@ a.showParamsTable = !0;
 d.unwatchAll(q);
 })) :void j.toProjectOverview(a.projectName);
 }));
-} ]), angular.module("openshiftConsole").controller("NewFromTemplateController", [ "$scope", "$http", "$routeParams", "DataService", "ProcessedParametersService", "AlertMessageService", "ProjectsService", "$q", "$location", "TaskList", "$parse", "Navigate", "$filter", "imageObjectRefFilter", "failureObjectNameFilter", "CachedTemplateService", function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) {
+} ]), angular.module("openshiftConsole").controller("NewFromTemplateController", [ "$scope", "$http", "$routeParams", "DataService", "ProcessedTemplateService", "AlertMessageService", "ProjectsService", "$q", "$location", "TaskList", "$parse", "Navigate", "$filter", "imageObjectRefFilter", "failureObjectNameFilter", "CachedTemplateService", function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) {
 var q = c.name, r = c.namespace || "";
 if (!q) return void l.toErrorPage("Cannot create from template: a template name was not specified.");
 a.emptyMessage = "Loading...", a.alerts = {}, a.projectName = c.project, a.projectPromise = $.Deferred(), a.breadcrumbs = [ {
@@ -5060,7 +5064,7 @@ started:"Creating " + a.templateDisplayName() + " in project " + a.projectDispla
 success:"Created " + a.templateDisplayName() + " in project " + a.projectDisplayName(),
 failure:"Failed to create " + a.templateDisplayName() + " in project " + a.projectDisplayName()
 };
-_.isEmpty(b.parameters) || e.setParams(b.parameters, a.template.parameters);
+e.setTemplateData(b.parameters, a.template.parameters, b.message);
 var i = o(a.template);
 j.clear(), j.add(g, i, function() {
 var c = h.defer();

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3814,6 +3814,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
+    "<div class=\"template-message\" ng-if=\"templateMessage.length\">\n" +
+    "<span class=\"pficon pficon-info\" aria-hidden=\"true\"></span>\n" +
+    "<div class=\"resource-description\" ng-bind-html=\"templateMessage | linky\"></div>\n" +
+    "</div>\n" +
     "<div class=\"row\" ng-controller=\"TasksController\">\n" +
     "<div ng-if=\"!pendingTasks(tasks()).length && erroredTasks(tasks()).length\" class=\"col-md-12\">\n" +
     "<h2>Things you can do</h2>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3569,6 +3569,8 @@ label.checkbox{font-weight:400}
 .env-variable-list li .value,.label-list li .value{max-width:500px}
 .env-variable-list li .btn,.label-list li .btn{vertical-align:top}
 .label+.label{margin-left:3px}
+.template-message{background-color:#d9edf7;border-color:#31708f;border-width:1px;color:#000;border-style:solid;padding:21px}
+.template-message .pficon-info{float:left;font-size:18px;margin-right:6px;color:#31708f}
 .resource-description{overflow-wrap:break-word;min-width:0;white-space:pre-wrap}
 .action-inline{margin-left:5px;font-size:11px}
 .action-inline i.fa,.action-inline i.pficon{color:#4d5258;margin-right:5px}


### PR DESCRIPTION
Here is the first draft for the "Post-process template message" card. 
Wasn't sure if we want to also have possibility to edit the message in the `newfromtemplate` page, so I've add the extra input field just so we have the picture. Although not sure if it makes sense to update the message there(maybe if you don't save the template upon the creation process?!?).
![screenshot-6](https://cloud.githubusercontent.com/assets/1668218/16769273/522c88b2-4848-11e6-87fa-d25f1b6230c7.png)

Here is also how we would display the message on the `next-step` page.
![screenshot-7](https://cloud.githubusercontent.com/assets/1668218/16769603/b2e7e1b4-4849-11e6-8d04-8a5e2f573a5d.png)
Wasnt sure with the header wording. Wanted to go with 'Template Owner Message' , but went with 'Template Message'

@jwforres thoughts