### PR TITLE
Fix storage capacity values on  Storage page table view

### DIFF
--- a/app/views/storage.html
+++ b/app/views/storage.html
@@ -45,11 +45,11 @@
                     </td>
                     <td data-title="Capacity">
                       <span ng-if="pvc.spec.volumeName">
-                        <span ng-if="pvc.status.capacity['storage']">{{pvc.status.capacity['storage'] | usageWithUnits: 'storage'}}</span>
-                        <span ng-if="!pvc.status.capacity['storage']">unknown</span>
+                        <span ng-if="pvc.spec.resources.requests['storage']">{{pvc.spec.resources.requests['storage']}}</span>
+                        <span ng-if="!pvc.spec.resources.requests['storage']">unknown</span>
                       </span>
                       <span ng-if="!pvc.spec.volumeName">
-                        <span>-</span>
+                        <span ng-if="pvc.spec.resources.requests['storage']">{{pvc.spec.resources.requests['storage']}} Requested</span>
                       </span>
                     </td>
                     <td data-title="Access Modes">{{pvc.spec.accessModes | accessModes:'long' | join}}</td>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8435,11 +8435,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</td>\n" +
     "<td data-title=\"Capacity\">\n" +
     "<span ng-if=\"pvc.spec.volumeName\">\n" +
-    "<span ng-if=\"pvc.status.capacity['storage']\">{{pvc.status.capacity['storage'] | usageWithUnits: 'storage'}}</span>\n" +
-    "<span ng-if=\"!pvc.status.capacity['storage']\">unknown</span>\n" +
+    "<span ng-if=\"pvc.spec.resources.requests['storage']\">{{pvc.spec.resources.requests['storage']}}</span>\n" +
+    "<span ng-if=\"!pvc.spec.resources.requests['storage']\">unknown</span>\n" +
     "</span>\n" +
     "<span ng-if=\"!pvc.spec.volumeName\">\n" +
-    "<span>-</span>\n" +
+    "<span ng-if=\"pvc.spec.resources.requests['storage']\">{{pvc.spec.resources.requests['storage']}} Requested</span>\n" +
     "</span>\n" +
     "</td>\n" +
     "<td data-title=\"Access Modes\">{{pvc.spec.accessModes | accessModes:'long' | join}}</td>\n" +


### PR DESCRIPTION
The storage capacity is no longer being returned in the API call for PVCs.  I have changed the table view of the pvc values so that the "Capacity" column gets it value from the requests[storage] instead of capacity[storage].  I cannot find anything in the docs that says this was an intentional change to the API but I thought it was best to have this working properly.