### PR TITLE
Do not add log lines for empty messages

### DIFF
--- a/app/scripts/directives/logViewer.js
+++ b/app/scripts/directives/logViewer.js
@@ -298,6 +298,11 @@ angular.module('openshiftConsole')
                   }
                 });
 
+                // Completely empty messages (without even a newline character) should not add lines
+                if (!msg) {
+                  return;
+                }
+
                 if (options.limitBytes && cumulativeBytes >= options.limitBytes) {
                   $scope.$evalAsync(function() {
                     $scope.limitReached = true;

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8687,11 +8687,11 @@ c++, C.appendChild(k(c, a)), D();
 z.onMessage(function(b, e, f) {
 j.$evalAsync(function() {
 j.empty = !1, "logs" !== j.state && (j.state = "logs", setTimeout(x));
-}), a.limitBytes && f >= a.limitBytes && (j.$evalAsync(function() {
+}), b && (a.limitBytes && f >= a.limitBytes && (j.$evalAsync(function() {
 j.limitReached = !0, j.loading = !1;
 }), E(!0)), d(b), !j.largeLog && c >= a.tailLines && j.$evalAsync(function() {
 j.largeLog = !0;
-});
+}));
 }), z.onClose(function() {
 z = null, j.$evalAsync(function() {
 j.autoScrollActive = !1, 0 !== c || j.emptyStateMessage || (j.state = "empty", j.emptyStateMessage = "The logs are no longer available or could not be loaded.");


### PR DESCRIPTION
Found when debugging https://github.com/openshift/origin/issues/10601

An initial ping frame with 0-length data is being sent when streaming log messages. That should not result in an empty line. Actual empty log lines will at least contain a "\n"