### PR TITLE
Reducing width of project picker at medium screen sizes

### DIFF
--- a/app/styles/_project-menu.less
+++ b/app/styles/_project-menu.less
@@ -153,7 +153,7 @@
     float: left;
     margin: 0;
     padding-top: 0;
-    max-width: 450px; // Default project menu width
+    max-width: 400px; // Default project menu width
     .bootstrap-select.btn-group {
       .btn {
         padding: 15px 50px 15px 30px;
@@ -176,7 +176,7 @@
     .bootstrap-select .dropdown-toggle {
       height: 60px;
       max-width: 330px;
-      min-width: 300px;
+      min-width: 280px;
     }
   }
 }

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4204,12 +4204,12 @@ to{background-color:transparent}
 }
 @media (min-width:480px){.navbar-project-menu .bootstrap-select.btn-group .btn .filter-option{max-width:310px}
 }
-@media (min-width:768px){.navbar-project-menu{border-bottom:0;border-top:0;float:left;margin:0;padding-top:0;max-width:450px}
+@media (min-width:768px){.navbar-project-menu{border-bottom:0;border-top:0;float:left;margin:0;padding-top:0;max-width:400px}
 .navbar-project-menu .bootstrap-select.btn-group .btn{padding:15px 50px 15px 30px}
 .navbar-project-menu .bootstrap-select.btn-group .btn:before{color:#9c9c9c;content:'Project';font-size:10px;left:30px;position:absolute;top:8px}
 .navbar-project-menu .bootstrap-select.btn-group .btn .filter-option{max-width:470px}
 .navbar-project-menu .bootstrap-select.btn-group .dropdown-toggle .caret{right:30px}
-.navbar-project-menu .bootstrap-select .dropdown-toggle{height:60px;max-width:330px;min-width:300px}
+.navbar-project-menu .bootstrap-select .dropdown-toggle{height:60px;max-width:330px;min-width:280px}
 }
 @media (min-width:992px){.navbar-project-menu,.navbar-project-menu .bootstrap-select .dropdown-toggle{max-width:500px}
 }


### PR DESCRIPTION
in order to accommodate the wider sidebar

@sg00dwin, sanity check, please?   note:  this does not address the existing issue where the presence of an extension point navbar-utilty causes navbar-utility to wrap at viewport sizes 768 - ~ 810.  I filed https://github.com/openshift/origin-web-console/issues/197 about that.