### PR TITLE
Annotate latest builder in catalog

### DIFF
--- a/app/scripts/directives/catalog.js
+++ b/app/scripts/directives/catalog.js
@@ -47,6 +47,7 @@ angular.module('openshiftConsole')
         version: '=',
         project: '@',
         filterTag: "=",
+        referencedBy: "=",
         isBuilder: "=?"
       },
       templateUrl: 'views/catalog/_image.html'

--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -636,6 +636,9 @@ label.checkbox {
 
 .catalog {
   .tile-template, .tile-image {
+    h3 small {
+      vertical-align: 1px;
+    }
     a.tag {
       text-decoration: none;
       &:hover {

--- a/app/views/catalog/_catalog-category.html
+++ b/app/views/catalog/_catalog-category.html
@@ -15,6 +15,7 @@
       project="{{project}}"
       version="builder.version"
       filter-tag="filterTag"
+      referenced-by="builder.referencedBy"
       is-builder="true"
       ng-repeat="builder in builders | limitToOrAll: itemLimit track by builderID(builder)">
     </catalog-image>

--- a/app/views/catalog/_image.html
+++ b/app/views/catalog/_image.html
@@ -6,6 +6,12 @@
     <div flex>
       <h3>
         <a class="tile-target" ng-href="{{imageStream | createFromImageURL : imageTag : project}}">{{imageStream.metadata.name}}:{{imageTag}}</a>
+        <small ng-if="referencedBy.length">
+          &ndash;
+          <span ng-repeat="otherTag in referencedBy">
+            {{otherTag}}<span ng-if="!$last">,</span>
+          </span>
+        </small>
       </h3>
       <div ng-if="imageStream | imageStreamTagAnnotation : 'provider' : imageTag">
         <label style="margin-right: 5px;">Provider:</label>

--- a/app/views/create.html
+++ b/app/views/create.html
@@ -157,6 +157,7 @@
                               image-tag="image.imageStreamTag"
                               project="{{projectName}}"
                               version="image.version"
+                              referenced-by="image.referencedBy"
                               ng-repeat="image in filteredNonBuilders | orderBy : ['name', 'imageStream.metadata.namespace']">
                           </catalog-image>
 

--- a/app/views/directives/osc-image-summary.html
+++ b/app/views/directives/osc-image-summary.html
@@ -4,12 +4,4 @@
   <div ng-show="resource | annotation:'provider'">Provider: {{ resource | annotation:'provider' }}</div>
   <div ng-show="resource.metadata.namespace">Namespace: {{ resource.metadata.namespace }}</div>
 </div>
-<div class="resource-description"
-     ng-bind-html="resource | description | linky"
-     ng-class="{'gutter-bottom': tag !== 'latest'}">
-</div>
-
-<div ng-if="tag === 'latest'" class="alert alert-info">
-  <span class="pficon pficon-info" aria-hidden="true"></span>
-  This builder image tracks the latest version of the {{name}} image, which could be updated to a newer major version in the future.  If your application will not run on a different major version go <a href="#" back>back</a> and choose a specific version.
-</div>
+<div class="resource-description gutter-bottom" ng-bind-html="resource | description | linky"></div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5763,19 +5763,22 @@ return s(a.name, a.description, a.categoryTags);
 function w(a) {
 angular.forEach(a, function(a) {
 if (a.status) {
-var b = {};
+var b = {}, c = {}, d = {};
 a.spec && a.spec.tags && angular.forEach(a.spec.tags, function(a) {
-a.annotations && a.annotations.tags && (b[a.name] = a.annotations.tags.split(/\s*,\s*/));
-}), angular.forEach(a.status.tags, function(c) {
-var d, e = c.tag, f = b[e] || [], g = {
+a.annotations && a.annotations.tags && (b[a.name] = a.annotations.tags.split(/\s*,\s*/)), a.from && "ImageStreamTag" === a.from.kind && a.from.name.indexOf(":") === -1 && !a.from.namespace && (c[a.name] = !0, d[a.from.name] = d[a.from.name] || [], d[a.from.name].push(a.name));
+}), angular.forEach(a.status.tags, function(e) {
+if (!c[e.tag]) {
+var f, g = e.tag, h = b[g] || [], i = {
 imageStream:a,
-imageStreamTag:e,
-name:a.metadata.name + ":" + e,
-description:j(a, "description", e),
-version:j(a, "version", e),
-categoryTags:f
+imageStreamTag:g,
+name:a.metadata.name + ":" + g,
+description:j(a, "description", g),
+version:j(a, "version", g),
+categoryTags:h,
+referencedBy:d[g]
 };
-f.indexOf("builder") >= 0 ? (d = y(f), E[d] = E[d] || [], E[d].push(g)) :G.push(g);
+h.indexOf("builder") >= 0 ? (f = y(h), E[f] = E[f] || [], E[f].push(i)) :G.push(i);
+}
 });
 }
 });
@@ -7808,6 +7811,7 @@ imageTag:"=",
 version:"=",
 project:"@",
 filterTag:"=",
+referencedBy:"=",
 isBuilder:"=?"
 },
 templateUrl:"views/catalog/_image.html"

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3203,7 +3203,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</h3>\n" +
     "<div class=\"catalog\">\n" +
     "\n" +
-    "<catalog-image image-stream=\"builder.imageStream\" image-tag=\"builder.imageStreamTag\" project=\"{{project}}\" version=\"builder.version\" filter-tag=\"filterTag\" is-builder=\"true\" ng-repeat=\"builder in builders | limitToOrAll: itemLimit track by builderID(builder)\">\n" +
+    "<catalog-image image-stream=\"builder.imageStream\" image-tag=\"builder.imageStreamTag\" project=\"{{project}}\" version=\"builder.version\" filter-tag=\"filterTag\" referenced-by=\"builder.referencedBy\" is-builder=\"true\" ng-repeat=\"builder in builders | limitToOrAll: itemLimit track by builderID(builder)\">\n" +
     "</catalog-image>\n" +
     "\n" +
     "<catalog-template template=\"template\" project=\"{{project}}\" filter-tag=\"filterTag\" ng-repeat=\"template in templates | orderBy : ['metadata.name', 'metadata.namespace'] | limitToOrAll: itemLimit track by (template | uid)\">\n" +
@@ -3222,6 +3222,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div flex>\n" +
     "<h3>\n" +
     "<a class=\"tile-target\" ng-href=\"{{imageStream | createFromImageURL : imageTag : project}}\">{{imageStream.metadata.name}}:{{imageTag}}</a>\n" +
+    "<small ng-if=\"referencedBy.length\">\n" +
+    "&ndash;\n" +
+    "<span ng-repeat=\"otherTag in referencedBy\">\n" +
+    "{{otherTag}}<span ng-if=\"!$last\">,</span>\n" +
+    "</span>\n" +
+    "</small>\n" +
     "</h3>\n" +
     "<div ng-if=\"imageStream | imageStreamTagAnnotation : 'provider' : imageTag\">\n" +
     "<label style=\"margin-right: 5px\">Provider:</label>\n" +
@@ -3632,7 +3638,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Some images in this list may not be able to build source. Use with caution.\n" +
     "</div>\n" +
     "<div class=\"catalog catalog-fluid\">\n" +
-    "<catalog-image image-stream=\"image.imageStream\" image-tag=\"image.imageStreamTag\" project=\"{{projectName}}\" version=\"image.version\" ng-repeat=\"image in filteredNonBuilders | orderBy : ['name', 'imageStream.metadata.namespace']\">\n" +
+    "<catalog-image image-stream=\"image.imageStream\" image-tag=\"image.imageStreamTag\" project=\"{{projectName}}\" version=\"image.version\" referenced-by=\"image.referencedBy\" ng-repeat=\"image in filteredNonBuilders | orderBy : ['name', 'imageStream.metadata.namespace']\">\n" +
     "</catalog-image>\n" +
     "\n" +
     "<div style=\"height: 0\" class=\"tile-image\"></div>\n" +
@@ -5593,12 +5599,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-show=\"resource | annotation:'provider'\">Provider: {{ resource | annotation:'provider' }}</div>\n" +
     "<div ng-show=\"resource.metadata.namespace\">Namespace: {{ resource.metadata.namespace }}</div>\n" +
     "</div>\n" +
-    "<div class=\"resource-description\" ng-bind-html=\"resource | description | linky\" ng-class=\"{'gutter-bottom': tag !== 'latest'}\">\n" +
-    "</div>\n" +
-    "<div ng-if=\"tag === 'latest'\" class=\"alert alert-info\">\n" +
-    "<span class=\"pficon pficon-info\" aria-hidden=\"true\"></span>\n" +
-    "This builder image tracks the latest version of the {{name}} image, which could be updated to a newer major version in the future. If your application will not run on a different major version go <a href=\"#\" back>back</a> and choose a specific version.\n" +
-    "</div>"
+    "<div class=\"resource-description gutter-bottom\" ng-bind-html=\"resource | description | linky\"></div>"
   );
 
 

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3555,6 +3555,7 @@ label.checkbox{font-weight:400}
 .action-button,[data-toggle=tooltip]{cursor:pointer}
 .command-args .drag-handle .fa{padding-left:5px}
 .command-args .drag-handle,.command-args .remove-arg{background-color:inherit;border:0;font-size:15px;padding-top:5px;vertical-align:top}
+.catalog .tile-image h3 small,.catalog .tile-template h3 small{vertical-align:1px}
 .catalog .tile-image a.tag,.catalog .tile-template a.tag{text-decoration:none}
 .catalog .tile-image a.tag:hover,.catalog .tile-template a.tag:hover{color:#000;background:#dfdfdf;text-decoration:none}
 .catalog-fluid{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column}


### PR DESCRIPTION
Remove the :latest tile, but annotate the image stream tag that it tracks.

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/17447494/acafca10-5b1c-11e6-8926-c3c61f912df2.png)

Fixes #242

@jwforres PTAL
@luciddreamz CC