### PR TITLE
Removing extra spacing when no parameters exist in a template

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -744,23 +744,27 @@ label.checkbox {
 }
 
 .template-message {
+  background-color: #d9edf7;
+  border-color: #31708f;
+  border-style: solid;
+  border-width: 1px;
+  color: black;
+  padding: 21px;
   .pficon-info {
     float: left;
     font-size: 18px;
     margin-right: 6px;
     color: #31708f;
   }
-  background-color: #d9edf7;
-  border-color: #31708f;
-  border-width: 1px;
-  color: black;
-  border-style: solid;
-  padding: 21px;
+  .resource-description {
+    margin-bottom: 0;
+  }
 }
 
 .resource-description {
-  .word-break();
+  margin-bottom: (@grid-gutter-width / 2);
   .pre-wrap();
+  .word-break();
 }
 
 // Misc

--- a/app/views/directives/osc-image-summary.html
+++ b/app/views/directives/osc-image-summary.html
@@ -4,4 +4,4 @@
   <div ng-show="resource | annotation:'provider'">Provider: {{ resource | annotation:'provider' }}</div>
   <div ng-show="resource.metadata.namespace">Namespace: {{ resource.metadata.namespace }}</div>
 </div>
-<div class="resource-description gutter-bottom" ng-bind-html="resource | description | linky"></div>
+<div class="resource-description" ng-bind-html="resource | description | linky"></div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5995,7 +5995,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-show=\"resource | annotation:'provider'\">Provider: {{ resource | annotation:'provider' }}</div>\n" +
     "<div ng-show=\"resource.metadata.namespace\">Namespace: {{ resource.metadata.namespace }}</div>\n" +
     "</div>\n" +
-    "<div class=\"resource-description gutter-bottom\" ng-bind-html=\"resource | description | linky\"></div>"
+    "<div class=\"resource-description\" ng-bind-html=\"resource | description | linky\"></div>"
   );
 
 

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3586,10 +3586,11 @@ label.checkbox{font-weight:400}
 .env-variable-list li .value,.label-list li .value{max-width:500px}
 .env-variable-list li .btn,.label-list li .btn{vertical-align:top}
 .label+.label{margin-left:3px}
-.template-message{background-color:#d9edf7;border-color:#31708f;border-width:1px;color:#000;border-style:solid;padding:21px}
+.template-message{background-color:#d9edf7;border-color:#31708f;border-style:solid;border-width:1px;color:#000;padding:21px}
 .attention-message,.tasks,div.code,pre.code{background-color:#fff}
 .template-message .pficon-info{float:left;font-size:18px;margin-right:6px;color:#31708f}
-.resource-description{overflow-wrap:break-word;min-width:0;white-space:pre-wrap}
+.template-message .resource-description{margin-bottom:0}
+.resource-description{margin-bottom:20px;white-space:pre-wrap;overflow-wrap:break-word;min-width:0}
 .action-inline{margin-left:5px;font-size:11px}
 .action-inline i.fa,.action-inline i.pficon{color:#4d5258;margin-right:5px}
 a.subtle-link{color:#9c9c9c;border-bottom:1px dotted #BBB}


### PR DESCRIPTION
by swapping padding for margin so that abutting margins collapse and provide the desired spacing

Fixes #480 

For the purposes of this screenshot, I manipulated the page contents using the web inspector to delete the div.images and div.template-options nodes in order to reproduce the issue.  No idea where @spadgett got that crazy template.

![screen shot 2016-09-16 at 10 03 41 am](https://cloud.githubusercontent.com/assets/895728/18588560/ffa06ee8-7bf4-11e6-99e8-6a706e1e5052.PNG)

@jwforres or @spadgett, PTAL.