### PR TITLE
Add key-value-editor directive to replication-controller page

### DIFF
--- a/app/views/browse/deployment.html
+++ b/app/views/browse/deployment.html
@@ -83,7 +83,17 @@
                     <uib-tab-heading>Environment</uib-tab-heading>
                     <div ng-repeat="container in deployment.spec.template.spec.containers">
                       <h3>Container {{container.name}} Environment Variables</h3>
-                      <environment env-vars="container.env" ng-if="container.env.length"></environment>
+                      <p>
+                        <span class="pficon pficon-info" aria-hidden="true"></span>
+                        Environment variables can be edited on the <a ng-href="{{deployment | configURLForResource}}?tab=environment">deployment configuration</a>.
+                      </p>
+                      <key-value-editor
+                        ng-if="container.env.length"
+                        entries="container.env"
+                        cannot-add
+                        cannot-delete
+                        cannot-sort
+                        is-readonly></key-value-editor>
                       <em ng-if="!container.env.length">The container specification has no environment variables set.</em>
                     </div>
                   </uib-tab>

--- a/app/views/browse/replication-controller.html
+++ b/app/views/browse/replication-controller.html
@@ -65,7 +65,7 @@
               </div>
             </h1>
             <labels labels="deployment.metadata.labels" clickable="true" kind="deployments" project-name="{{deployment.metadata.namespace}}" limit="3"></labels>
-          </div><!-- /deployment -->          
+          </div><!-- /deployment -->
         </div>
       </div><!-- /middle-header-->
       <div class="middle-content">
@@ -78,6 +78,31 @@
                   <div class="resource-details">
                     <ng-include src=" 'views/browse/_deployment-details.html' "></ng-include>
                   </div>
+                </uib-tab>
+                <uib-tab heading="Environment" active="selectedTab.environment">
+                  <uib-tab-heading>Environment</uib-tab-heading>
+                  <ng-form name="envForm">
+                    <div ng-repeat="container in updatedDeployment.spec.template.spec.containers">
+                      <h3>Container {{container.name}} Environment Variables</h3>
+                      <p>
+                        <span class="pficon pficon-info" aria-hidden="true"></span>
+                        Environment variable updates will only apply to new pods.
+                      </p>
+                      <div>
+                        <key-value-editor
+                          entries="container.env"
+                          key-placeholder="Name"
+                          value-placeholder="Value"
+                          key-validator="[A-Za-z_][A-Za-z0-9_]*"
+                          key-validator-error="Please enter a valid key"
+                          key-validator-error-tooltip="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."></key-value-editor>
+                        <button
+                          class="btn btn-default"
+                          ng-click="saveEnvVars()"
+                          ng-disabled="envForm.$pristine || envForm.$invalid">Save</button>
+                      </div>
+                    </div>
+                  </ng-form>
                 </uib-tab>
                 <uib-tab ng-if="metricsAvailable" heading="Metrics" active="selectedTab.metrics">
                   <!-- Use ng-if to remove the metrics directive when the tab is not active so

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4354,11 +4354,30 @@ a.metricsAvailable = b;
 });
 var m = function(c) {
 a.logOptions.container = b("annotation")(c, "pod"), a.logCanRun = !_.includes([ "New", "Pending" ], b("deploymentStatus")(c));
+}, n = function(a) {
+return _.each(a.spec.template.spec.containers, function(a) {
+a.env = a.env || [];
+}), a;
 };
-h.get(c.project).then(_.spread(function(d, g) {
+a.saveEnvVars = function() {
+_.each(a.updatedDeployment.spec.template.spec.containers, function(a) {
+a.env = _.filter(a.env, "name");
+}), e.update("replicationcontrollers", c.replicationcontroller, angular.copy(a.updatedDeployment), a.projectContext).then(function() {
+a.alerts.saveEnvSuccess = {
+type:"success",
+message:a.deployment.metadata.name + " was updated."
+};
+}, function(c) {
+a.alerts.saveEnvError = {
+type:"error",
+message:a.deployment.metadata.name + " was not updated.",
+details:"Reason: " + b("getErrorDetails")(c)
+};
+});
+}, h.get(c.project).then(_.spread(function(d, g) {
 function h() {
-if (a.hpaForRC = f.hpaForRC(r, c.deployment || c.replicationcontroller), a.isActive) {
-var b = f.hpaForDC(r, c.deploymentconfig);
+if (a.hpaForRC = f.hpaForRC(s, c.deployment || c.replicationcontroller), a.isActive) {
+var b = f.hpaForDC(s, c.deploymentconfig);
 a.autoscalers = a.hpaForRC.concat(b);
 } else a.autoscalers = a.hpaForRC;
 }
@@ -4368,7 +4387,7 @@ a.podTemplates[c] = b.spec.template;
 });
 }
 a.project = d, a.projectContext = g;
-var n, o, p = function() {
+var o, p, q = function() {
 l.push(e.watch("replicationcontrollers", g, function(c) {
 var d, e = [], f = b("annotation");
 angular.forEach(c.by("metadata.name"), function(b) {
@@ -4376,27 +4395,27 @@ var c = f(b, "deploymentConfig") || "";
 c === a.deploymentConfigName && e.push(b);
 }), d = i.getActiveDeployment(e), a.isActive = d && d.metadata.uid === a.deployment.metadata.uid, h();
 }));
-}, q = function() {
-n && o && (a.podsForDeployment = _.filter(n, function(a) {
-return o.matches(a);
+}, r = function() {
+o && p && (a.podsForDeployment = _.filter(o, function(a) {
+return p.matches(a);
 }));
-}, r = {}, s = {}, t = function() {
-f.getHPAWarnings(a.deployment, a.autoscalers, s, d).then(function(b) {
+}, s = {}, t = {}, u = function() {
+f.getHPAWarnings(a.deployment, a.autoscalers, t, d).then(function(b) {
 a.hpaWarnings = b;
 });
 };
 e.get("replicationcontrollers", c.deployment || c.replicationcontroller, g).then(function(d) {
-a.loaded = !0, a.deployment = d, m(d), t();
+a.loaded = !0, a.deployment = d, m(d), u();
 var f = b("annotation")(d, "deploymentVersion");
 f && (a.breadcrumbs[2].title = "#" + f, a.logOptions.version = f), a.deploymentConfigName = b("annotation")(d, "deploymentConfig"), l.push(e.watchObject("replicationcontrollers", c.deployment || c.replicationcontroller, g, function(b, d) {
 "DELETED" === d && (a.alerts.deleted = {
 type:"warning",
 message:c.deployment ? "This deployment has been deleted." :"This replication controller has been deleted."
-}), a.deployment = b, m(b), t();
-})), a.deploymentConfigName && p(), a.$watch("deployment.spec.selector", function() {
-o = new LabelSelector(a.deployment.spec.selector), q();
+}), a.deployment = b, a.updatedDeployment = n(b), m(b), u();
+})), a.deploymentConfigName && q(), a.$watch("deployment.spec.selector", function() {
+p = new LabelSelector(a.deployment.spec.selector), r();
 }, !0), l.push(e.watch("pods", g, function(a) {
-n = a.by("metadata.name"), q();
+o = a.by("metadata.name"), r();
 }));
 }, function(d) {
 a.loaded = !0, a.alerts.load = {
@@ -4434,9 +4453,9 @@ a.builds = b.by("metadata.name"), Logger.log("builds (subscribe)", a.builds);
 group:"extensions",
 resource:"horizontalpodautoscalers"
 }, g, function(a) {
-r = a.by("metadata.name"), h(), t();
+s = a.by("metadata.name"), h(), u();
 })), e.list("limitranges", g, function(a) {
-s = a.by("metadata.name"), t();
+t = a.by("metadata.name"), u();
 }), a.startLatestDeployment = function(b) {
 i.startLatestDeployment(b, g, a);
 }, a.retryFailedDeployment = function(b) {
@@ -4455,9 +4474,9 @@ details:b("getErrorDetails")(c)
 };
 a.deploymentConfig ? i.scaleDC(a.deploymentConfig, c).then(_.noop, d) :i.scaleRC(a.deployment, c).then(_.noop, d);
 };
-var u = b("isDeployment");
+var v = b("isDeployment");
 a.isScalable = function() {
-return !_.isEmpty(a.autoscalers) || (!u(a.deployment) || (!!a.deploymentConfigMissing || !!a.deploymentConfig && a.isActive));
+return !_.isEmpty(a.autoscalers) || (!v(a.deployment) || (!!a.deploymentConfigMissing || !!a.deploymentConfig && a.isActive));
 }, a.$on("$destroy", function() {
 e.unwatchAll(l);
 });

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2146,7 +2146,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<uib-tab-heading>Environment</uib-tab-heading>\n" +
     "<div ng-repeat=\"container in deployment.spec.template.spec.containers\">\n" +
     "<h3>Container {{container.name}} Environment Variables</h3>\n" +
-    "<environment env-vars=\"container.env\" ng-if=\"container.env.length\"></environment>\n" +
+    "<p>\n" +
+    "<span class=\"pficon pficon-info\" aria-hidden=\"true\"></span>\n" +
+    "Environment variables can be edited on the <a ng-href=\"{{deployment | configURLForResource}}?tab=environment\">deployment configuration</a>.\n" +
+    "</p>\n" +
+    "<key-value-editor ng-if=\"container.env.length\" entries=\"container.env\" cannot-add cannot-delete cannot-sort is-readonly></key-value-editor>\n" +
     "<em ng-if=\"!container.env.length\">The container specification has no environment variables set.</em>\n" +
     "</div>\n" +
     "</uib-tab>\n" +
@@ -2680,6 +2684,22 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"resource-details\">\n" +
     "<ng-include src=\" 'views/browse/_deployment-details.html' \"></ng-include>\n" +
     "</div>\n" +
+    "</uib-tab>\n" +
+    "<uib-tab heading=\"Environment\" active=\"selectedTab.environment\">\n" +
+    "<uib-tab-heading>Environment</uib-tab-heading>\n" +
+    "<ng-form name=\"envForm\">\n" +
+    "<div ng-repeat=\"container in updatedDeployment.spec.template.spec.containers\">\n" +
+    "<h3>Container {{container.name}} Environment Variables</h3>\n" +
+    "<p>\n" +
+    "<span class=\"pficon pficon-info\" aria-hidden=\"true\"></span>\n" +
+    "Environment variable updates will only apply to new pods.\n" +
+    "</p>\n" +
+    "<div>\n" +
+    "<key-value-editor entries=\"container.env\" key-placeholder=\"Name\" value-placeholder=\"Value\" key-validator=\"[A-Za-z_][A-Za-z0-9_]*\" key-validator-error=\"Please enter a valid key\" key-validator-error-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\"></key-value-editor>\n" +
+    "<button class=\"btn btn-default\" ng-click=\"saveEnvVars()\" ng-disabled=\"envForm.$pristine || envForm.$invalid\">Save</button>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</ng-form>\n" +
     "</uib-tab>\n" +
     "<uib-tab ng-if=\"metricsAvailable\" heading=\"Metrics\" active=\"selectedTab.metrics\">\n" +
     "\n" +


### PR DESCRIPTION
Fixes #277 
(kinda)

@jwforres @spadgett This would be the quick fix to get a table showing environment vars on the `replication-controller.html` page.  I would expect a follow-up to migrate to `<key-value-editor>`.  Looking into the `valueFrom` component now.