### PR TITLE
Fix swallowed keys in BC editor

### DIFF
--- a/app/scripts/controllers/edit/buildConfig.js
+++ b/app/scripts/controllers/edit/buildConfig.js
@@ -133,6 +133,8 @@ angular.module('openshiftConsole')
     AlertMessageService.clearAlerts();
     var watches = [];
 
+    var buildStrategy = $filter('buildStrategy');
+
     ProjectsService
       .get($routeParams.project)
       .then(_.spread(function(project, context) {
@@ -146,16 +148,12 @@ angular.module('openshiftConsole')
           function(buildConfig) {
             $scope.buildConfig = buildConfig;
             $scope.updatedBuildConfig = angular.copy($scope.buildConfig);
-            $scope.buildStrategy = $filter('buildStrategy')($scope.updatedBuildConfig);
+            $scope.buildStrategy = buildStrategy($scope.updatedBuildConfig);
             $scope.strategyType = $scope.buildConfig.spec.strategy.type;
-            $scope.envVars = _.map(
-                              $filter('envVarsPair')($scope.buildStrategy.env),
-                              function(val, key) {
-                                return {
-                                  name: key,
-                                  value: val
-                                }
-                              });
+            $scope.envVars = $scope.buildStrategy.env || [];
+            _.each($scope.envVars, function(env) {
+              $filter('altTextForValueFrom')(env);
+            });
             $scope.triggers = $scope.getTriggerMap($scope.triggers, $scope.buildConfig.spec.triggers);
             $scope.sources = $scope.getSourceMap($scope.sources, $scope.buildConfig.spec.source);
 

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -22,7 +22,7 @@ angular.module('openshiftConsole')
       "deploymentConfig":         ["openshift.io/deployment-config.name"],
       "deployment":               ["openshift.io/deployment.name"],
       "pod":                      ["openshift.io/deployer-pod.name"],
-      "deployerPod":              ["openshift.io/deployer-pod.name"],      
+      "deployerPod":              ["openshift.io/deployer-pod.name"],
       "deployerPodFor":           ["openshift.io/deployer-pod-for.name"],
       "deploymentStatus":         ["openshift.io/deployment.phase"],
       "deploymentStatusReason":   ["openshift.io/deployment.status-reason"],
@@ -350,7 +350,7 @@ angular.module('openshiftConsole')
       var parts = imageName.split('@');
       return parts.length > 1 ? parts[1] : '';
     };
-  })  
+  })
   .filter('imageEnv', function() {
     return function(image, envKey) {
       var envVars = image.dockerImageMetadata.Config.Env;
@@ -361,15 +361,6 @@ angular.module('openshiftConsole')
         }
       }
       return null;
-    };
-  })
-  .filter('envVarsPair', function() {
-    return function(configEnvVars) {
-      var pairs = {};
-      angular.forEach(configEnvVars, function(env) {
-        pairs[env.name] = env.value;
-      });
-      return pairs;
     };
   })
   .filter('destinationSourcePair', function() {

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4923,14 +4923,11 @@ configChangeTrigger:{}
 }, a.runPolicyTypes = [ "Serial", "Parallel", "SerialLatestOnly" ], a.availableProjects = [], i.getAlerts().forEach(function(b) {
 a.alerts[b.name] = b.data;
 }), i.clearAlerts();
-var l = [];
+var l = [], m = e("buildStrategy");
 d.get(b.project).then(_.spread(function(d, f) {
 a.project = d, a.breadcrumbs[0].title = e("displayName")(d), c.get("buildconfigs", b.buildconfig, f).then(function(d) {
-if (a.buildConfig = d, a.updatedBuildConfig = angular.copy(a.buildConfig), a.buildStrategy = e("buildStrategy")(a.updatedBuildConfig), a.strategyType = a.buildConfig.spec.strategy.type, a.envVars = _.map(e("envVarsPair")(a.buildStrategy.env), function(a, b) {
-return {
-name:b,
-value:a
-};
+if (a.buildConfig = d, a.updatedBuildConfig = angular.copy(a.buildConfig), a.buildStrategy = m(a.updatedBuildConfig), a.strategyType = a.buildConfig.spec.strategy.type, a.envVars = a.buildStrategy.env || [], _.each(a.envVars, function(a) {
+e("altTextForValueFrom")(a);
 }), a.triggers = a.getTriggerMap(a.triggers, a.buildConfig.spec.triggers), a.sources = a.getSourceMap(a.sources, a.buildConfig.spec.source), _.has(d, "spec.strategy.jenkinsPipelineStrategy.jenkinsfile") && (a.jenkinsfileOptions.type = "inline"), a.buildStrategy.from) {
 var g = a.buildStrategy.from;
 a.builderOptions = a.setPickedVariables(a.builderOptions, g.kind, g.namespace || d.metadata.namespace, g.name.split(":")[0], g.name.split(":")[1], "ImageStreamImage" === g.kind ? g.name :"", "ImageStreamTag" === g.kind ? d.metadata.namespace + "/" + g.name :g.name);
@@ -10177,13 +10174,6 @@ var e = c[d].split("=");
 if (e[0] === b) return e[1];
 }
 return null;
-};
-}).filter("envVarsPair", function() {
-return function(a) {
-var b = {};
-return angular.forEach(a, function(a) {
-b[a.name] = a.value;
-}), b;
 };
 }).filter("destinationSourcePair", function() {
 return function(a) {


### PR DESCRIPTION
Eliminates the `$filter('envVarsPair')` which was swallowing duplicate keys when converting array to hash, and is probably no longer needed since we are not using `<osc-key-values>`.

@jwforres @spadgett @jhadvig 