### PR TITLE
Fix log archives link

### DIFF
--- a/app/scripts/directives/logViewer.js
+++ b/app/scripts/directives/logViewer.js
@@ -389,6 +389,7 @@ angular.module('openshiftConsole')
                     // Need to explicitly tell it to trust this location or it will throw errors.
                     kibanaArchiveUrl: $sce.trustAsResourceUrl(logLinks.archiveUri({
                                         namespace: $scope.context.project.metadata.name,
+                                        namespaceUid: $scope.context.project.metadata.uid,
                                         podname: $scope.name,
                                         containername: $scope.options.container,
                                         backlink: URI.encode($window.location.href)

--- a/app/scripts/services/logLinks.js
+++ b/app/scripts/services/logLinks.js
@@ -49,7 +49,7 @@ angular.module('openshiftConsole')
         var uri = new URI();
         _.each(params, function(param) {
           uri.addSearch(param);
-        });        
+        });
         $window.open(uri.toString(), '_blank');
       };
 
@@ -65,12 +65,12 @@ angular.module('openshiftConsole')
         ")",
         "&_a=(",
           //"columns:!(_source),",
-          "columns:!(kubernetes_container_name,<%= containername %>),", 
-          "index:'<%= namespace %>.*',",
+          "columns:!(kubernetes_container_name,message),",
+          "index:'<%= namespace %>.<%= namespaceUid %>.*',",
           "query:(",
             "query_string:(",
               "analyze_wildcard:!t,",
-              "query:'kubernetes_pod_name: <%= podname %> %26%26 kubernetes_namespace_name: <%= namespace %>'",
+              "query:'kubernetes_pod_name:\"<%= podname %>\" AND kubernetes_namespace_name:\"<%= namespace %>\"'",
             ")",
           "),",
           "sort:!(time,desc)",

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8521,6 +8521,7 @@ access_token:d.UserStore().getToken()
 angular.extend(j, {
 kibanaArchiveUrl:a.trustAsResourceUrl(g.archiveUri({
 namespace:j.context.project.metadata.name,
+namespaceUid:j.context.project.metadata.uid,
 podname:j.name,
 containername:j.options.container,
 backlink:URI.encode(c.location.href)
@@ -10796,7 +10797,7 @@ var e = new URI();
 _.each(c, function(a) {
 e.addSearch(a);
 }), d.open(e.toString(), "_blank");
-}, i = _.template([ "/#/discover?", "_g=(", "time:(", "from:now-1w,", "mode:relative,", "to:now", ")", ")", "&_a=(", "columns:!(kubernetes_container_name,<%= containername %>),", "index:'<%= namespace %>.*',", "query:(", "query_string:(", "analyze_wildcard:!t,", "query:'kubernetes_pod_name: <%= podname %> %26%26 kubernetes_namespace_name: <%= namespace %>'", ")", "),", "sort:!(time,desc)", ")", "#console_container_name=<%= containername %>", "&console_back_url=<%= backlink %>" ].join("")), j = function(a) {
+}, i = _.template([ "/#/discover?", "_g=(", "time:(", "from:now-1w,", "mode:relative,", "to:now", ")", ")", "&_a=(", "columns:!(kubernetes_container_name,message),", "index:'<%= namespace %>.<%= namespaceUid %>.*',", "query:(", "query_string:(", "analyze_wildcard:!t,", 'query:\'kubernetes_pod_name:"<%= podname %>" AND kubernetes_namespace_name:"<%= namespace %>"\'', ")", "),", "sort:!(time,desc)", ")", "#console_container_name=<%= containername %>", "&console_back_url=<%= backlink %>" ].join("")), j = function(a) {
 return i(a);
 };
 return {


### PR DESCRIPTION
Fix bug 1358674 : "archive" link does not automatically select correct  index/pattern

@jwforres @spadgett 
@ewolinetz 

This update will drop the user on a kibana page something like this:
![screen shot 2016-08-03 at 11 56 15 am](https://cloud.githubusercontent.com/assets/280512/17373656/2c271552-5977-11e6-95cd-328dd41e383a.png)
