### PR TITLE
Assign app label for templates using name

### DIFF
--- a/app/scripts/controllers/newfromtemplate.js
+++ b/app/scripts/controllers/newfromtemplate.js
@@ -250,6 +250,10 @@ angular.module('openshiftConsole')
               value: value
             };
           });
+          $scope.labels.push({
+            name: 'app',
+            value: $scope.template.metadata.name
+          });
         }
 
         // Missing namespace indicates that the template should be received from from the 'CachedTemplateService'.

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5561,6 +5561,9 @@ return {
 name:b,
 value:a
 };
+}), a.labels.push({
+name:"app",
+value:a.template.metadata.name
 });
 }
 if (a.project = b, a.breadcrumbs[0].title = m("displayName")(b), a.projectDisplayName = function() {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/8325
Uses the same strategy as new-app since https://github.com/openshift/origin/pull/10192

Note that the app label is read-only, but my understanding from @jwforres is we will have a separate follow on to allow overriding default label values more generally.

@jwforres PTAL
@bparees CC