### PR TITLE
Remember collapsed service group state, open by default

### DIFF
--- a/app/scripts/directives/overview/serviceGroup.js
+++ b/app/scripts/directives/overview/serviceGroup.js
@@ -12,10 +12,35 @@ angular.module('openshiftConsole')
       scope: true,
       templateUrl: 'views/overview/_service-group.html',
       link: function($scope) {
-        // Collapse infrastructure services like Jenkins by default on page load.
-        if (ServicesService.isInfrastructure($scope.service)) {
-          $scope.collapse = true;
-        }
+        var localStorageCollapseKey = function() {
+          var uid = _.get($scope, 'service.metadata.uid');
+          if (!uid) {
+            return null;
+          }
+          return 'collapse/service/' + uid;
+        };
+
+        var wasCollapsed = function() {
+          var key = localStorageCollapseKey();
+          if (!key) {
+            return false;
+          }
+
+          return localStorage.getItem(key) === 'true';
+        };
+
+        var saveCollapsedState = function() {
+          var key = localStorageCollapseKey();
+          if (!key) {
+            return;
+          }
+
+          var value = $scope.collapse ? 'true' : 'false';
+          localStorage.setItem(key, value);
+        };
+
+        // Restore previous collapsed state.
+        $scope.collapse = wasCollapsed();
 
         $scope.toggleCollapse = function(e) {
           // Don't collapse when clicking on the route link.
@@ -24,6 +49,7 @@ angular.module('openshiftConsole')
           }
 
           $scope.collapse = !$scope.collapse;
+          saveCollapsedState();
         };
 
         $scope.linkService = function() {

--- a/app/views/overview.html
+++ b/app/views/overview.html
@@ -39,8 +39,7 @@
                 Loading...
               </div>
               <div ng-repeat="service in topLevelServices"
-                   ng-if="service.metadata.labels.app || routesByService[service.metadata.name].length || childServicesByParent[service.metadata.name].length"
-                   ng-init="collapse = (topLevelServices | hashSize) > 2 && !$first">
+                   ng-if="service.metadata.labels.app || routesByService[service.metadata.name].length || childServicesByParent[service.metadata.name].length">
                 <overview-service-group></overview-service-group>
               </div>
 

--- a/app/views/overview/_service-group.html
+++ b/app/views/overview/_service-group.html
@@ -1,7 +1,7 @@
 <div class="service-group">
   <div row tablet="column" class="service-group-header"
        ng-if="service.metadata.labels.app || displayRoute"
-       ng-click="toggleCollapse()"
+       ng-click="toggleCollapse($event)"
        ng-class="{ 'has-app-label': appName }">
     <div ng-if="appName" class="app-name">
       <i class="fa fa-angle-down fa-fw" aria-hidden="true" ng-if="!collapse"></i>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8417,8 +8417,21 @@ restrict:"E",
 scope:!0,
 templateUrl:"views/overview/_service-group.html",
 link:function(e) {
-d.isInfrastructure(e.service) && (e.collapse = !0), e.toggleCollapse = function(a) {
-a && a.target && "A" === a.target.tagName || (e.collapse = !e.collapse);
+var f = function() {
+var a = _.get(e, "service.metadata.uid");
+return a ? "collapse/service/" + a :null;
+}, g = function() {
+var a = f();
+return !!a && "true" === localStorage.getItem(a);
+}, h = function() {
+var a = f();
+if (a) {
+var b = e.collapse ? "true" :"false";
+localStorage.setItem(a, b);
+}
+};
+e.collapse = g(), e.toggleCollapse = function(a) {
+a && a.target && "A" === a.target.tagName || (e.collapse = !e.collapse, h());
 }, e.linkService = function() {
 var c = b.open({
 animation:!0,
@@ -8438,12 +8451,12 @@ details:a("getErrorDetails")(b)
 }, e.$watch("service.metadata.labels.app", function(a) {
 e.appName = a;
 });
-var f = function(a) {
+var i = function(a) {
 var b;
 return _.each(a, function(a) {
 return b ? void (b = c.getPreferredDisplayRoute(b, a)) :void (b = a);
 }), b;
-}, g = function() {
+}, j = function() {
 e.weightByService = {}, e.alternateServices = [], e.totalWeight = 0;
 var a = _.get(e.displayRoute, "spec.to.weight");
 e.weightByService[e.service.metadata.name] = a, e.totalWeight += a;
@@ -8459,7 +8472,7 @@ e.$watch(function() {
 var a = _.get(e, "service.metadata.name");
 return _.get(e, [ "routesByService", a ]);
 }, function(a) {
-e.displayRoute = f(a), e.primaryServiceRoutes = a, g();
+e.displayRoute = i(a), e.primaryServiceRoutes = a, j();
 }), e.$watchGroup([ "service", "childServicesByParent" ], function() {
 e.service && (e.childServices = _.get(e, [ "childServicesByParent", e.service.metadata.name ], []));
 });

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6941,7 +6941,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"renderOptions.showLoading\" class=\"loading-message\">\n" +
     "Loading...\n" +
     "</div>\n" +
-    "<div ng-repeat=\"service in topLevelServices\" ng-if=\"service.metadata.labels.app || routesByService[service.metadata.name].length || childServicesByParent[service.metadata.name].length\" ng-init=\"collapse = (topLevelServices | hashSize) > 2 && !$first\">\n" +
+    "<div ng-repeat=\"service in topLevelServices\" ng-if=\"service.metadata.labels.app || routesByService[service.metadata.name].length || childServicesByParent[service.metadata.name].length\">\n" +
     "<overview-service-group></overview-service-group>\n" +
     "</div>\n" +
     "<div row wrap>\n" +
@@ -7140,7 +7140,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/overview/_service-group.html',
     "<div class=\"service-group\">\n" +
-    "<div row tablet=\"column\" class=\"service-group-header\" ng-if=\"service.metadata.labels.app || displayRoute\" ng-click=\"toggleCollapse()\" ng-class=\"{ 'has-app-label': appName }\">\n" +
+    "<div row tablet=\"column\" class=\"service-group-header\" ng-if=\"service.metadata.labels.app || displayRoute\" ng-click=\"toggleCollapse($event)\" ng-class=\"{ 'has-app-label': appName }\">\n" +
     "<div ng-if=\"appName\" class=\"app-name\">\n" +
     "<i class=\"fa fa-angle-down fa-fw\" aria-hidden=\"true\" ng-if=\"!collapse\"></i>\n" +
     "<i class=\"fa fa-angle-right fa-fw\" aria-hidden=\"true\" ng-if=\"collapse\"></i>\n" +


### PR DESCRIPTION
Leave service groups open by default, but remember the collapsed state between sessions. Since #168, metrics are only loaded for deployments in view, so there is less of a performance concern defaulting to open.

Also fixes an issue where clicking the route link collapsed the section.

@jwforres PTAL