### PR TITLE
Avoid empty space at bottom of overview when no visible deployments

### DIFF
--- a/app/views/overview/_service.html
+++ b/app/views/overview/_service.html
@@ -12,6 +12,7 @@
 
 <div ng-attr-row="{{!service ? '' : undefined}}"
      ng-attr-wrap="{{!service ? '' : undefined}}"
+     ng-if="(visibleDeploymentsByConfig | hashSize) || (monopodsByService[service.metadata.name || ''] | hashSize)"
      class="deployment-block"
      ng-class="{
        'no-service': !service,

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8082,7 +8082,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-attr-row=\"{{!service ? '' : undefined}}\" ng-attr-wrap=\"{{!service ? '' : undefined}}\" class=\"deployment-block\" ng-class=\"{\n" +
+    "<div ng-attr-row=\"{{!service ? '' : undefined}}\" ng-attr-wrap=\"{{!service ? '' : undefined}}\" ng-if=\"(visibleDeploymentsByConfig | hashSize) || (monopodsByService[service.metadata.name || ''] | hashSize)\" class=\"deployment-block\" ng-class=\"{\n" +
     "       'no-service': !service,\n" +
     "       'service-multiple-targets': (rcTileCount + (monopodsByService[service.metadata.name] | hashSize) > 1)\n" +
     "     }\">\n" +


### PR DESCRIPTION
Fixes #421

Removes the div from https://github.com/openshift/origin-web-console/issues/421#issuecomment-241052111 when it's empty.

@jwforres PTAL
@rhamilto CC