### PR TITLE
Don't show metrics for builds on monitoring page

### DIFF
--- a/app/views/monitoring.html
+++ b/app/views/monitoring.html
@@ -135,9 +135,6 @@
                         </div>
 
                       </log-viewer>
-                      <div class="mar-top-lg" ng-if="metricsAvailable && podsByName[(build | annotation : 'buildPod')]">
-                        <metrics pod="podsByName[(build | annotation : 'buildPod')]"></metrics>
-                      </div>
                     </div>
                   </div>
                 </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7432,9 +7432,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</div>\n" +
     "</log-viewer>\n" +
-    "<div class=\"mar-top-lg\" ng-if=\"metricsAvailable && podsByName[(build | annotation : 'buildPod')]\">\n" +
-    "<metrics pod=\"podsByName[(build | annotation : 'buildPod')]\"></metrics>\n" +
-    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
The charts usually are empty or contain only one or two data points. We
could add more helpful metrics at some point (like maximum memory and
CPU used during the build), but currently the charts aren't useful.

@jwforres PTAL