### PR TITLE
Create persistent volume claim form on console

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -227,6 +227,7 @@
         <script src="scripts/controllers/modals/linkService.js"></script>
         <script src="scripts/controllers/about.js"></script>
         <script src="scripts/controllers/commandLine.js"></script>
+        <script src="scripts/controllers/createPersistentVolumeClaim.js"></script>
         <script src="scripts/directives/date.js"></script>
         <script src="scripts/directives/deleteLink.js"></script>
         <script src="scripts/directives/editLink.js"></script>
@@ -239,6 +240,7 @@
         <script src="scripts/directives/oscImageSummary.js"></script>
         <script src="scripts/directives/oscKeyValues.js"></script>
         <script src="scripts/directives/oscRouting.js"></script>
+        <script src="scripts/directives/oscPersistentVolumeClaim.js"></script>
         <script src="scripts/directives/oscUnique.js"></script>
         <script src="scripts/directives/oscAutoscaling.js"></script>
         <script src="scripts/directives/replicas.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -219,7 +219,11 @@ angular
       .when('/project/:project/edit', {
         templateUrl: 'views/edit/project.html',
         controller: 'EditProjectController'
-      })      
+      })
+      .when('/project/:project/create-pvc', {
+        templateUrl: 'views/create-persistent-volume-claim.html',
+        controller: 'CreatePersistentVolumeClaimController'
+      })
       .when('/project/:project/attach-pvc', {
         templateUrl: 'views/attach-pvc.html',
         controller: 'AttachPVCController'

--- a/app/scripts/controllers/createPersistentVolumeClaim.js
+++ b/app/scripts/controllers/createPersistentVolumeClaim.js
@@ -1,0 +1,83 @@
+'use strict';
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:CreatePersistentVolumeClaimController
+ * @description
+ * # CreatePersistentVolumeClaimController
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('CreatePersistentVolumeClaimController', function ($filter, $routeParams, $scope, $window, ApplicationGenerator, DataService, Navigate, ProjectsService) {
+    $scope.alerts = {};
+    $scope.projectName = $routeParams.project;
+    $scope.accessModes="ReadWriteOnce";
+    $scope.claim = {};
+
+    $scope.breadcrumbs = [
+      {
+        title: $scope.projectName,
+        link: "project/" + $scope.projectName
+      },
+      {
+        title: "Storage",
+        link: "project/" + $scope.projectName + "/browse/storage"
+      },
+      {
+        title: "Request Storage"
+      }
+    ];
+
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+        // Update project breadcrumb with display name.
+        $scope.breadcrumbs[0].title = $filter('displayName')(project);
+
+        $scope.createPersistentVolumeClaim = function() {
+          if ($scope.createPersistentVolumeClaimForm.$valid) {
+            $scope.disableInputs = true;
+            var claim = generatePersistentVolumeClaim();
+            DataService.create('persistentvolumeclaims', null, claim, context)
+              .then(function() { // Success
+                // Return to the previous page
+                $window.history.back();
+              },
+              function(result) { // Failure
+                $scope.disableInputs = false;
+                $scope.alerts['create-persistent-volume-claim'] = {
+                    type: "error",
+                    message: "An error occurred requesting storage claim.",
+                    details: $filter('getErrorDetails')(result)
+                };
+              });
+          }
+        };
+
+      function generatePersistentVolumeClaim() {
+        var pvc = {
+          kind: "PersistentVolumeClaim",
+          apiVersion: "v1",
+          metadata: {
+            name: $scope.claim.name,
+            labels: {}
+          },
+          spec: {
+            resources: {
+              requests:{}
+
+            }
+          }
+        };
+
+        pvc.spec.accessModes = [$scope.claim.accessModes || "ReadWriteOnce"] ;
+        var unit =  $scope.claim.unit || "Mi";
+        pvc.spec.resources.requests.storage = $scope.claim.amount + unit;
+
+        return pvc;
+      }
+
+
+    }));
+  });

--- a/app/scripts/directives/oscPersistentVolumeClaim.js
+++ b/app/scripts/directives/oscPersistentVolumeClaim.js
@@ -1,0 +1,28 @@
+"use strict";
+
+angular.module("openshiftConsole")
+  .directive("oscPersistentVolumeClaim", function(){
+    return {
+      restrict: 'E',
+      scope: {
+        claim: "=model"
+      },
+      templateUrl: 'views/directives/osc-persistent-volume-claim.html',
+      link: function(scope) {
+        scope.claim.unit = 'Mi';
+        scope.units = [{
+          value: "Mi",
+          label: "MiB"
+          }, {
+          value: "Gi",
+          label: "GiB"
+          }, {
+          value: "Ti",
+          label: "TiB"
+          }, {
+          value: "Pi",
+          label: "PiB"
+          }];
+        }
+    };
+  });

--- a/app/views/create-persistent-volume-claim.html
+++ b/app/views/create-persistent-volume-claim.html
@@ -1,0 +1,52 @@
+<default-header class="top-header"></default-header>
+<div class="wrap no-sidebar">
+  <div class="sidebar-left collapse navbar-collapse navbar-collapse-2">
+    <navbar-utility-mobile></navbar-utility-mobile>
+  </div>
+  <div class="middle">
+    <!-- Middle section -->
+    <div class="middle-section surface-shaded">
+      <div class="middle-container has-scroll">
+        <div class="middle-content">
+          <div class="container surface-shaded">
+            <div class="col-md-12">
+              <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
+              <alerts alerts="alerts"></alerts>
+
+              <div class="row">
+                <div class="create-route-icon col-md-2 gutter-top hidden-sm hidden-xs">
+                  <span class="fa fa-hdd-o icon-xl"></span>
+                </div>
+                <div class="col-md-8">
+                  <h1>Request Storage</h1>
+                  <div>
+                    <span class="help-block">
+                      Create a request for an administrator defined storage asset by requesting size and access mode attributes for a best fit.
+                    </span>
+                  </div>
+                  <form name="createPersistentVolumeClaimForm">
+                    <div>
+                      <fieldset ng-disabled="disableInputs">
+                        <osc-persistent-volume-claim
+                          model="claim">
+                        </osc-persistent-volume-claim>
+                        <div class="button-group gutter-top gutter-bottom">
+                          <button type="submit"
+                                  class="btn btn-primary btn-lg"
+                                  ng-click="createPersistentVolumeClaim()"
+                                  ng-disabled="createPersistentVolumeClaimForm.$invalid || disableInputs"
+                                  value="">Create</button>
+                          <a class="btn btn-default btn-lg" href="" back>Cancel</a>
+                        </div>
+                      </fieldset>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div><!-- /middle-content -->
+      </div><!-- /middle-container -->
+    </div><!-- /middle-section -->
+  </div><!-- /middle -->
+</div><!-- /wrap -->

--- a/app/views/directives/osc-persistent-volume-claim.html
+++ b/app/views/directives/osc-persistent-volume-claim.html
@@ -1,0 +1,95 @@
+<ng-form name="persistentVolumeClaimForm">
+  <fieldset ng-disabled="claimDisabled">
+
+    <!-- Name -->
+    <div class="form-group">
+      <label for="claim-name" class="required">Name</label>
+      <input
+        id="claim-name"
+        class="form-control"
+        type="text"
+        name="name"
+        ng-model="claim.name"
+        ng-required="true"
+        ng-pattern="/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/"
+        ng-maxlength="253"
+        ng-minlength="2"
+        placeholder="my-storage-request"
+        select-on-focus
+        autocorrect="off"
+        autocapitalize="off"
+        spellcheck="false"
+        aria-describedby="claim-name-help">
+      <div>
+        <span id="claim-name-help" class="help-block">A unique name for the storage claim within the project.</span>
+      </div>
+      <div class="has-error" ng-show="persistentVolumeClaimForm.name.$error.pattern && persistentVolumeClaimForm.name.$touched && !claimDisabled">
+        <span class="help-block">
+          Claim names may only contain lower-case letters, numbers, and dashes.
+          They may not start or end with a dash. Max length of 253.
+        </span>
+      </div>
+    </div>
+
+    <div class="form-group" >
+      <label class="required">Access Mode</label><br/>
+      <div class="radio">
+
+        <label class="radio-inline">
+            <input type="radio" name="accessModes" ng-model="claim.accessModes" value="ReadWriteOnce" aria-describedby="access-modes-help" ng-checked="true" >
+            Single User (RWO)
+        </label>
+
+        <label class="radio-inline">
+          <input type="radio" id="accessModes" name="accessModes" ng-model="claim.accessModes" value="ReadWriteMany" aria-describedby="access-modes-help" >
+            Shared Access (RWX)
+        </label>
+
+        <label class="radio-inline">
+            <input type="radio" name="accessModes" ng-model="claim.accessModes" value="ReadOnlyMany" aria-describedby="access-modes-help">
+            Read Only (ROX)
+        </label>
+
+      </div>
+      <div>
+        <span id="access-modes-help" class="help-block">Permissions to the mounted volume.</span>
+      </div>
+    </div>
+
+    <!-- capacity -->
+    <div class="form-group">
+      <fieldset class="form-inline compute-resource">
+      <label class="required">Capacity</label>
+      <div ng-class="{ 'has-error': form.$invalid }">
+        <label class="sr-only">Amount</label>
+        <input type="number"
+               name="amount"
+               ng-attr-id="claim-amount"
+               ng-model="claim.amount"
+               ng-required="true"
+               min="0"
+               ng-attr-placeholder="10"
+               class="form-control"
+               ng-attr-aria-describedby="claim-capacity-help">
+        <label class="sr-only" >Unit</label>
+        <select ng-model="claim.unit"
+                name="unit"
+                ng-options="option.value as option.label for option in units"
+                ng-attr-id="claim-capacity-unit"
+                class="form-control inline-select">
+        </select>
+        </div>
+      <div>
+         <span id="claim-capacity-help" class="help-block">
+           Size of the storage request.
+        </span>
+      </div>
+      <div class="has-error" ng-show="persistentVolumeClaimForm.capacity.$error.pattern && persistentVolumeClaimForm.capacity.$touched && !claimDisabled">
+        <span class="help-block">
+          Must be a postive integer.
+        </span>
+      </div>
+      </fieldset>
+    </div>
+  </fieldset>
+</ng-form>

--- a/app/views/storage.html
+++ b/app/views/storage.html
@@ -21,7 +21,12 @@
         <div class="container-fluid">
           <div class="row">
             <div class="col-md-12">
-              <h2>Persistent Volume Claims</h2>
+              <div class="page-header page-header-bleed-right page-header-bleed-left">
+                <div class="pull-right">
+                  <a ng-href="project/{{project.metadata.name}}/create-pvc" class="btn btn-default">Request Storage</a>
+                </div>
+                <h2>Persistent Volume Claims</h2>
+              </div>
               <table class="table table-bordered table-hover table-mobile">
                 <thead>
                   <tr>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -227,6 +227,9 @@ controller:"CreateRouteController"
 }).when("/project/:project/edit", {
 templateUrl:"views/edit/project.html",
 controller:"EditProjectController"
+}).when("/project/:project/create-pvc", {
+templateUrl:"views/create-persistent-volume-claim.html",
+controller:"CreatePersistentVolumeClaimController"
 }).when("/project/:project/attach-pvc", {
 templateUrl:"views/attach-pvc.html",
 controller:"AttachPVCController"
@@ -5847,6 +5850,50 @@ kubernetes:c.VERSION.kubernetes
 c.withUser(), a.cliDownloadURL = d.CLI, a.cliDownloadURLPresent = a.cliDownloadURL && !_.isEmpty(a.cliDownloadURL), a.loginBaseURL = b.openshiftAPIBaseUrl(), a.sessionToken = c.UserStore().getToken(), a.showSessionToken = !1, a.toggleShowSessionToken = function() {
 a.showSessionToken = !a.showSessionToken;
 };
+} ]), angular.module("openshiftConsole").controller("CreatePersistentVolumeClaimController", [ "$filter", "$routeParams", "$scope", "$window", "ApplicationGenerator", "DataService", "Navigate", "ProjectsService", function(a, b, c, d, e, f, g, h) {
+c.alerts = {}, c.projectName = b.project, c.accessModes = "ReadWriteOnce", c.claim = {}, c.breadcrumbs = [ {
+title:c.projectName,
+link:"project/" + c.projectName
+}, {
+title:"Storage",
+link:"project/" + c.projectName + "/browse/storage"
+}, {
+title:"Request Storage"
+} ], h.get(b.project).then(_.spread(function(b, e) {
+function g() {
+var a = {
+kind:"PersistentVolumeClaim",
+apiVersion:"v1",
+metadata:{
+name:c.claim.name,
+labels:{}
+},
+spec:{
+resources:{
+requests:{}
+}
+}
+};
+a.spec.accessModes = [ c.claim.accessModes || "ReadWriteOnce" ];
+var b = c.claim.unit || "Mi";
+return a.spec.resources.requests.storage = c.claim.amount + b, a;
+}
+c.project = b, c.breadcrumbs[0].title = a("displayName")(b), c.createPersistentVolumeClaim = function() {
+if (c.createPersistentVolumeClaimForm.$valid) {
+c.disableInputs = !0;
+var b = g();
+f.create("persistentvolumeclaims", null, b, e).then(function() {
+d.history.back();
+}, function(b) {
+c.disableInputs = !1, c.alerts["create-persistent-volume-claim"] = {
+type:"error",
+message:"An error occurred requesting storage claim.",
+details:a("getErrorDetails")(b)
+};
+});
+}
+};
+}));
 } ]), angular.module("openshiftConsole").directive("relativeTimestamp", function() {
 return {
 restrict:"E",
@@ -6652,6 +6699,29 @@ link:function(a, b, c, d) {
 a.form = d, a.id = _.uniqueId("osc-routing-service-"), a.$watchGroup([ "model.service", "services" ], function() {
 _.has(a, "model.service") && !_.isEmpty(a.services) || _.set(a, "model.service", _.find(a.services));
 });
+}
+};
+}), angular.module("openshiftConsole").directive("oscPersistentVolumeClaim", function() {
+return {
+restrict:"E",
+scope:{
+claim:"=model"
+},
+templateUrl:"views/directives/osc-persistent-volume-claim.html",
+link:function(a) {
+a.claim.unit = "Mi", a.units = [ {
+value:"Mi",
+label:"MiB"
+}, {
+value:"Gi",
+label:"GiB"
+}, {
+value:"Ti",
+label:"TiB"
+}, {
+value:"Pi",
+label:"PiB"
+} ];
 }
 };
 }), angular.module("openshiftConsole").directive("oscUnique", function() {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3331,6 +3331,56 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/create-persistent-volume-claim.html',
+    "<default-header class=\"top-header\"></default-header>\n" +
+    "<div class=\"wrap no-sidebar\">\n" +
+    "<div class=\"sidebar-left collapse navbar-collapse navbar-collapse-2\">\n" +
+    "<navbar-utility-mobile></navbar-utility-mobile>\n" +
+    "</div>\n" +
+    "<div class=\"middle\">\n" +
+    "\n" +
+    "<div class=\"middle-section surface-shaded\">\n" +
+    "<div class=\"middle-container has-scroll\">\n" +
+    "<div class=\"middle-content\">\n" +
+    "<div class=\"container surface-shaded\">\n" +
+    "<div class=\"col-md-12\">\n" +
+    "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
+    "<div class=\"row\">\n" +
+    "<div class=\"create-route-icon col-md-2 gutter-top hidden-sm hidden-xs\">\n" +
+    "<span class=\"fa fa-hdd-o icon-xl\"></span>\n" +
+    "</div>\n" +
+    "<div class=\"col-md-8\">\n" +
+    "<h1>Request Storage</h1>\n" +
+    "<div>\n" +
+    "<span class=\"help-block\">\n" +
+    "Create a request for an administrator defined storage asset by requesting size and access mode attributes for a best fit.\n" +
+    "</span>\n" +
+    "</div>\n" +
+    "<form name=\"createPersistentVolumeClaimForm\">\n" +
+    "<div>\n" +
+    "<fieldset ng-disabled=\"disableInputs\">\n" +
+    "<osc-persistent-volume-claim model=\"claim\">\n" +
+    "</osc-persistent-volume-claim>\n" +
+    "<div class=\"button-group gutter-top gutter-bottom\">\n" +
+    "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-click=\"createPersistentVolumeClaim()\" ng-disabled=\"createPersistentVolumeClaimForm.$invalid || disableInputs\" value=\"\">Create</button>\n" +
+    "<a class=\"btn btn-default btn-lg\" href=\"\" back>Cancel</a>\n" +
+    "</div>\n" +
+    "</fieldset>\n" +
+    "</div>\n" +
+    "</form>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>"
+  );
+
+
   $templateCache.put('views/create-project.html',
     "<default-header class=\"top-header\"></default-header>\n" +
     "<div class=\"wrap no-sidebar\">\n" +
@@ -5557,6 +5607,70 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<kubernetes-object-describer kind=\"{{kind}}\" resource=\"resource\" ng-if=\"resource\"></kubernetes-object-describer>\n" +
     "</div>"
+  );
+
+
+  $templateCache.put('views/directives/osc-persistent-volume-claim.html',
+    "<ng-form name=\"persistentVolumeClaimForm\">\n" +
+    "<fieldset ng-disabled=\"claimDisabled\">\n" +
+    "\n" +
+    "<div class=\"form-group\">\n" +
+    "<label for=\"claim-name\" class=\"required\">Name</label>\n" +
+    "<input id=\"claim-name\" class=\"form-control\" type=\"text\" name=\"name\" ng-model=\"claim.name\" ng-required=\"true\" ng-pattern=\"/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/\" ng-maxlength=\"253\" ng-minlength=\"2\" placeholder=\"my-storage-request\" select-on-focus autocorrect=\"off\" autocapitalize=\"off\" spellcheck aria-describedby=\"claim-name-help\">\n" +
+    "<div>\n" +
+    "<span id=\"claim-name-help\" class=\"help-block\">A unique name for the storage claim within the project.</span>\n" +
+    "</div>\n" +
+    "<div class=\"has-error\" ng-show=\"persistentVolumeClaimForm.name.$error.pattern && persistentVolumeClaimForm.name.$touched && !claimDisabled\">\n" +
+    "<span class=\"help-block\">\n" +
+    "Claim names may only contain lower-case letters, numbers, and dashes. They may not start or end with a dash. Max length of 253.\n" +
+    "</span>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\">\n" +
+    "<label class=\"required\">Access Mode</label><br/>\n" +
+    "<div class=\"radio\">\n" +
+    "<label class=\"radio-inline\">\n" +
+    "<input type=\"radio\" name=\"accessModes\" ng-model=\"claim.accessModes\" value=\"ReadWriteOnce\" aria-describedby=\"access-modes-help\" ng-checked=\"true\">\n" +
+    "Single User (RWO)\n" +
+    "</label>\n" +
+    "<label class=\"radio-inline\">\n" +
+    "<input type=\"radio\" id=\"accessModes\" name=\"accessModes\" ng-model=\"claim.accessModes\" value=\"ReadWriteMany\" aria-describedby=\"access-modes-help\">\n" +
+    "Shared Access (RWX)\n" +
+    "</label>\n" +
+    "<label class=\"radio-inline\">\n" +
+    "<input type=\"radio\" name=\"accessModes\" ng-model=\"claim.accessModes\" value=\"ReadOnlyMany\" aria-describedby=\"access-modes-help\">\n" +
+    "Read Only (ROX)\n" +
+    "</label>\n" +
+    "</div>\n" +
+    "<div>\n" +
+    "<span id=\"access-modes-help\" class=\"help-block\">Permissions to the mounted volume.</span>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "\n" +
+    "<div class=\"form-group\">\n" +
+    "<fieldset class=\"form-inline compute-resource\">\n" +
+    "<label class=\"required\">Capacity</label>\n" +
+    "<div ng-class=\"{ 'has-error': form.$invalid }\">\n" +
+    "<label class=\"sr-only\">Amount</label>\n" +
+    "<input type=\"number\" name=\"amount\" ng-attr-id=\"claim-amount\" ng-model=\"claim.amount\" ng-required=\"true\" min=\"0\" ng-attr-placeholder=\"10\" class=\"form-control\" ng-attr-aria-describedby=\"claim-capacity-help\">\n" +
+    "<label class=\"sr-only\">Unit</label>\n" +
+    "<select ng-model=\"claim.unit\" name=\"unit\" ng-options=\"option.value as option.label for option in units\" ng-attr-id=\"claim-capacity-unit\" class=\"form-control inline-select\">\n" +
+    "</select>\n" +
+    "</div>\n" +
+    "<div>\n" +
+    "<span id=\"claim-capacity-help\" class=\"help-block\">\n" +
+    "Size of the storage request.\n" +
+    "</span>\n" +
+    "</div>\n" +
+    "<div class=\"has-error\" ng-show=\"persistentVolumeClaimForm.capacity.$error.pattern && persistentVolumeClaimForm.capacity.$touched && !claimDisabled\">\n" +
+    "<span class=\"help-block\">\n" +
+    "Must be a postive integer.\n" +
+    "</span>\n" +
+    "</div>\n" +
+    "</fieldset>\n" +
+    "</div>\n" +
+    "</fieldset>\n" +
+    "</ng-form>"
   );
 
 
@@ -8573,7 +8687,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
+    "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
+    "<div class=\"pull-right\">\n" +
+    "<a ng-href=\"project/{{project.metadata.name}}/create-pvc\" class=\"btn btn-default\">Request Storage</a>\n" +
+    "</div>\n" +
     "<h2>Persistent Volume Claims</h2>\n" +
+    "</div>\n" +
     "<table class=\"table table-bordered table-hover table-mobile\">\n" +
     "<thead>\n" +
     "<tr>\n" +


### PR DESCRIPTION
This adds a new request button to the storage page that allows users to request a very simple storage claim.  The new form currently only allows for 3 basic inputs, which are sufficient to create a new PVC.
@jwforres @erinboyd 