### PR TITLE
Fix route "Show annotations" link margins

### DIFF
--- a/app/views/browse/route.html
+++ b/app/views/browse/route.html
@@ -195,8 +195,8 @@
                   <div ng-if="!route.spec.tls"><em>TLS is not enabled for this route</em></div>
                 </div>
               </div>
+              <annotations annotations="route.metadata.annotations"></annotations>
             </div><!-- /col-* -->
-            <annotations annotations="route.metadata.annotations"></annotations>
           </div>
         </div>
       </div><!-- /middle-content -->

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2779,8 +2779,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"!route.spec.tls\"><em>TLS is not enabled for this route</em></div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "</div>\n" +
     "<annotations annotations=\"route.metadata.annotations\"></annotations>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
The annotations directive was moved outside of the col div, causing this problem:

![screen shot 2016-07-14 at 3 42 00 pm](https://cloud.githubusercontent.com/assets/1167259/16853260/a7752cf6-49d9-11e6-9ba4-385c3d7cd802.png)
