### PR TITLE
WIP - enable PKCE

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -21,6 +21,7 @@ window.OPENSHIFT_CONFIG = {
   },
   auth: {
     oauth_authorize_uri: "https://localhost:8443/oauth/authorize",
+    oauth_token_uri: "https://localhost:8443/oauth/token",
     oauth_redirect_base: "https://localhost:9000",
     oauth_client_id: "openshift-web-console",
     logout_uri: ""

--- a/app/index.html
+++ b/app/index.html
@@ -162,6 +162,7 @@
         <script src="scripts/app.js"></script>
         <script src="scripts/services/logger.js"></script>
         <script src="scripts/services/ws.js"></script>
+        <script src="scripts/services/crypto.js"></script>
         <script src="scripts/services/userstore.js"></script>
         <script src="scripts/services/api.js"></script>
         <script src="scripts/services/auth.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -351,6 +351,7 @@ angular
 
     RedirectLoginServiceProvider.OAuthClientID(AUTH_CFG.oauth_client_id);
     RedirectLoginServiceProvider.OAuthAuthorizeURI(AUTH_CFG.oauth_authorize_uri);
+    RedirectLoginServiceProvider.OAuthTokenURI(AUTH_CFG.oauth_token_uri);
     RedirectLoginServiceProvider.OAuthRedirectURI(URI(AUTH_CFG.oauth_redirect_base).segment("oauth").toString());
 
     // Configure the container terminal

--- a/app/scripts/controllers/util/oauth.js
+++ b/app/scripts/controllers/util/oauth.js
@@ -8,7 +8,7 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('OAuthController', function ($scope, $location, $q, RedirectLoginService, DataService, AuthService, Logger) {
+  .controller('OAuthController', function ($scope, $location, $q, $http, RedirectLoginService, DataService, AuthService, Logger) {
     var authLogger = Logger.get("auth");
 
     // Initialize to a no-op function.
@@ -19,7 +19,7 @@ angular.module('openshiftConsole')
       $location.url("./");
     };
 
-    RedirectLoginService.finish()
+    RedirectLoginService.finish($http)
     .then(function(data) {
       var token = data.token;
       var then = data.then;

--- a/app/scripts/services/crypto.js
+++ b/app/scripts/services/crypto.js
@@ -1,0 +1,43 @@
+'use strict';
+
+angular.module("openshiftConsole")
+  .factory("CryptoService", function(Logger){
+
+    return {
+        base64URLEncode: function(source) {
+            var retval = window.btoa(source);
+            // convert to base64url alphabet and remove padding
+            retval = retval.replace(/\+/g, "-");
+            retval = retval.replace(/\//g, "_");
+            retval = retval.replace(/=/g, "");
+            return retval;
+        },
+
+        randomBytes: function(length) {
+            var retval = [];
+            if (window.crypto && window.Uint8Array) {
+                try {
+                    var r = new Uint8Array(length);
+                    window.crypto.getRandomValues(r);
+                    for (var j=0; j < length; j++) { retval.push(r[j]); }
+                } catch(e) {
+                    Logger.debug("RedirectLoginService.randomBytes: ", e);
+                }
+            }
+
+            while (retval.length < length) { retval.push(Math.round(Math.random() * 256)); }
+            
+            return retval;
+        },
+
+        randomBase64URLString: function(length) {
+            // base64 expands 4/3, so we need 3/4 as many source bytes
+            var sourceBytes = this.randomBytes(Math.ceil(length * 0.75));
+            var source = "";
+            for (var i=0; i < sourceBytes.length; i++) {
+                source = source + String.fromCharCode(sourceBytes[i]);
+            }
+            return this.base64URLEncode(source).substring(0,length);
+        }
+    };
+  });


### PR DESCRIPTION
Switches the web console from using an implicit token flow to using an authorization code flow in combination with PKCE (a hash of a privately held "verifier" is bound to the authorization code, and the original verifier must be presented when exchanging the authorization code for a token).

TODO:
- [ ] tests for crypto pieces
- [ ] find sha256 hash algorithm implemented in javascript
- [ ] switch from plain PKCE to S256 PKCE
- [ ] dist build
