### PR TITLE
Fixing bug where "Add to Project" overlays project picker

### DIFF
--- a/app/styles/_project-menu.less
+++ b/app/styles/_project-menu.less
@@ -154,7 +154,7 @@
     float: left;
     margin: 0;
     padding-top: 0;
-    max-width: 280px; // Leave enough space for the status indicator extension point
+    max-width: 360px; // Leave enough space for the status indicator extension point
     .bootstrap-select.btn-group {
       .btn {
         padding: 15px 50px 15px 30px;
@@ -176,24 +176,23 @@
     }
     .bootstrap-select .dropdown-toggle {
       height: 60px;
-      max-width: 280px;
-      min-width: 280px;
+      max-width: 240px;
     }
   }
 }
 
-// At 900 there is enough space to make the menu bigger and still have space for the status indicator extension
-@media (min-width: 900px) {
+// At 890 there is enough space to make the menu bigger and still have space for the status indicator extension
+@media (min-width: 890px) {
   .navbar-project-menu .bootstrap-select .dropdown-toggle,
   .navbar-project-menu {
-    max-width: 400px;
+    max-width: 380px;
   }
 }
 
 @media (min-width: @screen-md-min) {
   .navbar-project-menu .bootstrap-select .dropdown-toggle,
   .navbar-project-menu {
-    max-width: 500px;
+    max-width: 470px;
   }
 }
 

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4272,16 +4272,16 @@ to{background-color:transparent}
 }
 @media (min-width:480px){.navbar-project-menu .bootstrap-select.btn-group .btn .filter-option{max-width:310px}
 }
-@media (min-width:768px){.navbar-project-menu{border-bottom:0;border-top:0;float:left;margin:0;padding-top:0;max-width:280px}
+@media (min-width:768px){.navbar-project-menu{border-bottom:0;border-top:0;float:left;margin:0;padding-top:0;max-width:360px}
 .navbar-project-menu .bootstrap-select.btn-group .btn{padding:15px 50px 15px 30px}
 .navbar-project-menu .bootstrap-select.btn-group .btn:before{color:#9c9c9c;content:'Project';font-size:10px;left:30px;position:absolute;top:8px}
 .navbar-project-menu .bootstrap-select.btn-group .btn .filter-option{max-width:470px}
 .navbar-project-menu .bootstrap-select.btn-group .dropdown-toggle .caret{right:30px}
-.navbar-project-menu .bootstrap-select .dropdown-toggle{height:60px;max-width:280px;min-width:280px}
+.navbar-project-menu .bootstrap-select .dropdown-toggle{height:60px;max-width:240px}
 }
-@media (min-width:900px){.navbar-project-menu,.navbar-project-menu .bootstrap-select .dropdown-toggle{max-width:400px}
+@media (min-width:890px){.navbar-project-menu,.navbar-project-menu .bootstrap-select .dropdown-toggle{max-width:380px}
 }
-@media (min-width:992px){.navbar-project-menu,.navbar-project-menu .bootstrap-select .dropdown-toggle{max-width:500px}
+@media (min-width:992px){.navbar-project-menu,.navbar-project-menu .bootstrap-select .dropdown-toggle{max-width:470px}
 }
 @-ms-viewport{width:device-width}
 .visible-lg,.visible-lg-block,.visible-lg-inline,.visible-lg-inline-block,.visible-md,.visible-md-block,.visible-md-inline,.visible-md-inline-block,.visible-sm,.visible-sm-block,.visible-sm-inline,.visible-sm-inline-block,.visible-xs,.visible-xs-block,.visible-xs-inline,.visible-xs-inline-block{display:none!important}


### PR DESCRIPTION
at certain resolutions in IE11.

Also adjusts project menu size for other resolutions so there is enough
room to accommodate the status icon comfortably.

Fixes #368 

![screen shot 2016-08-15 at 4 23 53 pm](https://cloud.githubusercontent.com/assets/895728/17678346/b64b4e9c-6304-11e6-9769-2104a055b012.PNG)
![screen shot 2016-08-15 at 4 20 53 pm](https://cloud.githubusercontent.com/assets/895728/17678305/945774c8-6304-11e6-892d-03143e659a70.PNG)
![screen shot 2016-08-15 at 4 21 30 pm](https://cloud.githubusercontent.com/assets/895728/17678307/945dc0d0-6304-11e6-952d-8fc53e99daa9.PNG)
![screen shot 2016-08-15 at 4 21 43 pm](https://cloud.githubusercontent.com/assets/895728/17678306/945ce03e-6304-11e6-810b-83f34df1b1c4.PNG)

@jwforres, PTAL