### PR TITLE
Fix for equal height tiles and no deployment blocks

### DIFF
--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -7,6 +7,9 @@
 @service-group-vertical-margin: 6px;
 @service-group-horizontal-margin: 8px;
 @two-column-min-width: 568px;
+@tile-min-height:      256px;
+@tile-min-height-lg:   346px;
+
 
 .overview {
   font-weight: 300;
@@ -155,10 +158,10 @@
       .overview-services {
         .flex-direction(@direction: row);
         @media (min-width: @screen-sm-min) {
-          min-height: 345px;
+          min-height: @tile-min-height-lg;
         }
         @media (min-width: @screen-md-min) {
-          min-height: 255px;
+          min-height: @tile-min-height;
         }
         overview-service,.no-child-services-message {
           max-width: none;
@@ -271,6 +274,7 @@
       .deployment-block {
         .flex-display(@display: flex);
         .flex(@columns: 1 0 0%);
+        height: 100%;
         &.service-multiple-targets, &.service-multiple-targets .deployment-tile-wrapper {
           display: block;
         }
@@ -552,6 +556,13 @@
   }
   .standalone-service .no-deployments-block {
     margin-left: 0;
+    // Min heights matching .overview-services
+    @media (min-width: @screen-sm-min) {
+      min-height: @tile-min-height-lg;
+    }
+    @media (min-width: @screen-md-min) {
+      min-height: @tile-min-height;
+    }
     .no-deployments-message {
       margin-top: 0;
     }

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3845,7 +3845,7 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .navbar-flex-btn.toggle-menu{display:none}
 .navbar-flex-btn.project-action{-webkit-flex:0 0 120px;-moz-flex:0 0 120px;-ms-flex:0 0 120px;flex:0 0 120px}
 .navbar-flex-btn.project-action .project-action-btn{border-right:1px solid #050505}
-.overview .standalone-service .service-group-body .overview-services{min-height:345px}
+.overview .standalone-service .service-group-body .overview-services{min-height:346px}
 }
 @media (min-width:992px){.navbar-pf-alt .navbar-iconic .username{max-width:150px}
 }
@@ -3996,7 +3996,7 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview h2{line-height:1.4}
 .overview .container-fluid{margin-top:20px}
 @media (min-width:992px){.overview .container-fluid{margin-top:30px}
-.overview .standalone-service .service-group-body .overview-services{min-height:255px}
+.overview .standalone-service .service-group-body .overview-services{min-height:256px}
 }
 .overview .builds-block{background-color:#fff;margin-left:0;border-right:1px solid #d6d6d6}
 .overview .builds-block .builds{overflow:inherit}
@@ -4054,7 +4054,7 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview .service-group-body .overview-services{-webkit-justify-content:space-between;-moz-justify-content:space-between;justify-content:space-between;display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex-wrap:wrap;-moz-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column}
 @media (max-width:567px){.overview .service-group-body .overview-services overview-service:nth-child(n+2){margin-top:6px}
 }
-.overview .service-group-body .overview-services .deployment-block{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex:1 0 0%;-moz-flex:1 0 0%;-ms-flex:1 0 0%;flex:1 0 0%}
+.overview .service-group-body .overview-services .deployment-block{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex:1 0 0%;-moz-flex:1 0 0%;-ms-flex:1 0 0%;flex:1 0 0%;height:100%}
 .overview .service-group-body .overview-services .deployment-block.service-multiple-targets,.overview .service-group-body .overview-services .deployment-block.service-multiple-targets .deployment-tile-wrapper{display:block}
 .overview .service-group-body .overview-services .deployment-tile-wrapper{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex:1 0 0%;-moz-flex:1 0 0%;-ms-flex:1 0 0%;flex:1 0 0%}
 .overview .service-group-body .overview-services .deployment-tile{-webkit-flex:1 0 0%;-moz-flex:1 0 0%;-ms-flex:1 0 0%;flex:1 0 0%;position:relative}
@@ -4128,6 +4128,10 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 }
 .overview .standalone-service-row{-webkit-justify-content:space-between;-moz-justify-content:space-between;justify-content:space-between}
 .overview .standalone-service .no-deployments-block{margin-left:0}
+@media (min-width:768px){.overview .standalone-service .no-deployments-block{min-height:346px}
+}
+@media (min-width:992px){.overview .standalone-service .no-deployments-block{min-height:256px}
+}
 .overview .standalone-service .no-deployments-block .no-deployments-message{margin-top:0}
 .overview .shield{background:#ebebeb;border:1px solid #d6d6d6;border-bottom:0;width:36px;position:absolute;-webkit-align-items:center;-moz-align-items:center;align-items:center;right:10px;top:-1px;z-index:9}
 .overview .shield .shield-number{display:flex;font-size:11px;font-weight:500;height:30px;position:relative;width:36px;-webkit-align-items:center;-moz-align-items:center;align-items:center;-webkit-justify-content:center;-moz-justify-content:center;justify-content:center}


### PR DESCRIPTION
fixes https://github.com/openshift/origin-web-console/issues/273

This fixes 90% of the scenarios by setting min-heights for .overview-services and .no-deployment-block

To fix this so that each grows/shrinks for all scenarios using flex, then the underlying markup structure for no deployment blocks will need to be different from the general service-group blocks since fundamentally they behave differently.