### PR TITLE
Remove trigger button wraps to next line on mobile

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -1129,7 +1129,7 @@ a.disabled-link {
   }
 
   .trigger-info {
-    margin: 10px 0px 10px 10px;
+    margin: 10px 0px 10px 0px;
     .trigger-url {
       display: inline-block;
       vertical-align: middle;
@@ -1148,6 +1148,9 @@ a.disabled-link {
     padding-bottom: 15px;
   }
   @media (max-width: @screen-sm-min) {
+    .trigger-url {
+      max-width: 90%;
+    }
     .labels {
       .form-group {
         width: 100%;

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3666,12 +3666,13 @@ a.disabled-link:active,a.disabled-link:focus,a.disabled-link:hover{color:#bbb;te
 .edit-form .labels .form-group{width:44%}
 .edit-form .labels .form-group .form-control{width:100%}
 .edit-form .checkbox{margin:10px}
-.edit-form .trigger-info{margin:10px 0px 10px 10px}
+.edit-form .trigger-info{margin:10px 0px}
 .edit-form .trigger-info .trigger-url{display:inline-block;vertical-align:middle}
 .edit-form .trigger-info .trigger-actions{display:inline-block;margin-left:5px}
 .edit-form .trigger-info .trigger-actions .action-icon,.edit-form .trigger-info .trigger-actions .action-icon:hover{color:#4d5258}
 .edit-form .section{padding-bottom:15px}
-@media (max-width:768px){.edit-form .labels .form-group{width:100%}
+@media (max-width:768px){.edit-form .trigger-url{max-width:90%}
+.edit-form .labels .form-group{width:100%}
 }
 .status{min-width:130px}
 .status .status-icon{margin-right:6px;width:13px;text-align:center}


### PR DESCRIPTION
Remove the extra left margin + set `max-width` for mobile. Screen:
![screenshot-22](https://cloud.githubusercontent.com/assets/1668218/18313364/c609dee0-750e-11e6-9fa9-c5be2408bc59.png)

Tested it with different screen resolutions and should be ok for them.

@spadgett PTAL

Closes https://github.com/openshift/origin-web-console/issues/515