### PR TITLE
Resolves issue where unsuccessful deployments were not obvious

### DIFF
--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -462,6 +462,9 @@
     }
     .overview-unsuccessful-state {
       text-align: center;
+      & .text-danger {
+        color: @brand-danger;
+      }
     }
     .deployment-status-msg {
       .text-muted();

--- a/app/views/overview/_dc.html
+++ b/app/views/overview/_dc.html
@@ -49,7 +49,7 @@
     <!-- deployment in progress (connecting arrow) -->
     <div column class="overview-donut-connector" ng-class="{'contains-deployment-status-msg':deployments.length === 1}" ng-if="anyDeploymentInProgress">
       <div ng-if="deployments.length > 1" class="deployment-connector-arrow">
-        
+
       </div>
       <div ng-if="deployments.length === 1" class="deployment-status-msg">
         <status-icon status="deployments[0] | deploymentStatus" class="mar-right-xs"></status-icon>
@@ -65,7 +65,7 @@
     <!-- cancelled/failed state -->
     <div column class="overview-unsuccessful-state" ng-if="!activeDeployment && !anyDeploymentInProgress" ng-switch="deployments[0] | deploymentStatus">
       <div ng-switch-when="Cancelled">
-        <span class="text-warning deployment-status-msg">
+        <span class="deployment-status-msg">
           <i class="fa fa-ban" aria-hidden="true"></i>
           {{dcName}}
           <a ng-href="{{deployments[0] | navigateResourceURL}}">#{{deployments[0] | annotation: 'deploymentVersion'}}</a>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7865,7 +7865,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<div column class=\"overview-unsuccessful-state\" ng-if=\"!activeDeployment && !anyDeploymentInProgress\" ng-switch=\"deployments[0] | deploymentStatus\">\n" +
     "<div ng-switch-when=\"Cancelled\">\n" +
-    "<span class=\"text-warning deployment-status-msg\">\n" +
+    "<span class=\"deployment-status-msg\">\n" +
     "<i class=\"fa fa-ban\" aria-hidden=\"true\"></i>\n" +
     "{{dcName}}\n" +
     "<a ng-href=\"{{deployments[0] | navigateResourceURL}}\">#{{deployments[0] | annotation: 'deploymentVersion'}}</a>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4113,6 +4113,7 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview .deployment-tile .overview-donut-connector .deployment-connector-arrow{color:#ccc;font-size:200%}
 .overview .deployment-tile .overview-donut-connector .deployment-connector-arrow:before{content:'\2193';padding-right:23px}
 .overview .deployment-tile .overview-unsuccessful-state{text-align:center}
+.overview .deployment-tile .overview-unsuccessful-state .text-danger{color:#c00}
 .overview .deployment-tile .deployment-status-msg{color:#9c9c9c;line-height:normal;margin-bottom:10px}
 @keyframes simpleSlideOut{0%{margin-left:0%;opacity:1}
 100%{margin-left:-50%;opacity:0}


### PR DESCRIPTION
Fixes #453 

@jwforres @spadgett, PTAL.  IMO, this is a very safe fix as it is simply restoring the warning and danger colors to the overview-unsuccessful-state.

<img width="593" alt="screen shot 2016-08-23 at 11 45 58 am" src="https://cloud.githubusercontent.com/assets/895728/17899442/5a0b7c6c-6929-11e6-921e-74a9e6d7df1c.PNG">
<img width="598" alt="screen shot 2016-08-23 at 11 43 50 am" src="https://cloud.githubusercontent.com/assets/895728/17899447/5d658236-6929-11e6-96e1-a0c9b469662d.PNG">
<img width="594" alt="screen shot 2016-08-23 at 11 45 10 am" src="https://cloud.githubusercontent.com/assets/895728/17899449/5d753078-6929-11e6-82db-c956762c4ad1.PNG">
<img width="599" alt="screen shot 2016-08-23 at 11 45 20 am" src="https://cloud.githubusercontent.com/assets/895728/17899448/5d718202-6929-11e6-9cbb-5d7858ca173d.PNG">
