### PR TITLE
Too much gap between warning icon and reason in events table

### DIFF
--- a/app/styles/_tables.less
+++ b/app/styles/_tables.less
@@ -145,13 +145,13 @@
 // table for events
 .events-table {
   table-layout: fixed;
-  th:nth-child(1) {width:90px;} // time
-  th:nth-child(2) {width:190px;} // name
-  th:nth-child(3) {width:160px;} // kind
-  th:nth-child(4) {width:10px;padding:0;} // icon
-  th:nth-child(5) {width:150px;} // reason
-  th:last-child   {width:100%;} // message; ensures it gets remaining width
-  td:nth-child(2),td:last-child {
+  th#time {width:90px;}
+  th#kind-name {width:190px;}
+  th#kind {width:160px;}
+  th#severity {width:10px;padding:0;}
+  th#reason {width:150px;}
+  th#message   {width:100%;} // ensures it gets remaining width
+  th#kind-name,th#message  {
     .word-break;
   }
   .pficon {

--- a/app/views/directives/events.html
+++ b/app/views/directives/events.html
@@ -18,18 +18,18 @@
   <table class="table table-bordered table-condensed table-mobile table-hover events-table">
     <thead>
       <tr>
-        <th>Time</th>
+        <th id="time">Time</th>
         <!-- Only show Name and Kind columns if not passed to the directive. -->
-        <th ng-if="!resourceKind || !resourceName">
+        <th id="kind-name" ng-if="!resourceKind || !resourceName">
           <span class="hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline">Kind and Name</span>
           <span class="visible-lg-inline">Name</span>
         </th>
-        <th ng-if="!resourceKind || !resourceName" class="hidden-sm hidden-md">
+        <th id="kind" ng-if="!resourceKind || !resourceName" class="hidden-sm hidden-md">
           <span class="visible-lg-inline">Kind</span>
         </th>
-        <th class="hidden-xs hidden-sm hidden-md"><span class="sr-only">Severity</span></th>
-        <th class="hidden-sm hidden-md"><span class="visible-lg-inline">Reason</span></th>
-        <th><span class="hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline">Reason and </span>Message</th>
+        <th id="severity" class="hidden-xs hidden-sm hidden-md"><span class="sr-only">Severity</span></th>
+        <th id="reason" class="hidden-sm hidden-md"><span class="visible-lg-inline">Reason</span></th>
+        <th id="message"><span class="hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline">Reason and </span>Message</th>
       </tr>
     </thead>
     <tbody ng-if="(filteredEvents | hashSize) === 0">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4958,18 +4958,18 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<table class=\"table table-bordered table-condensed table-mobile table-hover events-table\">\n" +
     "<thead>\n" +
     "<tr>\n" +
-    "<th>Time</th>\n" +
+    "<th id=\"time\">Time</th>\n" +
     "\n" +
-    "<th ng-if=\"!resourceKind || !resourceName\">\n" +
+    "<th id=\"kind-name\" ng-if=\"!resourceKind || !resourceName\">\n" +
     "<span class=\"hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline\">Kind and Name</span>\n" +
     "<span class=\"visible-lg-inline\">Name</span>\n" +
     "</th>\n" +
-    "<th ng-if=\"!resourceKind || !resourceName\" class=\"hidden-sm hidden-md\">\n" +
+    "<th id=\"kind\" ng-if=\"!resourceKind || !resourceName\" class=\"hidden-sm hidden-md\">\n" +
     "<span class=\"visible-lg-inline\">Kind</span>\n" +
     "</th>\n" +
-    "<th class=\"hidden-xs hidden-sm hidden-md\"><span class=\"sr-only\">Severity</span></th>\n" +
-    "<th class=\"hidden-sm hidden-md\"><span class=\"visible-lg-inline\">Reason</span></th>\n" +
-    "<th><span class=\"hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline\">Reason and </span>Message</th>\n" +
+    "<th id=\"severity\" class=\"hidden-xs hidden-sm hidden-md\"><span class=\"sr-only\">Severity</span></th>\n" +
+    "<th id=\"reason\" class=\"hidden-sm hidden-md\"><span class=\"visible-lg-inline\">Reason</span></th>\n" +
+    "<th id=\"message\"><span class=\"hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline\">Reason and </span>Message</th>\n" +
     "</tr>\n" +
     "</thead>\n" +
     "<tbody ng-if=\"(filteredEvents | hashSize) === 0\">\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4514,13 +4514,13 @@ body,html{margin:0;padding:0}
 .table-filter-wrapper{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;padding:10px 10px 5px;border-top:1px solid #d1d1d1;border-left:1px solid #d1d1d1;border-right:1px solid #d1d1d1;background-color:#f9f9f9}
 .label-tags a.label,.log-header .log-actions form{display:inline-block}
 .events-table{table-layout:fixed}
-.events-table th:nth-child(1){width:90px}
-.events-table th:nth-child(2){width:190px}
-.events-table th:nth-child(3){width:160px}
-.events-table th:nth-child(4){width:10px;padding:0}
-.events-table th:nth-child(5){width:150px}
-.events-table th:last-child{width:100%}
-.events-table td:last-child,.events-table td:nth-child(2){word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
+.events-table th#time{width:90px}
+.events-table th#kind-name{width:190px}
+.events-table th#kind{width:160px}
+.events-table th#severity{width:10px;padding:0}
+.events-table th#reason{width:150px}
+.events-table th#message{width:100%}
+.events-table th#kind-name,.events-table th#message{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .events-table .pficon{vertical-align:middle}
 .events-table .severity-icon-td{padding-left:0;padding-right:0}
 .tile{background:#fff;box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09);padding:10px 20px;margin-bottom:20px;word-wrap:break-word;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;overflow-x:hidden}


### PR DESCRIPTION
In `_table.less` we are specifying table header width based on the position, but since we are showing different column based on the screen width, so I switched to ID selector.

@spadgett PTAL

Closes https://github.com/openshift/origin-web-console/issues/32