### PR TITLE
Don't set spec.host when creating debug pod

### DIFF
--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -1285,9 +1285,25 @@ angular.module('openshiftConsole')
       return scopeMessages[scope];
     };
   })
-  .filter('debugLabel', function(PodsService) {
+  .filter('isDebugPod', function(annotationFilter) {
     return function(pod) {
-      return PodsService.getDebugLabel(pod);
+      return !!annotationFilter(pod, 'debug.openshift.io/source-resource');
+    };
+  })
+  .filter('debugPodSourceName', function(annotationFilter) {
+    return function(pod) {
+      var source = annotationFilter(pod, 'debug.openshift.io/source-resource');
+      if (!source) {
+        return '';
+      }
+
+      var parts = source.split('/');
+      if (parts.length !== 2) {
+        Logger.warn('Invalid debug.openshift.io/source-resource annotation value "' + source + '"');
+        return '';
+      }
+
+      return parts[1];
     };
   })
   // Determines the container entrypoint command from the container and docker image metadata.

--- a/app/scripts/services/pods.js
+++ b/app/scripts/services/pods.js
@@ -1,15 +1,8 @@
 'use strict';
 
 angular.module("openshiftConsole")
-  .factory("PodsService", function($filter) {
-    var getLabel = $filter('label');
-    var debugLabelKey = _.constant('debug.openshift.io/name');
-
+  .factory("PodsService", function() {
     return {
-      getDebugLabel: function(pod) {
-        return getLabel(pod, debugLabelKey());
-      },
-
       // Generates a copy of pod for debugging crash loops.
       generateDebugPod: function(pod, containerName) {
         // Copy the pod and make some changes for debugging.
@@ -24,14 +17,14 @@ angular.module("openshiftConsole")
           name: pod.metadata.name + "-debug",
           annotations: {
             "debug.openshift.io/source-container": containerName,
-            "debug.openshift.io/source-resource": "pod/" + pod.metadata.name
+            "debug.openshift.io/source-resource": "pods/" + pod.metadata.name
           },
           labels: {}
         };
-        debugPod.metadata.labels[debugLabelKey()] = pod.metadata.name;
 
         // Never restart.
         debugPod.spec.restartPolicy = "Never";
+        delete debugPod.spec.host;
         delete debugPod.spec.nodeName;
         debugPod.status = {};
         delete container.readinessProbe;
@@ -61,7 +54,7 @@ angular.module("openshiftConsole")
 
         return podsByRC;
       },
-      
+
       // includeFn is an optional filter to only include certain pods in the map
       // common use case is to hide infrastructure pods like build and deployer
       groupByService: function(pods, services, includeFn) {

--- a/app/views/browse/_pod-details.html
+++ b/app/views/browse/_pod-details.html
@@ -3,9 +3,9 @@
     <div class="col-lg-6">
       <h3>
         Status
-        <small ng-if="pod | debugLabel">
+        <small ng-if="pod | isDebugPod">
           debugging
-          <a ng-href="{{pod | debugLabel | navigateResourceURL : 'Pod' : pod.metadata.namespace}}">{{pod | debugLabel}}</a>
+          <a ng-href="{{pod | debugPodSourceName | navigateResourceURL : 'Pod' : pod.metadata.namespace}}">{{pod | debugPodSourceName}}</a>
         </small>
       </h3>
       <dl class="dl-horizontal left">
@@ -62,7 +62,7 @@
           <dd>{{containerStatus.ready}}</dd>
           <dt>Restart Count:</dt>
           <dd>{{containerStatus.restartCount}}</dd>
-          <div ng-if="pod.status.phase !== 'Completed' && !(pod | annotation : 'openshift.io/build.name') && (!containerStatus.state.running || !containerStatus.ready) && !(pod | debugLabel) && ('pods' | canI : 'create')" class="debug-pod-action">
+          <div ng-if="pod.status.phase !== 'Completed' && !(pod | annotation : 'openshift.io/build.name') && (!containerStatus.state.running || !containerStatus.ready) && !(pod | isDebugPod) && ('pods' | canI : 'create')" class="debug-pod-action">
             <a href="" ng-click="debugTerminal(containerStatus.name)" role="button">Debug in terminal</a>
           </div>
         </dl>

--- a/app/views/directives/pods-table.html
+++ b/app/views/directives/pods-table.html
@@ -18,13 +18,13 @@
         <span ng-if="pod | isTroubledPod">
           <pod-warnings pod="pod"></pod-warnings>
         </span>
-        <span ng-if="pod | debugLabel">
+        <span ng-if="pod | isDebugPod">
           <i class="fa fa-bug info-popover"
              aria-hidden="true"
              data-toggle="popover"
              data-trigger="hover"
-             dynamic-content="Debugging pod {{pod | debugLabel}}"></i>
-           <span class="sr-only">Debugging pod {{pod | debugLabel}}</span>
+             dynamic-content="Debugging pod {{pod | debugPodSourceName}}"></i>
+           <span class="sr-only">Debugging pod {{pod | debugPodSourceName}}</span>
         </span>
       </td>
       <td data-title="Status">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2729,24 +2729,20 @@ hasCPURequest:o,
 filterHPA:p,
 getHPAWarnings:s
 };
-} ]), angular.module("openshiftConsole").factory("PodsService", [ "$filter", function(a) {
-var b = a("label"), c = _.constant("debug.openshift.io/name");
+} ]), angular.module("openshiftConsole").factory("PodsService", function() {
 return {
-getDebugLabel:function(a) {
-return b(a, c());
-},
 generateDebugPod:function(a, b) {
-var d = angular.copy(a), e = _.find(d.spec.containers, {
+var c = angular.copy(a), d = _.find(c.spec.containers, {
 name:b
 });
-return e ? (d.metadata = {
+return d ? (c.metadata = {
 name:a.metadata.name + "-debug",
 annotations:{
 "debug.openshift.io/source-container":b,
-"debug.openshift.io/source-resource":"pod/" + a.metadata.name
+"debug.openshift.io/source-resource":"pods/" + a.metadata.name
 },
 labels:{}
-}, d.metadata.labels[c()] = a.metadata.name, d.spec.restartPolicy = "Never", delete d.spec.nodeName, d.status = {}, delete e.readinessProbe, delete e.livenessProbe, e.command = [ "sleep" ], e.args = [ "3600" ], d.spec.containers = [ e ], d) :null;
+}, c.spec.restartPolicy = "Never", delete c.spec.host, delete c.spec.nodeName, c.status = {}, delete d.readinessProbe, delete d.livenessProbe, d.command = [ "sleep" ], d.args = [ "3600" ], c.spec.containers = [ d ], c) :null;
 },
 groupByReplicationController:function(a, b) {
 var c = {};
@@ -2771,7 +2767,7 @@ _.set(d, [ f, a.metadata.name ], a);
 }), d;
 }
 };
-} ]), angular.module("openshiftConsole").service("CachedTemplateService", function() {
+}), angular.module("openshiftConsole").service("CachedTemplateService", function() {
 var a = null;
 return {
 setTemplate:function(b) {
@@ -10799,9 +10795,16 @@ NotBestEffort:"Matches pods that do not have best effort quality of service."
 return function(b) {
 return a[b];
 };
-}).filter("debugLabel", [ "PodsService", function(a) {
+}).filter("isDebugPod", [ "annotationFilter", function(a) {
 return function(b) {
-return a.getDebugLabel(b);
+return !!a(b, "debug.openshift.io/source-resource");
+};
+} ]).filter("debugPodSourceName", [ "annotationFilter", function(a) {
+return function(b) {
+var c = a(b, "debug.openshift.io/source-resource");
+if (!c) return "";
+var d = c.split("/");
+return 2 !== d.length ? (Logger.warn('Invalid debug.openshift.io/source-resource annotation value "' + c + '"'), "") :d[1];
 };
 } ]).filter("entrypoint", function() {
 var a = function(a) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1162,9 +1162,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"col-lg-6\">\n" +
     "<h3>\n" +
     "Status\n" +
-    "<small ng-if=\"pod | debugLabel\">\n" +
+    "<small ng-if=\"pod | isDebugPod\">\n" +
     "debugging\n" +
-    "<a ng-href=\"{{pod | debugLabel | navigateResourceURL : 'Pod' : pod.metadata.namespace}}\">{{pod | debugLabel}}</a>\n" +
+    "<a ng-href=\"{{pod | debugPodSourceName | navigateResourceURL : 'Pod' : pod.metadata.namespace}}\">{{pod | debugPodSourceName}}</a>\n" +
     "</small>\n" +
     "</h3>\n" +
     "<dl class=\"dl-horizontal left\">\n" +
@@ -1221,7 +1221,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dd>{{containerStatus.ready}}</dd>\n" +
     "<dt>Restart Count:</dt>\n" +
     "<dd>{{containerStatus.restartCount}}</dd>\n" +
-    "<div ng-if=\"pod.status.phase !== 'Completed' && !(pod | annotation : 'openshift.io/build.name') && (!containerStatus.state.running || !containerStatus.ready) && !(pod | debugLabel) && ('pods' | canI : 'create')\" class=\"debug-pod-action\">\n" +
+    "<div ng-if=\"pod.status.phase !== 'Completed' && !(pod | annotation : 'openshift.io/build.name') && (!containerStatus.state.running || !containerStatus.ready) && !(pod | isDebugPod) && ('pods' | canI : 'create')\" class=\"debug-pod-action\">\n" +
     "<a href=\"\" ng-click=\"debugTerminal(containerStatus.name)\" role=\"button\">Debug in terminal</a>\n" +
     "</div>\n" +
     "</dl>\n" +
@@ -6468,9 +6468,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"pod | isTroubledPod\">\n" +
     "<pod-warnings pod=\"pod\"></pod-warnings>\n" +
     "</span>\n" +
-    "<span ng-if=\"pod | debugLabel\">\n" +
-    "<i class=\"fa fa-bug info-popover\" aria-hidden=\"true\" data-toggle=\"popover\" data-trigger=\"hover\" dynamic-content=\"Debugging pod {{pod | debugLabel}}\"></i>\n" +
-    "<span class=\"sr-only\">Debugging pod {{pod | debugLabel}}</span>\n" +
+    "<span ng-if=\"pod | isDebugPod\">\n" +
+    "<i class=\"fa fa-bug info-popover\" aria-hidden=\"true\" data-toggle=\"popover\" data-trigger=\"hover\" dynamic-content=\"Debugging pod {{pod | debugPodSourceName}}\"></i>\n" +
+    "<span class=\"sr-only\">Debugging pod {{pod | debugPodSourceName}}</span>\n" +
     "</span>\n" +
     "</td>\n" +
     "<td data-title=\"Status\">\n" +


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1371489

Don't set spec.host when creating debug pod. Unfortunately I missed this in my previous fix, #498. Also don't set label `debug.openshift.io/name`, which isn't used by `oc debug`.

@jwforres I did a diff on the JSON between the web console and CLI. I tested in staging by POSTing directly to the API server with `spec.host` removed, and it worked. PTAL