### PR TITLE
Honor server sort for builder images

### DIFF
--- a/app/views/catalog/_catalog-category.html
+++ b/app/views/catalog/_catalog-category.html
@@ -7,7 +7,8 @@
     </small>
   </h3>
   <div class="catalog">
-    <!-- Show builder images first. -->
+    <!-- Show builder images first. Show them in the order the server returns since it sorts by
+         semantic version. -->
     <catalog-image
       image-stream="builder.imageStream"
       image-tag="builder.imageStreamTag"
@@ -15,7 +16,7 @@
       version="builder.version"
       filter-tag="filterTag"
       is-builder="true"
-      ng-repeat="builder in builders | orderBy : ['name', 'imageStream.metadata.namespace'] | limitToOrAll: itemLimit track by builderID(builder)">
+      ng-repeat="builder in builders | limitToOrAll: itemLimit track by builderID(builder)">
     </catalog-image>
 
     <!-- Show any templates. -->

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3203,7 +3203,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</h3>\n" +
     "<div class=\"catalog\">\n" +
     "\n" +
-    "<catalog-image image-stream=\"builder.imageStream\" image-tag=\"builder.imageStreamTag\" project=\"{{project}}\" version=\"builder.version\" filter-tag=\"filterTag\" is-builder=\"true\" ng-repeat=\"builder in builders | orderBy : ['name', 'imageStream.metadata.namespace'] | limitToOrAll: itemLimit track by builderID(builder)\">\n" +
+    "<catalog-image image-stream=\"builder.imageStream\" image-tag=\"builder.imageStreamTag\" project=\"{{project}}\" version=\"builder.version\" filter-tag=\"filterTag\" is-builder=\"true\" ng-repeat=\"builder in builders | limitToOrAll: itemLimit track by builderID(builder)\">\n" +
     "</catalog-image>\n" +
     "\n" +
     "<catalog-template template=\"template\" project=\"{{project}}\" filter-tag=\"filterTag\" ng-repeat=\"template in templates | orderBy : ['metadata.name', 'metadata.namespace'] | limitToOrAll: itemLimit track by (template | uid)\">\n" +


### PR DESCRIPTION
The server returns status tags ordered by semantic version (most recent first).

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/17443817/bb94d1e0-5b0a-11e6-8049-d13bd32fa3ce.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1325069
Fixes https://github.com/openshift/origin/issues/7847

@jwforres PTAL