### PR TITLE
Prevent the status indicator extension point from overlapping at certain screen widths

### DIFF
--- a/app/styles/_project-menu.less
+++ b/app/styles/_project-menu.less
@@ -154,7 +154,7 @@
     float: left;
     margin: 0;
     padding-top: 0;
-    max-width: 400px; // Default project menu width
+    max-width: 280px; // Leave enough space for the status indicator extension point
     .bootstrap-select.btn-group {
       .btn {
         padding: 15px 50px 15px 30px;
@@ -176,9 +176,17 @@
     }
     .bootstrap-select .dropdown-toggle {
       height: 60px;
-      max-width: 400px;
+      max-width: 280px;
       min-width: 280px;
     }
+  }
+}
+
+// At 900 there is enough space to make the menu bigger and still have space for the status indicator extension
+@media (min-width: 900px) {
+  .navbar-project-menu .bootstrap-select .dropdown-toggle,
+  .navbar-project-menu {
+    max-width: 400px;
   }
 }
 

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4264,12 +4264,14 @@ to{background-color:transparent}
 }
 @media (min-width:480px){.navbar-project-menu .bootstrap-select.btn-group .btn .filter-option{max-width:310px}
 }
-@media (min-width:768px){.navbar-project-menu{border-bottom:0;border-top:0;float:left;margin:0;padding-top:0;max-width:400px}
+@media (min-width:768px){.navbar-project-menu{border-bottom:0;border-top:0;float:left;margin:0;padding-top:0;max-width:280px}
 .navbar-project-menu .bootstrap-select.btn-group .btn{padding:15px 50px 15px 30px}
 .navbar-project-menu .bootstrap-select.btn-group .btn:before{color:#9c9c9c;content:'Project';font-size:10px;left:30px;position:absolute;top:8px}
 .navbar-project-menu .bootstrap-select.btn-group .btn .filter-option{max-width:470px}
 .navbar-project-menu .bootstrap-select.btn-group .dropdown-toggle .caret{right:30px}
-.navbar-project-menu .bootstrap-select .dropdown-toggle{height:60px;max-width:400px;min-width:280px}
+.navbar-project-menu .bootstrap-select .dropdown-toggle{height:60px;max-width:280px;min-width:280px}
+}
+@media (min-width:900px){.navbar-project-menu,.navbar-project-menu .bootstrap-select .dropdown-toggle{max-width:400px}
 }
 @media (min-width:992px){.navbar-project-menu,.navbar-project-menu .bootstrap-select .dropdown-toggle{max-width:500px}
 }


### PR DESCRIPTION
Fixes #197 