### PR TITLE
Don't show debug action for completed pods or build pods

### DIFF
--- a/app/views/browse/_pod-details.html
+++ b/app/views/browse/_pod-details.html
@@ -62,7 +62,7 @@
           <dd>{{containerStatus.ready}}</dd>
           <dt>Restart Count:</dt>
           <dd>{{containerStatus.restartCount}}</dd>
-          <div ng-if="(!containerStatus.state.running || !containerStatus.ready) && !(pod | debugLabel) && ('pods' | canI : 'create')" class="debug-pod-action">
+          <div ng-if="pod.status.phase !== 'Completed' && !(pod | annotation : 'openshift.io/build.name') && (!containerStatus.state.running || !containerStatus.ready) && !(pod | debugLabel) && ('pods' | canI : 'create')" class="debug-pod-action">
             <a href="" ng-click="debugTerminal(containerStatus.name)" role="button">Debug in terminal</a>
           </div>
         </dl>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1348,7 +1348,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dd>{{containerStatus.ready}}</dd>\n" +
     "<dt>Restart Count:</dt>\n" +
     "<dd>{{containerStatus.restartCount}}</dd>\n" +
-    "<div ng-if=\"(!containerStatus.state.running || !containerStatus.ready) && !(pod | debugLabel) && ('pods' | canI : 'create')\" class=\"debug-pod-action\">\n" +
+    "<div ng-if=\"pod.status.phase !== 'Completed' && !(pod | annotation : 'openshift.io/build.name') && (!containerStatus.state.running || !containerStatus.ready) && !(pod | debugLabel) && ('pods' | canI : 'create')\" class=\"debug-pod-action\">\n" +
     "<a href=\"\" ng-click=\"debugTerminal(containerStatus.name)\" role=\"button\">Debug in terminal</a>\n" +
     "</div>\n" +
     "</dl>\n" +


### PR DESCRIPTION
@jwforres PTAL

We might move this logic into the controller, but I didn't want to do that right before 1.3.