### PR TITLE
Show empty state message if there is only a DC and nothing else

### DIFF
--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -330,8 +330,7 @@ angular.module('openshiftConsole')
       var projectEmpty =
         _.isEmpty(services) &&
         _.isEmpty($scope.monopodsByService) &&
-        _.isEmpty(deployments) &&
-        _.isEmpty(deploymentConfigs);
+        _.isEmpty(deployments);
 
       // Check if we've loaded everything we show on the overview.
       var loaded = services && pods && deployments && deploymentConfigs;

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3360,7 +3360,7 @@ u && (c.recentPipelinesByDC = {}, c.recentBuildsByOutputImage = {}, _.each(e.int
 return z(a) ? void Y(a) :void W(a);
 }));
 }, $ = function() {
-var a = _.isEmpty(p) && _.isEmpty(c.monopodsByService) && _.isEmpty(r) && _.isEmpty(q), b = p && s && r && q;
+var a = _.isEmpty(p) && _.isEmpty(c.monopodsByService) && _.isEmpty(r), b = p && s && r && q;
 c.renderOptions.showGetStarted = b && a, c.renderOptions.showLoading = !b && a;
 };
 c.viewPodsForDeployment = function(a) {


### PR DESCRIPTION
A lonely deployment config with no services or replication controllers will result in an empty overview.

Fixes #334
@jwforres PTAL