### PR TITLE
Update styling for the task list

### DIFF
--- a/app/scripts/controllers/tasks.js
+++ b/app/scripts/controllers/tasks.js
@@ -15,4 +15,8 @@ angular.module('openshiftConsole')
     $scope.delete = function(task) {
       TaskList.deleteTask(task);
     };
+    $scope.hasTaskWithError = function() {
+      var tasks = TaskList.taskList();
+      return _.some(tasks, {hasErrors: true});
+    };
   });

--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -756,6 +756,32 @@ a.subtle-link {
   width: 50px;
 }
 
+.tasks {
+  margin-bottom: 20px;
+  padding-left: 15px;
+  padding-right: 15px;
+  padding-bottom: 10px;
+  background-color: #ffffff;
+  &.success {
+    border: 1px solid #3f9c35;
+    border-left: 3px solid #3f9c35;
+  }
+  &.failure {
+    border: 1px solid #cc0000;
+    border-left: 3px solid #cc0000;
+  }
+  .task-icon {
+    font-size: 45px;
+    position: absolute;
+  }
+  .task-content {
+    min-height: 45px;
+  }
+  .task-info {
+    margin-left: 55px;
+  }
+}
+
 label.required:before {
   content: '*';
   position: absolute;

--- a/app/views/_tasks.html
+++ b/app/views/_tasks.html
@@ -1,32 +1,41 @@
 <div ng-controller="TasksController">
   <div ng-repeat="task in tasks()">
-    <div class="row">
-      <div class="col-md-12">
-          <h3>
-            <i class="spinner spinner-xs spinner-inline" ng-show="task.status=='started'"></i>
-            {{ task | taskTitle }}
-            <a ng-show="task.status=='completed'" ng-click="delete(task)" style="cursor:pointer">
-              <i class="pficon pficon-close btn-sm"></i>
-            </a>
-          </h3>
-          <div ng-if="task.helpLinks.length">
-            <h4>Helpful Links</h4>
-            <ul class="list-unstyled">
-              <li ng-repeat="link in task.helpLinks">
-                <a href="{{ link.link }}" target="_blank">{{ link.title }}</a>
-              </li>
-            </ul>
+    <div class="tasks" ng-class="hasTaskWithError() ? 'failure' : 'success'">
+      <div class="row">
+        <div class="col-md-12">
+          <div class="task-content">
+            <i class="pficon task-icon" ng-class="task.hasErrors ? 'pficon-error-circle-o' : 'pficon-ok'"></i>
+            <div class="task-info">
+              <h3>
+                {{ task | taskTitle }}.
+              </h3>
+              <div ng-if="task.helpLinks.length">
+                <h4>Helpful Links</h4>
+                <ul class="list-unstyled">
+                  <li ng-repeat="link in task.helpLinks">
+                    <a href="{{ link.link }}" target="_blank">{{ link.title }}</a>
+                  </li>
+                </ul>
+              </div>
+              <span>
+                <a href="" ng-click="expanded = !expanded">
+                  <span ng-hide="expanded">Show details</span>
+                  <span ng-show="expanded">Hide details</span>
+                </a>
+                <span class="action-divider" aria-hidden="true">|</span>
+              </span>
+              <span ng-show="task.status=='completed'">
+                <a href="" ng-click="delete(task)">
+                  Dismiss
+                </a>
+              </span>
+            </div>
           </div>
-          <div ng-show="task.hasErrors">
-            <a href="javascript:;" ng-click="expanded = !expanded">
-              <span ng-hide="expanded">Show details</span>
-              <span ng-show="expanded">Hide details</span>
-            </a>
-          </div>
-          <div ng-show="!task.hasErrors || expanded">
+          <div ng-show="expanded">
             <!-- Don't show a close button for each alert since we have one above for all tasks. -->
             <alerts alerts="task.alerts" hide-close-button="true"></alerts>
           </div>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/create/next-steps.html
+++ b/app/views/create/next-steps.html
@@ -17,23 +17,31 @@
               <h1 ng-if="!pendingTasks(tasks()).length && erroredTasks(tasks()).length">Completed, with errors</h1>
 
               <div ng-repeat="task in tasks()" ng-if="tasks().length && !allTasksSuccessful(tasks())">
-                <h3>
-                  <i class="spinner spinner-xs spinner-inline" ng-show="task.status=='started'"></i>
-                  {{ task | taskTitle }}.
-                </h3>
-                <div ng-repeat="alert in task.alerts">
-                  <div ng-switch="alert.type">
-                    <div ng-switch-when="error" class="alert alert-danger">
-                      <span class="pficon pficon-error-circle-o"></span>
-                      <span ng-if="alert.message">{{alert.message}}</span><span ng-if="alert.details">{{alert.details}}.</span>
+                <div class="tasks" ng-class="hasTaskWithError() ? 'failure' : 'success'">
+                  <div class="task-content">
+                    <i class="pficon task-icon" ng-class="task.hasErrors ? 'pficon-error-circle-o' : 'pficon-ok'"></i>
+                    <div class="task-info">
+                      <h3>
+                        {{ task | taskTitle }}.
+                      </h3>
                     </div>
-                    <div ng-switch-when="warning" class="alert alert-warning">
-                      <span class="pficon pficon-warning-triangle-o"></span>
-                      <span ng-if="alert.message">{{alert.message}}</span><span ng-if="alert.details">{{alert.details}}.</span>
-                    </div>
-                    <div ng-switch-when="success" class="alert alert-success">
-                      <span class="pficon pficon-ok"></span>
-                      <span ng-if="alert.message">{{alert.message}}</span><span ng-if="alert.details">{{alert.details}}</span>
+                  </div>
+                  <div class="alerts">
+                    <div ng-repeat="alert in task.alerts">
+                      <div ng-switch="alert.type">
+                        <div ng-switch-when="error" class="alert alert-danger">
+                          <span class="pficon pficon-error-circle-o"></span>
+                          <span ng-if="alert.message">{{alert.message}}</span><span ng-if="alert.details">{{alert.details}}.</span>
+                        </div>
+                        <div ng-switch-when="warning" class="alert alert-warning">
+                          <span class="pficon pficon-warning-triangle-o"></span>
+                          <span ng-if="alert.message">{{alert.message}}</span><span ng-if="alert.details">{{alert.details}}.</span>
+                        </div>
+                        <div ng-switch-when="success" class="alert alert-success">
+                          <span class="pficon pficon-ok"></span>
+                          <span ng-if="alert.message">{{alert.message}}</span><span ng-if="alert.details">{{alert.details}}.</span>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5228,6 +5228,11 @@ a.tasks = function() {
 return b.taskList();
 }, a["delete"] = function(a) {
 b.deleteTask(a);
+}, a.hasTaskWithError = function() {
+var a = b.taskList();
+return _.some(a, {
+hasErrors:!0
+});
 };
 } ]), angular.module("openshiftConsole").controller("EventsController", [ "$routeParams", "$scope", "ProjectsService", function(a, b, c) {
 b.projectName = a.project, b.renderOptions = {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -619,14 +619,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   $templateCache.put('views/_tasks.html',
     "<div ng-controller=\"TasksController\">\n" +
     "<div ng-repeat=\"task in tasks()\">\n" +
+    "<div class=\"tasks\" ng-class=\"hasTaskWithError() ? 'failure' : 'success'\">\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
+    "<div class=\"task-content\">\n" +
+    "<i class=\"pficon task-icon\" ng-class=\"task.hasErrors ? 'pficon-error-circle-o' : 'pficon-ok'\"></i>\n" +
+    "<div class=\"task-info\">\n" +
     "<h3>\n" +
-    "<i class=\"spinner spinner-xs spinner-inline\" ng-show=\"task.status=='started'\"></i>\n" +
-    "{{ task | taskTitle }}\n" +
-    "<a ng-show=\"task.status=='completed'\" ng-click=\"delete(task)\" style=\"cursor:pointer\">\n" +
-    "<i class=\"pficon pficon-close btn-sm\"></i>\n" +
-    "</a>\n" +
+    "{{ task | taskTitle }}.\n" +
     "</h3>\n" +
     "<div ng-if=\"task.helpLinks.length\">\n" +
     "<h4>Helpful Links</h4>\n" +
@@ -636,15 +636,24 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</li>\n" +
     "</ul>\n" +
     "</div>\n" +
-    "<div ng-show=\"task.hasErrors\">\n" +
-    "<a href=\"javascript:;\" ng-click=\"expanded = !expanded\">\n" +
+    "<span>\n" +
+    "<a href=\"\" ng-click=\"expanded = !expanded\">\n" +
     "<span ng-hide=\"expanded\">Show details</span>\n" +
     "<span ng-show=\"expanded\">Hide details</span>\n" +
     "</a>\n" +
+    "<span class=\"action-divider\" aria-hidden=\"true\">|</span>\n" +
+    "</span>\n" +
+    "<span ng-show=\"task.status=='completed'\">\n" +
+    "<a href=\"\" ng-click=\"delete(task)\">\n" +
+    "Dismiss\n" +
+    "</a>\n" +
+    "</span>\n" +
     "</div>\n" +
-    "<div ng-show=\"!task.hasErrors || expanded\">\n" +
+    "</div>\n" +
+    "<div ng-show=\"expanded\">\n" +
     "\n" +
     "<alerts alerts=\"task.alerts\" hide-close-button=\"true\"></alerts>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -3845,10 +3854,16 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<h1 ng-if=\"pendingTasks(tasks()).length\">Creating...</h1>\n" +
     "<h1 ng-if=\"!pendingTasks(tasks()).length && erroredTasks(tasks()).length\">Completed, with errors</h1>\n" +
     "<div ng-repeat=\"task in tasks()\" ng-if=\"tasks().length && !allTasksSuccessful(tasks())\">\n" +
+    "<div class=\"tasks\" ng-class=\"hasTaskWithError() ? 'failure' : 'success'\">\n" +
+    "<div class=\"task-content\">\n" +
+    "<i class=\"pficon task-icon\" ng-class=\"task.hasErrors ? 'pficon-error-circle-o' : 'pficon-ok'\"></i>\n" +
+    "<div class=\"task-info\">\n" +
     "<h3>\n" +
-    "<i class=\"spinner spinner-xs spinner-inline\" ng-show=\"task.status=='started'\"></i>\n" +
     "{{ task | taskTitle }}.\n" +
     "</h3>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"alerts\">\n" +
     "<div ng-repeat=\"alert in task.alerts\">\n" +
     "<div ng-switch=\"alert.type\">\n" +
     "<div ng-switch-when=\"error\" class=\"alert alert-danger\">\n" +
@@ -3861,7 +3876,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div ng-switch-when=\"success\" class=\"alert alert-success\">\n" +
     "<span class=\"pficon pficon-ok\"></span>\n" +
-    "<span ng-if=\"alert.message\">{{alert.message}}</span><span ng-if=\"alert.details\">{{alert.details}}</span>\n" +
+    "<span ng-if=\"alert.message\">{{alert.message}}</span><span ng-if=\"alert.details\">{{alert.details}}.</span>\n" +
+    "</div>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3573,6 +3573,7 @@ label.checkbox{font-weight:400}
 .env-variable-list li .btn,.label-list li .btn{vertical-align:top}
 .label+.label{margin-left:3px}
 .template-message{background-color:#d9edf7;border-color:#31708f;border-width:1px;color:#000;border-style:solid;padding:21px}
+.attention-message,.tasks,div.code,pre.code{background-color:#fff}
 .template-message .pficon-info{float:left;font-size:18px;margin-right:6px;color:#31708f}
 .resource-description{overflow-wrap:break-word;min-width:0;white-space:pre-wrap}
 .action-inline{margin-left:5px;font-size:11px}
@@ -3581,12 +3582,18 @@ a.subtle-link{color:#9c9c9c;border-bottom:1px dotted #BBB}
 a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;border-bottom:1px dotted #00659c;text-decoration:none}
 .project-summary{-webkit-flex:1 0 90%;-moz-flex:1 0 90%;-ms-flex:1 0 90%;flex:1 0 90%;max-width:90%}
 .project-actions{width:50px}
+.tasks{margin-bottom:20px;padding-left:15px;padding-right:15px;padding-bottom:10px}
+.tasks.success{border:1px solid #3f9c35;border-left:3px solid #3f9c35}
+.tasks.failure{border:1px solid #c00;border-left:3px solid #c00}
+.tasks .task-icon{font-size:45px;position:absolute}
+.tasks .task-content{min-height:45px}
+.tasks .task-info{margin-left:55px}
 label.required:before{content:'*';position:absolute;left:10px}
 .btn-group-xs>.btn,.btn-xs{padding:0 4px}
 .btn-group-lg>.btn,.btn-lg{line-height:1.334}
 code{white-space:normal}
 .nowrap,.truncate{white-space:nowrap}
-div.code,pre.code{background-color:#fff;border:none;border-left:2px solid #ccc}
+div.code,pre.code{border:none;border-left:2px solid #ccc}
 abbr[data-original-title],abbr[title]{text-decoration:none}
 .dl-horizontal.left dt{text-align:left}
 .dl-horizontal.indent{margin-left:20px}
@@ -3601,7 +3608,7 @@ select:invalid{box-shadow:none}
 .well h1:first-child,.well h2:first-child,.well h3:first-child,.well h4:first-child,.well h5:first-child{margin:5px 0 15px}
 .spinner.spinner-xs{height:12px;width:12px}
 .spinner.spinner-inverse{border-color:rgba(0,153,211,.25);border-top-color:rgba(0,153,211,.75)}
-.attention-message{background-color:#fff;border:1px solid #228bc0;position:absolute;left:50%;margin-top:100px;transform:translateX(-50%);padding:1em 1em 2em;min-width:85%}
+.attention-message{border:1px solid #228bc0;position:absolute;left:50%;margin-top:100px;transform:translateX(-50%);padding:1em 1em 2em;min-width:85%}
 .attention-message h1,.attention-message p{text-align:center}
 .attention-message p{max-width:70em;margin:auto}
 .actions-dropdown-btn,.alert .close{margin-left:5px}


### PR DESCRIPTION
Updated the styling for the Tasks on the Overview and Next-steps pages.
Overview page:
![screenshot-52](https://cloud.githubusercontent.com/assets/1668218/17133635/3790117e-5327-11e6-803e-3f44cbd79e9c.png)
![screenshot-53](https://cloud.githubusercontent.com/assets/1668218/17133639/3b25b406-5327-11e6-9661-3a89846b3b02.png)
![screenshot-56](https://cloud.githubusercontent.com/assets/1668218/17133656/4ac032c4-5327-11e6-9408-1ed89741a0b5.png)
![screenshot-57](https://cloud.githubusercontent.com/assets/1668218/17133657/4ac10e9c-5327-11e6-81fe-c0c0b49e49b4.png)

Next-steps page:
![screenshot-54](https://cloud.githubusercontent.com/assets/1668218/17133673/5d3fc450-5327-11e6-82e8-f0a722d3ae26.png)

@spadgett PTAL

Closes https://github.com/openshift/origin-web-console/issues/154