### PR TITLE
Fixed "View Archive" button

### DIFF
--- a/app/views/directives/logs/_log-viewer.html
+++ b/app/views/directives/logs/_log-viewer.html
@@ -44,7 +44,7 @@
     <form
       action="{{kibanaAuthUrl}}"
       method="POST">
-      <input type="hidden" name="redirect" value="{{archiveLocation}}">
+      <input type="hidden" name="redirect" value="{{kibanaArchiveUrl}}">
       <input type="hidden" name="access_token" value="{{access_token}}">
       <button class="btn btn-primary btn-lg">
         View Archive

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5413,7 +5413,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "<div ng-if=\"kibanaAuthUrl\">\n" +
     "<form action=\"{{kibanaAuthUrl}}\" method=\"POST\">\n" +
-    "<input type=\"hidden\" name=\"redirect\" value=\"{{archiveLocation}}\">\n" +
+    "<input type=\"hidden\" name=\"redirect\" value=\"{{kibanaArchiveUrl}}\">\n" +
     "<input type=\"hidden\" name=\"access_token\" value=\"{{access_token}}\">\n" +
     "<button class=\"btn btn-primary btn-lg\">\n" +
     "View Archive\n" +


### PR DESCRIPTION
The "View Archive" button has an incorrect variable linked to
it resulting in logs not working properly.  The link on the top
right menu works properly with no problem.  This patch fixes
the button to point towards the same URL as the top right link
that works.