### PR TITLE
Replace osc-key-values with key-value-editor in create from image flow

### DIFF
--- a/app/views/create/fromimage.html
+++ b/app/views/create/fromimage.html
@@ -194,13 +194,15 @@
                                   <i class="pficon pficon-help"></i>
                                 </a>
                               </span></h3>
-                              <osc-key-values
-                                entries="buildConfig.envVars"
-                                delimiter="="
-                                key-validator="env"
-                                delete-policy="added"
-                                key-validation-tooltip="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."></osc-key-values>
+                              <key-value-editor
+                                entries="buildConfigEnvVars"
+                                key-placeholder="name"
+                                value-placeholder="value"
+                                key-validator="[a-zA-Z][a-zA-Z0-9_]*"
+                                key-validator-error-tooltip="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."></key-value-editor>
+
                             </osc-form-section>
+
 
                             <!-- /build config -->
 
@@ -210,8 +212,7 @@
                               about="Deployment configurations describe how your application is configured
                                 by the cluster and under what conditions it should be recreated (e.g. when the image changes)."
                               expand="true"
-                              can-toggle="false"
-                              >
+                              can-toggle="false">
                               <div class="animate-drawer" ng-show="$parent.expand">
                                 <h3>Autodeploy when</h3>
                                 <div class="checkbox">
@@ -228,17 +229,36 @@
                                 </div>
                                 <div>
                                   <h3>Environment Variables (Runtime only) <span class="help action-inline">
-                                    <a href data-toggle="tooltip"
+                                    <a href="" data-toggle="tooltip"
                                        data-original-title="Environment variables are used to configure and pass information to running containers.  These environment variables will only be available at runtime.">
                                       <i class="pficon pficon-help"></i>
                                     </a>
                                   </span></h3>
-                                  <osc-key-values
-                                    entries="deploymentConfig.envVars"
-                                    delimiter="="
-                                    key-validator="env"
-                                    delete-policy="added"
-                                    key-validation-tooltip="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."></osc-key-values>
+                                  <p ng-show="DCEnvVarsFromImage.length">
+                                    <a
+                                      href=""
+                                      ng-click="showDCEnvs = (!showDCEnvs)">
+                                      {{showDCEnvs ? 'Hide' : 'Show'}} image environment variables
+                                    </a>
+                                  </p>
+                                  <div ng-show="showDCEnvs">
+                                    <div class="help-block">
+                                      <p>These variables exist on the image and will be available at runtime. You may override them below.</p>
+                                    </div>
+                                    <key-value-editor
+                                      entries="DCEnvVarsFromImage"
+                                      is-readonly
+                                      cannot-add
+                                      cannot-sort
+                                      cannot-delete></key-value-editor>
+                                  </div>
+                                  <key-value-editor
+                                    entries="DCEnvVarsFromUser"
+                                    key-placeholder="name"
+                                    value-placeholder="value"
+                                    key-validator="[a-zA-Z][a-zA-Z0-9_]*"
+                                    key-validator-error-tooltip="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."></key-value-editor>
+
                                 </div>
                               </div>
                             </osc-form-section>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4815,10 +4815,10 @@ details:a("getErrorDetails")(b)
 }));
 };
 }));
-} ]), angular.module("openshiftConsole").controller("CreateFromImageController", [ "$scope", "Logger", "$q", "$routeParams", "APIService", "DataService", "ProjectsService", "Navigate", "ApplicationGenerator", "LimitRangesService", "MetricsService", "HPAService", "TaskList", "failureObjectNameFilter", "$filter", "$parse", "SOURCE_URL_PATTERN", function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) {
-var r = o("displayName"), s = o("humanize");
+} ]), angular.module("openshiftConsole").controller("CreateFromImageController", [ "$scope", "Logger", "$q", "$routeParams", "APIService", "DataService", "ProjectsService", "Navigate", "ApplicationGenerator", "LimitRangesService", "MetricsService", "HPAService", "TaskList", "failureObjectNameFilter", "$filter", "$parse", "SOURCE_URL_PATTERN", "keyValueEditorUtils", function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) {
+var s = o("displayName"), t = o("humanize");
 a.projectName = d.project, a.sourceURLPattern = q;
-var t = d.imageName;
+var u = d.imageName;
 a.breadcrumbs = [ {
 title:a.projectName,
 link:"project/" + a.projectName
@@ -4826,19 +4826,17 @@ link:"project/" + a.projectName
 title:"Add to Project",
 link:"project/" + a.projectName + "/create"
 }, {
-title:t
+title:u
 } ], g.get(d.project).then(_.spread(function(g, n) {
-function q(b) {
-t || h.toErrorPage("Cannot create from source: a base image was not specified"), d.imageTag || h.toErrorPage("Cannot create from source: a base image tag was not specified"), b.emptyMessage = "Loading...", b.imageName = t, b.imageTag = d.imageTag, b.namespace = d.namespace, b.buildConfig = {
+function p(b) {
+u || h.toErrorPage("Cannot create from source: a base image was not specified"), d.imageTag || h.toErrorPage("Cannot create from source: a base image tag was not specified"), b.emptyMessage = "Loading...", b.imageName = u, b.imageTag = d.imageTag, b.namespace = d.namespace, b.buildConfig = {
 buildOnSourceChange:!0,
 buildOnImageChange:!0,
-buildOnConfigChange:!0,
-envVars:{}
-}, b.deploymentConfig = {
+buildOnConfigChange:!0
+}, b.buildConfigEnvVars = [], b.deploymentConfig = {
 deployOnNewImage:!0,
-deployOnConfigChange:!0,
-envVars:{}
-}, b.routing = {
+deployOnConfigChange:!0
+}, b.DCEnvVarsFromImage, b.DCEnvVarsFromUser = [], b.routing = {
 include:!0,
 portOptions:[]
 }, b.labels = {}, b.annotations = {}, b.scaling = {
@@ -4868,14 +4866,15 @@ var c = b.imageTag;
 f.get("imagestreamtags", a.metadata.name + ":" + c, {
 namespace:b.namespace
 }).then(function(a) {
-b.image = a.image;
-var c = p("dockerImageMetadata.ContainerConfig.Env")(a.image) || [];
-angular.forEach(c, function(a) {
-var c = a.split("=");
-b.deploymentConfig.envVars[c[0]] = c[1];
+b.image = a.image, b.DCEnvVarsFromImage = _.map(_.get(a, "image.dockerImageMetadata.Config.Env"), function(a) {
+var b = a.split("=");
+return {
+name:_.head(b),
+value:_.last(b)
+};
 });
-var d = i.parsePorts(a.image);
-0 === d.length ? (b.routing.include = !1, b.routing.portOptions = []) :(b.routing.portOptions = _.map(d, function(a) {
+var c = i.parsePorts(a.image);
+0 === c.length ? (b.routing.include = !1, b.routing.portOptions = []) :(b.routing.portOptions = _.map(c, function(a) {
 var b = i.getServicePort(a);
 return {
 port:b.name,
@@ -4890,16 +4889,16 @@ h.toErrorPage("Cannot create from source: the specified image could not be retri
 });
 }
 a.project = g, a.breadcrumbs[0].title = o("displayName")(g);
-var u = function() {
+var q = function() {
 a.hideCPU || (a.cpuProblems = j.validatePodLimits(a.limitRanges, "cpu", [ a.container ], g)), a.memoryProblems = j.validatePodLimits(a.limitRanges, "memory", [ a.container ], g);
 };
 f.list("limitranges", n, function(b) {
-a.limitRanges = b.by("metadata.name"), 0 !== o("hashSize")(b) && a.$watch("container", u, !0);
+a.limitRanges = b.by("metadata.name"), 0 !== o("hashSize")(b) && a.$watch("container", q, !0);
 });
 var v = function() {
 return a.scaling.autoscale ? void (a.showCPURequestWarning = !l.hasCPURequest([ a.container ], a.limitRanges, g)) :void (a.showCPURequestWarning = !1);
 };
-a.$watch("scaling.autoscale", v), a.$watch("container", v, !0), q(a);
+a.$watch("scaling.autoscale", v), a.$watch("container", v, !0), p(a);
 var w = function(a, b) {
 function g() {
 0 === k && (i.length > 0 ? h.reject(i) :h.resolve(a));
@@ -4938,13 +4937,13 @@ var c = [], e = !1;
 b.failure.length > 0 ? (e = !0, b.failure.forEach(function(a) {
 c.push({
 type:"error",
-message:"Cannot create " + s(a.object.kind).toLowerCase() + ' "' + a.object.metadata.name + '". ',
+message:"Cannot create " + t(a.object.kind).toLowerCase() + ' "' + a.object.metadata.name + '". ',
 details:a.data.message
 });
 }), b.success.forEach(function(a) {
 c.push({
 type:"success",
-message:"Created " + s(a.kind).toLowerCase() + ' "' + a.metadata.name + '" successfully. '
+message:"Created " + t(a.kind).toLowerCase() + ' "' + a.metadata.name + '" successfully. '
 });
 })) :c.push({
 type:"success",
@@ -4967,9 +4966,9 @@ fromSample:!0
 a.nameTaken = !0, a.disableInputs = !1;
 };
 a.projectDisplayName = function() {
-return r(this.project) || this.projectName;
+return s(this.project) || this.projectName;
 }, a.createApp = function() {
-a.disableInputs = !0;
+a.disableInputs = !0, a.buildConfig.envVars = r.mapEntries(a.buildConfigEnvVars), a.deploymentConfig.envVars = r.mapEntries(a.DCEnvVarsFromUser);
 var c = i.generate(a), d = [];
 angular.forEach(c, function(a) {
 null !== a && (b.debug("Generated resource definition:", a), d.push(a));

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3689,7 +3689,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<i class=\"pficon pficon-help\"></i>\n" +
     "</a>\n" +
     "</span></h3>\n" +
-    "<osc-key-values entries=\"buildConfig.envVars\" delimiter=\"=\" key-validator=\"env\" delete-policy=\"added\" key-validation-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\"></osc-key-values>\n" +
+    "<key-value-editor entries=\"buildConfigEnvVars\" key-placeholder=\"name\" value-placeholder=\"value\" key-validator=\"[a-zA-Z][a-zA-Z0-9_]*\" key-validator-error-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\"></key-value-editor>\n" +
     "</osc-form-section>\n" +
     "\n" +
     "<osc-form-section header=\"Deployment Configuration\" about-title=\"Deployment Configuration\" about=\"Deployment configurations describe how your application is configured\n" +
@@ -3710,11 +3710,22 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div>\n" +
     "<h3>Environment Variables (Runtime only) <span class=\"help action-inline\">\n" +
-    "<a href data-toggle=\"tooltip\" data-original-title=\"Environment variables are used to configure and pass information to running containers.  These environment variables will only be available at runtime.\">\n" +
+    "<a href=\"\" data-toggle=\"tooltip\" data-original-title=\"Environment variables are used to configure and pass information to running containers.  These environment variables will only be available at runtime.\">\n" +
     "<i class=\"pficon pficon-help\"></i>\n" +
     "</a>\n" +
     "</span></h3>\n" +
-    "<osc-key-values entries=\"deploymentConfig.envVars\" delimiter=\"=\" key-validator=\"env\" delete-policy=\"added\" key-validation-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\"></osc-key-values>\n" +
+    "<p ng-show=\"DCEnvVarsFromImage.length\">\n" +
+    "<a href=\"\" ng-click=\"showDCEnvs = (!showDCEnvs)\">\n" +
+    "{{showDCEnvs ? 'Hide' : 'Show'}} image environment variables\n" +
+    "</a>\n" +
+    "</p>\n" +
+    "<div ng-show=\"showDCEnvs\">\n" +
+    "<div class=\"help-block\">\n" +
+    "<p>These variables exist on the image and will be available at runtime. You may override them below.</p>\n" +
+    "</div>\n" +
+    "<key-value-editor entries=\"DCEnvVarsFromImage\" is-readonly cannot-add cannot-sort cannot-delete></key-value-editor>\n" +
+    "</div>\n" +
+    "<key-value-editor entries=\"DCEnvVarsFromUser\" key-placeholder=\"name\" value-placeholder=\"value\" key-validator=\"[a-zA-Z][a-zA-Z0-9_]*\" key-validator-error-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\"></key-value-editor>\n" +
     "</div>\n" +
     "</div>\n" +
     "</osc-form-section>\n" +


### PR DESCRIPTION
Re [this trello card](https://trello.com/c/VYlArUB4) and [this bug ticket](https://bugzilla.redhat.com/show_bug.cgi?id=1354519).
- replaces buildConfig.envVars editor
- replaces deploymentConfig.envVars editor
- Fixes incorrectly referenced DC vars (see bug)

Does not address the key-value-editor within the label-editor (is a separate PR).

@spadgett @jwforres @rhamilto 
