### PR TITLE
Add an events sidebar directive

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -230,6 +230,7 @@
         <script src="scripts/directives/deleteLink.js"></script>
         <script src="scripts/directives/editLink.js"></script>
         <script src="scripts/directives/events.js"></script>
+        <script src="scripts/directives/eventsSidebar.js"></script>
         <script src="scripts/directives/fromFile.js"></script>
         <script src="scripts/directives/oscFileInput.js"></script>
         <script src="scripts/directives/oscFormSection.js"></script>

--- a/app/scripts/directives/eventsSidebar.js
+++ b/app/scripts/directives/eventsSidebar.js
@@ -1,0 +1,27 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .directive('eventsSidebar', function($filter, DataService, Logger) {
+    return {
+      restrict: 'E',
+      scope: {
+        projectContext: "="
+      },
+      templateUrl: 'views/directives/events-sidebar.html',
+      controller: function($scope) {
+        var watches = [];
+        var sort = $filter('orderObjectsByDate');
+        watches.push(DataService.watch("events", $scope.projectContext, function(eventData) {
+          var events = eventData.by('metadata.name');
+          $scope.events = sort(events, true);
+          $scope.warningCount = _.size(_.filter(events, { type: 'Warning' }));
+          Logger.log("events (subscribe)", $scope.events);
+        }));
+
+        $scope.$on('$destroy', function() {
+          DataService.unwatchAll(watches);
+        });
+      },
+    };
+  });
+

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -1044,6 +1044,21 @@ angular.module('openshiftConsole')
       return humanized.toLowerCase();
     };
   })
+  .filter('abbreviateKind', function() {
+    var abbreviated = {
+      Build: 'build',
+      BuildConfig: 'bc',
+      DeploymentConfig: 'dc',
+      ImageStream: 'is',
+      Pod: 'pod',
+      ReplicationController: 'rc',
+      Route: 'route',
+      Service: 'svc',
+    };
+    return function(kind) {
+      return abbreviated[kind] || kind;
+    };
+  })
   .filter('kindToResource', function (APIService) {
     return APIService.kindToResource;
   })

--- a/app/styles/_sidebar.less
+++ b/app/styles/_sidebar.less
@@ -173,18 +173,6 @@
         padding-top: 0;
       }
     }
-    .dl-horizontal {
-      margin: 0 0 @line-height-computed;
-      dt {
-        text-align: left;
-      }
-      dd {
-        .word-break();
-      }
-    }
-    .sidebar-help {
-      color: @gray-light;
-    }
   }
 }
 
@@ -268,23 +256,6 @@
   }
 }
 
-@media (min-width: @screen-sm-min) and (max-width: @screen-md-max) {
-  .show-sidebar-right {
-    .sidebar-right {
-      .dl-horizontal {
-        dt {
-          float: none;
-          width: auto;
-        }
-        dd {
-          margin-left: 0;
-          margin-bottom: (@line-height-computed / 2);
-        }
-      }
-    }
-  }
-}
-
 @media (min-width: @screen-lg-min) {
   .sidebar-left {
     .navbar-sidebar {
@@ -331,16 +302,73 @@
       }
     }
   }
-  .show-sidebar-right {
-    .sidebar-right {
-        .dl-horizontal {
-          dt {
-            width: 49%;
+}
+
+.events-sidebar {
+  .pficon {
+    vertical-align: middle;
+  }
+  .sidebar-header {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    h2 {
+      .h5();
+      display: inline-block;
+    }
+    .event-details-link {
+      .small();
+      margin-right: 30px;
+    }
+  }
+  .right-content {
+    .event {
+      display: flex;
+      align-items: center;
+      margin-bottom: 10px;
+      .event-icon {
+        font-size: 18px;
+        margin-right: 10px;
+      }
+      .event-details {
+        .truncate();
+        flex-grow: 1;
+        .detail-group {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-between;
+        }
+        .event-reason, .event-object, .event-message {
+          .truncate();
+        }
+        .event-message {
+          .small();
+        }
+        .event-timestamp {
+          .small();
+          .text-muted();
+        }
+        @media (min-width: @screen-lg-min) {
+          .detail-group {
+            flex-direction: row;
           }
-          dd {
-            margin-left: 50%;
+          .event-object {
+            order: 1;
+          }
+          .event-reason {
+            order: 2;
+          }
+          .event-timestamp {
+            .text-right();
+            margin-left: 5px;
+            min-width: 100px;
           }
         }
+      }
+    }
+    .event + .event {
+      border-top: 1px solid #ededed;
+      padding-top: 10px;
     }
   }
 }

--- a/app/views/_project-page.html
+++ b/app/views/_project-page.html
@@ -1,4 +1,4 @@
-<div ng-class="{'show-sidebar-right': renderOptions.showSidebarRight}" class="wrap">
+<div ng-class="{'show-sidebar-right': renderOptions.showEventsSidebar}" class="wrap">
   <div class="sidebar-left collapse navbar-collapse navbar-collapse-1">
     <sidebar></sidebar>
   </div>
@@ -7,16 +7,9 @@
 
     </div>
   </div>
-  <div class="sidebar-right sidebar-pf sidebar-pf-right">
+  <div ng-if="renderOptions.showEventsSidebar" class="sidebar-right sidebar-pf sidebar-pf-right">
     <div class="right-section">
-      <div class="right-container">
-        <div class="sidebar-header right-header">
-            <h2 class="h5">Details</h2>
-        </div>
-        <div class="right-content">
-          <osc-object-describer></osc-object-describer>
-        </div>
-      </div>
+      <events-sidebar ng-if="projectContext" project-context="projectContext"></events-sidebar>
     </div><!-- /right-section -->
   </div>
 </div>

--- a/app/views/directives/events-sidebar.html
+++ b/app/views/directives/events-sidebar.html
@@ -1,0 +1,63 @@
+<div class="right-container events-sidebar">
+  <div class="sidebar-header right-header">
+    <div>
+      <h2>
+        Events
+        <small ng-if="warningCount" class="mar-left-sm">
+          <span class="pficon pficon-warning-triangle-o"></span>
+          {{warningCount}}
+          <span class="hidden-xs hidden-sm">
+            <span ng-if="warningCount === 1">warning</span>
+            <span ng-if="warningCount > 1">warnings</span>
+          </span>
+        </small>
+      </h2>
+    </div>
+    <div ng-if="events | hashSize" class="event-details-link">
+      <a ng-href="project/{{projectContext.projectName}}/browse/events">View Details</a>
+    </div>
+  </div>
+  <div class="right-content">
+    <div ng-if="!events">
+      Loading...
+    </div>
+    <div ng-if="events">
+      <div ng-if="!(events | hashSize)">
+        <em>No events.</em>
+      </div>
+      <div ng-repeat="event in events" class="event animate-repeat">
+        <span class="sr-only">{{event.type}}</span>
+        <div class="event-icon" aria-hidden="true">
+          <div ng-switch="event.type" class="hide-ng-leave">
+            <span ng-switch-when="Warning" class="pficon pficon-warning-triangle-o"></span>
+            <span ng-switch-when="Normal" class="pficon pficon-info text-muted"></span>
+          </div>
+        </div>
+        <div class="event-details">
+          <div class="detail-group">
+            <div class="event-reason">
+              {{event.reason | sentenceCase}}
+            </div>
+            <div class="event-object">
+              {{event.involvedObject.kind | abbreviateKind}}/{{event.involvedObject.name}}
+            </div>
+          </div>
+          <div class="detail-group">
+            <div class="event-message">
+              {{event.message}}
+            </div>
+            <div class="event-timestamp">
+              <relative-timestamp timestamp="event.lastTimestamp"></relative-timestamp>
+            </div>
+          </div>
+          <div ng-if="event.count > 1" class="text-muted small">
+            {{event.count}} times in the last
+            <duration-until-now timestamp="event.firstTimestamp" omit-single="true" precision="1"></duration-until-now>
+          </div>
+          <div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -6011,6 +6011,25 @@ c.unwatchAll(m);
 });
 } ]
 };
+} ]), angular.module("openshiftConsole").directive("eventsSidebar", [ "$filter", "DataService", "Logger", function(a, b, c) {
+return {
+restrict:"E",
+scope:{
+projectContext:"="
+},
+templateUrl:"views/directives/events-sidebar.html",
+controller:[ "$scope", function(d) {
+var e = [], f = a("orderObjectsByDate");
+e.push(b.watch("events", d.projectContext, function(a) {
+var b = a.by("metadata.name");
+d.events = f(b, !0), d.warningCount = _.size(_.filter(b, {
+type:"Warning"
+})), c.log("events (subscribe)", d.events);
+})), d.$on("$destroy", function() {
+b.unwatchAll(e);
+});
+} ]
+};
 } ]), angular.module("openshiftConsole").directive("fromFile", [ "$q", "$uibModal", "$location", "$filter", "CachedTemplateService", "AlertMessageService", "Navigate", "TaskList", "DataService", "APIService", function(a, b, c, d, e, f, g, h, i, j) {
 return {
 restrict:"E",
@@ -9477,7 +9496,21 @@ if (!a) return a;
 var c = _.startCase(a);
 return b ? c :c.toLowerCase();
 };
-} ]).filter("kindToResource", [ "APIService", function(a) {
+} ]).filter("abbreviateKind", function() {
+var a = {
+Build:"build",
+BuildConfig:"bc",
+DeploymentConfig:"dc",
+ImageStream:"is",
+Pod:"pod",
+ReplicationController:"rc",
+Route:"route",
+Service:"svc"
+};
+return function(b) {
+return a[b] || b;
+};
+}).filter("kindToResource", [ "APIService", function(a) {
 return a.kindToResource;
 } ]).filter("humanizeQuotaResource", function() {
 return function(a) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -474,7 +474,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/_project-page.html',
-    "<div ng-class=\"{'show-sidebar-right': renderOptions.showSidebarRight}\" class=\"wrap\">\n" +
+    "<div ng-class=\"{'show-sidebar-right': renderOptions.showEventsSidebar}\" class=\"wrap\">\n" +
     "<div class=\"sidebar-left collapse navbar-collapse navbar-collapse-1\">\n" +
     "<sidebar></sidebar>\n" +
     "</div>\n" +
@@ -482,16 +482,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-transclude>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"sidebar-right sidebar-pf sidebar-pf-right\">\n" +
+    "<div ng-if=\"renderOptions.showEventsSidebar\" class=\"sidebar-right sidebar-pf sidebar-pf-right\">\n" +
     "<div class=\"right-section\">\n" +
-    "<div class=\"right-container\">\n" +
-    "<div class=\"sidebar-header right-header\">\n" +
-    "<h2 class=\"h5\">Details</h2>\n" +
-    "</div>\n" +
-    "<div class=\"right-content\">\n" +
-    "<osc-object-describer></osc-object-describer>\n" +
-    "</div>\n" +
-    "</div>\n" +
+    "<events-sidebar ng-if=\"projectContext\" project-context=\"projectContext\"></events-sidebar>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>"
@@ -4662,6 +4655,73 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</tr>\n" +
     "</tbody>\n" +
     "</table>\n" +
+    "</div>"
+  );
+
+
+  $templateCache.put('views/directives/events-sidebar.html',
+    "<div class=\"right-container events-sidebar\">\n" +
+    "<div class=\"sidebar-header right-header\">\n" +
+    "<div>\n" +
+    "<h2>\n" +
+    "Events\n" +
+    "<small ng-if=\"warningCount\" class=\"mar-left-sm\">\n" +
+    "<span class=\"pficon pficon-warning-triangle-o\"></span>\n" +
+    "{{warningCount}}\n" +
+    "<span class=\"hidden-xs hidden-sm\">\n" +
+    "<span ng-if=\"warningCount === 1\">warning</span>\n" +
+    "<span ng-if=\"warningCount > 1\">warnings</span>\n" +
+    "</span>\n" +
+    "</small>\n" +
+    "</h2>\n" +
+    "</div>\n" +
+    "<div ng-if=\"events | hashSize\" class=\"event-details-link\">\n" +
+    "<a ng-href=\"project/{{projectContext.projectName}}/browse/events\">View Details</a>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"right-content\">\n" +
+    "<div ng-if=\"!events\">\n" +
+    "Loading...\n" +
+    "</div>\n" +
+    "<div ng-if=\"events\">\n" +
+    "<div ng-if=\"!(events | hashSize)\">\n" +
+    "<em>No events.</em>\n" +
+    "</div>\n" +
+    "<div ng-repeat=\"event in events\" class=\"event animate-repeat\">\n" +
+    "<span class=\"sr-only\">{{event.type}}</span>\n" +
+    "<div class=\"event-icon\" aria-hidden=\"true\">\n" +
+    "<div ng-switch=\"event.type\" class=\"hide-ng-leave\">\n" +
+    "<span ng-switch-when=\"Warning\" class=\"pficon pficon-warning-triangle-o\"></span>\n" +
+    "<span ng-switch-when=\"Normal\" class=\"pficon pficon-info text-muted\"></span>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"event-details\">\n" +
+    "<div class=\"detail-group\">\n" +
+    "<div class=\"event-reason\">\n" +
+    "{{event.reason | sentenceCase}}\n" +
+    "</div>\n" +
+    "<div class=\"event-object\">\n" +
+    "{{event.involvedObject.kind | abbreviateKind}}/{{event.involvedObject.name}}\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"detail-group\">\n" +
+    "<div class=\"event-message\">\n" +
+    "{{event.message}}\n" +
+    "</div>\n" +
+    "<div class=\"event-timestamp\">\n" +
+    "<relative-timestamp timestamp=\"event.lastTimestamp\"></relative-timestamp>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div ng-if=\"event.count > 1\" class=\"text-muted small\">\n" +
+    "{{event.count}} times in the last\n" +
+    "<duration-until-now timestamp=\"event.firstTimestamp\" omit-single=\"true\" precision=\"1\"></duration-until-now>\n" +
+    "</div>\n" +
+    "<div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
     "</div>"
   );
 

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4082,6 +4082,7 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 }
 .overview .deployment-tile .traffic-label{display:inline-block}
 .overview .deployment-tile .progress{background-color:inherit;border:0;box-shadow:none;display:inline-block;margin:0 0 0 5px;min-width:2em;vertical-align:-3px}
+.events-sidebar .pficon,.events-table .pficon{vertical-align:middle}
 .overview .deployment-tile .progress .progress-bar{width:100%}
 @media (min-width:1200px){.overview .deployment-tile .progress{width:250px}
 }
@@ -4303,6 +4304,7 @@ td.visible-print,th.visible-print{display:table-cell!important}
 }
 ::-webkit-scrollbar-corner{background:0 0}
 ::-webkit-scrollbar{height:10px;overflow:visible;width:14px}
+.events-sidebar .right-content .event .event-details,.events-sidebar .right-content .event .event-details .event-message,.events-sidebar .right-content .event .event-details .event-object,.events-sidebar .right-content .event .event-details .event-reason{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 ::-webkit-scrollbar-thumb{background-color:rgba(0,0,0,.08);background-clip:padding-box;border:solid transparent;border-width:1px;min-height:28px;max-height:60px;padding:100px 0 0;-webkit-box-shadow:inset 1px 1px 0 rgba(0,0,0,.1),inset 0 -1px 0 rgba(0,0,0,.07);box-shadow:inset 1px 1px 0 rgba(0,0,0,.1),inset 0 -1px 0 rgba(0,0,0,.07)}
 ::-webkit-scrollbar-thumb:active,::-webkit-scrollbar-thumb:hover{background-color:rgba(0,0,0,.18)}
 ::-webkit-scrollbar-track{background-clip:padding-box;background-color:rgba(0,0,0,.03)}
@@ -4343,10 +4345,6 @@ td.visible-print,th.visible-print{display:table-cell!important}
 .show-sidebar-right .sidebar-right .sidebar-header h2{margin-left:20px}
 .show-sidebar-right .sidebar-right h3{border-top:1px solid #dfdfdf;margin-top:0;padding-top:21px}
 .show-sidebar-right .sidebar-right h3:last-child{border-top:0;padding-top:0}
-.show-sidebar-right .sidebar-right .dl-horizontal{margin:0 0 21px}
-.show-sidebar-right .sidebar-right .dl-horizontal dt{text-align:left}
-.show-sidebar-right .sidebar-right .dl-horizontal dd{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
-.show-sidebar-right .sidebar-right .sidebar-help{color:#9c9c9c}
 @media (min-width:768px){.sidebar-left .navbar-sidebar{border-right:1px solid #050505;border-bottom:0;width:135px;position:absolute;top:1px;right:0;bottom:0;left:0}
 .sidebar-left .navbar-sidebar .sidebar-header{display:none}
 .sidebar-left .navbar-sidebar .hover-nav.dropdown-menu{border:0;border-radius:0;-webkit-box-shadow:2px 2px 2px rgba(0,0,0,.125);box-shadow:2px 2px 2px rgba(0,0,0,.125);left:100%;margin:0 0 0 1px;min-width:230px;position:absolute;padding:10px;top:-2px}
@@ -4360,9 +4358,6 @@ td.visible-print,th.visible-print{display:table-cell!important}
 .sidebar-left .navbar-sidebar ul.nav-sidenav-primary>li>a span{display:block;margin:0}
 .nav-sidenav-secondary .dropdown-header,.sidebar-left .navbar-sidebar ul.nav-sidenav-primary>li .hover-nav ul.nav-sidenav-secondary li a{padding-left:15px}
 }
-@media (min-width:768px) and (max-width:1199px){.show-sidebar-right .sidebar-right .dl-horizontal dt{float:none;width:auto}
-.show-sidebar-right .sidebar-right .dl-horizontal dd{margin-left:0;margin-bottom:10.5px}
-}
 @media (min-width:1200px){.sidebar-left .navbar-sidebar,.sidebar-left .navbar-sidebar .nav-sidenav-secondary.hover-nav.dropdown-menu{font-size:14px}
 .sidebar-left .navbar-sidebar ul.nav-sidenav-primary>li>a{padding-bottom:25px;padding-top:25px}
 .sidebar-left .navbar-sidebar ul.nav-sidenav-primary>li>a .fa-angle-right{font-size:18px}
@@ -4371,9 +4366,23 @@ td.visible-print,th.visible-print{display:table-cell!important}
 .sidebar-left .navbar-sidebar ul.nav-sidenav-primary>li>a .fa,.sidebar-left .navbar-sidebar ul.nav-sidenav-primary>li>a .pficon{display:inline-block;width:25px;margin-right:10px}
 .sidebar-left .navbar-sidebar ul.nav-sidenav-primary>li>a .fa-angle-right{height:18px;left:auto;padding:0;position:absolute;right:5px;text-align:right;top:23px}
 .sidebar-left .navbar-sidebar ul.nav-sidenav-primary>li>a .pficon{vertical-align:middle}
-.show-sidebar-right .sidebar-right .dl-horizontal dt{width:49%}
-.show-sidebar-right .sidebar-right .dl-horizontal dd{margin-left:50%}
 }
+.events-sidebar .sidebar-header{align-items:center;display:flex;justify-content:space-between}
+.events-sidebar .sidebar-header h2{font-family:inherit;font-weight:500;line-height:1.1;color:inherit;margin-top:10.5px;margin-bottom:10.5px;font-size:13px;display:inline-block}
+.events-sidebar .sidebar-header h2 .small,.events-sidebar .sidebar-header h2 small{font-weight:400;line-height:1;color:#9c9c9c;font-size:75%}
+.events-sidebar .sidebar-header .event-details-link{font-size:84%;margin-right:30px}
+.events-sidebar .right-content .event{display:flex;align-items:center;margin-bottom:10px}
+.events-sidebar .right-content .event .event-icon{font-size:18px;margin-right:10px}
+.events-sidebar .right-content .event .event-details{flex-grow:1}
+.events-sidebar .right-content .event .event-details .detail-group{display:flex;flex-direction:column;justify-content:space-between}
+.events-sidebar .right-content .event .event-details .event-message{font-size:84%}
+.events-sidebar .right-content .event .event-details .event-timestamp{font-size:84%;color:#9c9c9c}
+@media (min-width:1200px){.events-sidebar .right-content .event .event-details .detail-group{flex-direction:row}
+.events-sidebar .right-content .event .event-details .event-object{order:1}
+.events-sidebar .right-content .event .event-details .event-reason{order:2}
+.events-sidebar .right-content .event .event-details .event-timestamp{text-align:right;margin-left:5px;min-width:100px}
+}
+.events-sidebar .right-content .event+.event{border-top:1px solid #ededed;padding-top:10px}
 body,html{margin:0;padding:0}
 .layout-pf-alt.layout-pf-alt-fixed body{padding-top:0}
 .console-os{background-color:#fff}
@@ -4467,7 +4476,6 @@ body,html{margin:0;padding:0}
 .events-table th:nth-child(5){width:150px}
 .events-table th:last-child{width:100%}
 .events-table td:last-child,.events-table td:nth-child(2){word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
-.events-table .pficon{vertical-align:middle}
 .events-table .severity-icon-td{padding-left:0;padding-right:0}
 .tile{background:#fff;box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09);padding:10px 20px;margin-bottom:20px;word-wrap:break-word;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;overflow-x:hidden}
 .tile h1,.tile h2,.tile h3{margin:10.5px 0px}


### PR DESCRIPTION
Add an events sidebar to be used in the monitoring page. This PR only adds the directive. It's not yet visible on any page.

![banners_and_alerts_and_openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/17115745/cc6d827c-5282-11e6-9fd0-2673ac863697.png)

@jwforres PTAL