### PR TITLE
Fix issue #204, log link throws js error

### DIFF
--- a/app/scripts/services/logLinks.js
+++ b/app/scripts/services/logLinks.js
@@ -60,7 +60,7 @@ angular.module('openshiftConsole')
       };
 
       // broken up for readability:
-      var template = new URITemplate([
+      var template = _.template([
         "/#/discover?",
         "_g=(",
           "time:(",
@@ -71,25 +71,25 @@ angular.module('openshiftConsole')
         ")",
         "&_a=(",
           //"columns:!(_source),",
-          "columns:!(kubernetes_container_name,{containername}),",
-          "index:'{namespace}.*',",
+          "columns:!(kubernetes_container_name,<%= containername %>),", 
+          "index:'<%= namespace %>.*',",
           "query:(",
             "query_string:(",
               "analyze_wildcard:!t,",
-              "query:'kubernetes_pod_name: {podname} %26%26 kubernetes_namespace_name: {namespace}'",
+              "query:'kubernetes_pod_name: <%= podname %> %26%26 kubernetes_namespace_name: <%= namespace %>'",
             ")",
           "),",
           "sort:!(time,desc)",
         ")",
         // NOTE: slightly older versions of kibana require openshift_ prefix, not console_
-        "#console_container_name={containername}",
+        "#console_container_name=<%= containername %>",
         // backlink should be encoded.  passing URI.encode(backlink) should be sufficient
-        "&console_back_url={backlink}"
+        "&console_back_url=<%= backlink %>"
       ].join(''));
 
 
       var archiveUri = function(opts) {
-        return template.expand(opts);
+        return template(opts);
       };
 
       return {

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -9879,8 +9879,8 @@ var b = {
 view:"chromeless"
 };
 a && a.container && (b.container = a.container), h(b);
-}, j = new URITemplate([ "/#/discover?", "_g=(", "time:(", "from:now-1w,", "mode:relative,", "to:now", ")", ")", "&_a=(", "columns:!(kubernetes_container_name,{containername}),", "index:'{namespace}.*',", "query:(", "query_string:(", "analyze_wildcard:!t,", "query:'kubernetes_pod_name: {podname} %26%26 kubernetes_namespace_name: {namespace}'", ")", "),", "sort:!(time,desc)", ")", "#console_container_name={containername}", "&console_back_url={backlink}" ].join("")), k = function(a) {
-return j.expand(a);
+}, j = _.template([ "/#/discover?", "_g=(", "time:(", "from:now-1w,", "mode:relative,", "to:now", ")", ")", "&_a=(", "columns:!(kubernetes_container_name,<%= containername %>),", "index:'<%= namespace %>.*',", "query:(", "query_string:(", "analyze_wildcard:!t,", "query:'kubernetes_pod_name: <%= podname %> %26%26 kubernetes_namespace_name: <%= namespace %>'", ")", "),", "sort:!(time,desc)", ")", "#console_container_name=<%= containername %>", "&console_back_url=<%= backlink %>" ].join("")), k = function(a) {
+return j(a);
 };
 return {
 scrollTop:e,


### PR DESCRIPTION
Fixes #204 

Swapping out `URITemplate()` for `_.template()`, very similar API, I suspect lodash doesn't fuss because it just sees a string and isn't trying to conform to a spec about URIs.

generated:
```
/#/discover?_g=(time:(from:now-1w,mode:relative,to:now))&_a=(columns:!(kubernetes_container_name,ruby-sample-build-12-build),index:'muh-rubies.*',query:(query_string:(analyze_wildcard:!t,query:'kubernetes_pod_name: ruby-sample-build-12 %26%26 kubernetes_namespace_name: muh-rubies')),sort:!(time,desc))#console_container_name=ruby-sample-build-12-build&console_back_url=https%3A%2F%2Flocalhost%3A9000%2Fproject%2Fmuh-rubies%2Fbrowse%2Fbuilds%2Fruby-sample-build%2Fruby-sample-build-12
```

