### PR TITLE
Making pipeline builds dismissible on overview

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -228,6 +228,7 @@
         <script src="scripts/controllers/about.js"></script>
         <script src="scripts/controllers/commandLine.js"></script>
         <script src="scripts/controllers/createPersistentVolumeClaim.js"></script>
+        <script src="scripts/directives/buildClose.js"></script>
         <script src="scripts/directives/date.js"></script>
         <script src="scripts/directives/deleteLink.js"></script>
         <script src="scripts/directives/editLink.js"></script>

--- a/app/scripts/directives/buildClose.js
+++ b/app/scripts/directives/buildClose.js
@@ -1,0 +1,39 @@
+'use strict';
+/* jshint unused: false */
+
+angular.module('openshiftConsole')
+  .directive('buildClose', function($window) {
+    // so that builds can be dismissed on overview
+    var hideBuildKey = function(build) {
+      return 'hide/build/' + build.metadata.uid;
+    };
+
+    var isBuildHidden = function(build) {
+      var key = hideBuildKey(build);
+      return sessionStorage.getItem(key) === 'true';
+    };
+
+    return {
+      restrict: 'AE',
+      scope: {
+        build: '=',
+        hideBuild: '=' // for ng-show or ng-hide, not ng-if!
+      },
+      controller: function($scope) {
+        $scope.onHideBuild = function() {
+          var key = hideBuildKey($scope.build);
+          $scope.hideBuild = true;
+          sessionStorage.setItem(key, 'true');
+        };
+      },
+      link: function($scope, $elem, $attrs, ctrl) {
+        // initialize
+        $scope.hideBuild = false;
+        // if the build changes, check storage to see if its a hidden build
+        $scope.$watch('build', function(newVal) {
+          $scope.hideBuild = isBuildHidden(newVal);
+        });
+      },
+      templateUrl: 'views/directives/_build-close.html'
+    };
+  });

--- a/app/scripts/directives/resources.js
+++ b/app/scripts/directives/resources.js
@@ -79,25 +79,12 @@ angular.module('openshiftConsole')
   //})
 
   .directive('triggers', function() {
-    var hideBuildKey = function(build) {
-      return 'hide/build/' + build.metadata.uid;
-    };
     return {
       restrict: 'E',
       scope: {
         triggers: '=',
         buildsByOutputImage: '=',
         namespace: '='
-      },
-      link: function(scope) {
-        scope.isBuildHidden = function(build) {
-          var key = hideBuildKey(build);
-          return sessionStorage.getItem(key) === 'true';
-        };
-        scope.hideBuild = function(build) {
-          var key = hideBuildKey(build);
-          sessionStorage.setItem(key, 'true');
-        };
       },
       templateUrl: 'views/_triggers.html'
     };

--- a/app/views/_triggers.html
+++ b/app/views/_triggers.html
@@ -1,9 +1,9 @@
 <div class="triggers">
   <div class="builds" ng-repeat="trigger in triggers">
     <div ng-if="trigger.type === 'ImageChange'">
-      <div ng-repeat="build in buildsByOutputImage[(trigger.imageChangeParams.from | imageObjectRef : namespace)] | orderObjectsByDate track by (build | uid)"
-          ng-if="!isBuildHidden(build)"
-          class="build animate-repeat"
+      <div ng-repeat="build in buildsByOutputImage[(trigger.imageChangeParams.from | imageObjectRef : namespace)] | orderObjectsByDate : true track by (build | uid)"
+          ng-show="!(hideBuild)"
+          class="build animate-repeat hide-ng-leave"
           kind="Build"
           resource="build">
         <div class="build-summary" ng-class="{'dismissible' : !(build | isIncompleteBuild)}">
@@ -26,10 +26,7 @@
           <div ng-if="'builds/log' | canI : 'get'" class="build-links">
             <a ng-if="!!['New', 'Pending'].indexOf(build.status.phase) && (build | buildLogURL)" ng-href="{{build | buildLogURL}}">View Log</a>
           </div>
-          <button ng-hide="build | isIncompleteBuild" ng-click="hideBuild(build)" type="button" class="close">
-            <span class="pficon pficon-close" aria-hidden="true"></span>
-            <span class="sr-only">Dismiss</span>
-          </button>
+          <build-close build="build" hide-build="hideBuild"></build-close>
         </div>
       </div>
     </div>

--- a/app/views/directives/_build-close.html
+++ b/app/views/directives/_build-close.html
@@ -1,0 +1,4 @@
+<button ng-hide="build | isIncompleteBuild" ng-click="onHideBuild()" type="button" class="close">
+  <span class="pficon pficon-close" aria-hidden="true"></span>
+  <span class="sr-only">Dismiss</span>
+</button>

--- a/app/views/directives/_build-pipeline-collapsed.html
+++ b/app/views/directives/_build-pipeline-collapsed.html
@@ -1,5 +1,5 @@
-<div class="build-pipeline-collapsed">
-  <div class="build-summary">
+<div class="build-pipeline-collapsed" ng-show="!hideBuild">
+  <div class="build-summary" ng-class="{'dismissible' : !(build | isIncompleteBuild)}">
     <div class="build-name">
       <a ng-href="{{buildConfigName | navigateResourceURL : 'BuildConfig' : build.metadata.namespace}}">{{buildConfigName}}</a>,
       <a ng-href="{{build | navigateResourceURL}}">#{{build | annotation : 'buildNumber'}}</a>
@@ -10,9 +10,6 @@
     </div>
     <relative-timestamp timestamp="build.metadata.creationTimestamp" class="build-timestamp"></relative-timestamp>
     <div ng-include="'views/directives/_build-pipeline-links.html'" class="build-links"></div>
-    <button ng-hide="build | isIncompleteBuild" ng-click="hideBuild(build)" type="button" class="close">
-      <span class="pficon pficon-close" aria-hidden="true"></span>
-      <span class="sr-only">Dismiss</span>
-    </button>
+    <build-close build="build" hide-build="hideBuild"></build-close>
   </div>
 </div>

--- a/app/views/overview/_service-group.html
+++ b/app/views/overview/_service-group.html
@@ -35,7 +35,7 @@
     <div class="service-group-triggers">
       <div ng-repeat="dc in deploymentConfigsByService[service.metadata.name || '']">
         <div row ng-repeat="pipeline in recentPipelinesByDC[dc.metadata.name] | orderObjectsByDate : true track by (pipeline | uid)"
-            class="animate-repeat">
+            class="animate-repeat hide-ng-leave">
           <build-pipeline flex build="pipeline" collapse-stages-on-completion="true" build-config-name-on-expanded="true"></build-pipeline>
         </div>
         <div>
@@ -69,7 +69,7 @@
           <overview-service
               ng-repeat="service in childServices">
           </overview-service>
-          
+
           <div flex column ng-if="alternateServices.length === 0 && childServices.length === 0 && service" class="no-child-services-block">
             <div class="no-child-services-message">
               <div class="pad-left-lg pad-right-lg pad-top-lg pad-bottom-lg">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5894,6 +5894,32 @@ details:a("getErrorDetails")(b)
 }
 };
 }));
+} ]), angular.module("openshiftConsole").directive("buildClose", [ "$window", function(a) {
+var b = function(a) {
+return "hide/build/" + a.metadata.uid;
+}, c = function(a) {
+var c = b(a);
+return "true" === sessionStorage.getItem(c);
+};
+return {
+restrict:"AE",
+scope:{
+build:"=",
+hideBuild:"="
+},
+controller:[ "$scope", function(a) {
+a.onHideBuild = function() {
+var c = b(a.build);
+a.hideBuild = !0, sessionStorage.setItem(c, "true");
+};
+} ],
+link:function(a, b, d, e) {
+a.hideBuild = !1, a.$watch("build", function(b) {
+a.hideBuild = c(b);
+});
+},
+templateUrl:"views/directives/_build-close.html"
+};
 } ]), angular.module("openshiftConsole").directive("relativeTimestamp", function() {
 return {
 restrict:"E",
@@ -6820,24 +6846,12 @@ addHealthCheckUrl:"@?"
 templateUrl:"views/_pod-template.html"
 };
 }).directive("triggers", function() {
-var a = function(a) {
-return "hide/build/" + a.metadata.uid;
-};
 return {
 restrict:"E",
 scope:{
 triggers:"=",
 buildsByOutputImage:"=",
 namespace:"="
-},
-link:function(b) {
-b.isBuildHidden = function(b) {
-var c = a(b);
-return "true" === sessionStorage.getItem(c);
-}, b.hideBuild = function(b) {
-var c = a(b);
-sessionStorage.setItem(c, "true");
-};
 },
 templateUrl:"views/_triggers.html"
 };

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -707,7 +707,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"triggers\">\n" +
     "<div class=\"builds\" ng-repeat=\"trigger in triggers\">\n" +
     "<div ng-if=\"trigger.type === 'ImageChange'\">\n" +
-    "<div ng-repeat=\"build in buildsByOutputImage[(trigger.imageChangeParams.from | imageObjectRef : namespace)] | orderObjectsByDate track by (build | uid)\" ng-if=\"!isBuildHidden(build)\" class=\"build animate-repeat\" kind=\"Build\" resource=\"build\">\n" +
+    "<div ng-repeat=\"build in buildsByOutputImage[(trigger.imageChangeParams.from | imageObjectRef : namespace)] | orderObjectsByDate : true track by (build | uid)\" ng-show=\"!(hideBuild)\" class=\"build animate-repeat hide-ng-leave\" kind=\"Build\" resource=\"build\">\n" +
     "<div class=\"build-summary\" ng-class=\"{'dismissible' : !(build | isIncompleteBuild)}\">\n" +
     "<div class=\"build-name\">\n" +
     "<span ng-if=\"build | annotation : 'buildNumber'\">\n" +
@@ -728,10 +728,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"'builds/log' | canI : 'get'\" class=\"build-links\">\n" +
     "<a ng-if=\"!!['New', 'Pending'].indexOf(build.status.phase) && (build | buildLogURL)\" ng-href=\"{{build | buildLogURL}}\">View Log</a>\n" +
     "</div>\n" +
-    "<button ng-hide=\"build | isIncompleteBuild\" ng-click=\"hideBuild(build)\" type=\"button\" class=\"close\">\n" +
-    "<span class=\"pficon pficon-close\" aria-hidden=\"true\"></span>\n" +
-    "<span class=\"sr-only\">Dismiss</span>\n" +
-    "</button>\n" +
+    "<build-close build=\"build\" hide-build=\"hideBuild\"></build-close>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -4130,9 +4127,17 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/directives/_build-close.html',
+    "<button ng-hide=\"build | isIncompleteBuild\" ng-click=\"onHideBuild()\" type=\"button\" class=\"close\">\n" +
+    "<span class=\"pficon pficon-close\" aria-hidden=\"true\"></span>\n" +
+    "<span class=\"sr-only\">Dismiss</span>\n" +
+    "</button>"
+  );
+
+
   $templateCache.put('views/directives/_build-pipeline-collapsed.html',
-    "<div class=\"build-pipeline-collapsed\">\n" +
-    "<div class=\"build-summary\">\n" +
+    "<div class=\"build-pipeline-collapsed\" ng-show=\"!hideBuild\">\n" +
+    "<div class=\"build-summary\" ng-class=\"{'dismissible' : !(build | isIncompleteBuild)}\">\n" +
     "<div class=\"build-name\">\n" +
     "<a ng-href=\"{{buildConfigName | navigateResourceURL : 'BuildConfig' : build.metadata.namespace}}\">{{buildConfigName}}</a>,\n" +
     "<a ng-href=\"{{build | navigateResourceURL}}\">#{{build | annotation : 'buildNumber'}}</a>\n" +
@@ -4143,10 +4148,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<relative-timestamp timestamp=\"build.metadata.creationTimestamp\" class=\"build-timestamp\"></relative-timestamp>\n" +
     "<div ng-include=\"'views/directives/_build-pipeline-links.html'\" class=\"build-links\"></div>\n" +
-    "<button ng-hide=\"build | isIncompleteBuild\" ng-click=\"hideBuild(build)\" type=\"button\" class=\"close\">\n" +
-    "<span class=\"pficon pficon-close\" aria-hidden=\"true\"></span>\n" +
-    "<span class=\"sr-only\">Dismiss</span>\n" +
-    "</button>\n" +
+    "<build-close build=\"build\" hide-build=\"hideBuild\"></build-close>\n" +
     "</div>\n" +
     "</div>"
   );
@@ -7501,7 +7503,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div>\n" +
     "<div class=\"service-group-triggers\">\n" +
     "<div ng-repeat=\"dc in deploymentConfigsByService[service.metadata.name || '']\">\n" +
-    "<div row ng-repeat=\"pipeline in recentPipelinesByDC[dc.metadata.name] | orderObjectsByDate : true track by (pipeline | uid)\" class=\"animate-repeat\">\n" +
+    "<div row ng-repeat=\"pipeline in recentPipelinesByDC[dc.metadata.name] | orderObjectsByDate : true track by (pipeline | uid)\" class=\"animate-repeat hide-ng-leave\">\n" +
     "<build-pipeline flex build=\"pipeline\" collapse-stages-on-completion=\"true\" build-config-name-on-expanded=\"true\"></build-pipeline>\n" +
     "</div>\n" +
     "<div>\n" +


### PR DESCRIPTION
and reversing sort of triggered builds so that they display in the same order as pipeline builds; additionally, i removed animation on triggered builds so that they don't fade out but rather instantly disappear (which also makes them consistent with pipeline builds).

for dismissible pipeline builds, @benjaminapetersen helped me move the close functionality out of the triggers directive and put it in a separate directive so both the triggers directive and the build pipelines directive can make use of it.

we're still wrestling with persisting the latest complete builds while displaying any in progress builds.  a separate PR with that functionality will follow.

@jwforres, PTAL.