### PR TITLE
Fix unequal service header heights for multi-service routes in Firefox

### DIFF
--- a/app/views/overview/_service-header.html
+++ b/app/views/overview/_service-header.html
@@ -4,7 +4,7 @@
     <span class="sr-only">Service</span>
     <a ng-href="{{service | navigateResourceURL}}">{{service.metadata.name}}</a>
     <!-- Put the linking button next to the service name if we show traffic percent to the right. -->
-    <span ng-if="!isAlternate && alternateServices.length && !isChild" class="mar-left-sm small">
+    <span ng-if="!isAlternate && alternateServices.length && !isChild" class="small mar-left-sm mar-right-sm">
       <ng-include src="'views/overview/_service-linking-button.html'"></ng-include>
     </span>
   </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8058,7 +8058,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"sr-only\">Service</span>\n" +
     "<a ng-href=\"{{service | navigateResourceURL}}\">{{service.metadata.name}}</a>\n" +
     "\n" +
-    "<span ng-if=\"!isAlternate && alternateServices.length && !isChild\" class=\"mar-left-sm small\">\n" +
+    "<span ng-if=\"!isAlternate && alternateServices.length && !isChild\" class=\"small mar-left-sm mar-right-sm\">\n" +
     "<ng-include src=\"'views/overview/_service-linking-button.html'\"></ng-include>\n" +
     "</span>\n" +
     "</div>\n" +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1369404

Here is what was causing the unequal heights. Adding additional right margin to the icon fixes it.

![screen shot 2016-08-23 at 9 22 47 am](https://cloud.githubusercontent.com/assets/1167259/17893583/42fa643a-6914-11e6-8135-0e67ff213fac.png)

@jwforres PTAL