### PR TITLE
Issue #167 - Keep Terminal Tab Despite 0 Containers Available

### DIFF
--- a/app/views/browse/pod.html
+++ b/app/views/browse/pod.html
@@ -128,77 +128,84 @@
                   <uib-tab
                     active="selectedTab.terminal"
                     select="terminalTabWasSelected = true"
-                    ng-init="containers = pod.status.containerStatuses"
-                    ng-if="containersRunning(pod.status.containerStatuses) > 0">
+                    ng-init="containers = pod.status.containerStatuses">
                       <uib-tab-heading>Terminal</uib-tab-heading>
 
-                      <div class="mar-bottom-md">
-                        <span class="pficon pficon-info" aria-hidden="true"></span>
-                        When you navigate away from this pod, any open terminal connections will be closed.
-                        This will kill any foreground processes you started from the terminal.
+                      <div ng-if="noContainersYet" class="empty-state-message text-center">
+                        <h2>
+                          No running containers
+                        </h2>
                       </div>
 
-                      <alerts ng-if="selectedTerminalContainer.status === 'disconnected'" alerts="terminalDisconnectAlert"></alerts>
-
-                      <div class="mar-left-xl mar-bottom-lg">
-                        <div class="row">
-                          <div class="pad-left-none pad-bottom-md col-sm-6 col-lg-4">
-                            <span ng-if="pod.spec.containers.length === 1">
-                              <label for="selectLogContainer">Container:</label>
-                              {{pod.spec.containers[0].name}}
-                            </span>
-
-                            <ui-select
-                              ng-model="selectedTerminalContainer"
-                              on-select="onTerminalSelectChange(selectedTerminalContainer)"
-                              ng-if="pod.spec.containers.length > 1"
-                              class="mar-left-none pad-left-none pad-right-none">
-                             <ui-select-match
-                                class="truncate"
-                                placeholder="Container Name">
-                                  <span class="pad-left-md">
-                                    {{selectedTerminalContainer.containerName}}
-                                  </span>
-                              </ui-select-match>
-                              <ui-select-choices
-                                repeat="term in containerTerminals | filter: $select.search"
-                                ui-disable-choice="(term.containerState !== 'running') && !term.isUsed">
-                                <div row>
-                                  <span ng-bind-html="term.containerName | highlight: $select.search">
-                                  </span>
-                                  <span flex></span>
-                                  <span
-                                    ng-if="term.isUsed && (term.containerState === 'running')"
-                                    ng-class="{'text-muted' : (term.status === 'disconnected')}">
-                                      {{term.status}}
-                                  </span>
-                                  <span
-                                    ng-if="term.containerState !== 'running'"
-                                    ng-class="{'text-muted' : !term.isUsed}">
-                                      {{term.containerState}}
-                                  </span>
-                                </div>
-                              </ui-select-choices>
-                            </ui-select>
-                          </div>
+                      <div ng-if="!noContainersYet">
+                        <div class="mar-bottom-md">
+                          <span class="pficon pficon-info" aria-hidden="true"></span>
+                          When you navigate away from this pod, any open terminal connections will be closed.
+                          This will kill any foreground processes you started from the terminal.
                         </div>
 
-                        <div class="container-terminal-wrapper">
-                          <div class="row" ng-repeat="term in containerTerminals">
-                            <div class="column">
-                              <kubernetes-container-terminal
-                                prevent="!terminalTabWasSelected"
-                                ng-if="term.isUsed"
-                                ng-show="term.isVisible"
-                                pod="pod"
-                                container="term.containerName"
-                                status="term.status"
-                                rows="terminalRows"
-                                cols="terminalCols"
-                                autofocus="true"
-                                command='["/bin/sh", "-i", "-c", "TERM=xterm /bin/sh"]'
-                                >
-                              </kubernetes-container-terminal>
+                        <alerts ng-if="selectedTerminalContainer.status === 'disconnected'" alerts="terminalDisconnectAlert"></alerts>
+
+                        <div class="mar-left-xl mar-bottom-lg">
+                          <div class="row">
+                            <div class="pad-left-none pad-bottom-md col-sm-6 col-lg-4">
+                              <span ng-if="pod.spec.containers.length === 1">
+                                <label for="selectLogContainer">Container:</label>
+                                {{pod.spec.containers[0].name}}
+                               </span>
+
+                              <ui-select
+                                ng-model="selectedTerminalContainer"
+                                on-select="onTerminalSelectChange(selectedTerminalContainer)"
+                                ng-if="pod.spec.containers.length > 1"
+                                class="mar-left-none pad-left-none pad-right-none">
+                               <ui-select-match
+                                  class="truncate"
+                                  placeholder="Container Name">
+                                    <span class="pad-left-md">
+                                      {{selectedTerminalContainer.containerName}}
+                                    </span>
+                                </ui-select-match>
+                                <ui-select-choices
+                                  repeat="term in containerTerminals | filter: $select.search"
+                                  ui-disable-choice="(term.containerState !== 'running') && !term.isUsed">
+                                  <div row>
+                                    <span ng-bind-html="term.containerName | highlight: $select.search">
+                                    </span>
+                                    <span flex></span>
+                                    <span
+                                      ng-if="term.isUsed && (term.containerState === 'running')"
+                                      ng-class="{'text-muted' : (term.status === 'disconnected')}">
+                                        {{term.status}}
+                                    </span>
+                                    <span
+                                      ng-if="term.containerState !== 'running'"
+                                      ng-class="{'text-muted' : !term.isUsed}">
+                                        {{term.containerState}}
+                                    </span>
+                                  </div>
+                                </ui-select-choices>
+                              </ui-select>
+                            </div>
+                          </div>
+
+                          <div class="container-terminal-wrapper">
+                            <div class="row" ng-repeat="term in containerTerminals">
+                              <div class="column">
+                                <kubernetes-container-terminal
+                                  prevent="!terminalTabWasSelected"
+                                  ng-if="term.isUsed"
+                                  ng-show="term.isVisible"
+                                  pod="pod"
+                                  container="term.containerName"
+                                  status="term.status"
+                                  rows="terminalRows"
+                                  cols="terminalCols"
+                                  autofocus="true"
+                                  command='["/bin/sh", "-i", "-c", "TERM=xterm /bin/sh"]'
+                                  >
+                                </kubernetes-container-terminal>
+                              </div>
                             </div>
                           </div>
                         </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3160,7 +3160,7 @@ title:c.pod
 } ], a.terminalDisconnectAlert.disconnect = {
 type:"warning",
 message:"This terminal has been disconnected. If you reconnect, your terminal history will be lost."
-}, a.selectedTab = {}, c.tab && (a.selectedTab[c.tab] = !0);
+}, a.noContainersYet = !0, a.selectedTab = {}, c.tab && (a.selectedTab[c.tab] = !0);
 var k = [];
 h.isAvailable().then(function(b) {
 a.metricsAvailable = b;
@@ -3228,6 +3228,8 @@ containerState:e
 var c = _.head(b);
 return c.isVisible = !0, c.isUsed = !0, a.selectedTerminalContainer = c, b;
 }, t = function(b) {
+a.noContainersYet && (a.noContainersYet = 0 === a.containersRunning(b.status.containerStatuses));
+}, u = function(b) {
 _.each(b, function(b) {
 var c = _.find(a.pod.status.containerStatuses, {
 name:b.containerName
@@ -3239,11 +3241,11 @@ j.get(c.project).then(_.spread(function(d, h) {
 a.project = d, a.projectContext = h, f.get("pods", c.pod, h).then(function(b) {
 a.loaded = !0, a.pod = b, l(b), m();
 var d = {};
-d[b.metadata.name] = b, g.fetchReferencedImageStreamImages(d, a.imagesByDockerReference, a.imageStreamImageRefByDockerReference, h), a.containerTerminals = s(), k.push(f.watchObject("pods", c.pod, h, function(b, c) {
+d[b.metadata.name] = b, g.fetchReferencedImageStreamImages(d, a.imagesByDockerReference, a.imageStreamImageRefByDockerReference, h), a.containerTerminals = s(), t(b), k.push(f.watchObject("pods", c.pod, h, function(b, c) {
 "DELETED" === c && (a.alerts.deleted = {
 type:"warning",
 message:"This pod has been deleted."
-}), a.pod = b, l(b), m(), t(a.containerTerminals);
+}), a.pod = b, l(b), m(), u(a.containerTerminals), t(b);
 }));
 }, function(c) {
 a.loaded = !0, a.alerts.load = {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2784,8 +2784,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</log-viewer>\n" +
     "</uib-tab>\n" +
-    "<uib-tab active=\"selectedTab.terminal\" select=\"terminalTabWasSelected = true\" ng-init=\"containers = pod.status.containerStatuses\" ng-if=\"containersRunning(pod.status.containerStatuses) > 0\">\n" +
+    "<uib-tab active=\"selectedTab.terminal\" select=\"terminalTabWasSelected = true\" ng-init=\"containers = pod.status.containerStatuses\">\n" +
     "<uib-tab-heading>Terminal</uib-tab-heading>\n" +
+    "<div ng-if=\"noContainersYet\" class=\"empty-state-message text-center\">\n" +
+    "<h2>\n" +
+    "No running containers\n" +
+    "</h2>\n" +
+    "</div>\n" +
+    "<div ng-if=\"!noContainersYet\">\n" +
     "<div class=\"mar-bottom-md\">\n" +
     "<span class=\"pficon pficon-info\" aria-hidden=\"true\"></span>\n" +
     "When you navigate away from this pod, any open terminal connections will be closed. This will kill any foreground processes you started from the terminal.\n" +
@@ -2825,6 +2831,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"column\">\n" +
     "<kubernetes-container-terminal prevent=\"!terminalTabWasSelected\" ng-if=\"term.isUsed\" ng-show=\"term.isVisible\" pod=\"pod\" container=\"term.containerName\" status=\"term.status\" rows=\"terminalRows\" cols=\"terminalCols\" autofocus command=\"[&quot;/bin/sh&quot;, &quot;-i&quot;, &quot;-c&quot;, &quot;TERM=xterm /bin/sh&quot;]\">\n" +
     "</kubernetes-container-terminal>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
Fixes #167 

Should the number of containers available for a pod drop to 0, the terminal tab will switch to a Patternfly empty state table stating such.