### PR TITLE
Changes to show deployment connector arrow at mobile

### DIFF
--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -368,10 +368,33 @@
         .text-center();
       }
     }
+    .deployment-details {
+      .flex-order(@order: 1);
+    }
+    .overview-donut {
+      .flex-order(@order: 2);
+      &.latest {
+        .flex-order(@order: 4);
+      }
+    }
     .overview-donut-connector {
+      .align-items(@align: center);
+      color: #ccc;
+      .flex-order(@order: 3);
+      .justify-content(@justify: center);
+      line-height: 1;
+      padding-bottom: 10px;
+      position: relative;
       text-align: center;
+      &.contains-deployment-status-msg {
+        .flex-order(@order: 5);
+      }
       .deployment-connector-arrow {
-        display: none;
+        font-size: 200%;
+        &:before {
+          content: '\2193';
+          padding-right: 23px; // align down arrow with donuts
+        }
       }
     }
     .overview-unsuccessful-state {
@@ -391,37 +414,33 @@
       .deployment-details {
         padding-left: 30px;
         width: 50%;
-        .flex-order(@order: 1);
         &.ng-leave {
           animation: simpleSlide 1s ease forwards;
         }
       }
-      .overview-donut { 
-        .flex-order(@order: 2);
+      .overview-donut {
         min-height: 150px;
         width: 50%;
-        &.latest { 
+        &.latest {
           max-width: 50%;
-          .flex-order(@order: 4);
         }
       }
       .overview-donut-connector {
-        .flex-order(@order: 3);
-        font-size: 300%;
-        color: #ccc;
-        .align-items(@align: center);
-        .justify-content(@justify: center);
-        line-height: 1;
-        position: relative;
+        padding-bottom: 0;
         &.contains-deployment-status-msg {
+          .flex-order(@order: 3);
           width: 50%;
         }
         .deployment-connector-arrow {
-          display: block;
+          font-size: 300%;
           left: -20px;
           line-height: 0;
           position: absolute;
           top: 47%;
+          &:before {
+            content: '\2192';
+            padding-right: 0;
+          }
         }
       }
       .overview-unsuccessful-state {

--- a/app/views/overview/_dc.html
+++ b/app/views/overview/_dc.html
@@ -42,7 +42,7 @@
     <!-- deployment in progress (connecting arrow) -->
     <div column class="overview-donut-connector" ng-class="{'contains-deployment-status-msg':deployments.length === 1}" ng-if="anyDeploymentInProgress">
       <div ng-if="deployments.length > 1" class="deployment-connector-arrow">
-        &rarr;
+        
       </div>
       <div ng-if="deployments.length === 1" class="deployment-status-msg">
         <status-icon status="deployments[0] | deploymentStatus" class="mar-right-xs"></status-icon>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7845,7 +7845,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<div column class=\"overview-donut-connector\" ng-class=\"{'contains-deployment-status-msg':deployments.length === 1}\" ng-if=\"anyDeploymentInProgress\">\n" +
     "<div ng-if=\"deployments.length > 1\" class=\"deployment-connector-arrow\">\n" +
-    "&rarr;\n" +
     "</div>\n" +
     "<div ng-if=\"deployments.length === 1\" class=\"deployment-status-msg\">\n" +
     "<status-icon status=\"deployments[0] | deploymentStatus\" class=\"mar-right-xs\"></status-icon>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4058,6 +4058,7 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview .service-group-body .overview-services .deployment-block{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex:1 0 0%;-moz-flex:1 0 0%;-ms-flex:1 0 0%;flex:1 0 0%;height:100%}
 .overview .service-group-body .overview-services .deployment-block.service-multiple-targets,.overview .service-group-body .overview-services .deployment-block.service-multiple-targets .deployment-tile-wrapper{display:block}
 .overview .service-group-body .overview-services .deployment-tile-wrapper{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex:1 0 0%;-moz-flex:1 0 0%;-ms-flex:1 0 0%;flex:1 0 0%}
+.overview .no-deployments-block,.overview .shield .shield-number{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex}
 .overview .service-group-body .overview-services .deployment-tile{-webkit-flex:1 0 0%;-moz-flex:1 0 0%;-ms-flex:1 0 0%;flex:1 0 0%;position:relative}
 @media (min-width:568px){.overview .service-group-with-route-row .overview-services{-webkit-flex-direction:row;-moz-flex-direction:row;-ms-flex-direction:row;flex-direction:row}
 .overview .service-group-with-route-row .overview-services overview-service{width:50%}
@@ -4081,24 +4082,29 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview .deployment-tile .overview-donut,.overview .deployment-tile .overview-metrics{-webkit-align-items:center;-moz-align-items:center;align-items:center}
 @media (max-width:991px){.overview .deployment-tile .overview-metrics{margin:0 auto;text-align:center}
 }
-.overview .deployment-tile .overview-donut-connector{text-align:center}
-.overview .deployment-tile .overview-donut-connector .deployment-connector-arrow{display:none}
+.overview .deployment-tile .deployment-details{-webkit-order:1;-moz-order:1;-ms-order:1;order:1}
+.overview .deployment-tile .overview-donut{-webkit-order:2;-moz-order:2;-ms-order:2;order:2}
+.overview .deployment-tile .overview-donut.latest{-webkit-order:4;-moz-order:4;-ms-order:4;order:4}
+.overview .deployment-tile .overview-donut-connector{-webkit-align-items:center;-moz-align-items:center;align-items:center;color:#ccc;-webkit-order:3;-moz-order:3;-ms-order:3;order:3;-webkit-justify-content:center;-moz-justify-content:center;justify-content:center;line-height:1;padding-bottom:10px;position:relative;text-align:center}
+.overview .deployment-tile .overview-donut-connector.contains-deployment-status-msg{-webkit-order:5;-moz-order:5;-ms-order:5;order:5}
+.overview .deployment-tile .overview-donut-connector .deployment-connector-arrow{font-size:200%}
+.overview .deployment-tile .overview-donut-connector .deployment-connector-arrow:before{content:'\2193';padding-right:23px}
 .overview .deployment-tile .overview-unsuccessful-state{text-align:center}
 @keyframes simpleSlide{0%{margin-left:0%}
 100%{margin-left:-50%}
 }
-@media (min-width:992px){.overview .deployment-tile .deployment-details{padding-left:30px;width:50%;-webkit-order:1;-moz-order:1;-ms-order:1;order:1}
+@media (min-width:992px){.overview .deployment-tile .deployment-details{padding-left:30px;width:50%}
 .overview .deployment-tile .deployment-details.ng-leave{animation:simpleSlide 1s ease forwards}
-.overview .deployment-tile .overview-donut{-webkit-order:2;-moz-order:2;-ms-order:2;order:2;min-height:150px;width:50%}
-.overview .deployment-tile .overview-donut.latest{max-width:50%;-webkit-order:4;-moz-order:4;-ms-order:4;order:4}
-.overview .deployment-tile .overview-donut-connector{-webkit-order:3;-moz-order:3;-ms-order:3;order:3;font-size:300%;color:#ccc;-webkit-align-items:center;-moz-align-items:center;align-items:center;-webkit-justify-content:center;-moz-justify-content:center;justify-content:center;line-height:1;position:relative}
-.overview .deployment-tile .overview-donut-connector.contains-deployment-status-msg{width:50%}
-.overview .deployment-tile .overview-donut-connector .deployment-connector-arrow{display:block;left:-20px;line-height:0;position:absolute;top:47%}
+.overview .deployment-tile .overview-donut{min-height:150px;width:50%}
+.overview .deployment-tile .overview-donut.latest{max-width:50%}
+.overview .deployment-tile .overview-donut-connector{padding-bottom:0}
+.overview .deployment-tile .overview-donut-connector.contains-deployment-status-msg{-webkit-order:3;-moz-order:3;-ms-order:3;order:3;width:50%}
+.overview .deployment-tile .overview-donut-connector .deployment-connector-arrow{font-size:300%;left:-20px;line-height:0;position:absolute;top:47%}
+.overview .deployment-tile .overview-donut-connector .deployment-connector-arrow:before{content:'\2192';padding-right:0}
 .overview .deployment-tile .overview-unsuccessful-state{-webkit-flex:1 1 0%;-moz-flex:1 1 0%;-ms-flex:1 1 0%;flex:1 1 0%;-webkit-order:3;-moz-order:3;-ms-order:3;order:3;-webkit-align-items:center;-moz-align-items:center;align-items:center;-webkit-justify-content:center;-moz-justify-content:center;justify-content:center;line-height:1}
 .overview .deployment-tile .deployment-status-msg{color:#9c9c9c;font-size:16px;line-height:normal;margin-bottom:10px}
 .overview .deployment-tile .deployment-status-msg .deployment-log-link{font-size:14px}
 }
-.overview .no-deployments-block,.overview .shield .shield-number{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex}
 .overview .no-deployments-block{display:flex;height:100%;width:100%}
 .overview .no-child-services-block{padding-left:3px;width:50%}
 .overview .no-child-services-message,.overview .no-deployments-message{text-align:center;color:#9c9c9c;min-height:20px;background-color:#f5f5f5;border:1px solid #e3e3e3;border-radius:1px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.05);box-shadow:inset 0 1px 1px rgba(0,0,0,.05);-webkit-justify-content:center;-moz-justify-content:center;justify-content:center;margin-bottom:0;padding:0}


### PR DESCRIPTION
Moved right arrow from markup to css, so that it can be switched from down to right arrow and still be semantically correct.

Refactored the css so that it's mobile first.

<img width="495" alt="screen shot 2016-08-16 at 5 18 17 pm" src="https://cloud.githubusercontent.com/assets/1874151/17716156/8371948c-63d5-11e6-9bcf-f8a6faa10546.png">


