### PR TITLE
Remove ngTouch

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -16,7 +16,6 @@ angular
     'ngResource',
     'ngRoute',
     'ngSanitize',
-    'ngTouch',
     'openshiftUI',
     'kubernetesUI',
     'registryUI.images',

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -103,7 +103,7 @@ iconClass:"pficon pficon-screen",
 href:"/monitoring",
 prefixes:[ "/browse/events" ]
 } ]
-}, angular.module("openshiftConsole", [ "ngAnimate", "ngCookies", "ngResource", "ngRoute", "ngSanitize", "ngTouch", "openshiftUI", "kubernetesUI", "registryUI.images", "ui.bootstrap", "patternfly.charts", "patternfly.sort", "openshiftConsoleTemplates", "ui.ace", "extension-registry", "as.sortable", "ui.select", "key-value-editor", "angular-inview" ]).config([ "$routeProvider", function(a) {
+}, angular.module("openshiftConsole", [ "ngAnimate", "ngCookies", "ngResource", "ngRoute", "ngSanitize", "openshiftUI", "kubernetesUI", "registryUI.images", "ui.bootstrap", "patternfly.charts", "patternfly.sort", "openshiftConsoleTemplates", "ui.ace", "extension-registry", "as.sortable", "ui.select", "key-value-editor", "angular-inview" ]).config([ "$routeProvider", function(a) {
 a.when("/", {
 templateUrl:"views/projects.html",
 controller:"ProjectsController"


### PR DESCRIPTION
We're not using any of the swipe events, and the ng-click override is deprecated in Angular 1.5.

Fixes #442
@jwforres PTAL