### PR TITLE
Fix the calculation of ImageStreamTag name for lookup

### DIFF
--- a/app/scripts/controllers/image.js
+++ b/app/scripts/controllers/image.js
@@ -41,12 +41,7 @@ angular.module('openshiftConsole')
     var watches = [];
 
     var fetchImageStreamTag = _.debounce(function(tagData, context) {
-      var name;
-      if (tagData.spec) {
-        name = tagData.spec.from.name;
-      } else {
-        name = $routeParams.imagestream + ":" + $routeParams.tag;
-      }
+      var name = $routeParams.imagestream + ":" + $routeParams.tag;
       DataService.get("imagestreamtags", name, context).then(
         // success
         function(imageStreamTag) {


### PR DESCRIPTION
We were using the ImageStream spec tag 'from' field, when available
but this is not related to the ImageStreamTag name.

https://bugzilla.redhat.com/show_bug.cgi?id=1364355