### PR TITLE
Better service grouping

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -238,6 +238,7 @@
         <script src="scripts/controllers/edit/project.js"></script>
         <script src="scripts/controllers/createRoute.js"></script>
         <script src="scripts/controllers/attachPVC.js"></script>
+        <script src="scripts/controllers/modals/confirmModal.js"></script>
         <script src="scripts/controllers/modals/confirmScale.js"></script>
         <script src="scripts/controllers/modals/deleteModal.js"></script>
         <script src="scripts/controllers/modals/editModal.js"></script>

--- a/app/scripts/controllers/modals/confirmModal.js
+++ b/app/scripts/controllers/modals/confirmModal.js
@@ -1,0 +1,30 @@
+'use strict';
+/* jshint unused: false */
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:ConfirmModalController
+ * @description
+ * # ConfirmModalController
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('ConfirmModalController', function($scope,
+                                                 $uibModalInstance,
+                                                 message,
+                                                 details,
+                                                 buttonText,
+                                                 buttonClass) {
+    $scope.message = message;
+    $scope.details = details;
+    $scope.buttonText = buttonText;
+    $scope.buttonClass = buttonClass;
+
+    $scope.confirm = function() {
+      $uibModalInstance.close('confirm');
+    };
+
+    $scope.cancel = function() {
+      $uibModalInstance.dismiss('cancel');
+    };
+  });

--- a/app/scripts/controllers/modals/linkService.js
+++ b/app/scripts/controllers/modals/linkService.js
@@ -8,11 +8,12 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('LinkServiceModalController', function ($scope, $uibModalInstance) {
+  .controller('LinkServiceModalController', function ($scope, $uibModalInstance, ServicesService) {
     $scope.$watch('services', function(services) {
-      // Filter out the same service from the list.
+      var dependentServices = ServicesService.getDependentServices($scope.service);
+      // Filter out the same service and any existing links from the list.
       $scope.options = _.filter(services, function(service) {
-        return service !== $scope.service;
+        return service !== $scope.service && !_.includes(dependentServices, service.metadata.name);
       });
     });
     $scope.link = function() {

--- a/app/scripts/directives/overview/service.js
+++ b/app/scripts/directives/overview/service.js
@@ -18,8 +18,6 @@ angular.module('openshiftConsole')
           });
         }
 
-        var annotation = $filter('annotation');
-
         $scope.$watch('deploymentConfigsByService', function(deploymentConfigsByService) {
           if (!deploymentConfigsByService) {
             return;

--- a/app/scripts/directives/overview/serviceGroup.js
+++ b/app/scripts/directives/overview/serviceGroup.js
@@ -76,6 +76,48 @@ angular.module('openshiftConsole')
           });
         };
 
+        $scope.removeLink = function(service) {
+          var modalInstance = $uibModal.open({
+            animation: true,
+            templateUrl: 'views/modals/confirm.html',
+            controller: 'ConfirmModalController',
+            resolve: {
+              message: function() {
+                return "Remove service '" + service.metadata.name + "' from group?";
+              },
+              details: function() {
+                return "Services '" +
+                       $scope.primaryService.metadata.name +
+                       "' and '" +
+                       service.metadata.name +
+                       "' will no longer be displayed together on the overview.";
+              },
+              buttonText: function() {
+                return "Remove";
+              },
+              buttonClass: function() {
+                return "btn-danger";
+              }
+            }
+          });
+
+          modalInstance.result.then(function() {
+            ServicesService.removeServiceLink($scope.primaryService, service).then(
+              // success
+              _.noop,
+              // failure
+              function(result) {
+                $scope.alerts = $scope.alerts || {};
+                $scope.alerts["remove-service-link"] = {
+                  type: "error",
+                  message: "Could not remove service link.",
+                  details: $filter('getErrorDetails')(result)
+                };
+              }
+            );
+          });
+        };
+
         $scope.$watch('service.metadata.labels.app', function(appName) {
           $scope.appName = appName;
         });
@@ -136,6 +178,7 @@ angular.module('openshiftConsole')
           if (!$scope.service) {
             return;
           }
+          $scope.primaryService = $scope.service;
           $scope.childServices = _.get($scope, ['childServicesByParent', $scope.service.metadata.name], []);
         });
       }

--- a/app/views/modals/confirm.html
+++ b/app/views/modals/confirm.html
@@ -1,0 +1,10 @@
+<div class="modal-resource-action">
+  <div class="modal-body">
+    <h1>{{message}}</h1>
+    <p ng-if="details">{{details}}</p>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-lg" ng-class="buttonClass" type="button" ng-click="confirm()">{{buttonText}}</button>
+    <button class="btn btn-lg btn-default" type="button" ng-click="cancel()">Cancel</button>
+  </div>
+</div>

--- a/app/views/overview/_dc.html
+++ b/app/views/overview/_dc.html
@@ -1,13 +1,5 @@
 <div class="deployment-tile">
-  <div row class="service-title" ng-if="service">
-    <div>
-      Service:
-      <a ng-href="{{service | navigateResourceURL}}">{{service.metadata.name}}</a>
-    </div>
-    <div ng-if="weightByService[service.metadata.name]" class="service-metadata">
-      <ng-include src="'views/overview/_traffic-percent.html'"></ng-include>
-    </div>
-  </div>
+  <ng-include src="'views/overview/_service-header.html'"></ng-include>
   <div class="deployment-header">
     <div class="rc-header">
       <div>

--- a/app/views/overview/_pod.html
+++ b/app/views/overview/_pod.html
@@ -1,13 +1,5 @@
 <div class="deployment-tile" ng-if="pod.kind === 'Pod'">
-  <div row class="service-title" ng-if="service">
-    <div>
-      Service:
-      <a ng-href="{{service | navigateResourceURL}}">{{service.metadata.name}}</a>
-    </div>
-    <div ng-if="weightByService[service.metadata.name]" class="service-metadata">
-      <ng-include src="'views/overview/_traffic-percent.html'"></ng-include>
-    </div>
-  </div>  
+  <ng-include src="'views/overview/_service-header.html'"></ng-include>
   <div class="rc-header"> <!-- TODO may want different treatment for a pod-name? -->
     <div>
       Pod:

--- a/app/views/overview/_rc.html
+++ b/app/views/overview/_rc.html
@@ -1,13 +1,5 @@
 <div class="deployment-tile" ng-if="deployment.kind === 'ReplicationController'">
-  <div row class="service-title" ng-if="service">
-    <div>
-      Service:
-      <a ng-href="{{service | navigateResourceURL}}">{{service.metadata.name}}</a>
-    </div>
-    <div ng-if="weightByService[service.metadata.name]" class="service-metadata">
-      <ng-include src="'views/overview/_traffic-percent.html'"></ng-include>
-    </div>
-  </div>
+  <ng-include src="'views/overview/_service-header.html'"></ng-include>
   <div class="deployment-header">
     <div class="rc-header">
       <div>

--- a/app/views/overview/_service-group.html
+++ b/app/views/overview/_service-group.html
@@ -61,12 +61,14 @@
         -->
         <div class="overview-services"
              ng-class="{ 'single-alternate-service': (alternateServices | hashSize) === 1 }">
-          <overview-service class="primary-service"></overview-service>
+          <overview-service ng-init="isPrimary = true" class="primary-service"></overview-service>
           <overview-service
+              ng-init="isAlternate = true"
               ng-repeat="service in alternateServices"
               class="alternate-service">
           </overview-service>
           <overview-service
+              ng-init="isChild = true"
               ng-repeat="service in childServices">
           </overview-service>
 

--- a/app/views/overview/_service-header.html
+++ b/app/views/overview/_service-header.html
@@ -1,0 +1,17 @@
+<div row class="service-title" ng-if="service">
+  <div>
+    Service:
+    <a ng-href="{{service | navigateResourceURL}}">{{service.metadata.name}}</a>
+    <!-- Put the linking button next to the service name if we show traffic percent to the right. -->
+    <span ng-if="!isAlternate && alternateServices.length && !isChild" class="mar-left-sm">
+      <ng-include src="'views/overview/_service-linking-button.html'"></ng-include>
+    </span>
+  </div>
+  <div ng-if="alternateServices.length && !isChild" class="service-metadata">
+    <ng-include src="'views/overview/_traffic-percent.html'"></ng-include>
+  </div>
+  <!-- Show the button in the upper right corner if we're not showing traffic percent there. -->
+  <div ng-if="!alternateServices.length || isChild">
+    <ng-include src="'views/overview/_service-linking-button.html'"></ng-include>
+  </div>
+</div>

--- a/app/views/overview/_service-linking-button.html
+++ b/app/views/overview/_service-linking-button.html
@@ -1,0 +1,13 @@
+<!-- Only show the button if there are other services not yet linked. -->
+<span ng-if="'services' | canI : 'update'">
+  <a href=""
+     ng-if="isPrimary && (services | hashSize) > ((childServices | hashSize) + 1)"
+     ng-click="linkService()"
+     role="button"
+     ng-attr-title="Group service to {{service.metadata.name}}"><i class="fa fa-chain action-button" aria-hidden="true"></i><span class="sr-only">Group service to {{service.metadata.name}}</span></a>
+  <a href=""
+     ng-if="isChild"
+     ng-click="removeLink(service)"
+     role="button"
+     ng-attr-title="Remove {{service.metadata.name}} from service group"><i class="fa fa-chain-broken action-button" aria-hidden="true"></i><span class="sr-only">Remove {{service.metadata.name}} from service group</span></a>
+ </span>

--- a/app/views/overview/_traffic-percent.html
+++ b/app/views/overview/_traffic-percent.html
@@ -1,21 +1,19 @@
-<div ng-if="alternateServices.length">
-  <div ng-if="!totalWeight">
-    No Traffic
-  </div>
-  <div ng-if="totalWeight">
-    <span class="visible-xs visible-sm">
-      Traffic {{(weightByService[service.metadata.name] / totalWeight) | percent}}
-    </span>
-    <div class="hidden-xs hidden-sm">
-      <span class="traffic-label">Traffic</span>
-      <!-- Calculate the width of the progress bar in px (max 250px) -->
-      <div class="progress progress-sm"
-           ng-style="{ width: ((weightByService[service.metadata.name] / totalWeight * 250) | number) + 'px'}">
-        <div class="progress-bar">
-          <span>
-            {{(weightByService[service.metadata.name] / totalWeight) | percent}}
-          </span>
-        </div>
+<div ng-if="!totalWeight">
+  No Traffic
+</div>
+<div ng-if="totalWeight">
+  <span class="visible-xs visible-sm">
+    Traffic {{(weightByService[service.metadata.name] / totalWeight) | percent}}
+  </span>
+  <div class="hidden-xs hidden-sm">
+    <span class="traffic-label">Traffic</span>
+    <!-- Calculate the width of the progress bar in px (max 250px) -->
+    <div class="progress progress-sm"
+         ng-style="{ width: ((weightByService[service.metadata.name] / totalWeight * 250) | number) + 'px'}">
+      <div class="progress-bar">
+        <span>
+          {{(weightByService[service.metadata.name] / totalWeight) | percent}}
+        </span>
       </div>
     </div>
   </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7014,6 +7014,20 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/modals/confirm.html',
+    "<div class=\"modal-resource-action\">\n" +
+    "<div class=\"modal-body\">\n" +
+    "<h1>{{message}}</h1>\n" +
+    "<p ng-if=\"details\">{{details}}</p>\n" +
+    "</div>\n" +
+    "<div class=\"modal-footer\">\n" +
+    "<button class=\"btn btn-lg\" ng-class=\"buttonClass\" type=\"button\" ng-click=\"confirm()\">{{buttonText}}</button>\n" +
+    "<button class=\"btn btn-lg btn-default\" type=\"button\" ng-click=\"cancel()\">Cancel</button>\n" +
+    "</div>\n" +
+    "</div>"
+  );
+
+
   $templateCache.put('views/modals/confirmScale.html',
     "<div class=\"modal-resource-action\">\n" +
     "<div class=\"modal-body\">\n" +
@@ -7738,15 +7752,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/overview/_dc.html',
     "<div class=\"deployment-tile\">\n" +
-    "<div row class=\"service-title\" ng-if=\"service\">\n" +
-    "<div>\n" +
-    "Service:\n" +
-    "<a ng-href=\"{{service | navigateResourceURL}}\">{{service.metadata.name}}</a>\n" +
-    "</div>\n" +
-    "<div ng-if=\"weightByService[service.metadata.name]\" class=\"service-metadata\">\n" +
-    "<ng-include src=\"'views/overview/_traffic-percent.html'\"></ng-include>\n" +
-    "</div>\n" +
-    "</div>\n" +
+    "<ng-include src=\"'views/overview/_service-header.html'\"></ng-include>\n" +
     "<div class=\"deployment-header\">\n" +
     "<div class=\"rc-header\">\n" +
     "<div>\n" +
@@ -7823,15 +7829,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/overview/_pod.html',
     "<div class=\"deployment-tile\" ng-if=\"pod.kind === 'Pod'\">\n" +
-    "<div row class=\"service-title\" ng-if=\"service\">\n" +
-    "<div>\n" +
-    "Service:\n" +
-    "<a ng-href=\"{{service | navigateResourceURL}}\">{{service.metadata.name}}</a>\n" +
-    "</div>\n" +
-    "<div ng-if=\"weightByService[service.metadata.name]\" class=\"service-metadata\">\n" +
-    "<ng-include src=\"'views/overview/_traffic-percent.html'\"></ng-include>\n" +
-    "</div>\n" +
-    "</div>\n" +
+    "<ng-include src=\"'views/overview/_service-header.html'\"></ng-include>\n" +
     "<div class=\"rc-header\"> \n" +
     "<div>\n" +
     "Pod:\n" +
@@ -7861,15 +7859,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/overview/_rc.html',
     "<div class=\"deployment-tile\" ng-if=\"deployment.kind === 'ReplicationController'\">\n" +
-    "<div row class=\"service-title\" ng-if=\"service\">\n" +
-    "<div>\n" +
-    "Service:\n" +
-    "<a ng-href=\"{{service | navigateResourceURL}}\">{{service.metadata.name}}</a>\n" +
-    "</div>\n" +
-    "<div ng-if=\"weightByService[service.metadata.name]\" class=\"service-metadata\">\n" +
-    "<ng-include src=\"'views/overview/_traffic-percent.html'\"></ng-include>\n" +
-    "</div>\n" +
-    "</div>\n" +
+    "<ng-include src=\"'views/overview/_service-header.html'\"></ng-include>\n" +
     "<div class=\"deployment-header\">\n" +
     "<div class=\"rc-header\">\n" +
     "<div>\n" +
@@ -7946,10 +7936,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div uib-collapse=\"collapse\" class=\"service-group-body\">\n" +
     "\n" +
     "<div class=\"overview-services\" ng-class=\"{ 'single-alternate-service': (alternateServices | hashSize) === 1 }\">\n" +
-    "<overview-service class=\"primary-service\"></overview-service>\n" +
-    "<overview-service ng-repeat=\"service in alternateServices\" class=\"alternate-service\">\n" +
+    "<overview-service ng-init=\"isPrimary = true\" class=\"primary-service\"></overview-service>\n" +
+    "<overview-service ng-init=\"isAlternate = true\" ng-repeat=\"service in alternateServices\" class=\"alternate-service\">\n" +
     "</overview-service>\n" +
-    "<overview-service ng-repeat=\"service in childServices\">\n" +
+    "<overview-service ng-init=\"isChild = true\" ng-repeat=\"service in childServices\">\n" +
     "</overview-service>\n" +
     "<div flex column ng-if=\"alternateServices.length === 0 && childServices.length === 0 && service\" class=\"no-child-services-block\">\n" +
     "<div class=\"no-child-services-message\">\n" +
@@ -7974,6 +7964,35 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>"
+  );
+
+
+  $templateCache.put('views/overview/_service-header.html',
+    "<div row class=\"service-title\" ng-if=\"service\">\n" +
+    "<div>\n" +
+    "Service:\n" +
+    "<a ng-href=\"{{service | navigateResourceURL}}\">{{service.metadata.name}}</a>\n" +
+    "\n" +
+    "<span ng-if=\"!isAlternate && alternateServices.length && !isChild\" class=\"mar-left-sm\">\n" +
+    "<ng-include src=\"'views/overview/_service-linking-button.html'\"></ng-include>\n" +
+    "</span>\n" +
+    "</div>\n" +
+    "<div ng-if=\"alternateServices.length && !isChild\" class=\"service-metadata\">\n" +
+    "<ng-include src=\"'views/overview/_traffic-percent.html'\"></ng-include>\n" +
+    "</div>\n" +
+    "\n" +
+    "<div ng-if=\"!alternateServices.length || isChild\">\n" +
+    "<ng-include src=\"'views/overview/_service-linking-button.html'\"></ng-include>\n" +
+    "</div>\n" +
+    "</div>"
+  );
+
+
+  $templateCache.put('views/overview/_service-linking-button.html',
+    " <span ng-if=\"'services' | canI : 'update'\">\n" +
+    "<a href=\"\" ng-if=\"isPrimary && (services | hashSize) > ((childServices | hashSize) + 1)\" ng-click=\"linkService()\" role=\"button\" ng-attr-title=\"Group service to {{service.metadata.name}}\"><i class=\"fa fa-chain action-button\" aria-hidden=\"true\"></i><span class=\"sr-only\">Group service to {{service.metadata.name}}</span></a>\n" +
+    "<a href=\"\" ng-if=\"isChild\" ng-click=\"removeLink(service)\" role=\"button\" ng-attr-title=\"Remove {{service.metadata.name}} from service group\"><i class=\"fa fa-chain-broken action-button\" aria-hidden=\"true\"></i><span class=\"sr-only\">Remove {{service.metadata.name}} from service group</span></a>\n" +
+    "</span>"
   );
 
 
@@ -8012,7 +8031,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/overview/_traffic-percent.html',
-    "<div ng-if=\"alternateServices.length\">\n" +
     "<div ng-if=\"!totalWeight\">\n" +
     "No Traffic\n" +
     "</div>\n" +
@@ -8028,7 +8046,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span>\n" +
     "{{(weightByService[service.metadata.name] / totalWeight) | percent}}\n" +
     "</span>\n" +
-    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
Allow users to add more than one dependent service on the overview and easily remove services from groups.

Link and unlink buttons:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/17632405/25a39234-6096-11e6-8b68-06dbbe6b263d.png)

Remove confirmation dialog:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/17632416/30307f78-6096-11e6-9593-e6998ca48c08.png)

Link button for A/B services:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/17632456/5678fa3e-6096-11e6-8d48-cd0950178aa7.png)

Fixes #103

@jwforres PTAL