### PR TITLE
Idled deployments 

### DIFF
--- a/app/scripts/directives/podDonut.js
+++ b/app/scripts/directives/podDonut.js
@@ -16,7 +16,8 @@ angular.module('openshiftConsole')
       restrict: 'E',
       scope: {
         pods: '=',
-        desired: '=?'
+        desired: '=?',
+        idled: '=?'
       },
       templateUrl: 'views/directives/pod-donut.html',
       link: function($scope, element) {
@@ -28,14 +29,19 @@ angular.module('openshiftConsole')
         $scope.chartId = _.uniqueId('pods-donut-chart-');
 
         function updateCenterText() {
-          var total = hashSizeFilter($scope.pods), smallText;
+          var total = hashSizeFilter($scope.pods);
+          var smallText;
           if (!angular.isNumber($scope.desired) || $scope.desired === total) {
             smallText = (total === 1) ? "pod" : "pods";
           } else {
             smallText = "scaling to " + $scope.desired + "...";
           }
 
-          ChartsService.updateDonutCenterText(element[0], total, smallText);
+          if($scope.idled) {
+            ChartsService.updateDonutCenterText(element[0], 'Idle');
+          } else {
+            ChartsService.updateDonutCenterText(element[0], total, smallText);
+          }
         }
 
         // c3.js config for the pods donut chart
@@ -176,7 +182,7 @@ angular.module('openshiftConsole')
 
         var debounceUpdate = _.debounce(updateChart, 350, { maxWait: 500 });
         $scope.$watch(countPodPhases, debounceUpdate, true);
-        $scope.$watch('desired', updateCenterText);
+        $scope.$watchGroup(['desired','idled'], updateCenterText);
 
         $scope.$on('destroy', function() {
           if (chart) {

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -34,7 +34,8 @@ angular.module('openshiftConsole')
       "buildPod":                 ["openshift.io/build.pod-name"],
       "jenkinsBuildURL":          ["openshift.io/jenkins-build-uri"],
       "jenkinsLogURL":            ["openshift.io/jenkins-log-url"],
-      "jenkinsStatus":            ["openshift.io/jenkins-status-json"]
+      "jenkinsStatus":            ["openshift.io/jenkins-status-json"],
+      "idledAt":                  ["idling.alpha.openshift.io/idled-at"]
     };
     return function(annotationKey) {
       return annotationMap[annotationKey] || null;

--- a/app/scripts/services/charts.js
+++ b/app/scripts/services/charts.js
@@ -15,16 +15,18 @@ angular.module("openshiftConsole")
         donutChartTitle
           .insert('tspan')
           .text(titleBig)
-          .classed('donut-title-big-pf', true)
-          .attr('dy', 0)
+          .classed(titleSmall ? 'donut-title-big-pf' : 'donut-title-med-pf', true)
+          .attr('dy', titleSmall ? 0 : 5)
           .attr('x', 0);
-        donutChartTitle
-          .insert('tspan')
-          .text(titleSmall)
-          .classed('donut-title-small-pf', true)
-          .attr('dy', 20)
-          .attr('x', 0);
+
+        if(titleSmall) {
+          donutChartTitle
+            .insert('tspan')
+            .text(titleSmall)
+            .classed('donut-title-small-pf', true)
+            .attr('dy', 20)
+            .attr('x', 0);
+        }
       }
     };
   });
-

--- a/app/styles/_components.less
+++ b/app/styles/_components.less
@@ -311,7 +311,7 @@ code.probe-command {
       }
     }
   }
-  .hpa-details {
+  .scaling-details {
     .small;
     .text-muted;
     .text-center;

--- a/app/styles/_patternfly-additions.less
+++ b/app/styles/_patternfly-additions.less
@@ -1,0 +1,11 @@
+// Classes that fill gaps or add to existing patternfly concepts
+
+// a medium class is needed between:
+// .donut-title-big-pf,
+//   @donut-font-size-big, 30px;
+// .donut-title-small-pf
+//   @font-size-base, 12px;
+.donut-title-med-pf {
+  font-size: @donut-font-size-big * .75;  // ~ 22.5px;
+  font-weight: 300;
+}

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -38,3 +38,4 @@
 @import "_log.less";
 @import "_settings.less";
 @import "_utils.less";
+@import "_patternfly-additions.less";

--- a/app/views/directives/deployment-donut.html
+++ b/app/views/directives/deployment-donut.html
@@ -4,6 +4,7 @@
       <pod-donut
           pods="pods"
           desired="getDesiredReplicas()"
+          idled="isIdled"
           ng-click="viewPodsForDeployment(rc)"
           ng-class="{ clickable: (pods | hashSize) > 0 }">
       </pod-donut>
@@ -19,7 +20,10 @@
     </div>
 
     <!-- Don't show the scaling controls until the HPAs load so they don't appear and quickly disappear. -->
-    <div column class="scaling-controls fade-inline" ng-if="hpa && !hpa.length && (rc | canIScale)">
+    <div
+      column
+      class="scaling-controls fade-inline"
+      ng-if="(hpa && !hpa.length) && (rc | canIScale) && !isIdled">
       <div>
         <a href=""
            ng-click="scaleUp()"
@@ -44,7 +48,8 @@
       </div>
     </div>
   </div>
-  <div row ng-if="hpa.length" class="hpa-details">
+
+  <div row ng-if="hpa.length" class="scaling-details">
     <div>
       Autoscaled:
       <span class="nowrap">min: {{hpa[0].spec.minReplicas || 1}},</span>
@@ -59,6 +64,16 @@
               aria-hidden="true">
         </span>
       </span>
+    </div>
+  </div>
+  <div
+    class="scaling-details"
+    ng-if="isIdled && (!getDesiredReplicas())">
+    <div ng-if="(!resuming)">
+      <span>Idled due to inactivity.</span>
+      <a
+        href=""
+        ng-click="unIdle()">Start {{hpa[0].spec.minReplicas || 1}} pod{{ (hpa[0].spec.minReplicas || 1) > 1 ? 's' : ''}}</a>
     </div>
   </div>
 </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4674,7 +4674,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div column class=\"deployment-donut\">\n" +
     "<div row>\n" +
     "<div column>\n" +
-    "<pod-donut pods=\"pods\" desired=\"getDesiredReplicas()\" ng-click=\"viewPodsForDeployment(rc)\" ng-class=\"{ clickable: (pods | hashSize) > 0 }\">\n" +
+    "<pod-donut pods=\"pods\" desired=\"getDesiredReplicas()\" idled=\"isIdled\" ng-click=\"viewPodsForDeployment(rc)\" ng-class=\"{ clickable: (pods | hashSize) > 0 }\">\n" +
     "</pod-donut>\n" +
     "\n" +
     "<a href=\"\" class=\"sr-only\" ng-click=\"viewPodsForDeployment(rc)\" ng-if=\"(pods | hashSize) > 0\" role=\"button\">\n" +
@@ -4682,7 +4682,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</a>\n" +
     "</div>\n" +
     "\n" +
-    "<div column class=\"scaling-controls fade-inline\" ng-if=\"hpa && !hpa.length && (rc | canIScale)\">\n" +
+    "<div column class=\"scaling-controls fade-inline\" ng-if=\"(hpa && !hpa.length) && (rc | canIScale) && !isIdled\">\n" +
     "<div>\n" +
     "<a href=\"\" ng-click=\"scaleUp()\" ng-class=\"{ disabled: !scalable }\" ng-attr-title=\"{{!scalable ? undefined : 'Scale up'}}\" ng-attr-aria-disabled=\"{{!scalable ? 'true' : undefined}}\">\n" +
     "<i class=\"fa fa-chevron-up\"></i>\n" +
@@ -4698,7 +4698,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div row ng-if=\"hpa.length\" class=\"hpa-details\">\n" +
+    "<div row ng-if=\"hpa.length\" class=\"scaling-details\">\n" +
     "<div>\n" +
     "Autoscaled:\n" +
     "<span class=\"nowrap\">min: {{hpa[0].spec.minReplicas || 1}},</span>\n" +
@@ -4707,6 +4707,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"hpaWarnings\" dynamic-content=\"{{hpaWarnings}}\" data-toggle=\"popover\" data-trigger=\"hover\" data-html=\"true\" class=\"pficon pficon-warning-triangle-o hpa-warning\" aria-hidden=\"true\">\n" +
     "</span>\n" +
     "</span>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"scaling-details\" ng-if=\"isIdled && (!getDesiredReplicas())\">\n" +
+    "<div ng-if=\"(!resuming)\">\n" +
+    "<span>Idled due to inactivity.</span>\n" +
+    "<a href=\"\" ng-click=\"unIdle()\">Start {{hpa[0].spec.minReplicas || 1}} pod{{ (hpa[0].spec.minReplicas || 1) > 1 ? 's' : ''}}</a>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>"

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3385,8 +3385,8 @@ code.probe-command{display:inline-block;line-height:1.3;margin-right:2px}
 .deployment-donut .scaling-controls a:active,.deployment-donut .scaling-controls a:hover{color:#72767b;text-decoration:none}
 .deployment-donut .scaling-controls a.disabled{opacity:.4;cursor:not-allowed}
 .deployment-donut .scaling-controls a.disabled:hover{color:#bbb}
-.deployment-donut .hpa-details{font-size:84%;color:#9c9c9c;text-align:center;align-items:center;margin-top:-5px;margin-bottom:7px}
-.deployment-donut .hpa-details .hpa-warning{cursor:help;margin-left:1px;vertical-align:-1px}
+.deployment-donut .scaling-details{font-size:84%;color:#9c9c9c;text-align:center;align-items:center;margin-top:-5px;margin-bottom:7px}
+.deployment-donut .scaling-details .hpa-warning{cursor:help;margin-left:1px;vertical-align:-1px}
 .browse-deployment-donut .deployment-donut{-webkit-align-items:center;-moz-align-items:center;align-items:center}
 .deployment-well:not(.active){background-color:#fff}
 .deployment-well:not(.detailed){padding-top:12px;padding-bottom:12px}
@@ -4651,3 +4651,4 @@ kubernetes-topology-graph{height:700px}
 .table-log-pods>tbody+tbody{border-top-width:1px}
 .settings-item{margin:4px 8px 4px 0}
 .hide-if-empty:empty{display:none!important}
+.donut-title-med-pf{font-size:22.5px;font-weight:300}


### PR DESCRIPTION
**Code is not ready for review.**

This is a PR to get some feedback on visuals for showing an idled deployment.  Here are a few screenshots.  I ended up putting the message below the donut rather than above because it seemed to fit better:


![screen shot 2016-07-12 at 11 02 23 am](https://cloud.githubusercontent.com/assets/280512/16772285/aaac8d9c-4821-11e6-9897-856661823a63.png)
![screen shot 2016-07-12 at 11 02 34 am](https://cloud.githubusercontent.com/assets/280512/16772284/aaaae226-4821-11e6-9eff-a6e669362614.png)
Adjacent to autoscaling message for reference:
![screen shot 2016-07-12 at 11 01 56 am](https://cloud.githubusercontent.com/assets/280512/16772283/aaa0282c-4821-11e6-8315-14243f20d6d7.png)

- Might make sense to move the `i` with the tooltip to the right of the text rather than next to the button
- Need to play with the wording of the tooltip a bit

@spadgett @jwforres appreciate any feedback!