### PR TITLE
Bug 1357389: canI filter blocks some button from displaying

### DIFF
--- a/app/views/browse/routes.html
+++ b/app/views/browse/routes.html
@@ -7,7 +7,7 @@
       <div class="middle-header header-light">
         <div class="container-fluid">
           <div class="page-header page-header-bleed-right page-header-bleed-left">
-            <div class="pull-right" ng-if="'routes' | canI : 'create'">
+            <div class="pull-right" ng-if="project && 'routes' | canI : 'create'">
               <a ng-href="project/{{project.metadata.name}}/create-route" class="btn btn-default">Create Route</a>
             </div>
             <h1>Routes</h1>

--- a/app/views/browse/service.html
+++ b/app/views/browse/service.html
@@ -21,7 +21,7 @@
                    class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
                    data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                 <ul class="dropdown-menu actions action-link">
-                  <li ng-if="'services' | canI : 'create'">
+                  <li ng-if="'routes' | canI : 'create'">
                     <a ng-href="project/{{project.metadata.name}}/create-route?service={{service.metadata.name}}"
                        role="button">Create Route</a>
                   </li>
@@ -76,7 +76,7 @@
                       <dt>Routes:</dt>
                       <dd>
                         <span ng-if="!routesForService.length">
-                          <a ng-href="project/{{project.metadata.name}}/create-route?service={{service.metadata.name}}"  ng-if="'services' | canI : 'create'">Create route</a>
+                          <a ng-href="project/{{project.metadata.name}}/create-route?service={{service.metadata.name}}"  ng-if="'routes' | canI : 'create'">Create route</a>
                         </span>
                         <span ng-repeat="route in routesForService">
                             <span ng-if="route | isWebRoute"><a ng-href="{{route | routeWebURL}}">{{route | routeLabel}}</a></span>

--- a/app/views/settings.html
+++ b/app/views/settings.html
@@ -19,7 +19,7 @@
                    class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
                    data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                 <ul class="dropdown-menu actions action-button">
-                  <li ng-if="!project || 'projects' | canI : 'update'">
+                  <li ng-if="project && 'projects' | canI : 'update'">
                     <a
                       href=""
                       role="button"
@@ -27,7 +27,7 @@
                       ng-click="setEditing(true)"
                       ng-class="{ 'disabled-link': show.editing }">Edit</a>
                   </li>
-                  <li ng-if="!project || 'projects' | canI : 'delete'">
+                  <li ng-if="project && 'projects' | canI : 'delete'">
                     <delete-link
                       class="button-delete"
                       kind="Project"

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2799,7 +2799,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-header header-light\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
-    "<div class=\"pull-right\" ng-if=\"'routes' | canI : 'create'\">\n" +
+    "<div class=\"pull-right\" ng-if=\"project && 'routes' | canI : 'create'\">\n" +
     "<a ng-href=\"project/{{project.metadata.name}}/create-route\" class=\"btn btn-default\">Create Route</a>\n" +
     "</div>\n" +
     "<h1>Routes</h1>\n" +
@@ -2902,7 +2902,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</button>\n" +
     "<a href=\"\" class=\"dropdown-toggle actions-dropdown-kebab visible-xs-inline\" data-toggle=\"dropdown\"><i class=\"fa fa-ellipsis-v\"></i><span class=\"sr-only\">Actions</span></a>\n" +
     "<ul class=\"dropdown-menu actions action-link\">\n" +
-    "<li ng-if=\"'services' | canI : 'create'\">\n" +
+    "<li ng-if=\"'routes' | canI : 'create'\">\n" +
     "<a ng-href=\"project/{{project.metadata.name}}/create-route?service={{service.metadata.name}}\" role=\"button\">Create Route</a>\n" +
     "</li>\n" +
     "<li ng-if=\"'services' | canI : 'update'\">\n" +
@@ -2948,7 +2948,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt>Routes:</dt>\n" +
     "<dd>\n" +
     "<span ng-if=\"!routesForService.length\">\n" +
-    "<a ng-href=\"project/{{project.metadata.name}}/create-route?service={{service.metadata.name}}\" ng-if=\"'services' | canI : 'create'\">Create route</a>\n" +
+    "<a ng-href=\"project/{{project.metadata.name}}/create-route?service={{service.metadata.name}}\" ng-if=\"'routes' | canI : 'create'\">Create route</a>\n" +
     "</span>\n" +
     "<span ng-repeat=\"route in routesForService\">\n" +
     "<span ng-if=\"route | isWebRoute\"><a ng-href=\"{{route | routeWebURL}}\">{{route | routeLabel}}</a></span>\n" +
@@ -7773,10 +7773,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</button>\n" +
     "<a href=\"\" class=\"dropdown-toggle actions-dropdown-kebab visible-xs-inline\" data-toggle=\"dropdown\"><i class=\"fa fa-ellipsis-v\"></i><span class=\"sr-only\">Actions</span></a>\n" +
     "<ul class=\"dropdown-menu actions action-button\">\n" +
-    "<li ng-if=\"!project || 'projects' | canI : 'update'\">\n" +
+    "<li ng-if=\"project && 'projects' | canI : 'update'\">\n" +
     "<a href=\"\" role=\"button\" class=\"button-edit\" ng-click=\"setEditing(true)\" ng-class=\"{ 'disabled-link': show.editing }\">Edit</a>\n" +
     "</li>\n" +
-    "<li ng-if=\"!project || 'projects' | canI : 'delete'\">\n" +
+    "<li ng-if=\"project && 'projects' | canI : 'delete'\">\n" +
     "<delete-link class=\"button-delete\" kind=\"Project\" resource-name=\"{{project.metadata.name}}\" project-name=\"{{project.metadata.name}}\" display-name=\"{{(project | displayName)}}\" type-name-to-confirm=\"true\" alerts=\"alerts\">\n" +
     "</delete-link>\n" +
     "</li>\n" +


### PR DESCRIPTION
The issue was the same as in case of settings page where we had to check if the `project` has been already loaded.
Checked the rest of the buttons where we use the `canI` filter found one additional resource mismatch.
@jwforres PTAL