### PR TITLE
Don't set container name for build log options on monitoring page

### DIFF
--- a/app/scripts/controllers/monitoring.js
+++ b/app/scripts/controllers/monitoring.js
@@ -119,9 +119,7 @@ angular.module('openshiftConsole')
     };
 
     var setBuildLogVars = function(build) {
-      $scope.logOptions.builds[build.metadata.name] = {
-        container: $filter("annotation")(build, "buildPod")
-      };
+      $scope.logOptions.builds[build.metadata.name] = {};
       $scope.logCanRun.builds[build.metadata.name] = !(_.includes(['New', 'Pending', 'Error'], build.status.phase));
     };
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3774,9 +3774,7 @@ b.logOptions.deployments[a.metadata.name] = {};
 var d = c("annotation")(a, "deploymentVersion");
 d && (b.logOptions.deployments[a.metadata.name].version = d), b.logCanRun.deployments[a.metadata.name] = !_.includes([ "New", "Pending" ], c("deploymentStatus")(a));
 }, w = function(a) {
-b.logOptions.builds[a.metadata.name] = {
-container:c("annotation")(a, "buildPod")
-}, b.logCanRun.builds[a.metadata.name] = !_.includes([ "New", "Pending", "Error" ], a.status.phase);
+b.logOptions.builds[a.metadata.name] = {}, b.logCanRun.builds[a.metadata.name] = !_.includes([ "New", "Pending", "Error" ], a.status.phase);
 }, x = function() {
 p = _.filter(b.pods, function(a) {
 return !b.filters.hideOlderResources || "Succeeded" !== a.status.phase && "Failed" !== a.status.phase;


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1372195

@jwforres We were incorrectly setting the build pod name as the container name for build log options on the monitoring page. This caused the view archive link to show up with bad parameters.