### PR TITLE
Add warning regarding terminal history wipe

### DIFF
--- a/app/scripts/controllers/pod.js
+++ b/app/scripts/controllers/pod.js
@@ -24,6 +24,7 @@ angular.module('openshiftConsole')
     $scope.imageStreamImageRefByDockerReference = {}; // lets us determine if a particular container's docker image reference belongs to an imageStream
     $scope.builds = {};
     $scope.alerts = {};
+    $scope.terminalDisconnectAlert = {};
     $scope.renderOptions = $scope.renderOptions || {};
     $scope.renderOptions.hideFilterWidget = true;
     $scope.logOptions = {};
@@ -37,10 +38,14 @@ angular.module('openshiftConsole')
         title: $routeParams.pod
       }
     ];
+    $scope.terminalDisconnectAlert["disconnect"] = {
+      type: "warning",
+      message: "This terminal has been disconnected. If you reconnect, your terminal history will be lost."
+    };
 
     // Must always be initialized so we can check the selectedTab elsewhere
     $scope.selectedTab = {};
-    // Check for a ?tab=<name> query param to allow linking directly to a tab.    
+    // Check for a ?tab=<name> query param to allow linking directly to a tab.
     if ($routeParams.tab) {
       $scope.selectedTab[$routeParams.tab] = true;
     }
@@ -126,7 +131,7 @@ angular.module('openshiftConsole')
     if (!characterBoundingBox.height || !characterBoundingBox.width) {
       Logger.warn("Unable to calculate the bounding box for a character.  Terminal will not be able to resize.");
     }
-    else {   
+    else {
       $(window).on('resize.terminalsize', _.debounce(calculateTerminalSize, 100));
     }
 
@@ -147,6 +152,7 @@ angular.module('openshiftConsole')
 
       newTerm.isVisible = true;
       newTerm.isUsed = true;
+      $scope.selectedTerminalContainer = newTerm;
     };
 
     var getState = function(containerStatus) {
@@ -221,7 +227,6 @@ angular.module('openshiftConsole')
               setContainerVars();
 
               updateTerminals($scope.containerTerminals);
-
             }));
           },
           // failure

--- a/app/views/browse/pod.html
+++ b/app/views/browse/pod.html
@@ -132,6 +132,8 @@
                         This will kill any foreground processes you started from the terminal.
                       </div>
 
+                      <alerts ng-if="selectedTerminalContainer.status === 'disconnected'" alerts="terminalDisconnectAlert"></alerts>
+
                       <div class="mar-left-xl mar-bottom-lg">
                         <div class="row">
                           <div class="pad-left-none pad-bottom-lg col-xs-4 col-lg-3">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3106,12 +3106,15 @@ c.unwatchAll(i);
 });
 }));
 } ]), angular.module("openshiftConsole").controller("PodController", [ "$scope", "$filter", "$routeParams", "$timeout", "$uibModal", "DataService", "ImageStreamResolver", "MetricsService", "PodsService", "ProjectsService", function(a, b, c, d, e, f, g, h, i, j) {
-a.projectName = c.project, a.pod = null, a.imageStreams = {}, a.imagesByDockerReference = {}, a.imageStreamImageRefByDockerReference = {}, a.builds = {}, a.alerts = {}, a.renderOptions = a.renderOptions || {}, a.renderOptions.hideFilterWidget = !0, a.logOptions = {}, a.terminalTabWasSelected = !1, a.breadcrumbs = [ {
+a.projectName = c.project, a.pod = null, a.imageStreams = {}, a.imagesByDockerReference = {}, a.imageStreamImageRefByDockerReference = {}, a.builds = {}, a.alerts = {}, a.terminalDisconnectAlert = {}, a.renderOptions = a.renderOptions || {}, a.renderOptions.hideFilterWidget = !0, a.logOptions = {}, a.terminalTabWasSelected = !1, a.breadcrumbs = [ {
 title:"Pods",
 link:"project/" + c.project + "/browse/pods"
 }, {
 title:c.pod
-} ], a.selectedTab = {}, c.tab && (a.selectedTab[c.tab] = !0);
+} ], a.terminalDisconnectAlert.disconnect = {
+type:"warning",
+message:"This terminal has been disconnected. If you reconnect, your terminal history will be lost."
+}, a.selectedTab = {}, c.tab && (a.selectedTab[c.tab] = !0);
 var k = [];
 h.isAvailable().then(function(b) {
 a.metricsAvailable = b;
@@ -3155,7 +3158,7 @@ a && d(q, 0);
 }), a.onTerminalSelectChange = function(b) {
 _.each(a.containerTerminals, function(a) {
 a.isVisible = !1;
-}), b.isVisible = !0, b.isUsed = !0;
+}), b.isVisible = !0, b.isUsed = !0, a.selectedTerminalContainer = b;
 };
 var r = function(a) {
 var b = _.get(a, "state", {});

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2566,6 +2566,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"pficon pficon-info\" aria-hidden=\"true\"></span>\n" +
     "When you navigate away from this pod, any open terminal connections will be closed. This will kill any foreground processes you started from the terminal.\n" +
     "</div>\n" +
+    "<alerts ng-if=\"selectedTerminalContainer.status === 'disconnected'\" alerts=\"terminalDisconnectAlert\"></alerts>\n" +
     "<div class=\"mar-left-xl mar-bottom-lg\">\n" +
     "<div class=\"row\">\n" +
     "<div class=\"pad-left-none pad-bottom-lg col-xs-4 col-lg-3\">\n" +


### PR DESCRIPTION
Fixes #353 

When a terminal is disconnected and currently visible, an orange, dismiss-able warning box will remind the user that clicking the 'reconnect' button will wipe their terminal history.

![image](https://cloud.githubusercontent.com/assets/19572090/17631503/5260d484-6092-11e6-90fc-6bd632edbed4.png)

Also fixes a bug in containerTerminalSelector where selectedTerminalContainer was not updating on dropdown change, which was necessary for this issue to be fixed.

@jwforres 