### PR TITLE
Permissive mode for the what-can-i-do authorization

### DIFF
--- a/app/scripts/services/authorization.js
+++ b/app/scripts/services/authorization.js
@@ -1,12 +1,14 @@
 'use strict';
 
 angular.module("openshiftConsole")
-  .factory("AuthorizationService", function($q, $cacheFactory, Logger, $interval, DataService){
+  .factory("AuthorizationService", function($q, $cacheFactory, Logger, $interval, APIService, DataService){
     
     var currentProject = null;
     var cachedRulesByProject = $cacheFactory('rulesCache', {
           number: 10
         });
+    // Permisive mode will cause no checks to be done for the user actions.
+    var permissiveMode = false;
 
     var REVIEW_RESOURCES = ["localresourceaccessreviews", "localsubjectaccessreviews", "resourceaccessreviews", "selfsubjectrulesreviews", "subjectaccessreviews"];
 
@@ -40,7 +42,7 @@ angular.module("openshiftConsole")
     };
 
     // Check if user can create/update any resource on the 'Add to project' so the button will be displayed.
-    var canAddToProject = function(rules) {
+    var canAddToProjectCheck = function(rules) {
       return _.some(rules, function(rule) {
         return _.some(rule.resources, function(resource) {
           return checkResource(resource) && !_.isEmpty(_.intersection(rule.verbs ,(["*", "create", "update"])));
@@ -52,24 +54,33 @@ angular.module("openshiftConsole")
       var deferred = $q.defer();
       currentProject = projectName;
       var projectRules = cachedRulesByProject.get(projectName);
+      var rulesResource = "selfsubjectrulesreviews";
       if (!projectRules || projectRules.forceRefresh) {
-        Logger.log("AuthorizationService, loading user rules for " + projectName + " project");
-        var object = {kind: "SelfSubjectRulesReview",
-                      apiVersion: "v1"
-                    };
-        DataService.create('selfsubjectrulesreviews', null, object, {namespace: projectName}).then(
-          function(data) {
-            var normalizedData = normalizeRules(data.status.rules);
-            var canUserAddToProject = canAddToProject(data.status.rules);
-            cachedRulesByProject.put(projectName, {rules: normalizedData,
-                                                        canAddToProject: canUserAddToProject,
-                                                        forceRefresh: false,
-                                                        cacheTimestamp: _.now()
-                                                      });
-            deferred.resolve();
-          }, function() {
-            deferred.reject();
-        });
+        // Check if APIserver contains 'selfsubjectrulesreviews' resource. If not switch to permissive mode.
+        if (APIService.apiInfo(rulesResource)) {
+          Logger.log("AuthorizationService, loading user rules for " + projectName + " project");
+          var object = {kind: "SelfSubjectRulesReview",
+                        apiVersion: "v1"
+                      };
+          DataService.create(rulesResource, null, object, {namespace: projectName}).then(
+            function(data) {
+              var normalizedData = normalizeRules(data.status.rules);
+              var canUserAddToProject = canAddToProjectCheck(data.status.rules);
+              cachedRulesByProject.put(projectName, {rules: normalizedData,
+                                                      canAddToProject: canUserAddToProject,
+                                                      forceRefresh: false,
+                                                      cacheTimestamp: _.now()
+                                                    });
+              deferred.resolve();
+            }, function() {
+              permissiveMode = true;
+              deferred.resolve();
+          });
+        } else {
+          Logger.log("AuthorizationService, resource 'selfsubjectrulesreviews' is not part of APIserver. Switching into permissive mode.");
+          permissiveMode = true;
+          deferred.resolve();
+        }
       } else {
         // Using cached data.
         Logger.log("AuthorizationService, using cached rules for " + projectName + " project");
@@ -88,7 +99,9 @@ angular.module("openshiftConsole")
     var canI = function(verb, resource, projectName) {
       projectName = projectName || currentProject;
       var rules = getRulesForProject(projectName);
-      if (rules) {
+      if (permissiveMode) {
+        return true;
+      } else if (rules) {
         if (rules[resource]) {
           return _.contains(rules[resource], verb) || _.contains(rules[resource], '*');
         } else if (rules['*']) {
@@ -102,7 +115,11 @@ angular.module("openshiftConsole")
     };
 
     var canIAddToProject = function(projectName) {
-      return !!_.get(cachedRulesByProject.get(projectName || currentProject), ['canAddToProject']);
+      if (permissiveMode) {
+        return true;
+      } else {
+        return !!_.get(cachedRulesByProject.get(projectName || currentProject), ['canAddToProject']);
+      }
     };
 
     return {

--- a/app/scripts/services/projects.js
+++ b/app/scripts/services/projects.js
@@ -38,13 +38,6 @@ angular.module('openshiftConsole')
                                           context.projectPromise.resolve(project);
                                           // TODO: fix need to return context & projectPromise
                                           return [project, context];
-                                        }, function() {
-                                          $location.url(URI('error')
-                                                    .query({
-                                                      "error" : 'error',
-                                                      "error_description": 'User permissions for project ' + projectName + ' could not be loaded.'
-                                                    })
-                                                    .toString());
                                         });
                               }, function(e) {
                                 context.projectPromise.reject(e);


### PR DESCRIPTION
@jwforres @liggitt I've update the `AuthorizationService` so before loading projects rules it will check with the `ApiService.apiInfo()` if it's aware of the 'selfsubjectrulesreviews'. If not, that means that the console is running against older APIserver, then set the "permissive mode" in which `canI` and `canIAddToProject` will return `true` without checking anything and all the action buttons will be rendered. If the 'selfsubjectrulesreviews' type is present in the APIserver then do the regular checks to determine if the action buttons shall be rendered.
PTAL

Closes https://github.com/openshift/origin-web-console/issues/176