### PR TITLE
Fix problem with parse-error directive close button

### DIFF
--- a/app/scripts/directives/parseError.js
+++ b/app/scripts/directives/parseError.js
@@ -7,6 +7,11 @@ angular.module('openshiftConsole')
       scope: {
         error: '='
       },
-      templateUrl: 'views/_parse-error.html'
+      templateUrl: 'views/_parse-error.html',
+      link: function($scope) {
+        $scope.$watch('error', function() {
+          $scope.hidden = false;
+        });
+      }
     };
   });

--- a/app/views/_parse-error.html
+++ b/app/views/_parse-error.html
@@ -1,5 +1,5 @@
-<div ng-show="error" class="alert alert-danger">
-  <button ng-click="error = null" type="button" class="close" aria-hidden="true">
+<div ng-show="error && !hidden" class="alert alert-danger">
+  <button ng-click="hidden = true" type="button" class="close" aria-hidden="true">
     <span class="pficon pficon-close"></span>
   </button>
   <span class="pficon pficon-error-circle-o"></span>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -6867,7 +6867,12 @@ restrict:"E",
 scope:{
 error:"="
 },
-templateUrl:"views/_parse-error.html"
+templateUrl:"views/_parse-error.html",
+link:function(a) {
+a.$watch("error", function() {
+a.hidden = !1;
+});
+}
 };
 }), angular.module("openshiftConsole").directive("toggle", function() {
 return {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -251,8 +251,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/_parse-error.html',
-    "<div ng-show=\"error\" class=\"alert alert-danger\">\n" +
-    "<button ng-click=\"error = null\" type=\"button\" class=\"close\" aria-hidden=\"true\">\n" +
+    "<div ng-show=\"error && !hidden\" class=\"alert alert-danger\">\n" +
+    "<button ng-click=\"hidden = true\" type=\"button\" class=\"close\" aria-hidden=\"true\">\n" +
     "<span class=\"pficon pficon-close\"></span>\n" +
     "</button>\n" +
     "<span class=\"pficon pficon-error-circle-o\"></span>\n" +


### PR DESCRIPTION
New errors were not displayed after the first error is dismissed.

@jwforres PTAL