### PR TITLE
Show failed run-once pods on overview page (BZ#1355950)

### DIFF
--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -158,11 +158,10 @@ angular.module('openshiftConsole')
 
     // Filter out monopods we know we don't want to see
     var showMonopod = function(pod) {
-      // Hide pods in the Succeeded, Terminated, and Failed phases since these
+      // Hide pods in the Succeeded & Terminated phases since these
       // are run once pods that are done.
       if (pod.status.phase === 'Succeeded' ||
-          pod.status.phase === 'Terminated' ||
-          pod.status.phase === 'Failed') {
+          pod.status.phase === 'Terminated') {
         // TODO we may want to show pods for X amount of time after they have completed
         return false;
       }

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3193,7 +3193,7 @@ h.warn("Unexpected HPA scaleRef kind", c);
 }
 }), c.hpaByDC = w, c.hpaByRC = x;
 }, N = function(a) {
-return "Succeeded" !== a.status.phase && "Terminated" !== a.status.phase && "Failed" !== a.status.phase && (!B(a, "openshift.io/deployer-pod-for.name") && (!A(a, "openshift.io/build.name") && "slave" !== B(a, "jenkins")));
+return "Succeeded" !== a.status.phase && "Terminated" !== a.status.phase && (!B(a, "openshift.io/deployer-pod-for.name") && (!A(a, "openshift.io/build.name") && "slave" !== B(a, "jenkins")));
 }, O = function() {
 s && r && (c.podsByDeployment = i.groupByReplicationController(s, r), c.monopodsByService = i.groupByService(c.podsByDeployment[""], p, N));
 }, P = {}, Q = function(a) {


### PR DESCRIPTION
Fixes [Bugzilla #1355950](https://bugzilla.redhat.com/show_bug.cgi?id=1355950) 
-Show pods with a status of 'Failed' on the overview page

@jwforres 