### PR TITLE
Improving the display of IN_PROGRESS stages

### DIFF
--- a/app/scripts/filters/date.js
+++ b/app/scripts/filters/date.js
@@ -121,27 +121,32 @@ angular.module('openshiftConsole')
       return moment.duration(duration, unit).humanize();
     };
   })
-  .filter('conciseDuration', function() {
-    // Return a duration like "1h" or "30s".
+  .filter('timeOnlyDuration', function(){
     return function(value) {
+      var result = [];
       var duration = moment.duration(value);
-
-      var days = Math.floor(duration.asDays());
-      if (days) {
-        return days + "d";
-      }
-
       var hours = Math.floor(duration.asHours());
+      var minutes = duration.minutes();
+      var seconds = duration.seconds();
+
+      if (!hours && !minutes && !seconds) {
+        return '';
+      }
+
       if (hours) {
-        return hours + "h";
+        result.push(hours + "h");
       }
 
-      var minutes = Math.floor(duration.minutes());
       if (minutes) {
-        return minutes + "m";
+        result.push(minutes + "m");
       }
 
-      var seconds = Math.floor(duration.seconds());
-      return seconds + "s";
+      // Only show seconds if not duration doesn't include hours.
+      // Always show seconds otherwise (even 0s).
+      if (!hours) {
+        result.push(seconds + "s");
+      }
+
+      return result.join(" ");
     };
   });

--- a/app/styles/_pipeline.less
+++ b/app/styles/_pipeline.less
@@ -1,14 +1,27 @@
+@build-pipeline-aborted-color: #e8e8e8;
 @build-pipeline-border-color: #d1d1d1;
-
-// Statuses
+@build-pipeline-failed-color: #cc0000;
+@build-pipeline-in-progress-color: #0088ce;
 @build-pipeline-new-color: #bee1f4;
 @build-pipeline-pending-color: #d1d1d1;
-@build-pipeline-in-progress-color: #0088ce;
 @build-pipeline-success-color: #3f9c35;
-@build-pipeline-failed-color: #cc0000;
-@build-pipeline-aborted-color: #e8e8e8;
+@circle-animation-time: 0.35s;
+@circle-diameter: 18px;
+@circle-border-width: (@line-border-width / 2);
+@circle-radius: (@circle-diameter / 2);
+@icon-animation-time: @inner-circle-animation-time;
+@inner-circle-animation-time: 0.1s;
+@inner-circle-color: #fff;
+@line-animation-time: 0.35s;
+@line-border-width: 8px;
+@line-grow-animation-time: 0.5s;
+@line-height: (@line-border-width / 2);
+@pipeline-margin: 10px;
+@progress-line: 100%;
+@progress-rail-animation-time: 6s;
+@semi-circle-animation-time: (@circle-animation-time / 2);
 
-
+// Animations
 @keyframes flexGrow {
   to {
     .flex-grow(@grow: 1);
@@ -23,6 +36,72 @@
     .flex-grow(@grow: 0.000001);
     .flex-shrink(@shrink: 1);
   }
+}
+
+@keyframes progress-line {
+  from {
+    width: 0;
+  }
+  to {
+    width: @progress-line;
+  }
+}
+
+@keyframes progress-rail {
+  to {
+    transform: translateX(400%)
+  }
+}
+
+@keyframes progress {
+  from {
+    -webkit-transform: rotate(0);
+    transform: rotate(0);
+  }
+  to {
+    -webkit-transform: rotate(180deg);
+    transform: rotate(180deg);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  from {
+    background-color: @build-pipeline-pending-color;
+  }
+  to {
+    background-color: transparent;
+  }
+}
+
+// Solid circle backgrounds
+@keyframes fadeInSuccess {
+  to {background-color: @build-pipeline-success-color;}
+}
+
+@keyframes fadeInFailed {
+  to {background-color: @build-pipeline-failed-color;}
+}
+
+@keyframes fadeInProgress {
+  to {background-color: @build-pipeline-in-progress-color;}
+}
+
+@keyframes fadeInAborted {
+  to {background-color: @build-pipeline-aborted-color;}
+}
+
+@keyframes fadeInNotExecuted {
+  to {background-color: @build-pipeline-pending-color;}
 }
 
 .pipeline-container {
@@ -47,15 +126,15 @@
 }
 
 .new-stage {
+  animation: flexGrow @line-grow-animation-time ease forwards;
   .flex-basis(@width: 1);
   .flex-grow(@grow: 0.000001);
   .flex-shrink(@shrink: 1);
-  animation: flexGrow 0.5s ease forwards;
 }
 
 .remove-stage {
+  animation: flexShrink @line-grow-animation-time ease forwards;
   .flex(@columns: 1 1 0%);
-  animation: flexShrink 0.5s ease forwards;
 }
 
 .pipeline-stage-name, .pipeline-time {
@@ -71,8 +150,11 @@
   }
 }
 .pipeline-time {
-  .text-muted();
   margin-top: 12px;
+  .text-muted();
+  &.IN_PROGRESS {
+    color: @gray;
+  }
 }
 
 .build-summary, .stage {
@@ -142,78 +224,6 @@
   }
 }
 
-
-// pipeline animation
-// ------------------------------------
-
-@pipeline-margin: 10px;
-@progress-line: 100%;
-@circle-diameter: 18px;
-@line-border-width: 8px;
-@line-height: (@line-border-width / 2);
-
-@line-animation-time: 0.35s;
-@circle-animation-time: 0.35s;
-
-@inner-circle-color: #fff;
-
-@circle-radius: (@circle-diameter / 2);
-@semi-circle-animation-time: (@circle-animation-time / 2);
-@circle-border-width: (@line-border-width / 2);
-
-@keyframes progress-line {
-	from {
-		width: 0;
-	}
-	to {
-		width: @progress-line;
-	}
-}
-@keyframes progress {
-	from {
-		-webkit-transform: rotate(0);
-		transform: rotate(0);
-	}
-	to {
-		-webkit-transform: rotate(180deg);
-		transform: rotate(180deg);
-	}
-}
-@keyframes fadeIn {
-	from {
-		opacity: 0;
-
-	}
-	to {
-		opacity: 1;
-	}
-}
-@keyframes fadeOut {
-	from {
-		background-color: @build-pipeline-pending-color;
-	}
-	to {
-		background-color: transparent;
-	}
-}
-// Solid circle backgrounds
-@keyframes fadeInSuccess {
-  to {background-color: @build-pipeline-success-color;}
-}
-@keyframes fadeInFailed {
-  to {background-color: @build-pipeline-failed-color;}
-}
-@keyframes fadeInProgress {
-  to {background-color: @build-pipeline-in-progress-color;}
-}
-@keyframes fadeInAborted {
-  to {background-color: @build-pipeline-aborted-color;}
-}
-@keyframes fadeInNotExecuted {
-  to {background-color: @build-pipeline-pending-color;}
-}
-
-
 // Shared by both the build pipeline and overview pipeline.
 .pipeline-status-bar  {
   .pipeline-line:before,
@@ -257,7 +267,15 @@
 }
 
 .pipeline-status-bar.IN_PROGRESS  {
-  .pipeline-line:before,
+  .pipeline-line {
+    overflow: hidden;
+    &:before {
+      animation: progress-rail @progress-rail-animation-time @line-grow-animation-time linear infinite;
+      background-color: @build-pipeline-in-progress-color;
+      transform: translateX(-100%);
+      width: 25%;
+    }
+  }
   .clip1:before,
   .clip2:before,
   .inner-circle-fill {
@@ -337,7 +355,6 @@
   margin-top: (-(@circle-diameter / 2) - (@line-height / 2));
   position: relative;
   transform: rotate(-90deg);
-  animation: fadeOut 0.1s (@line-animation-time + @circle-animation-time) linear forwards;
   &:after {
     position: absolute;
     color: @inner-circle-color;
@@ -347,8 +364,7 @@
     top: 50%;
     left: 50%;
     opacity: 0;
-    animation: fadeIn .1s linear forwards;
-    animation-delay: .5s;
+    animation: fadeIn @icon-animation-time (@line-grow-animation-time + @semi-circle-animation-time + (@inner-circle-animation-time * 2)) linear forwards;
   }
   .clip1 {
     position: absolute;
@@ -388,7 +404,7 @@
     position: absolute;
     top: @circle-border-width;
     left: @circle-border-width;
-    animation: fadeOut 0.1s (@line-animation-time + @circle-animation-time) linear forwards;
+    animation: fadeOut @inner-circle-animation-time (@line-animation-time + @circle-animation-time) linear forwards;
     .inner-circle-fill {
       box-sizing: border-box;
       height: 100%;

--- a/app/views/directives/build-pipeline.html
+++ b/app/views/directives/build-pipeline.html
@@ -1,10 +1,10 @@
 <div row mobile="column" flex>
-  <div column class="build-summary">  
+  <div column class="build-summary">
     <div>
       <span class="status-icon" ng-class="build.status.phase">
         <span ng-switch="build.status.phase" class="hide-ng-leave">
           <span ng-switch-when="Complete" aria-hidden="true">
-            <i class="fa fa-check-circle"></i> 
+            <i class="fa fa-check-circle"></i>
           </span>
           <span ng-switch-when="Failed" aria-hidden="true">
             <i class="fa fa-times-circle"></i>
@@ -36,8 +36,8 @@
             <div class="pipeline-stage-name" ng-class="build.status.phase">{{stage.name}}</div>
             <pipeline-status ng-if="stage.status" status="stage.status"></pipeline-status>
             <!-- <div class="pipeline-time" ng-if="stage.durationMillis">{{stage.durationMillis | humanizeDurationValue}}</div> -->
-            <div class="pipeline-time" ng-if="stage.durationMillis">{{stage.durationMillis | conciseDuration}}</div>
-            <div class="pipeline-time" ng-if="!stage.durationMillis">not started</div>
+            <div class="pipeline-time" ng-class="stage.status" ng-if="stage.durationMillis">{{stage.durationMillis | timeOnlyDuration}}</div>
+            <div class="pipeline-time" ng-class="stage.status" ng-if="!stage.durationMillis">not started</div>
           </div>
         </div>
       </div>

--- a/app/views/directives/overview-pipeline.html
+++ b/app/views/directives/overview-pipeline.html
@@ -29,7 +29,7 @@
                 <div class="build-bar"></div>
               </div>
               <div class="build-circle">
-                <span ng-if="stage.durationMillis" class="build-time">{{stage.durationMillis | conciseDuration}}</span>
+                <span ng-if="stage.durationMillis" class="build-time">{{stage.durationMillis | timeOnlyDuration}}</span>
               </div>
             </div>
           </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8621,16 +8621,10 @@ return a.metadata.creationTimestamp < b.metadata.creationTimestamp ? c ? 1 :-1 :
 return function(a, b) {
 return moment.duration(a, b).humanize();
 };
-}).filter("conciseDuration", function() {
+}).filter("timeOnlyDuration", function() {
 return function(a) {
-var b = moment.duration(a), c = Math.floor(b.asDays());
-if (c) return c + "d";
-var d = Math.floor(b.asHours());
-if (d) return d + "h";
-var e = Math.floor(b.minutes());
-if (e) return e + "m";
-var f = Math.floor(b.seconds());
-return f + "s";
+var b = [], c = moment.duration(a), d = Math.floor(c.asHours()), e = c.minutes(), f = c.seconds();
+return d || e || f ? (d && b.push(d + "h"), e && b.push(e + "m"), d || b.push(f + "s"), b.join(" ")) :"";
 };
 }), angular.module("openshiftConsole").filter("uid", function() {
 return function(a) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4351,8 +4351,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"pipeline-stage-name\" ng-class=\"build.status.phase\">{{stage.name}}</div>\n" +
     "<pipeline-status ng-if=\"stage.status\" status=\"stage.status\"></pipeline-status>\n" +
     "\n" +
-    "<div class=\"pipeline-time\" ng-if=\"stage.durationMillis\">{{stage.durationMillis | conciseDuration}}</div>\n" +
-    "<div class=\"pipeline-time\" ng-if=\"!stage.durationMillis\">not started</div>\n" +
+    "<div class=\"pipeline-time\" ng-class=\"stage.status\" ng-if=\"stage.durationMillis\">{{stage.durationMillis | timeOnlyDuration}}</div>\n" +
+    "<div class=\"pipeline-time\" ng-class=\"stage.status\" ng-if=\"!stage.durationMillis\">not started</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -5649,7 +5649,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"build-bar\"></div>\n" +
     "</div>\n" +
     "<div class=\"build-circle\">\n" +
-    "<span ng-if=\"stage.durationMillis\" class=\"build-time\">{{stage.durationMillis | conciseDuration}}</span>\n" +
+    "<span ng-if=\"stage.durationMillis\" class=\"build-time\">{{stage.durationMillis | timeOnlyDuration}}</span>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4072,33 +4072,10 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 }
 @keyframes flexShrink{to{-webkit-flex-basis:1;-moz-flex-basis:1;-ms-flex-basis:1;flex-basis:1;-webkit-flex-grow:.000001;-moz-flex-grow:.000001;-ms-flex-grow:.000001;flex-grow:.000001;-webkit-flex-shrink:1;-moz-flex-shrink:1;-ms-flex-shrink:1;flex-shrink:1}
 }
-.pipeline-container{-webkit-flex:1 1 auto;-moz-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;border:1px solid #d1d1d1;overflow:hidden}
-.pipeline{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex-wrap:wrap;-moz-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;height:100%}
-.pipeline .pipeline-stage{border-top:1px solid #d1d1d1;margin:auto 0;min-width:150px;max-width:100%;padding:5px 10px}
-.pipeline .pipeline-stage:first-child{border-top:0}
-.new-stage{-webkit-flex-basis:1;-moz-flex-basis:1;-ms-flex-basis:1;flex-basis:1;-webkit-flex-grow:.000001;-moz-flex-grow:.000001;-ms-flex-grow:.000001;flex-grow:.000001;-webkit-flex-shrink:1;-moz-flex-shrink:1;-ms-flex-shrink:1;flex-shrink:1;animation:flexGrow .5s ease forwards}
-.remove-stage{-webkit-flex:1 1 0%;-moz-flex:1 1 0%;-ms-flex:1 1 0%;flex:1 1 0%;animation:flexShrink .5s ease forwards}
-.pipeline-stage-name,.pipeline-time{font-size:12px;text-align:center}
-.pipeline-stage-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;line-height:initial;margin-bottom:15px}
-.pipeline-stage-name.no-stages{margin:22.5px}
-.pipeline-time{color:#9c9c9c;margin-top:12px}
-.build-summary,.stage{text-align:center;min-width:150px}
-.build-summary .pipeline-link,.stage .pipeline-link{font-size:84%;display:inline-block}
-.build-summary .pipeline-link+.pipeline-link:before,.stage .pipeline-link+.pipeline-link:before{content:'';display:inline-block;border-left:1px solid #d1d1d1;height:10px;margin:0 5px 0 2px}
-.build-stage-animation,.pipeline-status-bar{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex}
-.build-summary,.stages-block{border:1px solid #d1d1d1}
-.build-summary{border-bottom-width:0;padding:10px;-webkit-flex-direction:row;-moz-flex-direction:row;-ms-flex-direction:row;flex-direction:row;-webkit-flex-wrap:wrap;-moz-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-justify-content:space-around;-moz-justify-content:space-around;justify-content:space-around}
-.build-summary .status-icon.Complete{color:#3f9c35}
-.build-summary .status-icon.Failed{color:#c00}
-@media (min-width:480px){.build-summary{border-bottom-width:1px;border-right-width:0;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;-webkit-justify-content:center;-moz-justify-content:center;justify-content:center}
-}
-@media (min-width:768px){.pipeline .pipeline-stage{border-top:0;border-left:1px solid #d1d1d1;margin:10px 0 10px -1px}
-.build-summary{border-right-width:0;-webkit-flex:0 0 200px;-moz-flex:0 0 200px;-ms-flex:0 0 200px;flex:0 0 200px;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;min-height:100px}
-}
-@media (max-width:767px){.pipeline{-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column}
-}
 @keyframes progress-line{from{width:0}
 to{width:100%}
+}
+@keyframes progress-rail{to{transform:translateX(400%)}
 }
 @keyframes progress{from{-webkit-transform:rotate(0);transform:rotate(0)}
 to{-webkit-transform:rotate(180deg);transform:rotate(180deg)}
@@ -4119,6 +4096,32 @@ to{background-color:transparent}
 }
 @keyframes fadeInNotExecuted{to{background-color:#d1d1d1}
 }
+.pipeline-container{-webkit-flex:1 1 auto;-moz-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;border:1px solid #d1d1d1;overflow:hidden}
+.pipeline{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex-wrap:wrap;-moz-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;height:100%}
+.pipeline .pipeline-stage{border-top:1px solid #d1d1d1;margin:auto 0;min-width:150px;max-width:100%;padding:5px 10px}
+.pipeline .pipeline-stage:first-child{border-top:0}
+.new-stage{animation:flexGrow .5s ease forwards;-webkit-flex-basis:1;-moz-flex-basis:1;-ms-flex-basis:1;flex-basis:1;-webkit-flex-grow:.000001;-moz-flex-grow:.000001;-ms-flex-grow:.000001;flex-grow:.000001;-webkit-flex-shrink:1;-moz-flex-shrink:1;-ms-flex-shrink:1;flex-shrink:1}
+.remove-stage{animation:flexShrink .5s ease forwards;-webkit-flex:1 1 0%;-moz-flex:1 1 0%;-ms-flex:1 1 0%;flex:1 1 0%}
+.pipeline-stage-name,.pipeline-time{font-size:12px;text-align:center}
+.pipeline-stage-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;line-height:initial;margin-bottom:15px}
+.pipeline-stage-name.no-stages{margin:22.5px}
+.pipeline-time{margin-top:12px;color:#9c9c9c}
+.pipeline-time.IN_PROGRESS{color:#555}
+.build-summary,.stage{text-align:center;min-width:150px}
+.build-summary .pipeline-link,.stage .pipeline-link{font-size:84%;display:inline-block}
+.build-summary .pipeline-link+.pipeline-link:before,.stage .pipeline-link+.pipeline-link:before{content:'';display:inline-block;border-left:1px solid #d1d1d1;height:10px;margin:0 5px 0 2px}
+.build-stage-animation,.pipeline-status-bar{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex}
+.build-summary,.stages-block{border:1px solid #d1d1d1}
+.build-summary{border-bottom-width:0;padding:10px;-webkit-flex-direction:row;-moz-flex-direction:row;-ms-flex-direction:row;flex-direction:row;-webkit-flex-wrap:wrap;-moz-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-justify-content:space-around;-moz-justify-content:space-around;justify-content:space-around}
+.build-summary .status-icon.Complete{color:#3f9c35}
+.build-summary .status-icon.Failed{color:#c00}
+@media (min-width:480px){.build-summary{border-bottom-width:1px;border-right-width:0;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;-webkit-justify-content:center;-moz-justify-content:center;justify-content:center}
+}
+@media (min-width:768px){.pipeline .pipeline-stage{border-top:0;border-left:1px solid #d1d1d1;margin:10px 0 10px -1px}
+.build-summary{border-right-width:0;-webkit-flex:0 0 200px;-moz-flex:0 0 200px;-ms-flex:0 0 200px;flex:0 0 200px;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;min-height:100px}
+}
+@media (max-width:767px){.pipeline{-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column}
+}
 .pipeline-status-bar .clip1:before,.pipeline-status-bar .clip2:before,.pipeline-status-bar .pipeline-line:before{background-color:#d1d1d1}
 .pipeline-status-bar .inner-circle-fill{background-color:#fff;opacity:0}
 .pipeline-status-bar.SUCCESS .clip1:before,.pipeline-status-bar.SUCCESS .clip2:before,.pipeline-status-bar.SUCCESS .inner-circle-fill,.pipeline-status-bar.SUCCESS .pipeline-line:before{background-color:#3f9c35}
@@ -4127,7 +4130,9 @@ to{background-color:transparent}
 .pipeline-status-bar.FAILED .clip1:before,.pipeline-status-bar.FAILED .clip2:before,.pipeline-status-bar.FAILED .inner-circle-fill,.pipeline-status-bar.FAILED .pipeline-line:before{background-color:#c00}
 .pipeline-status-bar.FAILED .pipeline-circle{animation:fadeInFailed 0s .7s linear forwards}
 .pipeline-status-bar.FAILED .pipeline-circle:after{content:"\f00d"}
-.pipeline-status-bar.IN_PROGRESS .clip1:before,.pipeline-status-bar.IN_PROGRESS .clip2:before,.pipeline-status-bar.IN_PROGRESS .inner-circle-fill,.pipeline-status-bar.IN_PROGRESS .pipeline-line:before{background-color:#0088ce}
+.pipeline-status-bar.IN_PROGRESS .pipeline-line{overflow:hidden}
+.pipeline-status-bar.IN_PROGRESS .pipeline-line:before{animation:progress-rail 6s .5s linear infinite;background-color:#0088ce;transform:translateX(-100%);width:25%}
+.pipeline-status-bar.IN_PROGRESS .clip1:before,.pipeline-status-bar.IN_PROGRESS .clip2:before,.pipeline-status-bar.IN_PROGRESS .inner-circle-fill{background-color:#0088ce}
 .pipeline-status-bar.IN_PROGRESS .pipeline-circle{animation:fadeInProgress 0s .7s linear forwards}
 .pipeline-status-bar.IN_PROGRESS .pipeline-circle:after{content:"\f021"}
 .pipeline-status-bar.NOT_EXECUTED .clip1:before,.pipeline-status-bar.NOT_EXECUTED .clip2:before,.pipeline-status-bar.NOT_EXECUTED .inner-circle-fill,.pipeline-status-bar.NOT_EXECUTED .pipeline-line:before{background-color:#d1d1d1}
@@ -4140,8 +4145,8 @@ to{background-color:transparent}
 .pipeline-status-bar{display:flex;-webkit-align-items:center;-moz-align-items:center;align-items:center;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;margin-bottom:-9px}
 .pipeline-status-bar .pipeline-line{width:100%;height:4px;background:#d1d1d1;position:relative}
 .pipeline-status-bar .pipeline-line:before{content:'';position:absolute;height:100%;animation:progress-line .35s ease-in forwards}
-.pipeline-circle{background:#d1d1d1;width:18px;height:18px;border-radius:9px;margin-top:-11px;position:relative;transform:rotate(-90deg);animation:fadeOut .1s .7s linear forwards}
-.pipeline-circle:after{position:absolute;color:#fff;font-family:FontAwesome;font-size:12px;transform:translate(-50%,-50%) rotate(90deg);top:50%;left:50%;opacity:0;animation:fadeIn .1s linear forwards;animation-delay:.5s}
+.pipeline-circle{background:#d1d1d1;width:18px;height:18px;border-radius:9px;margin-top:-11px;position:relative;transform:rotate(-90deg)}
+.pipeline-circle:after{position:absolute;color:#fff;font-family:FontAwesome;font-size:12px;transform:translate(-50%,-50%) rotate(90deg);top:50%;left:50%;opacity:0;animation:fadeIn .1s 875ms linear forwards}
 .pipeline-circle .clip1:before,.pipeline-circle .clip2:before{width:18px;height:18px;transform:rotate(360deg);border-radius:9px;position:absolute;content:''}
 .pipeline-circle .clip1{position:absolute;clip:rect(0,18px,18px,9px);z-index:-9}
 .pipeline-circle .clip1:before{clip:rect(0,9px,18px,0);animation:progress 175ms .35s linear forwards}


### PR DESCRIPTION
Improvements include:

* making the IN_PROGRESS stage bar animate in a similar fashion to the
way it does on the overview page.
* making the IN_PROGRESS stage time darker to help differentiate it
from other stages where the time is static and represents completion
time, not elapsed time
* changing the display of all stages’ time from seconds or minutes only
to seconds or minutes and seconds or hours and minutes and seconds
* misc pipelines animation cleanup

Note:  this does not address changes to the overview as they are to be covered by https://trello.com/c/Fpx4DBwy/675-2-improved-pipeline-overview-larger-visualization

Fixes #126

Note:  the jankiness of the animation in the screenshots below is a limitation of the fact they're animated gifs.  In-browser, the animation is much more fluid.

![pgsdt9ewzx](https://cloud.githubusercontent.com/assets/895728/16781625/2318d6be-484a-11e6-9796-6b9a8d232701.gif)

![e1so6207tc](https://cloud.githubusercontent.com/assets/895728/16781635/2801b06a-484a-11e6-9861-2ab06545765f.gif)

kudos to @sg00dwin for the assist on this one!

@jwforres, PTAL
