### PR TITLE
Minor fixes to pod template probe command display

### DIFF
--- a/app/styles/_components.less
+++ b/app/styles/_components.less
@@ -188,6 +188,15 @@
   }
 }
 
+code.probe-command {
+  // Use inline-block style to prevent trailing whitespace from being
+  // highlighted with a background color.  The extra whitespace is difficult to
+  // avoid due to use of `ng-repeat` and `truncate-long-text`.
+  display: inline-block;
+  line-height: 1.3;
+  margin-right: 2px;
+}
+
 .hash {
   font-family: @font-family-monospace;
   font-size: (@font-size-base - 1);

--- a/app/views/directives/_probe.html
+++ b/app/views/directives/_probe.html
@@ -3,7 +3,7 @@
   GET {{probe.httpGet.path || '/'}} on port {{probe.httpGet.port || 'unknown'}}
 </span>
 <span ng-if="probe.exec.command">
-  <code>
+  <code class="probe-command">
     <span ng-repeat="arg in probe.exec.command">
       <truncate-long-text
           content="arg"
@@ -20,6 +20,6 @@
 </span>
 
 <small class="text-muted">
-  <span ng-if="probe.initialDelaySeconds">{{probe.initialDelaySeconds}}s delay, </span>
-  {{probe.timeoutSeconds || 1}}s timeout
+  <span ng-if="probe.initialDelaySeconds" class="nowrap">{{probe.initialDelaySeconds}}s delay,</span>
+  <span class="nowrap">{{probe.timeoutSeconds || 1}}s timeout</span>
 </small>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4279,7 +4279,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "GET {{probe.httpGet.path || '/'}} on port {{probe.httpGet.port || 'unknown'}}\n" +
     "</span>\n" +
     "<span ng-if=\"probe.exec.command\">\n" +
-    "<code>\n" +
+    "<code class=\"probe-command\">\n" +
     "<span ng-repeat=\"arg in probe.exec.command\">\n" +
     "<truncate-long-text content=\"arg\" limit=\"80\" newline-limit=\"1\" expandable=\"false\" use-word-boundary=\"false\">\n" +
     "</truncate-long-text>\n" +
@@ -4290,8 +4290,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Open socket on port {{probe.tcpSocket.port}}\n" +
     "</span>\n" +
     "<small class=\"text-muted\">\n" +
-    "<span ng-if=\"probe.initialDelaySeconds\">{{probe.initialDelaySeconds}}s delay, </span>\n" +
-    "{{probe.timeoutSeconds || 1}}s timeout\n" +
+    "<span ng-if=\"probe.initialDelaySeconds\" class=\"nowrap\">{{probe.initialDelaySeconds}}s delay,</span>\n" +
+    "<span class=\"nowrap\">{{probe.timeoutSeconds || 1}}s timeout</span>\n" +
     "</small>"
   );
 

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3359,6 +3359,7 @@ to{transform:rotate(359deg)}
 .pod-template-block .pod-template .pod-template-key{font-weight:700}
 .components .pod-template-block .pod-template .pod-template-key,.overview .pod-template-block .pod-template .pod-template-key{font-weight:600}
 .surface-shaded .ui-select-bootstrap .ui-select-match-text,.ui-select-bootstrap .ui-select-placeholder{font-weight:400}
+code.probe-command{display:inline-block;line-height:1.3;margin-right:2px}
 .hash{font-size:12px}
 .pod-template-container{margin:0 0 20px}
 .components .pod-template-container{margin-bottom:0}


### PR DESCRIPTION
- Prevent trailing whitespace from being highlighted in the `<code>` block
- Use `nowrap` around "1s timeout" to prevent awkward wrapping

Before:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/17175581/54c707fc-53d6-11e6-9d36-d41086676755.png)

After:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/17175607/71d7d5ba-53d6-11e6-8463-b797a8f966cf.png)

@jwforres PTAL