### PR TITLE
Add secrets to BC for private repos and registries

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -191,6 +191,7 @@
         <script src="scripts/services/hpa.js"></script>
         <script src="scripts/services/pods.js"></script>
         <script src="scripts/services/templates.js"></script>
+        <script src="scripts/services/secrets.js"></script>
         <script src="scripts/services/services.js"></script>
         <script src="scripts/services/images.js"></script>
         <script src="scripts/services/keyword.js"></script>
@@ -242,6 +243,7 @@
         <script src="scripts/controllers/edit/project.js"></script>
         <script src="scripts/controllers/createRoute.js"></script>
         <script src="scripts/controllers/attachPVC.js"></script>
+        <script src="scripts/controllers/modals/createSecretModal.js"></script>
         <script src="scripts/controllers/modals/confirmModal.js"></script>
         <script src="scripts/controllers/modals/confirmScale.js"></script>
         <script src="scripts/controllers/modals/deleteModal.js"></script>
@@ -253,6 +255,7 @@
         <script src="scripts/controllers/commandLine.js"></script>
         <script src="scripts/controllers/createPersistentVolumeClaim.js"></script>
         <script src="scripts/directives/buildClose.js"></script>
+        <script src="scripts/directives/createSecret.js"></script>
         <script src="scripts/directives/date.js"></script>
         <script src="scripts/directives/deleteLink.js"></script>
         <script src="scripts/directives/editWebhookTriggers.js"></script>
@@ -269,6 +272,8 @@
         <script src="scripts/directives/oscPersistentVolumeClaim.js"></script>
         <script src="scripts/directives/oscUnique.js"></script>
         <script src="scripts/directives/oscAutoscaling.js"></script>
+        <script src="scripts/directives/oscSecrets.js"></script>
+        <script src="scripts/directives/oscSourceSecrets.js"></script> 
         <script src="scripts/directives/replicas.js"></script>
         <script src="scripts/directives/resources.js"></script>
         <script src="scripts/directives/overviewDeployment.js"></script>

--- a/app/scripts/constants.js
+++ b/app/scripts/constants.js
@@ -22,6 +22,11 @@ window.OPENSHIFT_CONSTANTS = {
     "compute_resources":       "https://docs.openshift.org/latest/dev_guide/compute_resources.html",
     "pod_autoscaling":         "https://docs.openshift.org/latest/dev_guide/pod_autoscaling.html",
     "application_health":      "https://docs.openshift.org/latest/dev_guide/application_health.html",
+    "source_secrets":          "https://docs.openshift.org/latest/dev_guide/builds.html#using-secrets",
+    "git_secret":              "https://docs.openshift.org/latest/dev_guide/builds.html#using-private-repositories-for-builds",
+    "pull_secret":             "https://docs.openshift.org/latest/dev_guide/managing_images.html#using-image-pull-secrets",
+    "managing_secrets":        "https://docs.openshift.org/latest/dev_guide/service_accounts.html#managing-allowed-secrets",
+    "creating_secrets":        "https://docs.openshift.org/latest/dev_guide/secrets.html#creating-and-using-secrets",
     "default":                 "https://docs.openshift.org/latest/welcome/index.html"
   },
   // Maps links names to URL's where the CLI tools can be downloaded, may point directly to files or to external pages in a CDN, for example.

--- a/app/scripts/controllers/modals/createSecretModal.js
+++ b/app/scripts/controllers/modals/createSecretModal.js
@@ -1,0 +1,23 @@
+'use strict';
+/* jshint unused: false */
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:CreateSecretModalController
+ * @description
+ * # CreateSecretModalController
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('CreateSecretModalController', function ($scope, $uibModalInstance) {
+
+    $scope.postCreateAction = function(newSecret, creationAlert) {
+      $uibModalInstance.close(newSecret);
+      // Add creation alert into scope
+      _.extend($scope.alerts, creationAlert);
+    };
+
+    $scope.cancel = function() {
+      $uibModalInstance.dismiss('cancel');
+    };
+  });

--- a/app/scripts/directives/createSecret.js
+++ b/app/scripts/directives/createSecret.js
@@ -1,0 +1,185 @@
+"use strict";
+
+angular.module("openshiftConsole")
+
+  .directive("createSecret", function() {
+    return {
+      restrict: 'E',
+      scope: {
+        type: '=',
+        serviceAccountToLink: '=?',
+        namespace: '=',
+        postCreateAction: '&',
+        cancel: '&'
+      },
+      templateUrl: 'views/directives/create-secret.html',
+      controller: function($scope, $filter, DataService) {
+        $scope.alerts = {};
+
+        $scope.secretAuthTypeMap = {
+          image: {
+            label: "Image Secret",
+            authTypes: [
+              {
+                id: "kubernetes.io/dockercfg",
+                label: "Image Registry Credentials"
+              },
+              {
+                id: "kubernetes.io/dockerconfigjson",
+                label: "Configuration File"
+              }
+            ]
+          },
+          source: {
+            label: "Source Secret",
+            authTypes: [
+              {
+                id: "kubernetes.io/basic-auth",
+                label: "Basic Authentication"
+              },
+              {
+                id: "kubernetes.io/ssh-auth",
+                label: "SSH Key"
+              }
+            ]
+          }
+        };
+
+        $scope.secretTypes = _.keys($scope.secretAuthTypeMap);
+        // newSecret format:
+        //   - type:                       image || source
+        //   - authType:                   image  = [kubernetes.io/dockercfg, "kubernetes.io/dockerconfigjson"]
+        //                                 source = ["kubernetes.io/basic-auth, "kubernetes.io/ssh-auth"]
+        //   - data:                       based on the authentication type
+        //   - pickedServiceAccountToLink  based on the view in which the directive is used.
+        //                                  - if in BC the 'builder' SA if picked automatically
+        //                                  - if in DC the 'deployer' SA if picked automatically
+        //                                  - else the user will have to pick the SA and type of linking
+        //   - linkAs                      user specifies how he wants to link the secret with SA
+        //                                  - as a 'secrets'
+        //                                  - as a 'imagePullSecret'
+        $scope.newSecret = {
+          type: $scope.type,
+          authType: $scope.secretAuthTypeMap[$scope.type].authTypes[0].id,
+          data: {},
+          linkSecret: false,
+          pickedServiceAccountToLink: $scope.serviceAccountToLink || "",
+          linkAs: {
+            secrets: $scope.type === 'source',
+            imagePullSecrets: $scope.type === 'image'
+          }
+        };
+        $scope.addGitconfig = false;
+
+        DataService.list("serviceaccounts", $scope, function(result) {
+          $scope.serviceAccounts = result.by('metadata.name');
+          $scope.serviceAccountsNames = _.keys($scope.serviceAccounts);
+        });
+
+        var constructSecretObject = function(data, authType) {
+          var secret = {
+            apiVersion: "v1",
+            kind: "Secret",
+            metadata: {
+              name: $scope.newSecret.data.secretName
+            },
+            type: authType,
+            data: {}
+          };
+
+          switch (authType) {
+            case "kubernetes.io/basic-auth":
+              secret.data = {password: window.btoa(data.password)};
+              if (data.username) {
+                secret.data.username = window.btoa(data.username);
+              }
+              if (data.gitconfig) {
+                secret.data[".gitconfig"] = window.btoa(data.gitconfig);
+              }
+              break;
+            case "kubernetes.io/ssh-auth":
+              secret.data = {'ssh-privatekey': window.btoa(data.privateKey)};
+              if (data.gitconfig) {
+                secret.data[".gitconfig"] = window.btoa(data.gitconfig);
+              }
+              break;
+            case "kubernetes.io/dockerconfigjson":
+              var encodedConfig = window.btoa(data.dockerConfig);
+              if (JSON.parse(data.dockerConfig).auths) {
+                secret.data[".dockerconfigjson"] = encodedConfig;
+              } else {
+                secret.type = "kubernetes.io/dockercfg";
+                secret.data[".dockercfg"] = encodedConfig;
+              }
+              break;
+            case "kubernetes.io/dockercfg":
+              var auth = window.btoa(data.dockerUsername + ":" + data.dockerPassword);
+              var configData = {};
+              configData[data.dockerServer] = {
+                username: data.dockerUsername,
+                password: data.dockerPassword,
+                email: data.dockerMail,
+                auth: auth
+              };
+              secret.data[".dockercfg"] = window.btoa(JSON.stringify(configData));
+              break;
+          }
+          return secret;
+        };
+
+        var linkSecretToServiceAccount = function(secret) {
+          var updatedSA = angular.copy($scope.serviceAccounts[$scope.newSecret.pickedServiceAccountToLink]);
+          if ($scope.newSecret.linkAs.secrets) {
+            updatedSA.secrets.push({name: secret.metadata.name});
+          }
+          if ($scope.newSecret.linkAs.imagePullSecrets) {
+            updatedSA.imagePullSecrets.push({name: secret.metadata.name});
+          }
+          DataService.update('serviceaccounts', $scope.newSecret.pickedServiceAccountToLink, updatedSA, $scope).then(function(sa) {
+            var alert = {
+              createAndLink: {
+                type: "success",
+                message: "Secret " + secret.metadata.name + " was created and linked with service account " + sa.metadata.name + "."
+              }
+            };
+            $scope.postCreateAction({newSecret: secret, creationAlert: alert});
+          }, function(result){
+            $scope.alerts["createAndLink"] = {
+              type: "error",
+              message: "An error occurred while linking the secret with service account.",
+              details: $filter('getErrorDetails')(result)
+            };
+          });
+        };
+
+        $scope.create = function() {
+          $scope.alerts = {};
+          var newSecret = constructSecretObject($scope.newSecret.data, $scope.newSecret.authType);
+          DataService.create('secrets', null, newSecret, $scope).then(function(secret) { // Success
+            if ($scope.newSecret.linkSecret && $scope.newSecret.pickedServiceAccountToLink) {
+              linkSecretToServiceAccount(secret);
+            } else {
+              var alert = {
+                create: {
+                  type: "success",
+                  message: "Secret " + newSecret.metadata.name + " was created."
+                }
+              };
+              $scope.postCreateAction({newSecret: secret, creationAlert: alert});
+            }
+          }, function(result) { // Failure
+            var data = result.data || {};
+            if (data.reason === 'AlreadyExists') {
+              $scope.nameTaken = true;
+              return;
+            }
+            $scope.alerts["create"] = {
+              type: "error",
+              message: "An error occurred while creating the secret.",
+              details: $filter('getErrorDetails')(result)
+            };
+          });
+        };
+      },
+    };
+  });

--- a/app/scripts/directives/oscSecrets.js
+++ b/app/scripts/directives/oscSecrets.js
@@ -1,0 +1,43 @@
+"use strict";
+
+angular.module("openshiftConsole")
+
+  .directive("oscSecrets", function($uibModal, $filter, DataService, SecretsService) {
+    return {
+      restrict: 'E',
+      scope: {
+        pickedSecret: "=model",
+        secretsByType: '=',
+        namespace: "=",
+        displayType: "@",
+        type: "@",
+        alerts: '=',
+        serviceAccountToLink: '@?'
+      },
+      templateUrl: 'views/directives/osc-secrets.html',
+      link: function($scope) {
+
+        $scope.openCreateSecretModal = function() {
+          $scope.newSecret = {};
+          var modalInstance = $uibModal.open({
+            animation: true,
+            templateUrl: 'views/modals/create-secret.html',
+            controller: 'CreateSecretModalController',
+            scope: $scope
+          });
+
+          modalInstance.result.then(function(newSecret) {
+            DataService.list("secrets", {namespace: $scope.namespace}, function(secrets) {
+              var secretsByType = SecretsService.groupSecretsByType(secrets);
+              // Add empty option to the image/source secrets
+              $scope.secretsByType = _.each(secretsByType, function(secretsArray) {
+                secretsArray.unshift("");
+              });
+              $scope.pickedSecret.name = newSecret.metadata.name;
+              $scope.secretsForm.$setDirty();
+            });
+          });
+        };
+      }
+    };
+  });

--- a/app/scripts/directives/oscSourceSecrets.js
+++ b/app/scripts/directives/oscSourceSecrets.js
@@ -1,0 +1,89 @@
+"use strict";
+
+angular.module("openshiftConsole")
+
+  .directive("oscSourceSecrets", function($uibModal, $filter, DataService, SecretsService) {
+    return {
+      restrict: 'E',
+      scope: {
+        pickedSecrets: "=model",
+        secretsByType: '=',
+        strategyType: '=',
+        type: "@",
+        displayType: "@",
+        namespace: "=",
+        alerts: '=',
+        serviceAccountToLink: '@?'
+      },
+      templateUrl: 'views/directives/osc-source-secrets.html',
+      link: function($scope) {
+        $scope.canAddSourceSecret = function() {
+          var lastSecret = _.last($scope.pickedSecrets);
+          switch ($scope.strategyType) {
+          case 'Custom':
+            return lastSecret.secretSource.name && lastSecret.mountPath;
+          default:
+            return lastSecret.secret.name && lastSecret.destinationDir;
+          }
+        };
+
+        $scope.setLastSecretsName = function(secretName) {
+          var lastSecret = _.last($scope.pickedSecrets);
+          switch ($scope.strategyType) {
+          case 'Custom':
+            lastSecret.secretSource.name = secretName;
+            return;
+          default:
+            lastSecret.secret.name = secretName;
+            return;
+          }
+        };
+
+        $scope.addSourceSecret = function() {
+          switch ($scope.strategyType) {
+          case 'Custom':
+            $scope.pickedSecrets.push({secretSource: {name: ""}, mountPath: ""});
+            return;
+          default:
+            $scope.pickedSecrets.push({secret: {name: ""}, destinationDir: ""});
+            return;
+          }
+        };
+
+        $scope.removeSecret = function(index) {
+          if ($scope.pickedSecrets.length === 1) {
+            switch ($scope.strategyType) {
+            case 'Custom':
+              $scope.pickedSecrets = [{secretSource: {name: ""}, mountPath: ""}];
+              break;
+            default:
+              $scope.pickedSecrets = [{secret: {name: ""}, destinationDir: ""}];
+            }
+          } else {
+            $scope.pickedSecrets.splice(index,1);
+          }          
+          $scope.secretsForm.$setDirty();
+        };
+
+        $scope.openCreateSecretModal = function() {
+          var modalInstance = $uibModal.open({
+            animation: true,
+            templateUrl: 'views/modals/create-secret.html',
+            controller: 'CreateSecretModalController',
+            scope: $scope
+          });
+
+          modalInstance.result.then(function(newSecret) {
+            DataService.list("secrets", {namespace: $scope.namespace}, function(secrets) {
+              var secretsByType = SecretsService.groupSecretsByType(secrets);
+              // Add empty option to the image/source secrets
+              $scope.secretsByType = _.each(secretsByType, function(secretsArray) {
+                secretsArray.unshift("");
+              });
+              $scope.setLastSecretsName(newSecret.metadata.name);
+            });
+          });
+        };
+      }
+    };
+  });

--- a/app/scripts/services/secrets.js
+++ b/app/scripts/services/secrets.js
@@ -1,0 +1,31 @@
+'use strict';
+
+angular.module("openshiftConsole")
+  .factory("SecretsService", function(){
+
+    var groupSecretsByType = function(secrets) {
+      var secretsByType = {
+        source: [],
+        image: []
+      };
+
+      _.each(secrets.by('metadata.name'), function(secret) {
+        switch (secret.type) {
+          case 'kubernetes.io/basic-auth':
+          case 'kubernetes.io/ssh-auth':
+          case 'Opaque':
+            secretsByType.source.push(secret.metadata.name);
+            break;
+          case 'kubernetes.io/dockercfg':
+          case 'kubernetes.io/dockerconfigjson':
+            secretsByType.image.push(secret.metadata.name);
+            break;
+        }
+      });      
+      return secretsByType;
+    };
+
+    return {
+      groupSecretsByType: groupSecretsByType
+    };
+  });

--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -98,6 +98,13 @@
     font-style: normal;
     margin-top: -5px;
   }
+  .ui-select-match-text > span {
+      width: 90%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      position: absolute;
+  }
+
   .btn {
     padding-right: 25px; // prevent text from showing behind select arrow
   }
@@ -529,6 +536,38 @@ label.checkbox {
     img {
       width: 100%;
     }
+  }
+}
+
+.osc-secrets-form {
+  .picked-secret {
+    margin-bottom: 5px;
+  }
+  .directory {
+    width:90%;
+    display: inline-block;
+  }
+  .remove-secret-row {
+    width: 10%;
+    margin-left: 7px;
+    display: inline;
+  }
+  .remove-btn {
+    color: #333;
+    opacity: 0.65;
+    font-size: 15px;
+    vertical-align: middle;
+    &:hover {
+      opacity: 1;
+      text-decoration: none;
+    }
+    &:focus {
+      text-decoration: none;
+    }
+  }
+  .ui-select-choices-row-inner {
+    height: 24px;
+    cursor: pointer;
   }
 }
 
@@ -1040,6 +1079,19 @@ a.disabled-link {
   color: inherit;
 }
 
+.create-secret-modal {
+  background-color: #F5F5F5;
+  .modal-footer{
+    margin-top: 0px
+  }
+  .modal-body {
+    padding: 0px 18px;
+    .create-secret-editor {
+      height: 150px;
+    }
+  }
+}
+
 .edit-yaml {
   h1 {
     line-height: 1.3;
@@ -1103,6 +1155,11 @@ a.disabled-link {
 }
 
 .edit-form {
+  .with-divider {
+    border-top: 1px solid rgba(0, 0, 0, 0.15);
+    padding-top: 21px;
+    padding-bottom: 10px;
+  }
   .labels {
     .form-group {
       width: 44%;
@@ -1132,7 +1189,7 @@ a.disabled-link {
   }
 
   .section {
-    padding-bottom: 15px;
+    padding-bottom: 5px;
   }
   @media (max-width: @screen-sm-min) {
     .trigger-url {

--- a/app/views/create/fromimage.html
+++ b/app/views/create/fromimage.html
@@ -66,53 +66,61 @@
                               </div>
                             </div>
                           </div>
+                          <div class="row">
+                            <div ng-class="{
+                              'col-md-8': advancedOptions,
+                              'col-lg-12': !advancedOptions}">
+                              <div class="form-group">
+                                <label for="sourceUrl" class="required">Git Repository URL</label>
+                                <div ng-class="{'has-warning': form.sourceUrl.$dirty && !sourceURLPattern.test(buildConfig.sourceUrl), 'has-error': (form.sourceUrl.$error.required && form.sourceUrl.$dirty)}">
+                                  <!-- Unfortunately, we can't set type="url" because some valid values don't pass browser validation. -->
+                                  <input class="form-control"
+                                    id="sourceUrl"
+                                    name="sourceUrl"
+                                    type="text"
+                                    required
+                                    aria-describedby="from_source_help"
+                                    ng-model="buildConfig.sourceUrl"
+                                    autocorrect="off"
+                                    autocapitalize="off"
+                                    spellcheck="false">
+                                </div>
+                                <div ng-if="image.metadata.annotations.sampleRepo" class="help-block">
+                                  Sample repository for {{imageName}}: {{image.metadata.annotations.sampleRepo}}<span ng-if="image.metadata.annotations.sampleRef">,
+                                    ref: {{image.metadata.annotations.sampleRef}}</span><span ng-if="image.metadata.annotations.sampleContextDir">,
+                                    context dir: {{image.metadata.annotations.sampleContextDir}}</span>
+                                  <a href="" ng-click="fillSampleRepo()"
+                                    style="margin-left: 3px;" class="nowrap">Try it<i class="fa fa-level-up" style="margin-left: 3px; font-size: 17px;"></i></a>
+                                </div>
+                                <div class="has-error" ng-show="form.sourceUrl.$error.required && form.sourceUrl.$dirty">
+                                  <span class="help-block">A Git repository URL is required.</span>
+                                </div>
+                                <div>
+                                  <span class="text-warning" ng-if="form.sourceUrl.$dirty && !sourceURLPattern.test(buildConfig.sourceUrl)">Git repository should be a URL.</span>
+                                </div>
+                              </div>
+                            </div>
 
-                          <div class="form-group">
-                            <label for="sourceUrl" class="required">Git Repository URL</label>
-                            <div ng-class="{'has-warning': form.sourceUrl.$dirty && !sourceURLPattern.test(buildConfig.sourceUrl), 'has-error': (form.sourceUrl.$error.required && form.sourceUrl.$dirty)}">
-                              <!-- Unfortunately, we can't set type="url" because some valid values don't pass browser validation. -->
-                              <input class="form-control"
-                                id="sourceUrl"
-                                name="sourceUrl"
-                                type="text"
-                                required
-                                aria-describedby="from_source_help"
-                                ng-model="buildConfig.sourceUrl"
-                                autocorrect="off"
-                                autocapitalize="off"
-                                spellcheck="false">
-                            </div>
-                            <div ng-if="image.metadata.annotations.sampleRepo" class="help-block">
-                              Sample repository for {{imageName}}: {{image.metadata.annotations.sampleRepo}}<span ng-if="image.metadata.annotations.sampleRef">,
-                                ref: {{image.metadata.annotations.sampleRef}}</span><span ng-if="image.metadata.annotations.sampleContextDir">,
-                                context dir: {{image.metadata.annotations.sampleContextDir}}</span>
-                              <a href="" ng-click="fillSampleRepo()"
-                                style="margin-left: 3px;" class="nowrap">Try it<i class="fa fa-level-up" style="margin-left: 3px; font-size: 17px;"></i></a>
-                            </div>
-                            <div class="has-error" ng-show="form.sourceUrl.$error.required && form.sourceUrl.$dirty">
-                              <span class="help-block">A Git repository URL is required.</span>
-                            </div>
-                            <div>
-                              <span class="text-warning" ng-if="form.sourceUrl.$dirty && !sourceURLPattern.test(buildConfig.sourceUrl)">Git repository should be a URL.</span>
+                            <div class="col-md-4" ng-if="advancedOptions">
+                              <div class="form-group">
+                                <label for="gitref">Git Reference</label>
+                                <div>
+                                  <input
+                                    id="gitref"
+                                    ng-model="buildConfig.gitRef"
+                                    type="text"
+                                    placeholder="master"
+                                    autocorrect="off"
+                                    autocapitalize="off"
+                                    spellcheck="false"
+                                    class="form-control">
+                                </div>
+                                <div class="help-block">Optional branch, tag, or commit.</div>
+                              </div>
                             </div>
                           </div>
 
-                          <div click-to-reveal link-text="Show advanced routing, build, and deployment options">
-                            <div class="form-group">
-                              <label for="gitref">Git Reference</label>
-                              <div>
-                                <input
-                                  id="gitref"
-                                  ng-model="buildConfig.gitRef"
-                                  type="text"
-                                  placeholder="master"
-                                  autocorrect="off"
-                                  autocapitalize="off"
-                                  spellcheck="false"
-                                  class="form-control">
-                              </div>
-                              <div class="help-block">Optional branch, tag, or commit.</div>
-                            </div>
+                          <div ng-if="advancedOptions">
                             <div class="form-group">
                               <label for="contextdir">Context Dir</label>
                               <div>
@@ -372,6 +380,9 @@
                             </label-editor>
                           </div>
                           <alerts alerts="alerts"></alerts>
+                          <div class="gutter-top">
+                            <a href="" ng-click="advancedOptions = !advancedOptions" role="button">{{advancedOptions ? 'Hide' : 'Show'}} advanced routing, build, and deployment options</a>
+                          </div>
                           <div class="buttons gutter-bottom" ng-class="{'gutter-top': !alerts.length}">
                             <!-- unable to use form.valid.  need to fix validators in labels and key values directive -->
                             <button type="submit"

--- a/app/views/directives/create-secret.html
+++ b/app/views/directives/create-secret.html
@@ -1,0 +1,310 @@
+<alerts alerts="alerts"></alerts>
+
+<ng-form name="secretForm">
+  <div for="secretType" ng-if="!type" class="form-group">
+    <label>Secret Type</label>
+    <ui-select required ng-model="newSecret.type" search-enabled="false" ng-change="newSecret.authType = secretAuthTypeMap[newSecret.type].authTypes[0].id">
+      <ui-select-match>{{$select.selected | upperFirst}} Secret</ui-select-match>
+      <ui-select-choices repeat="type in secretTypes">
+        {{type | upperFirst}} Secret
+      </ui-select-choices>
+    </ui-select>
+  </div>
+
+  <div class="form-group">
+    <label for="secretName" class="required">Secret Name</label>
+      <span ng-class="{'has-error': nameTaken || (secretForm.secretName.$error.pattern && secretForm.secretName.$touched)}">
+        <input class="form-control"
+          id="secretName"
+          name="secretName"
+          ng-model="newSecret.data.secretName"
+          type="text"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          aria-describedby="secret-name-help"
+          ng-maxlength="253"
+          ng-pattern="/^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/"
+          required>
+      </span>
+      <div class="has-error" ng-show="nameTaken">
+        <span class="help-block">
+          This name is already in use. Please choose a different name.
+        </span>
+      </div>
+      <div class="has-error" ng-show="secretForm.secretName.$error.pattern && secretForm.secretName.$touched">
+        <span class="help-block">
+          Secret name must consist of lower-case letters, numbers, periods, and
+          hyphens. It must start and end with a letter or number.
+        </span>
+      </div>
+      <div class="help-block" id="secret-name-help">
+        Unique name of the new secret.
+      </div>
+  </div>
+  <div class="form-group">
+    <label for="authentificationType">Authetication Type</label>
+    <ui-select required ng-model="newSecret.authType" search-enabled="false">
+      <ui-select-match>{{$select.selected.label}}</ui-select-match>
+      <ui-select-choices repeat="type.id as type in secretAuthTypeMap[newSecret.type].authTypes">
+        {{type.label}}
+      </ui-select-choices>
+    </ui-select>
+  </div>
+
+  <div ng-if="newSecret.authType === 'kubernetes.io/basic-auth'">
+    <div class="form-group">
+      <label for="username">Username</label>
+      <div>
+        <input class="form-control"
+          id="username"
+          name="username"
+          ng-model="newSecret.data.username"
+          type="text"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          aria-describedby="username-help">
+      </div>
+      <div class="help-block" id="username-help">
+        Optional username for SCM servers authentication.
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label for="passwordToken" class="required">Password or Token</label>
+      <div>
+        <input class="form-control"
+          id="passwordToken"
+          name="passwordToken"
+          ng-model="newSecret.data.passwordToken"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          aria-describedby="password-token-help"
+          type="password"
+          required>
+      </div>
+      <div class="help-block" id="password-token-help">
+        Password or token for SCM servers authentication.
+      </div>
+    </div>
+  </div>
+
+  <div ng-if="newSecret.authType === 'kubernetes.io/ssh-auth'">
+    <div class="form-group" id="private-key">
+      <label for="privateKey" class="required">SSH Private Key</label>
+      <osc-file-input 
+        id="private-key-file-input"
+        model="newSecret.data.privateKey"
+        drop-zone-id="private-key"
+        dragging="false"
+        help-text="Upload your private SSH key file."
+        show-values="false"></osc-file-input>
+      <div ui-ace="{
+        theme: 'eclipse',
+        onLoad: aceLoaded,
+        rendererOptions: {
+          fadeFoldWidgets: true,
+          showPrintMargin: false 
+        }
+      }" ng-model="newSecret.data.privateKey" class="create-secret-editor ace-bordered" id="private-key-editor" required></div>
+      <div class="help-block">
+        Private SSH key file for SCM servers authentication.
+      </div>
+    </div>
+  </div>
+  
+  <div ng-if="newSecret.type === 'source'">
+    <div class="form-group">
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" ng-model="addGitconfig">
+          Use a custom .gitconfig file
+        </label>
+      </div>
+    </div>
+
+    <div class="form-group" ng-if="addGitconfig" id="gitconfig" ng-show="addGitconfig">
+      <label class="required" for="gitconfig">Git Configuration File</label>
+      <osc-file-input 
+        id="gitconfig-file-input"
+        model="newSecret.data.gitconfig"
+        drop-zone-id="gitconfig"
+        dragging="false"
+        help-text="Upload your .gitconfig or  file."
+        show-values="false"
+        required="true"></osc-file-input>
+      <div ui-ace="{
+        mode: 'ini',
+        theme: 'eclipse',
+        onLoad: aceLoaded,
+        rendererOptions: {
+          fadeFoldWidgets: true,
+          showPrintMargin: false 
+        }
+      }" ng-model="newSecret.data.gitconfig" class="create-secret-editor ace-bordered" id="gitconfig-editor"></div>
+    </div>
+  </div>
+
+  <div ng-if="newSecret.authType === 'kubernetes.io/dockercfg'">
+    <div class="form-group">
+      <label for="dockerServer" class="required">Image Registry Server Address</label>
+      <div>
+        <input class="form-control"
+          id="dockerServer"
+          name="dockerServer"
+          ng-model="newSecret.data.dockerServer"
+          type="text"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          required>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label for="dockerUsername" class="required">Username</label>
+      <div>
+        <input class="form-control"
+          id="dockerUsername"
+          name="dockerUsername"
+          ng-model="newSecret.data.dockerUsername"
+          type="text"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          required>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label for="dockerPassword" class="required">Password</label>
+      <div>
+        <input class="form-control"
+          id="dockerPassword"
+          name="dockerPassword"
+          ng-model="newSecret.data.dockerPassword"
+          type="password"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          required>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label for="dockerEmail" class="required">Email</label>
+      <div>
+        <input class="form-control"
+          type="email"
+          id="dockerEmail"
+          name="dockerEmail"
+          ng-model="newSecret.data.dockerMail"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          required>
+      </div>
+    </div>
+  </div>
+
+  <div ng-if="newSecret.authType === 'kubernetes.io/dockerconfigjson'">
+    <div class="form-group" id="docker-config">
+      <label for="dockerConfig" class="required">Configuration File</label>
+      <osc-file-input
+        if="dockercfg-file-input"
+        model="newSecret.data.dockerConfig"
+        drop-zone-id="docker-config"
+        dragging="false"
+        help-text="Upload a .dockercfg or .docker/config.json file"
+        show-values="false"
+        required="true"></osc-file-input>
+      <div ui-ace="{
+        mode: 'json',
+        theme: 'eclipse',
+        onLoad: aceLoaded,
+        rendererOptions: {
+          fadeFoldWidgets: true,
+          showPrintMargin: false 
+        }
+      }" ng-model="newSecret.data.dockerConfig" class="create-secret-editor ace-bordered" id="dockerconfig-editor" required></div>
+      <div class="help-block">
+        File with credentials and other configuration for connecting to a secured image registry.
+      </div>
+    </div>
+  </div>
+
+  <div ng-if="'serviceaccounts' | canI : 'update'">
+    <div class="form-group">
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" ng-model="newSecret.linkSecret">
+          Use this secret automatically for other builds.
+        </label>
+      </div>
+    </div>
+
+    <div ng-if="!serviceAccountToLink && newSecret.linkSecret">
+      <div class="form-group">
+        <label for="serviceAccount" class="required">Service Account</label>
+        <ui-select required ng-model="newSecret.pickedServiceAccountToLink">
+          <ui-select-match placeholder="Service Account Name">{{$select.selected}}</ui-select-match>
+          <ui-select-choices repeat="sa in (serviceAccountsNames | filter : $select.search)">
+            <div ng-bind-html="sa | highlight : $select.search"></div>
+          </ui-select-choices>
+        </ui-select>
+      </div>
+
+      <div class="form-group" >
+        <label class="required">Link as</label>
+
+        <div class="form-group">
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" ng-model="newSecret.linkAs.secrets" ng-checked="newSecret.linkAs.secrets">
+              Link with {{newSecret.pickedServiceAccountToLink}} service account as a <b>source</b> secret.
+              <span class="help action-inline">
+                <a href="">
+                  <i class="pficon pficon-help" aria-hidden="true"
+                  data-toggle="tooltip" data-original-title="Pods using this service account will mount the content of secret into their containers for pulling sources during build time.">
+                </i>
+                </a>
+              </span>
+            </label>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" ng-model="newSecret.linkAs.imagePullSecrets" ng-checked="newSecret.linkAs.imagePullSecrets">
+              Link with {{newSecret.pickedServiceAccountToLink}} service account as a <b>image pull</b> secret.
+              <span class="help action-inline">
+                <a href="">
+                  <i class="pficon pficon-help" aria-hidden="true"
+                  data-toggle="tooltip" data-original-title="Pods using this service account will use provided creadentials to pull images for the pod’s containers.">
+                </i>
+                </a>
+              </span>
+            </label>
+          </div>
+        </div>
+        <div class="help-block">
+          Linking a secret enables a service account to automatically use that secret for some forms of authentication.
+          <a href="{{'managing_secrets' | helpLink}}" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="buttons gutter-top-bottom">
+    <button class="btn btn-lg btn-primary"
+            type="button"
+            ng-disabled="secretForm.$invalid || secretForm.$pristine"
+            ng-click="create()">Create</button>
+    <button class="btn btn-lg btn-default"
+            type="button"
+            ng-click="cancel()">Cancel</button>
+  </div>
+</ng-form>
+  

--- a/app/views/directives/edit-webhook-triggers.html
+++ b/app/views/directives/edit-webhook-triggers.html
@@ -27,6 +27,6 @@
     </span>
   </div>
 </div>
-<span class="learn-more-inline checkbox">
+<span>
   <a href="" role="button" ng-click="addWebhookTrigger(type)">Add {{type}} webhook</a>
 </span>

--- a/app/views/directives/osc-secrets.html
+++ b/app/views/directives/osc-secrets.html
@@ -1,0 +1,34 @@
+<ng-form name="secretsForm" class="osc-secrets-form">
+  <div class="form-group">
+
+    <label class="picker-label">{{displayType | startCase}} Secret</label>
+    <ui-select ng-model="pickedSecret.name">
+      <ui-select-match placeholder="Secret name">{{$select.selected}}</ui-select-match>
+      <ui-select-choices repeat="secret in (secretsByType[type] | filter : $select.search)">
+        <div ng-bind-html="secret | highlight : $select.search"></div>
+      </ui-select-choices>
+    </ui-select>
+    <div ng-switch="displayType">
+      <div class="help-block" ng-switch-when="source">
+        Secret with credentials for pulling your source code.
+        <a href="{{'git_secret' | helpLink}}" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a>
+      </div>
+      <div class="help-block" ng-switch-when="pull">
+        Secret for authentication when pulling images from a secured registry.
+        <a href="{{'pull_secret' | helpLink}}" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a>
+      </div>
+      <div class="help-block" ng-switch-when="push">
+        Secret for authentication when pushing images to a secured registry.
+        <a href="{{'pull_secret' | helpLink}}" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a>
+      </div>
+    </div>
+  </div>
+
+  <span>
+    <a href=""
+      ng-if="'secrets' | canI : 'create'"
+      role="button" 
+      ng-click="openCreateSecretModal()">Create {{displayType}} secret</a>
+  </span>
+    
+</ng-form>

--- a/app/views/directives/osc-source-secrets.html
+++ b/app/views/directives/osc-source-secrets.html
@@ -1,0 +1,120 @@
+<ng-form name="secretsForm" class="osc-secrets-form">  
+  <div ng-if="strategyType !== 'Custom'"> 
+    <div ng-repeat="pickedSecret in pickedSecrets">
+      <div class="form-group">
+        <div class="row picked-secret">
+          <div class="col-lg-6">
+            <label class="picker-label" ng-if="$first">Build Secret</label>
+            <ui-select ng-required="pickedSecret.destinationDir" ng-model="pickedSecret.secret.name">
+              <ui-select-match placeholder="Secret name">{{$select.selected}}</ui-select-match>
+              <ui-select-choices repeat="secret in (secretsByType[type] | filter : $select.search)">
+                <div ng-bind-html="secret | highlight : $select.search"></div>
+              </ui-select-choices>
+            </ui-select>
+          </div>
+
+          <div class="col-lg-6">
+            <div class="directory">
+              <label for="destinationDir" ng-if="$first">
+                Destination Directory
+              </label>
+              <div>
+                <input class="form-control"
+                  id="destinationDir"
+                  name="destinationDir"
+                  ng-model="pickedSecret.destinationDir"
+                  type="text"
+                  placeholder="/"
+                  autocorrect="off"
+                  autocapitalize="off"
+                  spellcheck="false"
+                  ng-required="pickedSecret.secret.name">
+              </div>
+            </div>
+            <div class="remove-secret-row">
+              <a ng-click="removeSecret($index)" href="" role="button">
+                <span class="pficon pficon-close remove-btn" aria-hidden="true"></span>
+                <span class="sr-only">Remove build secret</span>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div class="row" ng-if="$last">
+          <div class="col-lg-6">
+            <div class="help-block">Source secret to copy into the builder pod at build time.</div>
+          </div>
+          <div class="col-lg-6">
+            <div class="directory">
+              <div class="help-block">Directory where the files will be available at build time.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div ng-if="strategyType === 'Custom'">
+    <div ng-repeat="pickedSecret in pickedSecrets">
+      <div class="form-group">
+        <div class="row picked-secret">
+          <div class="col-lg-6">
+            <label class="picker-label" ng-if="$first">Build Secret</label>
+            <ui-select ng-required="pickedSecret.mountPath !== ''" ng-model="pickedSecret.secretSource.name">
+              <ui-select-match placeholder="Secret name">{{$select.selected}}</ui-select-match>
+              <ui-select-choices repeat="secret in (secretsByType | filter : $select.search)">
+                <div ng-bind-html="secret | highlight : $select.search"></div>
+              </ui-select-choices>
+            </ui-select>
+          </div>
+
+          <div class="col-lg-6">
+            <div class="directory">
+              <label for="mountPath" ng-if="$first">
+                Mount path
+              </label>
+              <div>
+                <input class="form-control"
+                  id="mountPath"
+                  name="mountPath"
+                  ng-model="pickedSecret.mountPath"
+                  type="text"
+                  placeholder="/"
+                  autocorrect="off"
+                  autocapitalize="off"
+                  spellcheck="false"
+                  ng-required="pickedSecret.sourceSecret.name">
+              </div>
+            </div>
+            <div class="remove-secret-row">
+              <label class="sr-only">Remove Build Secret</label>
+              <a class="pficon pficon-close remove-btn" aria-label="Delete row" role="button" ng-click="removeSecret($index)" href=""></a>
+            </div>
+          </div>
+        </div>
+        <div class="row" ng-if="$last">
+          <div class="col-lg-6">
+            <div class="help-block">Source secret to mount into the builder pod at build time.</div>
+          </div>
+          <div class="col-lg-6">
+            <div class="directory">
+              <div class="help-block">Path at which to mount the secret.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="osc-secret-actions">
+    <span ng-if="canAddSourceSecret()">
+      <a href=""
+        role="button" 
+        ng-click="addSourceSecret()">Add build secret</a>
+      <span ng-if="'secrets' | canI : 'create'" class="action-divider">|</span>
+    </span>
+    <a href=""
+      ng-if="'secrets' | canI : 'create'"
+      role="button"
+      ng-click="openCreateSecretModal()">Create source secret</a>
+  </div>
+
+</ng-form>

--- a/app/views/edit/build-config.html
+++ b/app/views/edit/build-config.html
@@ -18,49 +18,64 @@
             </h1>
             <fieldset ng-disabled="disableInputs">
               <form class="edit-form" name="form" novalidate ng-submit="save()">
-                <div class="resource-details">
-                  <div class="row">
-                    <div class="col-lg-6">
-                      <div ng-if="buildConfig.spec.source.type !== 'None'" class="section">
-                        <h3>Source Configuration</h3>
-                        <dl class="dl-horizontal left">
-                          <div ng-if="sources.git">
-                            <div class="form-group">
-                              <label for="sourceUrl">Source Repository URL</label>
-                              <div>
-                                <!-- Unfortunately, we can't set type="url" because some valid values don't pass browser validation. -->
-                                <input class="form-control"
-                                  id="sourceUrl"
-                                  name="sourceUrl"
-                                  ng-model="updatedBuildConfig.spec.source.git.uri"
-                                  type="text"
-                                  autocorrect="off"
-                                  autocapitalize="off"
-                                  spellcheck="false"
-                                  required>
+                <div class="row">
+                  <div class="col-lg-12">
+                    <div ng-if="buildConfig.spec.source.type !== 'None'" class="section">
+                      <h3>Source Configuration</h3>
+                      <dl class="dl-horizontal left">
+                        <div ng-if="sources.git">
+                          <div class="row">
+                            <div ng-class="{
+                              'col-lg-8': view.advancedOptions,
+                              'col-lg-12': !view.advancedOptions}">
+                              <div class="form-group">
+                                <label for="sourceUrl" class="required">Git Repository URL</label>
+                                <div>
+                                  <!-- Unfortunately, we can't set type="url" because some valid values don't pass browser validation. -->
+                                  <input class="form-control"
+                                    id="sourceUrl"
+                                    name="sourceUrl"
+                                    ng-model="updatedBuildConfig.spec.source.git.uri"
+                                    type="text"
+                                    autocorrect="off"
+                                    autocapitalize="off"
+                                    spellcheck="false"
+                                    aria-describedby="source-url-help"
+                                    required>
+                                </div>
+                                <div>
+                                  <span class="text-warning" ng-if="form.sourceUrl.$dirty && !sourceURLPattern.test(updatedBuildConfig.spec.source.git.uri)">Git repository should be a URL.</span>
+                                </div>
+                                <div class="help-block" id="source-url-help">
+                                  Git URL of the source code to build.
+                                  <span ng-if="!view.advancedOptions">If your Git repository is private, view the <a href="" ng-click="view.advancedOptions = true">advanced options</a> to set up authentication.</span>
+                                </div>
                               </div>
-                              <div>
-                                <span class="text-warning" ng-if="form.sourceUrl.$dirty && !sourceURLPattern.test(updatedBuildConfig.spec.source.git.uri)">Git repository should be a URL.</span>
+
+                            </div>
+                            <div class="col-lg-4" ng-if="view.advancedOptions">
+                              <div class="form-group editor">
+                                <label for="sourceRef">Git Reference</label>
+                                <div>
+                                  <input class="form-control"
+                                    id="sourceRef"
+                                    name="sourceRef"
+                                    type="text"
+                                    ng-model="updatedBuildConfig.spec.source.git.ref"
+                                    placeholder="master"
+                                    autocorrect="off"
+                                    autocapitalize="off"
+                                    spellcheck="false"
+                                    aria-describedby="source-ref-help">
+                                </div>
+                                <div class="help-block" id="source-ref-help">Optional branch, tag, or commit.</div>
                               </div>
                             </div>
+                          </div>
 
-                            <div class="form-group editor">
-                              <label for="sourceRef">Source Repository Ref</label>
-                              <div>
-                                <input class="form-control"
-                                  id="sourceRef"
-                                  name="sourceRef"
-                                  type="text"
-                                  ng-model="updatedBuildConfig.spec.source.git.ref"
-                                  placeholder="master"
-                                  autocorrect="off"
-                                  autocapitalize="off"
-                                  spellcheck="false">
-                              </div>
-                            </div>
-
+                          <div ng-if="view.advancedOptions">
                             <div class="form-group">
-                              <label for="sourceContextDir">Source Context Dir</label>
+                              <label for="sourceContextDir">Context Dir</label>
                               <div>
                                 <input class="form-control"
                                   id="sourceContextDir"
@@ -70,53 +85,65 @@
                                   placeholder="/"
                                   autocorrect="off"
                                   autocapitalize="off"
-                                  spellcheck="false">
+                                  spellcheck="false"
+                                  aria-describedby="context-dir-help">
                               </div>
+                              <div class="help-block" id="context-dir-help">Optional subdirectory for the application source code, used as the context directory for the build.</div>
                             </div>
-                          </div>
-
-                          <div ng-if="sources.dockerfile">
                             <div class="form-group">
-                            <label for="buildFrom">Dockerfile</label>
-                              <div ui-ace="{
-                                mode: 'dockerfile',
-                                theme: 'dreamweaver',
-                                onLoad: aceLoaded,
-                                rendererOptions: {
-                                  fadeFoldWidgets: true,
-                                  showPrintMargin: false
-                                }
-                              }" ng-model="updatedBuildConfig.spec.source.dockerfile" class="ace-bordered ace-inline dockerfile-mode"></div>
-                            </div>
-
-                            <div class="form-group" ng-if="updatedBuildConfig.spec.strategy.dockerStrategy.dockerfilePath">
-                              <label for="dockerfilePath">Dockerfile Path</label>
-                              <div>
-                                <input class="form-control"
-                                  id="dockerfilePath"
-                                  name="dockerfilePath"
-                                  type="text"
-                                  ng-model="updatedBuildConfig.spec.strategy.dockerStrategy.dockerfilePath"
-                                  autocorrect="off"
-                                  autocapitalize="off"
-                                  spellcheck="false">
-                              </div>
+                              <osc-secrets model="secrets.picked.gitSecret" 
+                                          namespace="projectName"
+                                          display-type="source"
+                                          type="source"
+                                          service-account-to-link="builder"
+                                          secrets-by-type="secrets.secretsByType"
+                                          alerts="alerts">
+                              </osc-secrets>
                             </div>
                           </div>
+                        </div>
 
-                          <div class="form-group" ng-if="strategyType === 'Docker'">
-                            <div class="checkbox">
-                              <label>
-                                <input type="checkbox" ng-model="options.noCache"/>
-                                Execute docker build without reusing cached instructions.
-                                <span class="help action-inline">
-                                  <a href>
-                                    <i class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Will run the docker build with '--no-cache=true' flag">
-                                    </i>
-                                  </a>
-                                </span>
-                              </label>
+                        <div ng-if="sources.dockerfile">
+                          <div class="form-group">
+                          <label for="buildFrom">Dockerfile</label>
+                            <div ui-ace="{
+                              mode: 'dockerfile',
+                              theme: 'dreamweaver',
+                              onLoad: aceLoaded,
+                              rendererOptions: {
+                                fadeFoldWidgets: true,
+                                showPrintMargin: false
+                              }
+                            }" ng-model="updatedBuildConfig.spec.source.dockerfile" class="ace-bordered ace-inline dockerfile-mode"></div>
+                          </div>
+
+                          <div class="form-group" ng-if="updatedBuildConfig.spec.strategy.dockerStrategy.dockerfilePath && view.advancedOptions">
+                            <label for="dockerfilePath">Dockerfile Path</label>
+                            <div>
+                              <input class="form-control"
+                                id="dockerfilePath"
+                                name="dockerfilePath"
+                                type="text"
+                                ng-model="updatedBuildConfig.spec.strategy.dockerStrategy.dockerfilePath"
+                                autocorrect="off"
+                                autocapitalize="off"
+                                spellcheck="false">
                             </div>
+                          </div>
+                        </div>
+
+                        <div class="form-group" ng-if="strategyType === 'Docker' && view.advancedOptions">
+                          <div class="checkbox">
+                            <label>
+                              <input type="checkbox" ng-model="options.noCache">
+                              Execute docker build without reusing cached instructions.
+                              <span class="help action-inline">
+                                <a href="">
+                                  <i class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Will run the docker build with '--no-cache=true' flag">
+                                  </i>
+                                </a>
+                              </span>
+                            </label>
                           </div>
 
                           <div ng-if="sources.binary && updatedBuildConfig.spec.source">
@@ -124,7 +151,7 @@
                               <label for="binaryAsBuild">
                                 Binary Input As File
                                 <span class="help action-inline">
-                                  <a href>
+                                  <a href="">
                                     <i class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Indicates that the provided binary input should be considered a single file within the build input. For example, specifying 'webapp.war' would place the provided binary as '/webapp.war' for the builder. If left empty, the Docker and Source build strategies assume this file is a zip, tar, or tar.gz file and extract it as the source. The custom strategy receives this binary as standard input. This filename may not contain slashes or be '..' or '.'."></i>
                                   </a>
                                 </span>
@@ -141,182 +168,32 @@
                               </div>
                             </div>
                           </div>
-
-                          <div class="form-groups" ng-show="sources.images">
-                            <div class="single-image-source" ng-if="sourceImages.length === 1">
-
-                              <div class="form-group">
-                                <label>Image Source From</label>
-                                <ui-select required ng-model="imageOptions.fromSource.type" search-enabled="false">
-                                  <ui-select-match>{{$select.selected | startCase}}</ui-select-match>
-                                  <ui-select-choices repeat="type in imageSourceTypes">
-                                    {{type | startCase}}
-                                  </ui-select-choices>
-                                </ui-select>
-                              </div>
-
-                              <div class="form-group" ng-if="imageOptions.fromSource.type==='ImageStreamTag'" >
-                                <istag-select include-shared-namespace="true"
-                                              model="imageOptions.fromSource.imageStreamTag"></istag-select>
-                              </div>
-
-                              <div ng-if="imageOptions.fromSource.type==='ImageStreamImage'" class="form-group">
-                                <label for="imageSourceImage">Image Stream Image</label>
-                                <div>
-                                  <input class="form-control"
-                                    type="text"
-                                    ng-model="imageOptions.fromSource.imageStreamImage"
-                                    placeholder="example: openshift/ruby-20-centos7@603bfa418"
-                                    autocorrect="off"
-                                    autocapitalize="off"
-                                    spellcheck="false"
-                                    required>
-                                </div>
-                              </div>
-
-
-                              <div ng-if="imageOptions.fromSource.type==='DockerImage'" class="form-group">
-                                <label for="imageSourceLink">Docker Image Repository</label>
-                                <div>
-                                  <input class="form-control"
-                                    id="imageSourceLink"
-                                    name="imageSourceLink"
-                                    type="text"
-                                    ng-model="imageOptions.fromSource.dockerImage"
-                                    placeholder="example: centos/ruby-20-centos7:latest"
-                                    autocorrect="off"
-                                    autocapitalize="off"
-                                    spellcheck="false"
-                                    required>
-                                </div>
-                              </div>
-
-                              <div class="form-group">
-                                <label for="buildFrom">Source and Destination Paths<span class="help action-inline">
-                                  <a href>
-                                  <i class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Paths is a list of source and destination paths to copy from the image. At least one pair has to be specified."></i>
-                                  </a>
-                                </span></label>
-                                <key-value-editor
-                                  entries="imageSourcePaths"
-                                  key-placeholder="Source Path"
-                                  key-validator="\/.*?$"
-                                  value-placeholder="Destination Dir"
-                                  key-validator-error-tooltip="A valid Source Path is an absolute path beginning with '/'"
-                                  add-row-link="Add image source path"></key-value-editor>
-                              </div>
-                            </div>
-
-
-                            <div class="multiple-image-source" ng-if="sourceImages.length !== 1">
-                              <label for="imageSourceFrom">Image Source From<span class="help action-inline">
-                                <a href>
-                                  <i class="pficon pficon-info" style="cursor: help;" aria-hidden="true" data-toggle="tooltip" data-original-title="This Build Config contains more then one Image Source. To edit them use the YAML editor.">
-                                </i>
-                                </a>
-                              </span></label>
-                              <div ng-repeat="fromObject in imageSourceFromObjects" class="imageSourceItem">
-                                {{selectTypes[fromObject.kind]}}: {{fromObject | imageObjectRef : buildConfig.metadata.namespace}}
-                              </div>
-                            </div>
-                          </div>
-                        </dl>
-                      </div>
-
-                      <div ng-if="updatedBuildConfig | isJenkinsPipelineStrategy" class="section">
-                        <h3>Jenkins Pipeline Configuration</h3>
-                        <div class="form-group" ng-if="buildConfig.spec.source.type === 'Git'">
-                          <label for="jenkinsfile-type">Jenkinsfile Type</label>
-                          <select
-                            id="jenkinsfile-type"
-                            class="form-control"
-                            ng-model="jenkinsfileOptions.type"
-                            ng-options="type.id as type.title for type in jenkinsfileTypes"
-                            aria-describedby="jenkinsfile-type-help">
-                          </select>
-                          <div class="help-block" id="jenkinsfile-type-help">
-                            Use a Jenkinsfile from the source repository or specify the
-                            Jenkinsfile content directly in the build configuration.
-                          </div>
                         </div>
 
-                        <div ng-if="jenkinsfileOptions.type === 'path'" class="form-group">
-                          <label for="jenkinsfilePath">Jenkinsfile Source Path</label>
-                          <input class="form-control"
-                                 id="jenkinsfilePath"
-                                 name="jenkinsfilePath"
-                                 type="text"
-                                 ng-model="updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath"
-                                 autocorrect="off"
-                                 autocapitalize="off"
-                                 spellcheck="false"
-                                 aria-describedby="jenkinsfile-path-help">
-                          <div class="help-block" id="jenkinsfile-path-help">
-                            Optional path to the Jenkinsfile relative to the context dir.
-                            Defaults to the Jenkinsfile in context dir.
-                          </div>
-                        </div>
+                        <div class="form-groups" ng-show="sources.images">
+                          <div class="single-image-source" ng-if="sourceImages.length === 1">
 
-                        <div ng-if="jenkinsfileOptions.type === 'inline'">
-                          <label>Jenkinsfile</label>
-                            <div ui-ace="{
-                              mode: 'groovy',
-                              theme: 'eclipse',
-                              onLoad: aceLoaded,
-                              rendererOptions: {
-                                fadeFoldWidgets: true,
-                                showPrintMargin: false
-                              }
-                            }" ng-model="updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile" class="ace-bordered ace-inline"></div>
-                        </div>
-                      </div>
-                      <div ng-if="sources.none">
-                        <div class="form-group">
-                          <i>No source inputs have been defined for this build configuration.</i>
-                        </div>
-                      </div>
-
-                      <div ng-if="updatedBuildConfig.spec.strategy.type !== 'JenkinsPipeline'" class="section">
-                        <h3>Image Configuration</h3>
-                        <dl class="dl-horizontal left">
-
-                          <div>
                             <div class="form-group">
-                              <label for="buildFrom">Build From</label>
-                              <ui-select required ng-model="imageOptions.from.type" search-enabled="false">
+                              <label>Image Source From</label>
+                              <ui-select required ng-model="imageOptions.fromSource.type" search-enabled="false">
                                 <ui-select-match>{{$select.selected | startCase}}</ui-select-match>
-                                <ui-select-choices repeat="type in buildFromTypes">
+                                <ui-select-choices repeat="type in imageSourceTypes">
                                   {{type | startCase}}
                                 </ui-select-choices>
                               </ui-select>
                             </div>
 
-
-                            <div class="form-group" ng-if="imageOptions.from.type==='ImageStreamTag'">
+                            <div class="form-group" ng-if="imageOptions.fromSource.type==='ImageStreamTag'" >
                               <istag-select include-shared-namespace="true"
-                                            model="imageOptions.from.imageStreamTag"></istag-select>
+                                            model="imageOptions.fromSource.imageStreamTag"></istag-select>
                             </div>
 
-                            <div ng-if="imageOptions.from.type==='DockerImage'" class="form-group">
-                              <label for="FromTypeLink">Docker Image Repository</label>
+                            <div ng-if="imageOptions.fromSource.type==='ImageStreamImage'" class="form-group">
+                              <label for="imageSourceImage">Image Stream Image</label>
                               <div>
                                 <input class="form-control"
                                   type="text"
-                                  ng-model="imageOptions.from.dockerImage"
-                                  autocorrect="off"
-                                  autocapitalize="off"
-                                  placeholder="example: centos/ruby-20-centos7:latest"
-                                  spellcheck="false"
-                                  required>
-                              </div>
-                            </div>
-
-                            <div ng-if="imageOptions.from.type==='ImageStreamImage'" class="form-group">
-                              <label for="FromTypeImage">Image Stream Image</label>
-                              <div>
-                                <input class="form-control"
-                                  type="text"
-                                  ng-model="imageOptions.from.imageStreamImage"
+                                  ng-model="imageOptions.fromSource.imageStreamImage"
                                   placeholder="example: openshift/ruby-20-centos7@603bfa418"
                                   autocorrect="off"
                                   autocapitalize="off"
@@ -324,40 +201,16 @@
                                   required>
                               </div>
                             </div>
-                          </div>
 
-                          <div class="form-group">
-                            <div class="checkbox">
-                              <label>
-                                <input type="checkbox" ng-model="options.forcePull"/>
-                                Always pull the builder image from the docker registry, even if it is present locally
-                              </label>
-                            </div>
-                          </div>
 
-                          <div>
-                            <div class="form-group">
-                              <label for="buildFrom">Push To</label>
-                              <ui-select required ng-model="imageOptions.to.type" search-enabled="false">
-                                <ui-select-match>{{$select.selected | startCase}}</ui-select-match>
-                                <ui-select-choices repeat="type in pushToTypes">
-                                  {{type | startCase}}
-                                </ui-select-choices>
-                              </ui-select>
-                            </div>
-                            <div class="form-group" ng-if="imageOptions.to.type==='ImageStreamTag'">
-                              <istag-select model="imageOptions.to.imageStreamTag"
-                                            allow-custom-tag="true"></istag-select>
-                            </div>
-
-                            <div ng-if="imageOptions.to.type==='DockerImage'" class="form-group">
-                              <label for="pushToLink">Docker Image Repository</label>
+                            <div ng-if="imageOptions.fromSource.type==='DockerImage'" class="form-group">
+                              <label for="imageSourceLink">Docker Image Repository</label>
                               <div>
                                 <input class="form-control"
-                                  id="pushToLink"
-                                  name="pushToLink"
+                                  id="imageSourceLink"
+                                  name="imageSourceLink"
                                   type="text"
-                                  ng-model="imageOptions.to.dockerImage"
+                                  ng-model="imageOptions.fromSource.dockerImage"
                                   placeholder="example: centos/ruby-20-centos7:latest"
                                   autocorrect="off"
                                   autocapitalize="off"
@@ -365,31 +218,229 @@
                                   required>
                               </div>
                             </div>
+
+                            <div class="form-group">
+                              <label for="buildFrom">Source and Destination Paths<span class="help action-inline">
+                                <a href="">
+                                <i class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Paths is a list of source and destination paths to copy from the image. At least one pair has to be specified."></i>
+                                </a>
+                              </span></label>
+                              <key-value-editor
+                                entries="imageSourcePaths"
+                                key-placeholder="Source Path"
+                                key-validator="\/.*?$"
+                                value-placeholder="Destination Dir"
+                                key-validator-error-tooltip="A valid Source Path is an absolute path beginning with '/'"
+                                add-row-link="Add image source path"></key-value-editor>
+                            </div>
                           </div>
-                        </dl>
+
+
+                          <div class="multiple-image-source" ng-if="sourceImages.length !== 1">
+                            <label for="imageSourceFrom">Image Source From<span class="help action-inline">
+                              <a href="">
+                                <i class="pficon pficon-info" style="cursor: help;" aria-hidden="true" data-toggle="tooltip" data-original-title="This Build Config contains more then one Image Source. To edit them use the YAML editor.">
+                              </i>
+                              </a>
+                            </span></label>
+                            <div ng-repeat="fromObject in imageSourceFromObjects" class="imageSourceItem">
+                              {{selectTypes[fromObject.kind]}}: {{fromObject | imageObjectRef : buildConfig.metadata.namespace}}
+                            </div>
+                          </div>
+                        </div>
+                      </dl>
+                    </div>
+
+                    <div ng-if="updatedBuildConfig | isJenkinsPipelineStrategy" class="section">
+                      <h3 class="with-divider">Jenkins Pipeline Configuration</h3>
+                      <div class="form-group" ng-if="buildConfig.spec.source.type === 'Git'">
+                        <label for="jenkinsfile-type">Jenkinsfile Type</label>
+                        <select
+                          id="jenkinsfile-type"
+                          class="form-control"
+                          ng-model="jenkinsfileOptions.type"
+                          ng-options="type.id as type.title for type in jenkinsfileTypes"
+                          aria-describedby="jenkinsfile-type-help">
+                        </select>
+                        <div class="help-block" id="jenkinsfile-type-help">
+                          Use a Jenkinsfile from the source repository or specify the
+                          Jenkinsfile content directly in the build configuration.
+                        </div>
+                      </div>
+
+                      <div ng-if="jenkinsfileOptions.type === 'path'" class="form-group">
+                        <label for="jenkinsfilePath">Jenkinsfile Source Path</label>
+                        <input class="form-control"
+                               id="jenkinsfilePath"
+                               name="jenkinsfilePath"
+                               type="text"
+                               ng-model="updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath"
+                               autocorrect="off"
+                               autocapitalize="off"
+                               spellcheck="false"
+                               aria-describedby="jenkinsfile-path-help">
+                        <div class="help-block" id="jenkinsfile-path-help">
+                          Optional path to the Jenkinsfile relative to the context dir.
+                          Defaults to the Jenkinsfile in context dir.
+                        </div>
+                      </div>
+
+                      <div ng-if="jenkinsfileOptions.type === 'inline'">
+                        <label>Jenkinsfile</label>
+                          <div ui-ace="{
+                            mode: 'groovy',
+                            theme: 'eclipse',
+                            onLoad: aceLoaded,
+                            rendererOptions: {
+                              fadeFoldWidgets: true,
+                              showPrintMargin: false
+                            }
+                          }" ng-model="updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile" class="ace-bordered ace-inline"></div>
+                      </div>
+                    </div>
+                    <div ng-if="sources.none">
+                      <div class="form-group">
+                        <i>No source inputs have been defined for this build configuration.</i>
                       </div>
                     </div>
 
+                    <div ng-if="strategyType !== 'JenkinsPipeline'" class="section">
+                      <h3 class="with-divider">Image Configuration</h3>
+                      <dl class="dl-horizontal left">
 
-                    <div class="col-lg-6">
-                      <div ng-if="!(updatedBuildConfig | isJenkinsPipelineStrategy)" class="section">
-                        <h3>Environment Variables<span class="help action-inline">
-                          <a href>
-                          <i class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Environment variables are used to configure and pass information to running containers.  These environment variables will be available during your build and at runtime."></i>
-                          </a>
-                        </span></h3>
                         <div>
-                          <key-value-editor
-                            ng-if="envVars"
-                            entries="envVars"
-                            key-validator="[a-zA-Z][a-zA-Z0-9_]*"
-                            key-validator-error-tooltip="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."
-                            add-row-link="Add environment variable"></key-value-editor>
+                          <div class="form-group">
+                            <label for="buildFrom">Build From</label>
+                            <ui-select required ng-model="imageOptions.from.type" search-enabled="false">
+                              <ui-select-match>{{$select.selected | startCase}}</ui-select-match>
+                              <ui-select-choices repeat="type in buildFromTypes">
+                                {{type | startCase}}
+                              </ui-select-choices>
+                            </ui-select>
+                          </div>
+
+
+                          <div class="form-group" ng-if="imageOptions.from.type==='ImageStreamTag'">
+                            <istag-select include-shared-namespace="true"
+                                          model="imageOptions.from.imageStreamTag"></istag-select>
+                          </div>
+
+                          <div ng-if="imageOptions.from.type==='DockerImage'" class="form-group">
+                            <label for="FromTypeLink">Docker Image Repository</label>
+                            <div>
+                              <input class="form-control"
+                                type="text"
+                                ng-model="imageOptions.from.dockerImage"
+                                autocorrect="off"
+                                autocapitalize="off"
+                                placeholder="example: centos/ruby-20-centos7:latest"
+                                spellcheck="false"
+                                required>
+                            </div>
+                          </div>
+
+                          <div ng-if="imageOptions.from.type==='ImageStreamImage'" class="form-group">
+                            <label for="FromTypeImage">Image Stream Image</label>
+                            <div>
+                              <input class="form-control"
+                                type="text"
+                                ng-model="imageOptions.from.imageStreamImage"
+                                placeholder="example: openshift/ruby-20-centos7@603bfa418"
+                                autocorrect="off"
+                                autocapitalize="off"
+                                spellcheck="false"
+                                required>
+                            </div>
+                          </div>
                         </div>
+
+                        <div class="form-group" ng-if="view.advancedOptions && strategyType !== 'JenkinsPipeline'">
+                          <osc-secrets model="secrets.picked.pullSecret"
+                                      namespace="projectName"
+                                      display-type="pull"
+                                      type="image"
+                                      secrets-by-type="secrets.secretsByType"
+                                      service-account-to-link="builder"
+                                      alerts="alerts">
+                          </osc-secrets>
+                        </div>
+
+                        <div class="form-group" ng-if="view.advancedOptions">
+                          <div class="checkbox">
+                            <label>
+                              <input type="checkbox" ng-model="options.forcePull">
+                              Always pull the builder image from the docker registry, even if it is present locally
+                            </label>
+                          </div>
+                        </div>
+
+                        <div>
+                          <div class="form-group">
+                            <label for="buildFrom">Push To</label>
+                            <ui-select required ng-model="imageOptions.to.type" search-enabled="false">
+                              <ui-select-match>{{$select.selected | startCase}}</ui-select-match>
+                              <ui-select-choices repeat="type in pushToTypes">
+                                {{type | startCase}}
+                              </ui-select-choices>
+                            </ui-select>
+                          </div>
+                          <div class="form-group" ng-if="imageOptions.to.type==='ImageStreamTag'">
+                            <istag-select model="imageOptions.to.imageStreamTag"
+                                          allow-custom-tag="true"></istag-select>
+                          </div>
+
+                          <div ng-if="imageOptions.to.type==='DockerImage'" class="form-group">
+                            <label for="pushToLink">Docker Image Repository</label>
+                            <div>
+                              <input class="form-control"
+                                id="pushToLink"
+                                name="pushToLink"
+                                type="text"
+                                ng-model="imageOptions.to.dockerImage"
+                                placeholder="example: centos/ruby-20-centos7:latest"
+                                autocorrect="off"
+                                autocapitalize="off"
+                                spellcheck="false"
+                                required>
+                            </div>
+                          </div>
+
+                          <div class="form-group" ng-if="view.advancedOptions">
+                            <osc-secrets model="secrets.picked.pushSecret"
+                                        namespace="projectName"
+                                        display-type="push"
+                                        type="image"
+                                        service-account-to-link="builder"
+                                        secrets-by-type="secrets.secretsByType"
+                                        alerts="alerts">
+                            </osc-secrets>
+                          </div>
+
+                        </div>
+                      </dl>
+                    </div>
+
+
+
+                    <div ng-if="!(updatedBuildConfig | isJenkinsPipelineStrategy)" class="section">
+                      <h3 class="with-divider">Environment Variables<span class="help action-inline">
+                        <a href="">
+                        <i class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Environment variables are used to configure and pass information to running containers.  These environment variables will be available during your build and at runtime."></i>
+                        </a>
+                      </span></h3>
+                      <div>
+                        <key-value-editor
+                          ng-if="envVars"
+                          entries="envVars"
+                          key-validator="[a-zA-Z][a-zA-Z0-9_]*"
+                          key-validator-error-tooltip="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."
+                          add-row-link="Add environment variable"></key-value-editor>
                       </div>
-                      <div ng-if="sources.git || !(updatedBuildConfig | isJenkinsPipelineStrategy)" class="section">
-                        <h3>Triggers
-                          <a href="{{'build-triggers' | helpLink}}" aria-hidden="true" target="_blank"><span class="learn-more-inline">Learn more<i class="fa fa-external-link"></i></span></a>
+                    </div>
+                    <div ng-if="sources.git || !(updatedBuildConfig | isJenkinsPipelineStrategy)" class="section">
+                      <div ng-if="view.advancedOptions">
+                        <h3 class="with-divider">Triggers
+                          <a href="{{'build-triggers' | helpLink}}" aria-hidden="true" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link"></i></span></a>
                         </h3>
                         <dl class="dl-horizontal left">
                           <div>
@@ -417,7 +468,7 @@
                             <!-- <h5>Config change</h5>
                             <div class="checkbox">
                               <label>
-                                <input type="checkbox" ng-model="triggers.configChangeTrigger.present"/>
+                                <input type="checkbox" ng-model="triggers.configChangeTrigger.present">
                                   Automatically build a new image when the build configuration changes
                               </label>
                             </div> -->
@@ -426,7 +477,7 @@
                               <h5>Image change</h5>
                               <div class="checkbox">
                                 <label>
-                                  <input type="checkbox" ng-model="triggers.builderImageChangeTrigger.present" ng-disabled="imageOptions.from.type === 'None'"/>
+                                  <input type="checkbox" ng-model="triggers.builderImageChangeTrigger.present" ng-disabled="imageOptions.from.type === 'None'">
                                     Automatically build a new image when the builder image changes
                                     <span class="help action-inline">
                                       <a href>
@@ -441,44 +492,66 @@
                           </div>
                         </dl>
                       </div>
-                      <div class="section">
-                        <h3>Run Policy
-                          <span class="help action-inline">
-                            <a href>
-                              <i class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="The build run policy describes the order in which the builds created from the build configuration should run."></i>
-                            </a>
-                          </span>
-                        </h3>
-                        <div class="form-group">
-                          <label class="sr-only">Run policy type</label>
-                          <ui-select required ng-model="updatedBuildConfig.spec.runPolicy" search-enabled="false">
-                            <ui-select-match>{{$select.selected | sentenceCase}}</ui-select-match>
-                            <ui-select-choices repeat="type in runPolicyTypes">
-                              {{type | sentenceCase}}
-                            </ui-select-choices>
-                          </ui-select>
+                    </div>
+                    <div class="section" ng-if="!(updatedBuildConfig | isJenkinsPipelineStrategy) && view.advancedOptions">
+                      <h3 class="with-divider">
+                        Build Secrets
+                        <a href="{{'source_secrets' | helpLink}}" aria-hidden="true" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link"></i></span></a>
+                      </h3>
+                      <div class="form-group">
+                        <osc-source-secrets model="secrets.picked.sourceSecrets" 
+                                    namespace="projectName"
+                                    secrets-by-type="secrets.secretsByType"
+                                    strategy-type="strategyType"
+                                    service-account-to-link="builder"
+                                    alerts="alerts"
+                                    display-type="source"
+                                    type="source">
+                        </osc-source-secrets>
+                      </div>
 
-                        </div>
-                        <div ng-switch="updatedBuildConfig.spec.runPolicy">
-                          <div ng-switch-when="Serial">Builds triggered from this Build Configuration will run one at the time, in the order they have been triggered.</div>
-                          <div ng-switch-when="Parallel">Builds triggered from this Build Configuration will run all at the same time. The order in which they will finish is not guranteed.</div>
-                          <div ng-switch-when="SerialLatestOnly">Builds triggered from this Build Configuration will run one at the time. When a currently running build completes, the next build that will run is the latest build created. Other queued builds will be cancelled.</div>
-                          <div ng-switch-default>Builds triggered from this Build Configuration will run using the {{updatedBuildConfig.spec.runPolicy | sentenceCase}} policy.</div>
-                        </div>
+                    </div>
+                    <div class="section" ng-if="view.advancedOptions">
+                      <h3 class="with-divider">Run Policy
+                        <span class="help action-inline">
+                          <a href="">
+                            <i class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="The build run policy describes the order in which the builds created from the build configuration should run."></i>
+                          </a>
+                        </span>
+                      </h3>
+                      <div class="form-group">
+                        <label class="sr-only">Run policy type</label>
+                        <ui-select required ng-model="updatedBuildConfig.spec.runPolicy" search-enabled="false">
+                          <ui-select-match>{{$select.selected | sentenceCase}}</ui-select-match>
+                          <ui-select-choices repeat="type in runPolicyTypes">
+                            {{type | sentenceCase}}
+                          </ui-select-choices>
+                        </ui-select>
+
+                      </div>
+                      <div ng-switch="updatedBuildConfig.spec.runPolicy">
+                        <div class="help-block" ng-switch-when="Serial">Builds triggered from this Build Configuration will run one at the time, in the order they have been triggered.</div>
+                        <div class="help-block" ng-switch-when="Parallel">Builds triggered from this Build Configuration will run all at the same time. The order in which they will finish is not guranteed.</div>
+                        <div class="help-block" ng-switch-when="SerialLatestOnly">Builds triggered from this Build Configuration will run one at the time. When a currently running build completes, the next build that will run is the latest build created. Other queued builds will be cancelled.</div>
+                        <div class="help-block" ng-switch-default>Builds triggered from this Build Configuration will run using the {{updatedBuildConfig.spec.runPolicy | sentenceCase}} policy.</div>
                       </div>
                     </div>
-                  </div>
-                  <div class="buttons gutter-top-bottom">
-                    <button
-                      type="submit"
-                      class="btn btn-primary btn-lg"
-                        ng-disabled="form.$invalid || form.$pristine || disableInputs">
-                        Save
-                    </button>
-                    <a class="btn btn-default btn-lg"
-                      href="{{updatedBuildConfig | navigateResourceURL}}">
-                      Cancel
-                    </a>
+                  
+                    <div class="gutter-top">
+                      <a href="" ng-click="view.advancedOptions = !view.advancedOptions" role="button">{{view.advancedOptions ? 'Hide' : 'Show'}} advanced options</a>
+                    </div>
+                    <div class="buttons gutter-top-bottom">
+                      <button
+                        type="submit"
+                        class="btn btn-primary btn-lg"
+                          ng-disabled="form.$invalid || form.$pristine || disableInputs">
+                          Save
+                      </button>
+                      <a class="btn btn-default btn-lg"
+                        href="{{updatedBuildConfig | navigateResourceURL}}">
+                        Cancel
+                      </a>
+                    </div>
                   </div>
                 </div>
               </form>

--- a/app/views/modals/create-secret.html
+++ b/app/views/modals/create-secret.html
@@ -1,0 +1,20 @@
+<div class="create-secret-modal">
+  <div class="modal-header">
+    <h2>
+      Create {{type | capitalize}} Secret
+      <span ng-switch="type">
+        <a ng-switch-when="source" ng-href="{{'git_secret' | helpLink}}" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a>
+        <a ng-switch-when="image" ng-href="{{'pull_secret' | helpLink}}" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a>
+        <a ng-switch-default ng-href="{{'source_secrets' | helpLink}}" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a>
+      </span>
+    </h2>
+  </div>
+  <div class="modal-body">
+    <create-secret type="type"
+                    service-account-to-link="serviceAccountToLink"
+                    namespace="namespace"
+                    alerts="alerts"
+                    post-create-action="postCreateAction(newSecret, creationAlert)"
+                    cancel="cancel()"></create-secret>
+  </div>
+</div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -19,6 +19,11 @@ persistent_volumes:"https://docs.openshift.org/latest/dev_guide/persistent_volum
 compute_resources:"https://docs.openshift.org/latest/dev_guide/compute_resources.html",
 pod_autoscaling:"https://docs.openshift.org/latest/dev_guide/pod_autoscaling.html",
 application_health:"https://docs.openshift.org/latest/dev_guide/application_health.html",
+source_secrets:"https://docs.openshift.org/latest/dev_guide/builds.html#using-secrets",
+git_secret:"https://docs.openshift.org/latest/dev_guide/builds.html#using-private-repositories-for-builds",
+pull_secret:"https://docs.openshift.org/latest/dev_guide/managing_images.html#using-image-pull-secrets",
+managing_secrets:"https://docs.openshift.org/latest/dev_guide/service_accounts.html#managing-allowed-secrets",
+creating_secrets:"https://docs.openshift.org/latest/dev_guide/secrets.html#creating-and-using-secrets",
 "default":"https://docs.openshift.org/latest/welcome/index.html"
 },
 CLI:{
@@ -2888,6 +2893,29 @@ clearTemplateData:function() {
 b = a();
 }
 };
+}), angular.module("openshiftConsole").factory("SecretsService", function() {
+var a = function(a) {
+var b = {
+source:[],
+image:[]
+};
+return _.each(a.by("metadata.name"), function(a) {
+switch (a.type) {
+case "kubernetes.io/basic-auth":
+case "kubernetes.io/ssh-auth":
+case "Opaque":
+b.source.push(a.metadata.name);
+break;
+
+case "kubernetes.io/dockercfg":
+case "kubernetes.io/dockerconfigjson":
+b.image.push(a.metadata.name);
+}
+}), b;
+};
+return {
+groupSecretsByType:a
+};
 }), angular.module("openshiftConsole").factory("ServicesService", [ "$filter", "$q", "DataService", function(a, b, c) {
 var d = "service.alpha.openshift.io/dependencies", e = "service.openshift.io/infrastructure", f = a("annotation"), g = function(a) {
 var b = f(a, d);
@@ -5231,8 +5259,8 @@ i.list("limitranges", l, function(b) {
 e.limitRanges = b.by("metadata.name"), 0 !== a("hashSize")(b) && e.$watch("containers", n, !0);
 });
 }));
-} ]), angular.module("openshiftConsole").controller("EditBuildConfigController", [ "$scope", "$routeParams", "DataService", "ProjectsService", "$filter", "ApplicationGenerator", "Navigate", "$location", "AlertMessageService", "SOURCE_URL_PATTERN", "keyValueEditorUtils", function(a, b, c, d, e, f, g, h, i, j, k) {
-a.projectName = b.project, a.buildConfig = null, a.alerts = {}, a.emptyMessage = "Loading...", a.sourceURLPattern = j, a.options = {}, a.jenkinsfileOptions = {
+} ]), angular.module("openshiftConsole").controller("EditBuildConfigController", [ "$scope", "$routeParams", "DataService", "SecretsService", "ProjectsService", "$filter", "ApplicationGenerator", "Navigate", "$location", "AlertMessageService", "SOURCE_URL_PATTERN", "keyValueEditorUtils", function(a, b, c, d, e, f, g, h, i, j, k, l) {
+a.projectName = b.project, a.buildConfig = null, a.alerts = {}, a.emptyMessage = "Loading...", a.sourceURLPattern = k, a.options = {}, a.jenkinsfileOptions = {
 type:"path"
 }, a.selectTypes = {
 ImageStreamTag:"Image Stream Tag",
@@ -5244,7 +5272,9 @@ title:"From Source Repository"
 }, {
 id:"inline",
 title:"Inline"
-} ], a.breadcrumbs = [ {
+} ], a.view = {
+advancedOptions:!1
+}, a.breadcrumbs = [ {
 title:b.project,
 link:"project/" + b.project
 } ], b.isPipeline ? (a.breadcrumbs.push({
@@ -5278,20 +5308,25 @@ genericWebhooks:[],
 imageChangeTriggers:[],
 builderImageChangeTrigger:{},
 configChangeTrigger:{}
-}, a.runPolicyTypes = [ "Serial", "Parallel", "SerialLatestOnly" ], i.getAlerts().forEach(function(b) {
+}, a.runPolicyTypes = [ "Serial", "Parallel", "SerialLatestOnly" ], j.getAlerts().forEach(function(b) {
 a.alerts[b.name] = b.data;
-}), i.clearAlerts();
-var l = [], m = e("buildStrategy");
-d.get(b.project).then(_.spread(function(d, f) {
-a.project = d, a.breadcrumbs[0].title = e("displayName")(d), c.get("buildconfigs", b.buildconfig, f).then(function(d) {
-a.buildConfig = d, a.updatedBuildConfig = angular.copy(a.buildConfig), a.buildStrategy = m(a.updatedBuildConfig), a.strategyType = a.buildConfig.spec.strategy.type, a.envVars = a.buildStrategy.env || [], _.each(a.envVars, function(a) {
-e("altTextForValueFrom")(a);
-}), a.triggers = n(a.triggers, a.buildConfig.spec.triggers), a.sources = s(a.sources, a.buildConfig.spec.source), _.has(d, "spec.strategy.jenkinsPipelineStrategy.jenkinsfile") && (a.jenkinsfileOptions.type = "inline");
-var g = function(a, b) {
+}), j.clearAlerts(), a.secrets = {};
+var m = [], n = f("buildStrategy");
+e.get(b.project).then(_.spread(function(e, g) {
+a.project = e, a.context = g, a.breadcrumbs[0].title = f("displayName")(e), c.get("buildconfigs", b.buildconfig, g).then(function(e) {
+a.buildConfig = e, a.updatedBuildConfig = angular.copy(a.buildConfig), a.buildStrategy = n(a.updatedBuildConfig), a.strategyType = a.buildConfig.spec.strategy.type, a.envVars = a.buildStrategy.env || [], _.each(a.envVars, function(a) {
+f("altTextForValueFrom")(a);
+}), a.triggers = o(a.triggers, a.buildConfig.spec.triggers), a.sources = w(a.sources, a.buildConfig.spec.source), _.has(e, "spec.strategy.jenkinsPipelineStrategy.jenkinsfile") && (a.jenkinsfileOptions.type = "inline"), c.list("secrets", g, function(b) {
+var c = d.groupSecretsByType(b);
+a.secrets.secretsByType = _.each(c, function(a) {
+a.unshift("");
+}), t();
+});
+var h = function(a, b) {
 a.type = b && b.kind ? b.kind :"None";
-var c = {}, e = "", f = "";
+var c = {}, d = "", f = "";
 c = "ImageStreamTag" === a.type ? {
-namespace:b.namespace || d.metadata.namespace,
+namespace:b.namespace || e.metadata.namespace,
 imageStream:b.name.split(":")[0],
 tagObject:{
 tag:b.name.split(":")[1]
@@ -5302,16 +5337,16 @@ imageStream:"",
 tagObject:{
 tag:""
 }
-}, e = "ImageStreamImage" === a.type ? (b.namespace || d.metadata.namespace) + "/" + b.name :"", f = "DockerImage" === a.type ? b.name :"", a.imageStreamTag = c, a.imageStreamImage = e, a.dockerImage = f;
+}, d = "ImageStreamImage" === a.type ? (b.namespace || e.metadata.namespace) + "/" + b.name :"", f = "DockerImage" === a.type ? b.name :"", a.imageStreamTag = c, a.imageStreamImage = d, a.dockerImage = f;
 };
-g(a.imageOptions.from, a.buildStrategy.from), g(a.imageOptions.to, a.updatedBuildConfig.spec.output.to), a.sources.images && (a.sourceImages = a.buildConfig.spec.source.images, 1 === a.sourceImages.length ? (a.imageSourceTypes = angular.copy(a.buildFromTypes), g(a.imageOptions.fromSource, a.sourceImages[0].from), a.imageSourcePaths = _.map(a.sourceImages[0].paths, function(a) {
+h(a.imageOptions.from, a.buildStrategy.from), h(a.imageOptions.to, a.updatedBuildConfig.spec.output.to), a.sources.images && (a.sourceImages = a.buildConfig.spec.source.images, 1 === a.sourceImages.length ? (a.imageSourceTypes = angular.copy(a.buildFromTypes), h(a.imageOptions.fromSource, a.sourceImages[0].from), a.imageSourcePaths = _.map(a.sourceImages[0].paths, function(a) {
 return {
 name:a.sourcePath,
 value:a.destinationDir
 };
 })) :(a.imageSourceFromObjects = [], a.sourceImages.forEach(function(b) {
 a.imageSourceFromObjects.push(b.from);
-}))), a.options.forcePull = !!a.buildStrategy.forcePull, a.sources.binary && (a.options.binaryAsFile = a.buildConfig.spec.source.binary.asFile ? a.buildConfig.spec.source.binary.asFile :""), "Docker" === a.strategyType && (a.options.noCache = !!a.buildConfig.spec.strategy.dockerStrategy.noCache, a.buildFromTypes.push("None")), l.push(c.watchObject("buildconfigs", b.buildconfig, f, function(b, c) {
+}))), a.options.forcePull = !!a.buildStrategy.forcePull, a.sources.binary && (a.options.binaryAsFile = a.buildConfig.spec.source.binary.asFile ? a.buildConfig.spec.source.binary.asFile :""), "Docker" === a.strategyType && (a.options.noCache = !!a.buildConfig.spec.strategy.dockerStrategy.noCache, a.buildFromTypes.push("None")), m.push(c.watchObject("buildconfigs", b.buildconfig, g, function(b, c) {
 "MODIFIED" === c && (a.alerts["updated/deleted"] = {
 type:"warning",
 message:"This build configuration has changed since you started editing it. You'll need to copy any changes you've made and edit again."
@@ -5324,16 +5359,16 @@ message:"This build configuration has been deleted."
 a.loaded = !0, a.alerts.load = {
 type:"error",
 message:"The build configuration details could not be loaded.",
-details:"Reason: " + e("getErrorDetails")(b)
+details:"Reason: " + f("getErrorDetails")(b)
 };
 });
 }));
-var n = function(b, c) {
+var o = function(b, c) {
 function d(b, c) {
-var d = e("imageObjectRef")(b, a.projectName), f = e("imageObjectRef")(c, a.projectName);
-return d === f;
+var d = f("imageObjectRef")(b, a.projectName), e = f("imageObjectRef")(c, a.projectName);
+return d === e;
 }
-var f = m(a.buildConfig).from;
+var e = n(a.buildConfig).from;
 return c.forEach(function(a) {
 switch (a.type) {
 case "Generic":
@@ -5352,12 +5387,12 @@ break;
 
 case "ImageChange":
 var c = a.imageChange.from;
-c || (c = f);
-var e = {
+c || (c = e);
+var f = {
 present:!0,
 data:a
 };
-d(c, f) ? b.builderImageChangeTrigger = e :b.imageChangeTriggers.push(e);
+d(c, e) ? b.builderImageChangeTrigger = f :b.imageChangeTriggers.push(f);
 break;
 
 case "ConfigChange":
@@ -5383,16 +5418,16 @@ a.aceLoaded = function(a) {
 var b = a.getSession();
 b.setOption("tabSize", 2), b.setOption("useSoftTabs", !0), a.$blockScrolling = 1 / 0;
 };
-var o = function(a) {
-return _.map(k.compactEntries(a), function(a) {
+var p = function(a) {
+return _.map(l.compactEntries(a), function(a) {
 return {
 sourcePath:a.name,
 destinationDir:a.value
 };
 });
-}, p = function() {
+}, q = function() {
 a.sources.binary && ("" !== a.options.binaryAsFile ? a.updatedBuildConfig.spec.source.binary.asFile = a.options.binaryAsFile :a.updatedBuildConfig.spec.source.binary = {});
-}, q = function(b) {
+}, r = function(b) {
 var c = {};
 switch (b.type) {
 case "ImageStreamTag":
@@ -5417,44 +5452,86 @@ name:_.last(d)
 }, c.namespace = 1 !== d.length ? d[0] :a.buildConfig.metadata.namespace;
 }
 return c;
-}, r = function() {
+}, s = function() {
 var b = [].concat(a.triggers.githubWebhooks, a.triggers.genericWebhooks, a.triggers.imageChangeTriggers, a.triggers.builderImageChangeTrigger, a.triggers.configChangeTrigger);
 return b = _.filter(b, function(a) {
 return _.has(a, "disabled") && !a.disabled || a.present;
 }), b = _.map(b, "data");
-}, s = function(a, b) {
+}, t = function() {
+switch (a.secrets.picked = {
+gitSecret:a.buildConfig.spec.source.sourceSecret || {
+name:""
+},
+pullSecret:n(a.buildConfig).pullSecret || {
+name:""
+},
+pushSecret:a.buildConfig.spec.output.pushSecret || {
+name:""
+}
+}, a.strategyType) {
+case "Source":
+case "Docker":
+a.secrets.picked.sourceSecrets = a.buildConfig.spec.source.secrets || [ {
+secret:{
+name:""
+},
+destinationDir:""
+} ];
+break;
+
+case "Custom":
+a.secrets.picked.sourceSecrets = n(a.buildConfig).secrets || [ {
+secretSource:{
+name:""
+},
+mountPath:""
+} ];
+}
+}, u = function(a, b, c) {
+b.name ? a[c] = b :delete a[c];
+}, v = function(b, c) {
+var d = _.head(c), e = "Custom" === a.strategyType ? "mountPath" :"destinationDir";
+d[e] ? b.secrets = c :delete b.secrets;
+}, w = function(a, b) {
 return "None" === b.type ? a :(a.none = !1, angular.forEach(b, function(b, c) {
 a[c] = !0;
 }), a);
 };
 a.save = function() {
-switch (a.disableInputs = !0, m(a.updatedBuildConfig).forcePull = a.options.forcePull, a.strategyType) {
+switch (a.disableInputs = !0, n(a.updatedBuildConfig).forcePull = a.options.forcePull, a.strategyType) {
 case "Docker":
-m(a.updatedBuildConfig).noCache = a.options.noCache;
+n(a.updatedBuildConfig).noCache = a.options.noCache;
 break;
 
 case "JenkinsPipeline":
 "path" === a.jenkinsfileOptions.type ? delete a.updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile :delete a.updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath;
 }
-p(), a.sources.images && !_.isEmpty(a.sourceImages) && (a.updatedBuildConfig.spec.source.images[0].paths = o(a.imageSourcePaths), a.updatedBuildConfig.spec.source.images[0].from = q(a.imageOptions.fromSource)), "None" === a.imageOptions.from.type ? delete m(a.updatedBuildConfig).from :m(a.updatedBuildConfig).from = q(a.imageOptions.from), "None" === a.imageOptions.to.type ? delete a.updatedBuildConfig.spec.output.to :a.updatedBuildConfig.spec.output.to = q(a.imageOptions.to), m(a.updatedBuildConfig).env = k.compactEntries(a.envVars), a.updatedBuildConfig.spec.triggers = r(), c.update("buildconfigs", a.updatedBuildConfig.metadata.name, a.updatedBuildConfig, {
-namespace:a.updatedBuildConfig.metadata.namespace
-}).then(function() {
-i.addAlert({
+switch (q(), a.sources.images && !_.isEmpty(a.sourceImages) && (a.updatedBuildConfig.spec.source.images[0].paths = p(a.imageSourcePaths), a.updatedBuildConfig.spec.source.images[0].from = r(a.imageOptions.fromSource)), "None" === a.imageOptions.from.type ? delete n(a.updatedBuildConfig).from :n(a.updatedBuildConfig).from = r(a.imageOptions.from), "None" === a.imageOptions.to.type ? delete a.updatedBuildConfig.spec.output.to :a.updatedBuildConfig.spec.output.to = r(a.imageOptions.to), n(a.updatedBuildConfig).env = l.compactEntries(a.envVars), u(a.updatedBuildConfig.spec.source, a.secrets.picked.gitSecret, "sourceSecret"), u(n(a.updatedBuildConfig), a.secrets.picked.pullSecret, "pullSecret"), u(a.updatedBuildConfig.spec.output, a.secrets.picked.pushSecret, "pushSecret"), a.strategyType) {
+case "Source":
+case "Docker":
+v(a.updatedBuildConfig.spec.source, a.secrets.picked.sourceSecrets);
+break;
+
+case "Custom":
+v(n(a.updatedBuildConfig), a.secrets.picked.sourceSecrets);
+}
+a.updatedBuildConfig.spec.triggers = s(), c.update("buildconfigs", a.updatedBuildConfig.metadata.name, a.updatedBuildConfig, a.context).then(function() {
+j.addAlert({
 name:a.updatedBuildConfig.metadata.name,
 data:{
 type:"success",
 message:"Build Config " + a.updatedBuildConfig.metadata.name + " was successfully updated."
 }
-}), h.path(g.resourceURL(a.updatedBuildConfig, "BuildConfig", a.updatedBuildConfig.metadata.namespace));
+}), i.path(h.resourceURL(a.updatedBuildConfig, "BuildConfig", a.updatedBuildConfig.metadata.namespace));
 }, function(b) {
 a.disableInputs = !1, a.alerts.save = {
 type:"error",
 message:"An error occurred updating the build " + a.updatedBuildConfig.metadata.name + "Build Config",
-details:e("getErrorDetails")(b)
+details:f("getErrorDetails")(b)
 };
 });
 }, a.$on("$destroy", function() {
-c.unwatchAll(l);
+c.unwatchAll(m);
 });
 } ]), angular.module("openshiftConsole").controller("EditAutoscalerController", [ "$scope", "$filter", "$routeParams", "$window", "APIService", "BreadcrumbsService", "DataService", "HPAService", "MetricsService", "Navigate", "ProjectsService", "keyValueEditorUtils", function(a, b, c, d, e, f, g, h, i, j, k, l) {
 if (!c.kind || !c.name) return void j.toErrorPage("Kind or name parameter missing.");
@@ -6568,6 +6645,12 @@ n("An error occurred attaching the persistent volume claim to the " + a("humaniz
 }
 };
 }));
+} ]), angular.module("openshiftConsole").controller("CreateSecretModalController", [ "$scope", "$uibModalInstance", function(a, b) {
+a.postCreateAction = function(c, d) {
+b.close(c), _.extend(a.alerts, d);
+}, a.cancel = function() {
+b.dismiss("cancel");
+};
 } ]), angular.module("openshiftConsole").controller("ConfirmModalController", [ "$scope", "$uibModalInstance", "modalConfig", function(a, b, c) {
 _.extend(a, c), a.confirm = function() {
 b.close("confirm");
@@ -6696,7 +6779,143 @@ a.hideBuild = c(b);
 },
 templateUrl:"views/directives/_build-close.html"
 };
-} ]), angular.module("openshiftConsole").directive("relativeTimestamp", function() {
+} ]), angular.module("openshiftConsole").directive("createSecret", function() {
+return {
+restrict:"E",
+scope:{
+type:"=",
+serviceAccountToLink:"=?",
+namespace:"=",
+postCreateAction:"&",
+cancel:"&"
+},
+templateUrl:"views/directives/create-secret.html",
+controller:[ "$scope", "$filter", "DataService", function(a, b, c) {
+a.alerts = {}, a.secretAuthTypeMap = {
+image:{
+label:"Image Secret",
+authTypes:[ {
+id:"kubernetes.io/dockercfg",
+label:"Image Registry Credentials"
+}, {
+id:"kubernetes.io/dockerconfigjson",
+label:"Configuration File"
+} ]
+},
+source:{
+label:"Source Secret",
+authTypes:[ {
+id:"kubernetes.io/basic-auth",
+label:"Basic Authentication"
+}, {
+id:"kubernetes.io/ssh-auth",
+label:"SSH Key"
+} ]
+}
+}, a.secretTypes = _.keys(a.secretAuthTypeMap), a.newSecret = {
+type:a.type,
+authType:a.secretAuthTypeMap[a.type].authTypes[0].id,
+data:{},
+linkSecret:!1,
+pickedServiceAccountToLink:a.serviceAccountToLink || "",
+linkAs:{
+secrets:"source" === a.type,
+imagePullSecrets:"image" === a.type
+}
+}, a.addGitconfig = !1, c.list("serviceaccounts", a, function(b) {
+a.serviceAccounts = b.by("metadata.name"), a.serviceAccountsNames = _.keys(a.serviceAccounts);
+});
+var d = function(b, c) {
+var d = {
+apiVersion:"v1",
+kind:"Secret",
+metadata:{
+name:a.newSecret.data.secretName
+},
+type:c,
+data:{}
+};
+switch (c) {
+case "kubernetes.io/basic-auth":
+d.data = {
+password:window.btoa(b.password)
+}, b.username && (d.data.username = window.btoa(b.username)), b.gitconfig && (d.data[".gitconfig"] = window.btoa(b.gitconfig));
+break;
+
+case "kubernetes.io/ssh-auth":
+d.data = {
+"ssh-privatekey":window.btoa(b.privateKey)
+}, b.gitconfig && (d.data[".gitconfig"] = window.btoa(b.gitconfig));
+break;
+
+case "kubernetes.io/dockerconfigjson":
+var e = window.btoa(b.dockerConfig);
+JSON.parse(b.dockerConfig).auths ? d.data[".dockerconfigjson"] = e :(d.type = "kubernetes.io/dockercfg", d.data[".dockercfg"] = e);
+break;
+
+case "kubernetes.io/dockercfg":
+var f = window.btoa(b.dockerUsername + ":" + b.dockerPassword), g = {};
+g[b.dockerServer] = {
+username:b.dockerUsername,
+password:b.dockerPassword,
+email:b.dockerMail,
+auth:f
+}, d.data[".dockercfg"] = window.btoa(JSON.stringify(g));
+}
+return d;
+}, e = function(d) {
+var e = angular.copy(a.serviceAccounts[a.newSecret.pickedServiceAccountToLink]);
+a.newSecret.linkAs.secrets && e.secrets.push({
+name:d.metadata.name
+}), a.newSecret.linkAs.imagePullSecrets && e.imagePullSecrets.push({
+name:d.metadata.name
+}), c.update("serviceaccounts", a.newSecret.pickedServiceAccountToLink, e, a).then(function(b) {
+var c = {
+createAndLink:{
+type:"success",
+message:"Secret " + d.metadata.name + " was created and linked with service account " + b.metadata.name + "."
+}
+};
+a.postCreateAction({
+newSecret:d,
+creationAlert:c
+});
+}, function(c) {
+a.alerts.createAndLink = {
+type:"error",
+message:"An error occurred while linking the secret with service account.",
+details:b("getErrorDetails")(c)
+};
+});
+};
+a.create = function() {
+a.alerts = {};
+var f = d(a.newSecret.data, a.newSecret.authType);
+c.create("secrets", null, f, a).then(function(b) {
+if (a.newSecret.linkSecret && a.newSecret.pickedServiceAccountToLink) e(b); else {
+var c = {
+create:{
+type:"success",
+message:"Secret " + f.metadata.name + " was created."
+}
+};
+a.postCreateAction({
+newSecret:b,
+creationAlert:c
+});
+}
+}, function(c) {
+var d = c.data || {};
+return "AlreadyExists" === d.reason ? void (a.nameTaken = !0) :void (a.alerts.create = {
+type:"error",
+message:"An error occurred while creating the secret.",
+details:b("getErrorDetails")(c)
+});
+});
+};
+} ]
+};
+}), angular.module("openshiftConsole").directive("relativeTimestamp", function() {
 return {
 restrict:"E",
 scope:{
@@ -7643,6 +7862,132 @@ a !== b && g(a);
 });
 }
 });
+}
+};
+} ]), angular.module("openshiftConsole").directive("oscSecrets", [ "$uibModal", "$filter", "DataService", "SecretsService", function(a, b, c, d) {
+return {
+restrict:"E",
+scope:{
+pickedSecret:"=model",
+secretsByType:"=",
+namespace:"=",
+displayType:"@",
+type:"@",
+alerts:"=",
+serviceAccountToLink:"@?"
+},
+templateUrl:"views/directives/osc-secrets.html",
+link:function(b) {
+b.openCreateSecretModal = function() {
+b.newSecret = {};
+var e = a.open({
+animation:!0,
+templateUrl:"views/modals/create-secret.html",
+controller:"CreateSecretModalController",
+scope:b
+});
+e.result.then(function(a) {
+c.list("secrets", {
+namespace:b.namespace
+}, function(c) {
+var e = d.groupSecretsByType(c);
+b.secretsByType = _.each(e, function(a) {
+a.unshift("");
+}), b.pickedSecret.name = a.metadata.name, b.secretsForm.$setDirty();
+});
+});
+};
+}
+};
+} ]), angular.module("openshiftConsole").directive("oscSourceSecrets", [ "$uibModal", "$filter", "DataService", "SecretsService", function(a, b, c, d) {
+return {
+restrict:"E",
+scope:{
+pickedSecrets:"=model",
+secretsByType:"=",
+strategyType:"=",
+type:"@",
+displayType:"@",
+namespace:"=",
+alerts:"=",
+serviceAccountToLink:"@?"
+},
+templateUrl:"views/directives/osc-source-secrets.html",
+link:function(b) {
+b.canAddSourceSecret = function() {
+var a = _.last(b.pickedSecrets);
+switch (b.strategyType) {
+case "Custom":
+return a.secretSource.name && a.mountPath;
+
+default:
+return a.secret.name && a.destinationDir;
+}
+}, b.setLastSecretsName = function(a) {
+var c = _.last(b.pickedSecrets);
+switch (b.strategyType) {
+case "Custom":
+return void (c.secretSource.name = a);
+
+default:
+return void (c.secret.name = a);
+}
+}, b.addSourceSecret = function() {
+switch (b.strategyType) {
+case "Custom":
+return void b.pickedSecrets.push({
+secretSource:{
+name:""
+},
+mountPath:""
+});
+
+default:
+return void b.pickedSecrets.push({
+secret:{
+name:""
+},
+destinationDir:""
+});
+}
+}, b.removeSecret = function(a) {
+if (1 === b.pickedSecrets.length) switch (b.strategyType) {
+case "Custom":
+b.pickedSecrets = [ {
+secretSource:{
+name:""
+},
+mountPath:""
+} ];
+break;
+
+default:
+b.pickedSecrets = [ {
+secret:{
+name:""
+},
+destinationDir:""
+} ];
+} else b.pickedSecrets.splice(a, 1);
+b.secretsForm.$setDirty();
+}, b.openCreateSecretModal = function() {
+var e = a.open({
+animation:!0,
+templateUrl:"views/modals/create-secret.html",
+controller:"CreateSecretModalController",
+scope:b
+});
+e.result.then(function(a) {
+c.list("secrets", {
+namespace:b.namespace
+}, function(c) {
+var e = d.groupSecretsByType(c);
+b.secretsByType = _.each(e, function(a) {
+a.unshift("");
+}), b.setLastSecretsName(a.metadata.name);
+});
+});
+};
 }
 };
 } ]), angular.module("openshiftConsole").directive("replicas", function() {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3960,6 +3960,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
+    "<div class=\"row\">\n" +
+    "<div ng-class=\"{\n" +
+    "                              'col-md-8': advancedOptions,\n" +
+    "                              'col-lg-12': !advancedOptions}\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"sourceUrl\" class=\"required\">Git Repository URL</label>\n" +
     "<div ng-class=\"{'has-warning': form.sourceUrl.$dirty && !sourceURLPattern.test(buildConfig.sourceUrl), 'has-error': (form.sourceUrl.$error.required && form.sourceUrl.$dirty)}\">\n" +
@@ -3977,7 +3981,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"text-warning\" ng-if=\"form.sourceUrl.$dirty && !sourceURLPattern.test(buildConfig.sourceUrl)\">Git repository should be a URL.</span>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div click-to-reveal link-text=\"Show advanced routing, build, and deployment options\">\n" +
+    "</div>\n" +
+    "<div class=\"col-md-4\" ng-if=\"advancedOptions\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"gitref\">Git Reference</label>\n" +
     "<div>\n" +
@@ -3985,6 +3990,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"help-block\">Optional branch, tag, or commit.</div>\n" +
     "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div ng-if=\"advancedOptions\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"contextdir\">Context Dir</label>\n" +
     "<div>\n" +
@@ -4137,6 +4145,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</label-editor>\n" +
     "</div>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
+    "<div class=\"gutter-top\">\n" +
+    "<a href=\"\" ng-click=\"advancedOptions = !advancedOptions\" role=\"button\">{{advancedOptions ? 'Hide' : 'Show'}} advanced routing, build, and deployment options</a>\n" +
+    "</div>\n" +
     "<div class=\"buttons gutter-bottom\" ng-class=\"{'gutter-top': !alerts.length}\">\n" +
     "\n" +
     "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-disabled=\"form.$invalid || nameTaken || cpuProblems.length || memoryProblems.length || disableInputs\">Create</button>\n" +
@@ -4895,6 +4906,214 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/directives/create-secret.html',
+    "<alerts alerts=\"alerts\"></alerts>\n" +
+    "<ng-form name=\"secretForm\">\n" +
+    "<div for=\"secretType\" ng-if=\"!type\" class=\"form-group\">\n" +
+    "<label>Secret Type</label>\n" +
+    "<ui-select required ng-model=\"newSecret.type\" search-enabled=\"false\" ng-change=\"newSecret.authType = secretAuthTypeMap[newSecret.type].authTypes[0].id\">\n" +
+    "<ui-select-match>{{$select.selected | upperFirst}} Secret</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"type in secretTypes\">\n" +
+    "{{type | upperFirst}} Secret\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\">\n" +
+    "<label for=\"secretName\" class=\"required\">Secret Name</label>\n" +
+    "<span ng-class=\"{'has-error': nameTaken || (secretForm.secretName.$error.pattern && secretForm.secretName.$touched)}\">\n" +
+    "<input class=\"form-control\" id=\"secretName\" name=\"secretName\" ng-model=\"newSecret.data.secretName\" type=\"text\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck aria-describedby=\"secret-name-help\" ng-maxlength=\"253\" ng-pattern=\"/^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/\" required>\n" +
+    "</span>\n" +
+    "<div class=\"has-error\" ng-show=\"nameTaken\">\n" +
+    "<span class=\"help-block\">\n" +
+    "This name is already in use. Please choose a different name.\n" +
+    "</span>\n" +
+    "</div>\n" +
+    "<div class=\"has-error\" ng-show=\"secretForm.secretName.$error.pattern && secretForm.secretName.$touched\">\n" +
+    "<span class=\"help-block\">\n" +
+    "Secret name must consist of lower-case letters, numbers, periods, and hyphens. It must start and end with a letter or number.\n" +
+    "</span>\n" +
+    "</div>\n" +
+    "<div class=\"help-block\" id=\"secret-name-help\">\n" +
+    "Unique name of the new secret.\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\">\n" +
+    "<label for=\"authentificationType\">Authetication Type</label>\n" +
+    "<ui-select required ng-model=\"newSecret.authType\" search-enabled=\"false\">\n" +
+    "<ui-select-match>{{$select.selected.label}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"type.id as type in secretAuthTypeMap[newSecret.type].authTypes\">\n" +
+    "{{type.label}}\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "</div>\n" +
+    "<div ng-if=\"newSecret.authType === 'kubernetes.io/basic-auth'\">\n" +
+    "<div class=\"form-group\">\n" +
+    "<label for=\"username\">Username</label>\n" +
+    "<div>\n" +
+    "<input class=\"form-control\" id=\"username\" name=\"username\" ng-model=\"newSecret.data.username\" type=\"text\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck aria-describedby=\"username-help\">\n" +
+    "</div>\n" +
+    "<div class=\"help-block\" id=\"username-help\">\n" +
+    "Optional username for SCM servers authentication.\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\">\n" +
+    "<label for=\"passwordToken\" class=\"required\">Password or Token</label>\n" +
+    "<div>\n" +
+    "<input class=\"form-control\" id=\"passwordToken\" name=\"passwordToken\" ng-model=\"newSecret.data.passwordToken\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck aria-describedby=\"password-token-help\" type=\"password\" required>\n" +
+    "</div>\n" +
+    "<div class=\"help-block\" id=\"password-token-help\">\n" +
+    "Password or token for SCM servers authentication.\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div ng-if=\"newSecret.authType === 'kubernetes.io/ssh-auth'\">\n" +
+    "<div class=\"form-group\" id=\"private-key\">\n" +
+    "<label for=\"privateKey\" class=\"required\">SSH Private Key</label>\n" +
+    "<osc-file-input id=\"private-key-file-input\" model=\"newSecret.data.privateKey\" drop-zone-id=\"private-key\" dragging=\"false\" help-text=\"Upload your private SSH key file.\" show-values=\"false\"></osc-file-input>\n" +
+    "<div ui-ace=\"{\n" +
+    "        theme: 'eclipse',\n" +
+    "        onLoad: aceLoaded,\n" +
+    "        rendererOptions: {\n" +
+    "          fadeFoldWidgets: true,\n" +
+    "          showPrintMargin: false \n" +
+    "        }\n" +
+    "      }\" ng-model=\"newSecret.data.privateKey\" class=\"create-secret-editor ace-bordered\" id=\"private-key-editor\" required></div>\n" +
+    "<div class=\"help-block\">\n" +
+    "Private SSH key file for SCM servers authentication.\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div ng-if=\"newSecret.type === 'source'\">\n" +
+    "<div class=\"form-group\">\n" +
+    "<div class=\"checkbox\">\n" +
+    "<label>\n" +
+    "<input type=\"checkbox\" ng-model=\"addGitconfig\">\n" +
+    "Use a custom .gitconfig file\n" +
+    "</label>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\" ng-if=\"addGitconfig\" id=\"gitconfig\" ng-show=\"addGitconfig\">\n" +
+    "<label class=\"required\" for=\"gitconfig\">Git Configuration File</label>\n" +
+    "<osc-file-input id=\"gitconfig-file-input\" model=\"newSecret.data.gitconfig\" drop-zone-id=\"gitconfig\" dragging=\"false\" help-text=\"Upload your .gitconfig or  file.\" show-values=\"false\" required></osc-file-input>\n" +
+    "<div ui-ace=\"{\n" +
+    "        mode: 'ini',\n" +
+    "        theme: 'eclipse',\n" +
+    "        onLoad: aceLoaded,\n" +
+    "        rendererOptions: {\n" +
+    "          fadeFoldWidgets: true,\n" +
+    "          showPrintMargin: false \n" +
+    "        }\n" +
+    "      }\" ng-model=\"newSecret.data.gitconfig\" class=\"create-secret-editor ace-bordered\" id=\"gitconfig-editor\"></div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div ng-if=\"newSecret.authType === 'kubernetes.io/dockercfg'\">\n" +
+    "<div class=\"form-group\">\n" +
+    "<label for=\"dockerServer\" class=\"required\">Image Registry Server Address</label>\n" +
+    "<div>\n" +
+    "<input class=\"form-control\" id=\"dockerServer\" name=\"dockerServer\" ng-model=\"newSecret.data.dockerServer\" type=\"text\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck required>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\">\n" +
+    "<label for=\"dockerUsername\" class=\"required\">Username</label>\n" +
+    "<div>\n" +
+    "<input class=\"form-control\" id=\"dockerUsername\" name=\"dockerUsername\" ng-model=\"newSecret.data.dockerUsername\" type=\"text\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck required>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\">\n" +
+    "<label for=\"dockerPassword\" class=\"required\">Password</label>\n" +
+    "<div>\n" +
+    "<input class=\"form-control\" id=\"dockerPassword\" name=\"dockerPassword\" ng-model=\"newSecret.data.dockerPassword\" type=\"password\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck required>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\">\n" +
+    "<label for=\"dockerEmail\" class=\"required\">Email</label>\n" +
+    "<div>\n" +
+    "<input class=\"form-control\" type=\"email\" id=\"dockerEmail\" name=\"dockerEmail\" ng-model=\"newSecret.data.dockerMail\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck required>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div ng-if=\"newSecret.authType === 'kubernetes.io/dockerconfigjson'\">\n" +
+    "<div class=\"form-group\" id=\"docker-config\">\n" +
+    "<label for=\"dockerConfig\" class=\"required\">Configuration File</label>\n" +
+    "<osc-file-input if=\"dockercfg-file-input\" model=\"newSecret.data.dockerConfig\" drop-zone-id=\"docker-config\" dragging=\"false\" help-text=\"Upload a .dockercfg or .docker/config.json file\" show-values=\"false\" required></osc-file-input>\n" +
+    "<div ui-ace=\"{\n" +
+    "        mode: 'json',\n" +
+    "        theme: 'eclipse',\n" +
+    "        onLoad: aceLoaded,\n" +
+    "        rendererOptions: {\n" +
+    "          fadeFoldWidgets: true,\n" +
+    "          showPrintMargin: false \n" +
+    "        }\n" +
+    "      }\" ng-model=\"newSecret.data.dockerConfig\" class=\"create-secret-editor ace-bordered\" id=\"dockerconfig-editor\" required></div>\n" +
+    "<div class=\"help-block\">\n" +
+    "File with credentials and other configuration for connecting to a secured image registry.\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div ng-if=\"'serviceaccounts' | canI : 'update'\">\n" +
+    "<div class=\"form-group\">\n" +
+    "<div class=\"checkbox\">\n" +
+    "<label>\n" +
+    "<input type=\"checkbox\" ng-model=\"newSecret.linkSecret\">\n" +
+    "Use this secret automatically for other builds.\n" +
+    "</label>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div ng-if=\"!serviceAccountToLink && newSecret.linkSecret\">\n" +
+    "<div class=\"form-group\">\n" +
+    "<label for=\"serviceAccount\" class=\"required\">Service Account</label>\n" +
+    "<ui-select required ng-model=\"newSecret.pickedServiceAccountToLink\">\n" +
+    "<ui-select-match placeholder=\"Service Account Name\">{{$select.selected}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"sa in (serviceAccountsNames | filter : $select.search)\">\n" +
+    "<div ng-bind-html=\"sa | highlight : $select.search\"></div>\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\">\n" +
+    "<label class=\"required\">Link as</label>\n" +
+    "<div class=\"form-group\">\n" +
+    "<div class=\"checkbox\">\n" +
+    "<label>\n" +
+    "<input type=\"checkbox\" ng-model=\"newSecret.linkAs.secrets\" ng-checked=\"newSecret.linkAs.secrets\">\n" +
+    "Link with {{newSecret.pickedServiceAccountToLink}} service account as a <b>source</b> secret.\n" +
+    "<span class=\"help action-inline\">\n" +
+    "<a href=\"\">\n" +
+    "<i class=\"pficon pficon-help\" aria-hidden=\"true\" data-toggle=\"tooltip\" data-original-title=\"Pods using this service account will mount the content of secret into their containers for pulling sources during build time.\">\n" +
+    "</i>\n" +
+    "</a>\n" +
+    "</span>\n" +
+    "</label>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\">\n" +
+    "<div class=\"checkbox\">\n" +
+    "<label>\n" +
+    "<input type=\"checkbox\" ng-model=\"newSecret.linkAs.imagePullSecrets\" ng-checked=\"newSecret.linkAs.imagePullSecrets\">\n" +
+    "Link with {{newSecret.pickedServiceAccountToLink}} service account as a <b>image pull</b> secret.\n" +
+    "<span class=\"help action-inline\">\n" +
+    "<a href=\"\">\n" +
+    "<i class=\"pficon pficon-help\" aria-hidden=\"true\" data-toggle=\"tooltip\" data-original-title=\"Pods using this service account will use provided creadentials to pull images for the pod’s containers.\">\n" +
+    "</i>\n" +
+    "</a>\n" +
+    "</span>\n" +
+    "</label>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"help-block\">\n" +
+    "Linking a secret enables a service account to automatically use that secret for some forms of authentication.\n" +
+    "<a href=\"{{'managing_secrets' | helpLink}}\" target=\"_blank\"><span class=\"learn-more-inline\">Learn more&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></span></a>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"buttons gutter-top-bottom\">\n" +
+    "<button class=\"btn btn-lg btn-primary\" type=\"button\" ng-disabled=\"secretForm.$invalid || secretForm.$pristine\" ng-click=\"create()\">Create</button>\n" +
+    "<button class=\"btn btn-lg btn-default\" type=\"button\" ng-click=\"cancel()\">Cancel</button>\n" +
+    "</div>\n" +
+    "</ng-form>"
+  );
+
+
   $templateCache.put('views/directives/delete-button.html',
     "<div class=\"actions\">\n" +
     "\n" +
@@ -5184,7 +5403,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<span class=\"learn-more-inline checkbox\">\n" +
+    "<span>\n" +
     "<a href=\"\" role=\"button\" ng-click=\"addWebhookTrigger(type)\">Add {{type}} webhook</a>\n" +
     "</span>"
   );
@@ -6319,6 +6538,135 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/directives/osc-secrets.html',
+    "<ng-form name=\"secretsForm\" class=\"osc-secrets-form\">\n" +
+    "<div class=\"form-group\">\n" +
+    "<label class=\"picker-label\">{{displayType | startCase}} Secret</label>\n" +
+    "<ui-select ng-model=\"pickedSecret.name\">\n" +
+    "<ui-select-match placeholder=\"Secret name\">{{$select.selected}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"secret in (secretsByType[type] | filter : $select.search)\">\n" +
+    "<div ng-bind-html=\"secret | highlight : $select.search\"></div>\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "<div ng-switch=\"displayType\">\n" +
+    "<div class=\"help-block\" ng-switch-when=\"source\">\n" +
+    "Secret with credentials for pulling your source code.\n" +
+    "<a href=\"{{'git_secret' | helpLink}}\" target=\"_blank\"><span class=\"learn-more-inline\">Learn more&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></span></a>\n" +
+    "</div>\n" +
+    "<div class=\"help-block\" ng-switch-when=\"pull\">\n" +
+    "Secret for authentication when pulling images from a secured registry.\n" +
+    "<a href=\"{{'pull_secret' | helpLink}}\" target=\"_blank\"><span class=\"learn-more-inline\">Learn more&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></span></a>\n" +
+    "</div>\n" +
+    "<div class=\"help-block\" ng-switch-when=\"push\">\n" +
+    "Secret for authentication when pushing images to a secured registry.\n" +
+    "<a href=\"{{'pull_secret' | helpLink}}\" target=\"_blank\"><span class=\"learn-more-inline\">Learn more&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></span></a>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<span>\n" +
+    "<a href=\"\" ng-if=\"'secrets' | canI : 'create'\" role=\"button\" ng-click=\"openCreateSecretModal()\">Create {{displayType}} secret</a>\n" +
+    "</span>\n" +
+    "</ng-form>"
+  );
+
+
+  $templateCache.put('views/directives/osc-source-secrets.html',
+    "<ng-form name=\"secretsForm\" class=\"osc-secrets-form\">\n" +
+    "<div ng-if=\"strategyType !== 'Custom'\">\n" +
+    "<div ng-repeat=\"pickedSecret in pickedSecrets\">\n" +
+    "<div class=\"form-group\">\n" +
+    "<div class=\"row picked-secret\">\n" +
+    "<div class=\"col-lg-6\">\n" +
+    "<label class=\"picker-label\" ng-if=\"$first\">Build Secret</label>\n" +
+    "<ui-select ng-required=\"pickedSecret.destinationDir\" ng-model=\"pickedSecret.secret.name\">\n" +
+    "<ui-select-match placeholder=\"Secret name\">{{$select.selected}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"secret in (secretsByType[type] | filter : $select.search)\">\n" +
+    "<div ng-bind-html=\"secret | highlight : $select.search\"></div>\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "</div>\n" +
+    "<div class=\"col-lg-6\">\n" +
+    "<div class=\"directory\">\n" +
+    "<label for=\"destinationDir\" ng-if=\"$first\">\n" +
+    "Destination Directory\n" +
+    "</label>\n" +
+    "<div>\n" +
+    "<input class=\"form-control\" id=\"destinationDir\" name=\"destinationDir\" ng-model=\"pickedSecret.destinationDir\" type=\"text\" placeholder=\"/\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck ng-required=\"pickedSecret.secret.name\">\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"remove-secret-row\">\n" +
+    "<a ng-click=\"removeSecret($index)\" href=\"\" role=\"button\">\n" +
+    "<span class=\"pficon pficon-close remove-btn\" aria-hidden=\"true\"></span>\n" +
+    "<span class=\"sr-only\">Remove build secret</span>\n" +
+    "</a>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"row\" ng-if=\"$last\">\n" +
+    "<div class=\"col-lg-6\">\n" +
+    "<div class=\"help-block\">Source secret to copy into the builder pod at build time.</div>\n" +
+    "</div>\n" +
+    "<div class=\"col-lg-6\">\n" +
+    "<div class=\"directory\">\n" +
+    "<div class=\"help-block\">Directory where the files will be available at build time.</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div ng-if=\"strategyType === 'Custom'\">\n" +
+    "<div ng-repeat=\"pickedSecret in pickedSecrets\">\n" +
+    "<div class=\"form-group\">\n" +
+    "<div class=\"row picked-secret\">\n" +
+    "<div class=\"col-lg-6\">\n" +
+    "<label class=\"picker-label\" ng-if=\"$first\">Build Secret</label>\n" +
+    "<ui-select ng-required=\"pickedSecret.mountPath !== ''\" ng-model=\"pickedSecret.secretSource.name\">\n" +
+    "<ui-select-match placeholder=\"Secret name\">{{$select.selected}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"secret in (secretsByType | filter : $select.search)\">\n" +
+    "<div ng-bind-html=\"secret | highlight : $select.search\"></div>\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "</div>\n" +
+    "<div class=\"col-lg-6\">\n" +
+    "<div class=\"directory\">\n" +
+    "<label for=\"mountPath\" ng-if=\"$first\">\n" +
+    "Mount path\n" +
+    "</label>\n" +
+    "<div>\n" +
+    "<input class=\"form-control\" id=\"mountPath\" name=\"mountPath\" ng-model=\"pickedSecret.mountPath\" type=\"text\" placeholder=\"/\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck ng-required=\"pickedSecret.sourceSecret.name\">\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"remove-secret-row\">\n" +
+    "<label class=\"sr-only\">Remove Build Secret</label>\n" +
+    "<a class=\"pficon pficon-close remove-btn\" aria-label=\"Delete row\" role=\"button\" ng-click=\"removeSecret($index)\" href=\"\"></a>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"row\" ng-if=\"$last\">\n" +
+    "<div class=\"col-lg-6\">\n" +
+    "<div class=\"help-block\">Source secret to mount into the builder pod at build time.</div>\n" +
+    "</div>\n" +
+    "<div class=\"col-lg-6\">\n" +
+    "<div class=\"directory\">\n" +
+    "<div class=\"help-block\">Path at which to mount the secret.</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"osc-secret-actions\">\n" +
+    "<span ng-if=\"canAddSourceSecret()\">\n" +
+    "<a href=\"\" role=\"button\" ng-click=\"addSourceSecret()\">Add build secret</a>\n" +
+    "<span ng-if=\"'secrets' | canI : 'create'\" class=\"action-divider\">|</span>\n" +
+    "</span>\n" +
+    "<a href=\"\" ng-if=\"'secrets' | canI : 'create'\" role=\"button\" ng-click=\"openCreateSecretModal()\">Create source secret</a>\n" +
+    "</div>\n" +
+    "</ng-form>"
+  );
+
+
   $templateCache.put('views/directives/pipeline-status.html',
     "<div class=\"pipeline-status-bar\" ng-class=\"status\">\n" +
     "<div class=\"pipeline-line\"></div>\n" +
@@ -6644,33 +6992,52 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</h1>\n" +
     "<fieldset ng-disabled=\"disableInputs\">\n" +
     "<form class=\"edit-form\" name=\"form\" novalidate ng-submit=\"save()\">\n" +
-    "<div class=\"resource-details\">\n" +
     "<div class=\"row\">\n" +
-    "<div class=\"col-lg-6\">\n" +
+    "<div class=\"col-lg-12\">\n" +
     "<div ng-if=\"buildConfig.spec.source.type !== 'None'\" class=\"section\">\n" +
     "<h3>Source Configuration</h3>\n" +
     "<dl class=\"dl-horizontal left\">\n" +
     "<div ng-if=\"sources.git\">\n" +
+    "<div class=\"row\">\n" +
+    "<div ng-class=\"{\n" +
+    "                              'col-lg-8': view.advancedOptions,\n" +
+    "                              'col-lg-12': !view.advancedOptions}\">\n" +
     "<div class=\"form-group\">\n" +
-    "<label for=\"sourceUrl\">Source Repository URL</label>\n" +
+    "<label for=\"sourceUrl\" class=\"required\">Git Repository URL</label>\n" +
     "<div>\n" +
     "\n" +
-    "<input class=\"form-control\" id=\"sourceUrl\" name=\"sourceUrl\" ng-model=\"updatedBuildConfig.spec.source.git.uri\" type=\"text\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck required>\n" +
+    "<input class=\"form-control\" id=\"sourceUrl\" name=\"sourceUrl\" ng-model=\"updatedBuildConfig.spec.source.git.uri\" type=\"text\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck aria-describedby=\"source-url-help\" required>\n" +
     "</div>\n" +
     "<div>\n" +
     "<span class=\"text-warning\" ng-if=\"form.sourceUrl.$dirty && !sourceURLPattern.test(updatedBuildConfig.spec.source.git.uri)\">Git repository should be a URL.</span>\n" +
     "</div>\n" +
+    "<div class=\"help-block\" id=\"source-url-help\">\n" +
+    "Git URL of the source code to build.\n" +
+    "<span ng-if=\"!view.advancedOptions\">If your Git repository is private, view the <a href=\"\" ng-click=\"view.advancedOptions = true\">advanced options</a> to set up authentication.</span>\n" +
     "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"col-lg-4\" ng-if=\"view.advancedOptions\">\n" +
     "<div class=\"form-group editor\">\n" +
-    "<label for=\"sourceRef\">Source Repository Ref</label>\n" +
+    "<label for=\"sourceRef\">Git Reference</label>\n" +
     "<div>\n" +
-    "<input class=\"form-control\" id=\"sourceRef\" name=\"sourceRef\" type=\"text\" ng-model=\"updatedBuildConfig.spec.source.git.ref\" placeholder=\"master\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck>\n" +
+    "<input class=\"form-control\" id=\"sourceRef\" name=\"sourceRef\" type=\"text\" ng-model=\"updatedBuildConfig.spec.source.git.ref\" placeholder=\"master\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck aria-describedby=\"source-ref-help\">\n" +
     "</div>\n" +
+    "<div class=\"help-block\" id=\"source-ref-help\">Optional branch, tag, or commit.</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div ng-if=\"view.advancedOptions\">\n" +
+    "<div class=\"form-group\">\n" +
+    "<label for=\"sourceContextDir\">Context Dir</label>\n" +
+    "<div>\n" +
+    "<input class=\"form-control\" id=\"sourceContextDir\" name=\"sourceContextDir\" type=\"text\" ng-model=\"updatedBuildConfig.spec.source.contextDir\" placeholder=\"/\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck aria-describedby=\"context-dir-help\">\n" +
+    "</div>\n" +
+    "<div class=\"help-block\" id=\"context-dir-help\">Optional subdirectory for the application source code, used as the context directory for the build.</div>\n" +
     "</div>\n" +
     "<div class=\"form-group\">\n" +
-    "<label for=\"sourceContextDir\">Source Context Dir</label>\n" +
-    "<div>\n" +
-    "<input class=\"form-control\" id=\"sourceContextDir\" name=\"sourceContextDir\" type=\"text\" ng-model=\"updatedBuildConfig.spec.source.contextDir\" placeholder=\"/\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck>\n" +
+    "<osc-secrets model=\"secrets.picked.gitSecret\" namespace=\"projectName\" display-type=\"source\" type=\"source\" service-account-to-link=\"builder\" secrets-by-type=\"secrets.secretsByType\" alerts=\"alerts\">\n" +
+    "</osc-secrets>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -6678,48 +7045,48 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"form-group\">\n" +
     "<label for=\"buildFrom\">Dockerfile</label>\n" +
     "<div ui-ace=\"{\n" +
-    "                                mode: 'dockerfile',\n" +
-    "                                theme: 'dreamweaver',\n" +
-    "                                onLoad: aceLoaded,\n" +
-    "                                rendererOptions: {\n" +
-    "                                  fadeFoldWidgets: true,\n" +
-    "                                  showPrintMargin: false\n" +
-    "                                }\n" +
-    "                              }\" ng-model=\"updatedBuildConfig.spec.source.dockerfile\" class=\"ace-bordered ace-inline dockerfile-mode\"></div>\n" +
+    "                              mode: 'dockerfile',\n" +
+    "                              theme: 'dreamweaver',\n" +
+    "                              onLoad: aceLoaded,\n" +
+    "                              rendererOptions: {\n" +
+    "                                fadeFoldWidgets: true,\n" +
+    "                                showPrintMargin: false\n" +
+    "                              }\n" +
+    "                            }\" ng-model=\"updatedBuildConfig.spec.source.dockerfile\" class=\"ace-bordered ace-inline dockerfile-mode\"></div>\n" +
     "</div>\n" +
-    "<div class=\"form-group\" ng-if=\"updatedBuildConfig.spec.strategy.dockerStrategy.dockerfilePath\">\n" +
+    "<div class=\"form-group\" ng-if=\"updatedBuildConfig.spec.strategy.dockerStrategy.dockerfilePath && view.advancedOptions\">\n" +
     "<label for=\"dockerfilePath\">Dockerfile Path</label>\n" +
     "<div>\n" +
     "<input class=\"form-control\" id=\"dockerfilePath\" name=\"dockerfilePath\" type=\"text\" ng-model=\"updatedBuildConfig.spec.strategy.dockerStrategy.dockerfilePath\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"form-group\" ng-if=\"strategyType === 'Docker'\">\n" +
+    "<div class=\"form-group\" ng-if=\"strategyType === 'Docker' && view.advancedOptions\">\n" +
     "<div class=\"checkbox\">\n" +
     "<label>\n" +
-    "<input type=\"checkbox\" ng-model=\"options.noCache\"/>\n" +
+    "<input type=\"checkbox\" ng-model=\"options.noCache\">\n" +
     "Execute docker build without reusing cached instructions.\n" +
     "<span class=\"help action-inline\">\n" +
-    "<a href>\n" +
+    "<a href=\"\">\n" +
     "<i class=\"pficon pficon-help\" data-toggle=\"tooltip\" aria-hidden=\"true\" data-original-title=\"Will run the docker build with '--no-cache=true' flag\">\n" +
     "</i>\n" +
     "</a>\n" +
     "</span>\n" +
     "</label>\n" +
     "</div>\n" +
-    "</div>\n" +
     "<div ng-if=\"sources.binary && updatedBuildConfig.spec.source\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"binaryAsBuild\">\n" +
     "Binary Input As File\n" +
     "<span class=\"help action-inline\">\n" +
-    "<a href>\n" +
+    "<a href=\"\">\n" +
     "<i class=\"pficon pficon-help\" data-toggle=\"tooltip\" aria-hidden=\"true\" data-original-title=\"Indicates that the provided binary input should be considered a single file within the build input. For example, specifying 'webapp.war' would place the provided binary as '/webapp.war' for the builder. If left empty, the Docker and Source build strategies assume this file is a zip, tar, or tar.gz file and extract it as the source. The custom strategy receives this binary as standard input. This filename may not contain slashes or be '..' or '.'.\"></i>\n" +
     "</a>\n" +
     "</span>\n" +
     "</label>\n" +
     "<div>\n" +
     "<input class=\"form-control\" id=\"binaryAsBuild\" name=\"binaryAsBuild\" type=\"text\" ng-model=\"options.binaryAsFile\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -6751,7 +7118,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"buildFrom\">Source and Destination Paths<span class=\"help action-inline\">\n" +
-    "<a href>\n" +
+    "<a href=\"\">\n" +
     "<i class=\"pficon pficon-help\" data-toggle=\"tooltip\" aria-hidden=\"true\" data-original-title=\"Paths is a list of source and destination paths to copy from the image. At least one pair has to be specified.\"></i>\n" +
     "</a>\n" +
     "</span></label>\n" +
@@ -6760,7 +7127,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"multiple-image-source\" ng-if=\"sourceImages.length !== 1\">\n" +
     "<label for=\"imageSourceFrom\">Image Source From<span class=\"help action-inline\">\n" +
-    "<a href>\n" +
+    "<a href=\"\">\n" +
     "<i class=\"pficon pficon-info\" style=\"cursor: help\" aria-hidden=\"true\" data-toggle=\"tooltip\" data-original-title=\"This Build Config contains more then one Image Source. To edit them use the YAML editor.\">\n" +
     "</i>\n" +
     "</a>\n" +
@@ -6773,7 +7140,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</dl>\n" +
     "</div>\n" +
     "<div ng-if=\"updatedBuildConfig | isJenkinsPipelineStrategy\" class=\"section\">\n" +
-    "<h3>Jenkins Pipeline Configuration</h3>\n" +
+    "<h3 class=\"with-divider\">Jenkins Pipeline Configuration</h3>\n" +
     "<div class=\"form-group\" ng-if=\"buildConfig.spec.source.type === 'Git'\">\n" +
     "<label for=\"jenkinsfile-type\">Jenkinsfile Type</label>\n" +
     "<select id=\"jenkinsfile-type\" class=\"form-control\" ng-model=\"jenkinsfileOptions.type\" ng-options=\"type.id as type.title for type in jenkinsfileTypes\" aria-describedby=\"jenkinsfile-type-help\">\n" +
@@ -6792,14 +7159,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"jenkinsfileOptions.type === 'inline'\">\n" +
     "<label>Jenkinsfile</label>\n" +
     "<div ui-ace=\"{\n" +
-    "                              mode: 'groovy',\n" +
-    "                              theme: 'eclipse',\n" +
-    "                              onLoad: aceLoaded,\n" +
-    "                              rendererOptions: {\n" +
-    "                                fadeFoldWidgets: true,\n" +
-    "                                showPrintMargin: false\n" +
-    "                              }\n" +
-    "                            }\" ng-model=\"updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile\" class=\"ace-bordered ace-inline\"></div>\n" +
+    "                            mode: 'groovy',\n" +
+    "                            theme: 'eclipse',\n" +
+    "                            onLoad: aceLoaded,\n" +
+    "                            rendererOptions: {\n" +
+    "                              fadeFoldWidgets: true,\n" +
+    "                              showPrintMargin: false\n" +
+    "                            }\n" +
+    "                          }\" ng-model=\"updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile\" class=\"ace-bordered ace-inline\"></div>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"sources.none\">\n" +
@@ -6807,8 +7174,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<i>No source inputs have been defined for this build configuration.</i>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-if=\"updatedBuildConfig.spec.strategy.type !== 'JenkinsPipeline'\" class=\"section\">\n" +
-    "<h3>Image Configuration</h3>\n" +
+    "<div ng-if=\"strategyType !== 'JenkinsPipeline'\" class=\"section\">\n" +
+    "<h3 class=\"with-divider\">Image Configuration</h3>\n" +
     "<dl class=\"dl-horizontal left\">\n" +
     "<div>\n" +
     "<div class=\"form-group\">\n" +
@@ -6836,10 +7203,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"form-group\">\n" +
+    "<div class=\"form-group\" ng-if=\"view.advancedOptions && strategyType !== 'JenkinsPipeline'\">\n" +
+    "<osc-secrets model=\"secrets.picked.pullSecret\" namespace=\"projectName\" display-type=\"pull\" type=\"image\" secrets-by-type=\"secrets.secretsByType\" service-account-to-link=\"builder\" alerts=\"alerts\">\n" +
+    "</osc-secrets>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\" ng-if=\"view.advancedOptions\">\n" +
     "<div class=\"checkbox\">\n" +
     "<label>\n" +
-    "<input type=\"checkbox\" ng-model=\"options.forcePull\"/>\n" +
+    "<input type=\"checkbox\" ng-model=\"options.forcePull\">\n" +
     "Always pull the builder image from the docker registry, even if it is present locally\n" +
     "</label>\n" +
     "</div>\n" +
@@ -6863,14 +7234,16 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<input class=\"form-control\" id=\"pushToLink\" name=\"pushToLink\" type=\"text\" ng-model=\"imageOptions.to.dockerImage\" placeholder=\"example: centos/ruby-20-centos7:latest\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck required>\n" +
     "</div>\n" +
     "</div>\n" +
+    "<div class=\"form-group\" ng-if=\"view.advancedOptions\">\n" +
+    "<osc-secrets model=\"secrets.picked.pushSecret\" namespace=\"projectName\" display-type=\"push\" type=\"image\" service-account-to-link=\"builder\" secrets-by-type=\"secrets.secretsByType\" alerts=\"alerts\">\n" +
+    "</osc-secrets>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</dl>\n" +
     "</div>\n" +
-    "</div>\n" +
-    "<div class=\"col-lg-6\">\n" +
     "<div ng-if=\"!(updatedBuildConfig | isJenkinsPipelineStrategy)\" class=\"section\">\n" +
-    "<h3>Environment Variables<span class=\"help action-inline\">\n" +
-    "<a href>\n" +
+    "<h3 class=\"with-divider\">Environment Variables<span class=\"help action-inline\">\n" +
+    "<a href=\"\">\n" +
     "<i class=\"pficon pficon-help\" data-toggle=\"tooltip\" aria-hidden=\"true\" data-original-title=\"Environment variables are used to configure and pass information to running containers.  These environment variables will be available during your build and at runtime.\"></i>\n" +
     "</a>\n" +
     "</span></h3>\n" +
@@ -6879,8 +7252,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"sources.git || !(updatedBuildConfig | isJenkinsPipelineStrategy)\" class=\"section\">\n" +
-    "<h3>Triggers\n" +
-    "<a href=\"{{'build-triggers' | helpLink}}\" aria-hidden=\"true\" target=\"_blank\"><span class=\"learn-more-inline\">Learn more<i class=\"fa fa-external-link\"></i></span></a>\n" +
+    "<div ng-if=\"view.advancedOptions\">\n" +
+    "<h3 class=\"with-divider\">Triggers\n" +
+    "<a href=\"{{'build-triggers' | helpLink}}\" aria-hidden=\"true\" target=\"_blank\"><span class=\"learn-more-inline\">Learn more&nbsp;<i class=\"fa fa-external-link\"></i></span></a>\n" +
     "</h3>\n" +
     "<dl class=\"dl-horizontal left\">\n" +
     "<div>\n" +
@@ -6896,7 +7270,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<h5>Image change</h5>\n" +
     "<div class=\"checkbox\">\n" +
     "<label>\n" +
-    "<input type=\"checkbox\" ng-model=\"triggers.builderImageChangeTrigger.present\" ng-disabled=\"imageOptions.from.type === 'None'\"/>\n" +
+    "<input type=\"checkbox\" ng-model=\"triggers.builderImageChangeTrigger.present\" ng-disabled=\"imageOptions.from.type === 'None'\">\n" +
     "Automatically build a new image when the builder image changes\n" +
     "<span class=\"help action-inline\">\n" +
     "<a href>\n" +
@@ -6910,10 +7284,21 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</dl>\n" +
     "</div>\n" +
-    "<div class=\"section\">\n" +
-    "<h3>Run Policy\n" +
+    "</div>\n" +
+    "<div class=\"section\" ng-if=\"!(updatedBuildConfig | isJenkinsPipelineStrategy) && view.advancedOptions\">\n" +
+    "<h3 class=\"with-divider\">\n" +
+    "Build Secrets\n" +
+    "<a href=\"{{'source_secrets' | helpLink}}\" aria-hidden=\"true\" target=\"_blank\"><span class=\"learn-more-inline\">Learn more&nbsp;<i class=\"fa fa-external-link\"></i></span></a>\n" +
+    "</h3>\n" +
+    "<div class=\"form-group\">\n" +
+    "<osc-source-secrets model=\"secrets.picked.sourceSecrets\" namespace=\"projectName\" secrets-by-type=\"secrets.secretsByType\" strategy-type=\"strategyType\" service-account-to-link=\"builder\" alerts=\"alerts\" display-type=\"source\" type=\"source\">\n" +
+    "</osc-source-secrets>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"section\" ng-if=\"view.advancedOptions\">\n" +
+    "<h3 class=\"with-divider\">Run Policy\n" +
     "<span class=\"help action-inline\">\n" +
-    "<a href>\n" +
+    "<a href=\"\">\n" +
     "<i class=\"pficon pficon-help\" data-toggle=\"tooltip\" aria-hidden=\"true\" data-original-title=\"The build run policy describes the order in which the builds created from the build configuration should run.\"></i>\n" +
     "</a>\n" +
     "</span>\n" +
@@ -6928,13 +7313,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</ui-select>\n" +
     "</div>\n" +
     "<div ng-switch=\"updatedBuildConfig.spec.runPolicy\">\n" +
-    "<div ng-switch-when=\"Serial\">Builds triggered from this Build Configuration will run one at the time, in the order they have been triggered.</div>\n" +
-    "<div ng-switch-when=\"Parallel\">Builds triggered from this Build Configuration will run all at the same time. The order in which they will finish is not guranteed.</div>\n" +
-    "<div ng-switch-when=\"SerialLatestOnly\">Builds triggered from this Build Configuration will run one at the time. When a currently running build completes, the next build that will run is the latest build created. Other queued builds will be cancelled.</div>\n" +
-    "<div ng-switch-default>Builds triggered from this Build Configuration will run using the {{updatedBuildConfig.spec.runPolicy | sentenceCase}} policy.</div>\n" +
+    "<div class=\"help-block\" ng-switch-when=\"Serial\">Builds triggered from this Build Configuration will run one at the time, in the order they have been triggered.</div>\n" +
+    "<div class=\"help-block\" ng-switch-when=\"Parallel\">Builds triggered from this Build Configuration will run all at the same time. The order in which they will finish is not guranteed.</div>\n" +
+    "<div class=\"help-block\" ng-switch-when=\"SerialLatestOnly\">Builds triggered from this Build Configuration will run one at the time. When a currently running build completes, the next build that will run is the latest build created. Other queued builds will be cancelled.</div>\n" +
+    "<div class=\"help-block\" ng-switch-default>Builds triggered from this Build Configuration will run using the {{updatedBuildConfig.spec.runPolicy | sentenceCase}} policy.</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "</div>\n" +
+    "<div class=\"gutter-top\">\n" +
+    "<a href=\"\" ng-click=\"view.advancedOptions = !view.advancedOptions\" role=\"button\">{{view.advancedOptions ? 'Hide' : 'Show'}} advanced options</a>\n" +
     "</div>\n" +
     "<div class=\"buttons gutter-top-bottom\">\n" +
     "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-disabled=\"form.$invalid || form.$pristine || disableInputs\">\n" +
@@ -6943,6 +7329,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a class=\"btn btn-default btn-lg\" href=\"{{updatedBuildConfig | navigateResourceURL}}\">\n" +
     "Cancel\n" +
     "</a>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</form>\n" +
@@ -7390,6 +7777,25 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"modal-footer\">\n" +
     "<button class=\"btn btn-lg btn-danger\" type=\"button\" ng-click=\"confirmScale()\">Scale Down</button>\n" +
     "<button class=\"btn btn-lg btn-default\" type=\"button\" ng-click=\"cancel()\">Cancel</button>\n" +
+    "</div>\n" +
+    "</div>"
+  );
+
+
+  $templateCache.put('views/modals/create-secret.html',
+    "<div class=\"create-secret-modal\">\n" +
+    "<div class=\"modal-header\">\n" +
+    "<h2>\n" +
+    "Create {{type | capitalize}} Secret\n" +
+    "<span ng-switch=\"type\">\n" +
+    "<a ng-switch-when=\"source\" ng-href=\"{{'git_secret' | helpLink}}\" target=\"_blank\"><span class=\"learn-more-inline\">Learn more&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></span></a>\n" +
+    "<a ng-switch-when=\"image\" ng-href=\"{{'pull_secret' | helpLink}}\" target=\"_blank\"><span class=\"learn-more-inline\">Learn more&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></span></a>\n" +
+    "<a ng-switch-default ng-href=\"{{'source_secrets' | helpLink}}\" target=\"_blank\"><span class=\"learn-more-inline\">Learn more&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></span></a>\n" +
+    "</span>\n" +
+    "</h2>\n" +
+    "</div>\n" +
+    "<div class=\"modal-body\">\n" +
+    "<create-secret type=\"type\" service-account-to-link=\"serviceAccountToLink\" namespace=\"namespace\" alerts=\"alerts\" post-create-action=\"postCreateAction(newSecret, creationAlert)\" cancel=\"cancel()\"></create-secret>\n" +
     "</div>\n" +
     "</div>"
   );

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3420,6 +3420,7 @@ body{padding-right:0px!important}
 }
 .ui-select-bootstrap .ui-select-search{width:100%!important}
 .ui-select-bootstrap .ui-select-toggle>.caret{font-style:normal;margin-top:-5px}
+.ui-select-bootstrap .ui-select-match-text>span{width:90%;overflow:hidden;text-overflow:ellipsis;position:absolute}
 .ui-select-bootstrap .btn{padding-right:25px}
 .surface-shaded .ui-select-bootstrap .ui-select-match>.btn{background-color:#fff;background-image:linear-gradient(to bottom,#fff 0%,#fbfbfb 100%)}
 .separator{border-top:1px solid rgba(0,0,0,.15)}
@@ -3538,6 +3539,13 @@ label.checkbox{font-weight:400}
 }
 .create-route-icon,.create-storage-icon{padding-top:0;text-align:right}
 .about .about-icon img,.command-line .about-icon img{width:100%}
+.osc-secrets-form .picked-secret{margin-bottom:5px}
+.osc-secrets-form .directory{width:90%;display:inline-block}
+.osc-secrets-form .remove-secret-row{width:10%;margin-left:7px;display:inline}
+.osc-secrets-form .remove-btn{color:#333;opacity:.65;font-size:15px;vertical-align:middle}
+.osc-secrets-form .remove-btn:hover{opacity:1;text-decoration:none}
+.osc-secrets-form .remove-btn:focus{text-decoration:none}
+.osc-secrets-form .ui-select-choices-row-inner{height:24px;cursor:pointer}
 .osc-form .template-name{text-align:right}
 .osc-form .template-name span.fa{font-size:40px}
 @media (min-width:768px){.osc-form .template-name span.fa{font-size:100px}
@@ -3645,6 +3653,10 @@ a.disabled-link:active,a.disabled-link:focus,a.disabled-link:hover{color:#bbb;te
 .modal-resource-action h1{font-size:21px;font-weight:500;margin-bottom:20px;overflow-wrap:break-word;min-width:0}
 .modal-resource-action p{font-size:16px}
 .ace_editor.dockerfile-mode .ace_constant.ace_numeric,.editor.yaml-mode .ace_constant.ace_numeric{color:inherit}
+.create-secret-modal{background-color:#F5F5F5}
+.create-secret-modal .modal-footer{margin-top:0px}
+.create-secret-modal .modal-body{padding:0px 18px}
+.create-secret-modal .modal-body .create-secret-editor{height:150px}
 .edit-yaml h1{line-height:1.3}
 .edit-yaml .editor{line-height:1.5;width:100%;min-height:140px;height:50vh}
 .edit-yaml .editor .ace_gutter{color:#8b8d8f}
@@ -3662,6 +3674,7 @@ a.disabled-link:active,a.disabled-link:focus,a.disabled-link:hover{color:#bbb;te
 .modal-debug-terminal .modal-footer{padding-top:0}
 .ace-inline{height:300px}
 #from-file .editor{height:350px}
+.edit-form .with-divider{border-top:1px solid rgba(0,0,0,.15);padding-top:21px;padding-bottom:10px}
 .edit-form .labels .form-group{width:44%}
 .edit-form .labels .form-group .form-control{width:100%}
 .edit-form .checkbox{margin:10px}
@@ -3669,7 +3682,7 @@ a.disabled-link:active,a.disabled-link:focus,a.disabled-link:hover{color:#bbb;te
 .edit-form .trigger-info .trigger-url{display:inline-block;vertical-align:middle}
 .edit-form .trigger-info .trigger-actions{display:inline-block;margin-left:5px}
 .edit-form .trigger-info .trigger-actions .action-icon,.edit-form .trigger-info .trigger-actions .action-icon:hover{color:#4d5258}
-.edit-form .section{padding-bottom:15px}
+.edit-form .section{padding-bottom:5px}
 @media (max-width:768px){.edit-form .trigger-url{max-width:90%}
 .edit-form .labels .form-group{width:100%}
 }


### PR DESCRIPTION
## Motivation
As an OpenShift user I want to add a secret to my Build config or Deployment Config so it can:
- pull from a private registry (BC/DC)
   - **SecretName** has to be specified
   - pullImageSecret in the DC takes an _array_
- push to a private registry (BC)
   - **SecretName** has to be specified
- access a private repository to get source code (BC)
   - **SecretName** and **DestinationDir** has to be specified
   - source secret in BC takes an _array_

Secrets for pushing/pulling from a private registry requires [_dockercfg_ or  _dockerconfigjson_](https://docs.openshift.org/latest/dev_guide/builds.html#using-docker-credentials-for-pushing-and-pulling-images)  type of secret.

Secrets accessing a private registry requires to be of [_basic-auth_](https://docs.openshift.org/latest/dev_guide/builds.html#basic-authentication), [_ssh-auth_](https://docs.openshift.org/latest/dev_guide/builds.html#ssh-key-authentication) or [_opaque_](https://docs.openshift.org/latest/dev_guide/builds.html#other-authentication) type of secret. 

Also as a user I want to have a way how to create secrets for these actions, if desired secret does not exist.

## Places to edit/add secrets
Secret should be added to the BC/DC on pages that are dedicated to edit the BC/DC resource. Those would be:
- BC editor:
  - `Source Configuration` section, when source is located in private repository. 
  - `Image Configuration` section.
  - `Image Configuration` section.

- _fromimage_ page in the Create flow: 
   - `Build Configuration` section where user could configure source secret to be pulled from a private repository.

- Since the DeploymentConfig does not have any editor then there are two options how to display the editation of DC with the secret:
   1. Add a `Secrets` section on the DC browse page
   2. Have a standalone page (eg. _Edit Health Checks_ on the DC) that would include the logic to edit DC with the image pull secret + create secrets of that type.

## Proposal
Create a directive that could be reused on all the places we need to edit BC/DC with secrets. Directive would consist from three components:
1. Selectbox using ui-select that would be used to display and pick desired secret(s). Based on the purpose of the secret single or a [multiple](https://github.com/angular-ui/ui-select/wiki/ui-select#examples-multiple-selection) secrets could be picked(eg. source secrets take an array). Secrets will be filtered based on annotation so user will pick only form relevant [secret types](https://github.com/openshift/origin/blob/master/vendor/k8s.io/kubernetes/pkg/api/types.go#L2615-L2693)
2. Input field that would take the **DestinationDir** in case of source secret
3. `Add Secret` button that would open a modal for creating the Secret that matches the secret type that is needed 

In the modal user will be able to only create Secret types that are appropriate for resource section user is trying to edit(eg. if user would want to add secret for pulling image in a BC, he would be only able to create _dockercfg_ or  _dockerconfigjson_ secret types)

The modal will consist of a select picker that would contain secret types from which user pick and create that secret type. Based on secret type different inputfields will be rendered:
- _dockercfg_ or  _dockerconfigjson_
   - `osc-file-input` directive with d'n'd text area for attaching _dockercfg_ file or  _config.json _
   - similar to `Import YAML / JSON` in `Add to Project`
- _ssh-auth_
   - `osc-file-input` directive with d'n'd text area for attaching private SSH key
   - optionaly: - `osc-file-input` directive with d'n'd text area for attaching .gitconfig
- _basic-auth_
   - combination of username/password/.gitconfig. Based on [docs](https://docs.openshift.org/latest/dev_guide/builds.html#basic-authentication)

Eventually, after the secret will be created the success callback will then link the secret with appropriate _service account_. But thats not necessary for the implementation, based on the conversation we have with @csrwng 

Not 100% if the modal is the best way how to handle the secret creation, but on the other hand, redirecting from the BC editor(in case of standalone secret page) is not the best thing to do imho(only if the secret creation action will redirect back to the previous page)., and have the creation form inside of the BC editor is not the best approach as well.

@jwforres @spadgett PTAL