### PR TITLE
Project Membership

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -182,6 +182,9 @@
         <script src="scripts/services/builds.js"></script>
         <script src="scripts/services/deployments.js"></script>
         <script src="scripts/services/imagestreams.js"></script>
+        <script src="scripts/services/membership/membership.js"></script>
+        <script src="scripts/services/membership/roles.js"></script>
+        <script src="scripts/services/membership/roleBindings.js"></script>
         <script src="scripts/services/metrics.js"></script>
         <script src="scripts/services/storage.js"></script>
         <script src="scripts/services/constants.js"></script>
@@ -206,6 +209,7 @@
         <script src="scripts/controllers/topology.js"></script>
         <script src="scripts/controllers/quota.js"></script>
         <script src="scripts/controllers/monitoring.js"></script>
+        <script src="scripts/controllers/membership.js"></script>
         <script src="scripts/controllers/builds.js"></script>
         <script src="scripts/controllers/pipelines.js"></script>
         <script src="scripts/controllers/buildConfig.js"></script>
@@ -275,7 +279,7 @@
         <script src="scripts/directives/oscUnique.js"></script>
         <script src="scripts/directives/oscAutoscaling.js"></script>
         <script src="scripts/directives/oscSecrets.js"></script>
-        <script src="scripts/directives/oscSourceSecrets.js"></script> 
+        <script src="scripts/directives/oscSourceSecrets.js"></script>
         <script src="scripts/directives/replicas.js"></script>
         <script src="scripts/directives/resources.js"></script>
         <script src="scripts/directives/overviewDeployment.js"></script>
@@ -286,6 +290,7 @@
         <script src="scripts/directives/util.js"></script>
         <script src="scripts/directives/labels.js"></script>
         <script src="scripts/directives/lifecycleHook.js"></script>
+		<script src="scripts/directives/actionChip.js"></script>
         <script src="scripts/directives/templateopt.js"></script>
         <script src="scripts/directives/tasks.js"></script>
         <script src="scripts/directives/truncate.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -63,6 +63,11 @@ angular
         controller: 'MonitoringController',
         reloadOnSearch: false
       })
+      .when('/project/:project/membership', {
+        templateUrl: 'views/membership.html',
+        controller: 'MembershipController',
+        reloadOnSearch: false
+      })
       .when('/project/:project/browse', {
         redirectTo: function(params) {
           return '/project/' + encodeURIComponent(params.project) + "/browse/pods";  // TODO decide what subtab to default to here

--- a/app/scripts/constants.js
+++ b/app/scripts/constants.js
@@ -33,6 +33,11 @@ window.OPENSHIFT_CONSTANTS = {
     "custom_strategy":         "https://docs.openshift.org/latest/dev_guide/deployments.html#custom-strategy",
     "lifecycle_hooks":         "https://docs.openshift.org/latest/dev_guide/deployments.html#lifecycle-hooks",
     "new_pod_exec":            "https://docs.openshift.org/latest/dev_guide/deployments.html#pod-based-lifecycle-hook",
+    "authorization":           "https://docs.openshift.org/latest/architecture/additional_concepts/authorization.html",
+    "roles":                   "https://docs.openshift.org/latest/architecture/additional_concepts/authorization.html#roles",
+    "service_accounts":        "https://docs.openshift.org/latest/dev_guide/service_accounts.html",
+    "users_and_groups":        "https://docs.openshift.org/latest/architecture/additional_concepts/authentication.html#users-and-groups",
+    // default should remain last, add new links above
     "default":                 "https://docs.openshift.org/latest/welcome/index.html"
   },
   // Maps links names to URL's where the CLI tools can be downloaded, may point directly to files or to external pages in a CDN, for example.
@@ -161,6 +166,16 @@ window.OPENSHIFT_CONSTANTS = {
             {
               label: "Other Resources",
               href: "/browse/other"
+            },
+            {
+              label: "Membership",
+              href: "/membership",
+              // TODO: coming soon, canI filtering for nav.
+              // supports: {resource: '', verb: '', group: '' }
+              canI: {
+                resource: 'rolebindings',
+                verb: 'list'
+              }
             }
           ]
         }

--- a/app/scripts/controllers/membership.js
+++ b/app/scripts/controllers/membership.js
@@ -1,0 +1,324 @@
+'use strict';
+
+angular
+  .module('openshiftConsole')
+  .controller('MembershipController',
+    function(
+      $filter,
+      $location,
+      $routeParams,
+      $scope,
+      $timeout,
+      $uibModal,
+      AuthService,
+      AuthorizationService,
+      DataService,
+      ProjectsService,
+      MembershipService,
+      RoleBindingsService,
+      RolesService) {
+
+      var requestContext;
+      var projectName = $routeParams.project;
+      var humanizeKind = $filter('humanizeKind');
+      var annotation = $filter('annotation');
+
+      var allRoles = [];
+
+      // NOTE: these could all be moved out into a strings service.
+      var messages = {
+        errorReason: _.template('Reason: "<%- httpErr %>"'),
+        notice: {
+          yourLastRole: _.template('Removing the role "<%- roleName %>" may completely remove your ability to see this project.')
+        },
+        warning: {
+          serviceAccount: _.template('Removing a system role granted to a service account may cause unexpected behavior.')
+        },
+        remove: {
+          areYouSure: {
+            subject: _.template('Are you sure you want to remove <strong><%- roleName %></strong> from the <%- kindName %> <strong><%- subjectName %></strong>?'),
+            self: _.template('Are you sure you want to remove <strong><%- roleName %></strong> from <strong><%- subjectName %></strong> (you)?')
+          },
+          success: _.template('The role "<%- roleName %>" was removed from "<%- subjectName %>".'),
+          error: _.template('The role "<%- roleName %>" was not removed from "<%- subjectName %>".')
+        },
+        update: {
+          subject: {
+            success: _.template('The role "<%- roleName %>" was given to "<%- subjectName %>".'),
+            error: _.template('The role "<%- roleName %>" was not given to "<%- subjectName %>".')
+          }
+        }
+      };
+
+      // NOTE: alert service?
+      var showAlert = function(name, type, msg, detail, scope) {
+        scope = scope || $scope;
+        scope.alerts[name] = {
+          type: type,
+          message: msg,
+          details: detail
+        };
+      };
+
+      var resetForm = function() {
+        $scope.disableAddForm = false;
+        $scope.newBinding.name = '';
+        $scope.newBinding.namespace = projectName;
+        $scope.newBinding.newRole = null;
+      };
+
+      var refreshRoleBindingList = function() {
+        DataService
+          .list('rolebindings', requestContext, function(resp) {
+            angular.extend($scope, {
+              canShowRoles: true,
+              roleBindings: resp.by('metadata.name'),
+              subjectKindsForUI: MembershipService.mapRolebindingsForUI(resp.by('metadata.name'), allRoles)
+            });
+          }, {
+            errorNotification: false
+          });
+      };
+
+      var createBinding = function(role, newSubject) {
+        $scope.disableAddForm = true;
+
+        RoleBindingsService
+          .create(role, newSubject, projectName, requestContext)
+          .then(function() {
+            resetForm();
+            refreshRoleBindingList();
+            showAlert('rolebindingCreate', 'success', messages.update.subject.success({
+              roleName: role.metadata.name,
+              subjectName: _.escape(newSubject.name)
+            }));
+          }, function(err) {
+            resetForm();
+            showAlert('rolebindingCreateFail', 'error', messages.update.subject.error({
+              roleName: role.metadata.name,
+              subjectName: _.escape(newSubject.name)
+            }), messages.errorReason({httpErr: $filter('getErrorDetails')(err)}));
+          });
+      };
+
+      var updateBinding = function(rb, newSubject, projectName) {
+        $scope.disableAddForm = true;
+        RoleBindingsService
+          .addSubject(rb, newSubject, projectName, requestContext)
+          .then(function() {
+            resetForm();
+            refreshRoleBindingList();
+            showAlert('rolebindingUpdate', 'success', messages.update.subject.success({
+              roleName: rb.roleRef.name,
+              subjectName: _.escape(newSubject.name)
+            }));
+          }, function(err) {
+            resetForm();
+            showAlert('rolebindingUpdateFail', 'error', messages.update.subject.error({
+              roleName: rb.roleRef.name,
+              subjectName: _.escape(newSubject.name)
+            }), messages.errorReason({httpErr: $filter('getErrorDetails')(err)}));
+          });
+      };
+
+      var selectedTab = {};
+      if($routeParams.tab) {
+        selectedTab[$routeParams.tab] = true; // ex: tab=Group for Groups, pluralized in the template
+      }
+
+      var subjectKinds = MembershipService.getSubjectKinds();
+
+      // initial scope setup
+      angular.extend($scope, {
+        selectedTab: selectedTab,
+        projectName: projectName,
+        alerts: {},
+        forms: {},
+        emptyMessage: 'Loading...',
+        subjectKinds: subjectKinds,
+        newBinding: {
+          role: '',
+          kind: $routeParams.tab || 'User',
+          name: ''
+        },
+        toggleEditMode: function() {
+          resetForm();
+          $scope.mode.edit = !$scope.mode.edit;
+        },
+        mode: {
+          edit: false
+        },
+        selectTab: function(selected) {
+          $scope.newBinding.kind = selected;
+        }
+      });
+
+      // filter functions not generic enough to be created as standard filters
+      angular.extend($scope, {
+        excludeExistingRoles: function(subjectRoles) {
+          return function(role) {
+            return !_.some(subjectRoles, {kind: role.kind, metadata: {name: role.metadata.name}});
+          };
+        },
+        roleHelp: function(role) {
+          if(!role) {
+            return;
+          }
+          var noInfoMessage = 'There is no additional information about this role.';
+          var namespace = _.get(role, 'metadata.namespace');
+          var name = _.get(role, 'metadata.name');
+          var prefix = namespace ? (namespace + ' / ' + name + ': ') : '';
+          return role ?
+                  prefix + (annotation(role, 'description') || noInfoMessage) :
+                  noInfoMessage;
+        }
+      });
+
+      var createModalScope = function(subjectName, kind, roleName, currentUserName) {
+        var modalScope = {
+          alerts: {},
+          detailsMarkup: messages.remove.areYouSure.subject({
+            roleName: roleName,
+            kindName: humanizeKind(kind),
+            subjectName:  _.escape(subjectName)
+          }),
+          okButtonText: 'Remove',
+          okButtonClass: 'btn-danger',
+          cancelButtonText: 'Cancel'
+        };
+        if(_.isEqual(subjectName, currentUserName)) {
+          modalScope.details = messages.remove.areYouSure.self({
+            roleName: roleName,
+            subjectName: _.escape(subjectName)
+          });
+          if(MembershipService.isLastRole($scope.user.metadata.name, $scope.roleBindings)) {
+            showAlert('currentUserLastRole', 'error', messages.notice.yourLastRole({roleName: roleName}), null, modalScope);
+          }
+        }
+        if(_.isEqual(kind, 'ServiceAccount') && _.startsWith(roleName, 'system:')) {
+          showAlert('editingServiceAccountRole', 'error', messages.warning.serviceAccount(), null, modalScope);
+        }
+        return modalScope;
+      };
+
+      AuthService
+        .withUser()
+        .then(function(resp) {
+          $scope.user = resp;
+        });
+
+
+      DataService.list('projects', {}, function(resp) {
+        angular.extend($scope, {
+          projects: _.map(resp.by('metadata.name'), function(project) {
+            return project.metadata.name;
+          })
+        });
+      });
+
+      ProjectsService
+        .get($routeParams.project)
+        .then(_.spread(function(project, context) {
+          requestContext = context;
+          refreshRoleBindingList();
+          angular.extend($scope, {
+            project: project,
+            subjectKinds: subjectKinds,
+            confirmRemove: function(subjectName, kindName, roleName) {
+              var redirectToProjectList = null;
+              var modalScope = createModalScope(subjectName, kindName, roleName, $scope.user.metadata.name);
+              if(_.isEqual(subjectName, $scope.user.metadata.name)) {
+                if(MembershipService.isLastRole($scope.user.metadata.name, $scope.roleBindings)) {
+                  redirectToProjectList = true;
+                }
+              }
+              $uibModal.open({
+                animation: true,
+                templateUrl: 'views/modals/confirm.html',
+                controller: 'ConfirmModalController',
+                resolve: {
+                  modalConfig: function() {
+                    return modalScope;
+                  }
+                }
+              })
+              .result.then(function() {
+                RoleBindingsService
+                  .removeSubject(subjectName, roleName, $scope.roleBindings, requestContext)
+                  .then(function() {
+                    if(redirectToProjectList) {
+                      $location.url("./");
+                    } else {
+                      refreshRoleBindingList();
+                      showAlert('rolebindingUpdate', 'success', messages.remove.success({
+                        roleName: roleName,
+                        subjectName: _.escape(subjectName)
+                      }));
+                    }
+                  }, function(err) {
+                    showAlert('rolebindingUpdateFail', 'error', messages.remove.error({
+                      roleName: roleName,
+                      subjectName: _.escape(subjectName)
+                    }),  messages.errorReason({
+                      httpErr: $filter('getErrorDetails')(err)
+                    }));
+                  });
+              });
+            },
+            // subjectNamespace is only needed for service accounts, thus it is last and optional
+            addRoleTo:function(subjectName, subjectKind, role, subjectNamespace) {
+              var subject = {
+                name: subjectName,
+                kind: subjectKind,
+                namespace: subjectNamespace
+              };
+              // TODO (bpeterse): future. Role/ClusterRole roleRef disambiguation
+              // Edge case a user creates a local Role with same name as ClusterRole,
+              // roleRef doesn't necessarily contain namespace. There may be a way to
+              // infer this, but isn't clear at the moment.  Will fast-follow PR if
+              // a good solution is found.
+              var rolebindingToUpdate = _.find($scope.roleBindings, {roleRef: {name: role.metadata.name}});
+
+              if(rolebindingToUpdate) {
+                return updateBinding(rolebindingToUpdate, subject, subjectNamespace);
+              }
+              return createBinding(role, subject, subjectNamespace);
+            }
+          });
+
+          // both clusterRoles and local roles are needed, though local are rare
+          RolesService
+            .listAllRoles(requestContext, {
+              errorNotification: false
+            })
+            .then(function(resp) {
+              // TODO: this should be by UID, not by Kind-Name, would be less janky.
+              // The only catch is matching them up w/Rolebindings, which do not have
+              // the UID
+              allRoles = MembershipService.mapRolesForUI(_.first(resp), _.last(resp));
+              var sortedRoles = MembershipService.sortRoles(allRoles);
+              var filteredRoles = MembershipService.filterRoles(allRoles);
+              var includesRole = function(roleName, roles) {
+                return _.some(roles, { metadata: { name: roleName } });
+              };
+              refreshRoleBindingList();
+              angular.extend($scope, {
+                toggle: {
+                  roles: false
+                },
+                filteredRoles: filteredRoles,
+                showAllRoles: function() {
+                  $scope.toggle.roles = !$scope.toggle.roles;
+                  if($scope.toggle.roles) {
+                    $scope.filteredRoles = sortedRoles;
+                  } else {
+                    $scope.filteredRoles = filteredRoles;
+                    if(!includesRole($scope.newBinding.role, filteredRoles)) {
+                      $scope.newBinding.role = null;
+                    }
+                  }
+                }
+              });
+            });
+        }));
+    });

--- a/app/scripts/controllers/modals/confirmModal.js
+++ b/app/scripts/controllers/modals/confirmModal.js
@@ -12,7 +12,10 @@ angular.module('openshiftConsole')
   .controller('ConfirmModalController', function($scope,
                                                  $uibModalInstance,
                                                  modalConfig) {
-
+    // content supplied in the following forms:
+    // heading: modalConfig.message
+    // content: modalConfig.details (plain text ONLY, no user imput)
+    // content: modalConfig.detailsHtml (pre-sanitized, see _.escape() or _.template('<%- %>') )
     _.extend($scope, modalConfig);
 
     $scope.confirm = function() {

--- a/app/scripts/directives/actionChip.js
+++ b/app/scripts/directives/actionChip.js
@@ -1,0 +1,36 @@
+'use strict';
+// <div>
+//   <div>Chips</div>
+//   <div row mobile="column">
+//     <action-chip
+//       key="'1'"></action-chip>
+//     <action-chip
+//       key="'2'"
+//       value="'foo'"></action-chip>
+//     <action-chip
+//       key="'3'"
+//       action="foo('shizzle', 'pop')"></action-chip>
+//     <action-chip
+//       key="'4'"
+//       value="'bar'"
+//       icon="'fa fa-check'"
+//       action="foo('shizzle', 'pop2')"></action-chip>
+//   </div>
+// </div>
+angular
+  .module('openshiftConsole')
+  .directive('actionChip', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        key: '=?',
+        value: '=?',
+        keyHelp: '=?',
+        valueHelp: '=?',
+        action: '&?',     // callback fn,
+        actionIcon: '=?', // default is pficon pficon-close
+        showAction: '=?'  // bool to show-hide the action button
+      },
+      templateUrl: 'views/directives/action-chip.html'
+    };
+  });

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -129,6 +129,7 @@ angular.module('openshiftConsole')
       return displayName;
     };
   })
+  // TODO: must wrap this filter in ng-if="project" or it will not update
   .filter('canI', function(AuthorizationService) {
     return function(resource, verb, projectName) {
       return AuthorizationService.canI(resource, verb, projectName);

--- a/app/scripts/services/membership/membership.js
+++ b/app/scripts/services/membership/membership.js
@@ -1,0 +1,150 @@
+'use strict';
+
+angular
+  .module('openshiftConsole')
+  .factory('MembershipService', function($filter) {
+
+    var annotation = $filter('annotation');
+
+    var isLastRole = function(userName, roleBindings) {
+      return _.filter(
+              roleBindings,
+              function(binding) {
+                return _.some(binding.subjects, { name: userName });
+              }).length === 1;
+    };
+
+    // internal helper to disambiguate objects with same name, etc:
+    //  - Role view
+    //  - ClusterRole view
+    // arbitrary key creation via any number of provided arguments
+    // examples:
+    //  - uniqueKey(subject.kind, subject.name) = user-foo
+    //  - uniqueKey(role.namespace, role.name) = proj-1-view
+    var uniqueKey = function() {
+      return _.reduce(
+              _.slice(arguments),
+              function(result, next, i) {
+                return next ?
+                      _.isEqual(i, 0) ?
+                        next :
+                        result + '-' + next :
+                      result;
+              }, '');
+    };
+
+    var getSubjectKinds = function() {
+      return {
+         "User":{
+            "kind":"User",
+            "sortOrder":1,
+            "name":"User",
+            "subjects":{
+
+            }
+         },
+         "Group":{
+            "kind":"Group",
+            "sortOrder":2,
+            "name":"Group",
+            "subjects":{
+
+            }
+         },
+         "ServiceAccount":{
+            "kind":"ServiceAccount",
+            "sortOrder":3,
+            "description":"Service accounts provide a flexible way to control API access without sharing a regular user’s credentials.",
+            "helpLinkKey":"service_accounts",
+            "name":"ServiceAccount",
+            "subjects":{
+
+            }
+         },
+         "SystemUser":{
+            "kind":"SystemUser",
+            "sortOrder":4,
+            "description":"System users are virtual users automatically provisioned by the system.",
+            "helpLinkKey":"users_and_groups",
+            "name":"SystemUser",
+            "subjects":{
+
+            }
+         },
+         "SystemGroup":{
+            "kind":"SystemGroup",
+            "sortOrder":5,
+            "description":"System groups are virtual groups automatically provisioned by the system.",
+            "helpLinkKey":"users_and_groups",
+            "name":"SystemGroup",
+            "subjects":{
+
+            }
+         }
+      };
+    };
+
+    var mapRolebindingsForUI =  function(rolebindings, roles) {
+      var mapForUI = _.reduce(
+                      rolebindings,
+                      function(result, rolebinding) {
+                        // hmm. dont like this here
+                        var roleKey = uniqueKey(rolebinding.roleRef.namespace ? 'Role' : 'ClusterRole', rolebinding.roleRef.name);
+                        // each subject, (user, bob; group: hobbits)
+                        _.each(rolebinding.subjects, function(subject) {
+                          var subjectKey = uniqueKey(subject.namespace, subject.name);
+                          if(!result[subject.kind].subjects[subjectKey]) {
+                            result[subject.kind].subjects[subjectKey]  = {
+                              name: subject.name,
+                              namespace: subject.namespace,
+                              roles: {}
+                            };
+                          }
+                          if(!_.includes(result[subject.kind].subjects[subjectKey].roles, roleKey)) {
+                            result[subject.kind].subjects[subjectKey].roles[roleKey] = roles[roleKey];
+                          }
+                        });
+                        return result;
+                      },
+                      getSubjectKinds());
+      return _.sortBy(mapForUI, 'sortOrder');
+    };
+
+    var sortRoles = function(roles) {
+      return _.sortBy(roles, 'metadata.name');
+    };
+
+    // TODO: follow-on PR, there will be an annotation for this
+    var filterRoles = function(roles) {
+      return _.filter(roles, function(item) {
+        // image-puller & image-pusher ok, other system: prob no
+        return (_.isEqual(item.metadata.name, 'system:image-puller')   ||
+                _.isEqual(item.metadata.name, 'system:image-pusher') ) ||
+                ! _.startsWith(item.metadata.name, 'cluster-') &&
+                ! _.startsWith(item.metadata.name, 'system:');
+      });
+    };
+
+    var keyedRoles = function(roles) {
+      return _.reduce(
+              roles,
+              function(result, role) {
+                result[uniqueKey(role.kind, role.metadata.name)] = role;
+                return result;
+              }, {});
+    };
+
+    var mapRolesForUI = function(roles, clusterRoles) {
+      return _.merge(keyedRoles(roles), keyedRoles(clusterRoles));
+    };
+
+    return {
+      sortRoles: sortRoles,
+      filterRoles: filterRoles,
+      mapRolesForUI: mapRolesForUI,
+      isLastRole: isLastRole,
+      getSubjectKinds: getSubjectKinds,
+      mapRolebindingsForUI: mapRolebindingsForUI
+    };
+
+  });

--- a/app/scripts/services/membership/roleBindings.js
+++ b/app/scripts/services/membership/roleBindings.js
@@ -1,0 +1,118 @@
+'use strict';
+
+angular
+  .module('openshiftConsole')
+  .factory('RoleBindingsService', function($q, DataService) {
+    // some API constraints worth nothing:
+    // ServiceAccountUsernamePrefix    = "system:serviceaccount:"
+    // ServiceAccountUsernameSeparator = ":"
+    // ServiceAccountGroupPrefix       = "system:serviceaccounts:"
+    // AllServiceAccountsGroup         = "system:serviceaccounts"
+
+    var cache = {};
+
+    // recurse until we get a unique binding name compared to what is cached
+    var qualifyBindingName = function(name, suffix) {
+      var search = suffix ?
+                name + suffix :
+                name;
+      return _.some(cache, _.matchesProperty('metadata.name', search)) ?
+              qualifyBindingName(name, _.uniqueId()) :
+              search;
+    };
+
+    var bindingTPL = function(role, projectNamespace) {
+      var roleName = _.get(role, 'metadata.name');
+      var bindingName = roleName ? qualifyBindingName(roleName) : null;
+      return {
+        kind: 'RoleBinding',
+        apiVersion: 'v1',
+        metadata: {
+          name: bindingName,
+          namespace: projectNamespace,
+        },
+        roleRef: {
+          name: _.get(role, 'metadata.name'),
+          // Roles have a namespace, clusterRoles do not
+          namespace:  _.get(role, 'metadata.namespace'),
+        },
+        subjects: []
+        // userNames & groupNames are legacy, do not use!
+        // we literally must null them out when we receive them
+      };
+    };
+
+    var qualifySubject = function(subject, namespace) {
+      // NOTE: so far, SAs are the only ones that need tweaking
+      if(_.isEqual(subject.kind, 'ServiceAccount')) {
+        subject.namespace = subject.namespace || namespace;
+      } else if(_.isEqual(subject.kind, 'SystemUser') || _.isEqual(subject.kind, 'SystemGroup')) {
+        if(!_.startsWith(subject.name, 'system:')) {
+          subject.name = 'system:'+subject.name;
+        }
+      }
+      return subject;
+    };
+
+    var cleanBinding = function(binding) {
+      // These generated lists must be removed to be regenerated
+      binding.userNames = null;
+      binding.groupNames = null;
+    };
+
+    var create = function(role, subject, namespace, context) {
+      var binding = bindingTPL(role, namespace);
+      subject = qualifySubject(subject, namespace);
+      binding.subjects.push(angular.copy(subject));
+      return DataService.create('rolebindings', null, binding, context);
+    };
+
+    var addSubject = function(rb, subject, namespace, context) {
+      var tpl = bindingTPL();
+      var binding = _.extend(tpl, rb);
+      if(!subject) {
+        return binding;
+      }
+      subject = qualifySubject(subject, namespace);
+      if(_.isArray(binding.subjects)) {
+        if(_.includes(binding.subjects, subject)) {
+          return; // nothing to see here, folks.
+        }
+        binding.subjects.push(subject);
+      } else {
+        binding.subjects = [subject];
+      }
+      cleanBinding(binding);
+      return DataService.update('rolebindings', binding.metadata.name, binding, context);
+    };
+
+    // has to handle multiple bindings or multiple reference to a subject within a single binding
+    var removeSubject = function(subjectName, role, roleBindings, context) {
+      var matches = _.filter(roleBindings, {roleRef: {name: role}});
+      return $q.all(
+        _.map(matches, function(binding) {
+          var tpl = bindingTPL();
+          binding = _.extend(tpl, binding);
+          cleanBinding(binding);
+          binding.subjects = _.reject(binding.subjects, {name: subjectName});
+          return binding.subjects.length ?
+                  DataService.update('rolebindings', binding.metadata.name, binding, context):
+                  DataService.delete('rolebindings', binding.metadata.name, context);
+        }));
+    };
+
+    var list = function(context, fn, opts) {
+      return DataService
+              .list('rolebindings', context, function(resp) {
+                cache = resp.by('metadata.name');
+                fn(resp);
+              }, opts);
+    };
+
+    return {
+      list: list,
+      create: create,
+      addSubject: addSubject,
+      removeSubject: removeSubject
+    };
+  });

--- a/app/scripts/services/membership/roles.js
+++ b/app/scripts/services/membership/roles.js
@@ -1,0 +1,41 @@
+'use strict';
+
+angular
+  .module('openshiftConsole')
+  .factory('RolesService', function($q, DataService) {
+
+    var listClusterRoles = function(cb, opts) {
+      DataService.list('clusterroles', {}, cb, opts);
+    };
+
+    var listRoles = function(context, cb, opts) {
+      DataService.list('roles', context, cb, opts);
+    };
+
+    // wraps the 2 API list calls in a promise for easier use, similar to above get()
+    var listAllRoles = function(context) {
+      var deferred = $q.defer();
+      var result = [];
+
+      var resolve = function(resp) {
+        result.push(resp.by('metadata.name'));
+        if(_.isEqual(result.length, 2)) {
+          deferred.resolve(result);
+        }
+      };
+
+      listRoles(context, function(resp) {
+        resolve(resp);
+      });
+      listClusterRoles(function(resp) {
+        resolve(resp);
+      });
+
+      return deferred.promise;
+    };
+
+
+    return {
+      listAllRoles: listAllRoles
+    };
+  });

--- a/app/styles/_action-chip.less
+++ b/app/styles/_action-chip.less
@@ -1,0 +1,64 @@
+.action-chip {
+  margin: 0 5px 2px 0;
+  font-size: 12px;
+  display: flex;
+  flex-direction: row;
+  .item {
+    padding: .2em .6em .3em;
+    // explicit radius as is possible 1 node will receive all rules
+    &:first-child {
+      border-top-left-radius: 2px;
+      border-bottom-left-radius: 2px;
+    }
+    &:last-child {
+      border-top-right-radius: 2px;
+      border-bottom-right-radius: 2px;
+    }
+    &:nth-child(3) {
+      border-left: 1px solid #f1f1f1;
+    }
+  }
+  .key {
+    background-color: #ededed;
+    color: #252525;
+  }
+  .value {
+    background-color: #bbb;
+    color: #FFFFFF;
+  }
+  .action {
+    background-color: #d1d1d1;
+    color: #FFFFFF;
+    &:hover {
+      background-color: #adadad;
+    }
+    i {
+      margin-top: 2px;
+    }
+  }
+}
+// <action-chip class="blue" for orig color scheme.
+// TODO: should be a better name
+.blue {
+  .action-chip {
+    .item {
+      &:nth-child(3) {
+        border-left: 1px solid #b2dcf3;
+      }
+    }
+    .key {
+      background-color: #bee1f4;
+      color: #00659c;
+    }
+    .value {
+      background-color: #7dc3e8;
+      color: #FFFFFF;
+    }
+    .action {
+      background-color: #7dc3e8;
+      &:hover {
+        background-color: #00659c;
+      }
+    }
+  }
+}

--- a/app/styles/_membership.less
+++ b/app/styles/_membership.less
@@ -1,0 +1,129 @@
+.membership {
+  .content-pane {
+    max-width: 1024px;
+    margin-top: 50px;
+    .col-add-role {
+      padding: 10px 0;
+      min-width: 150px;
+    }
+    .add-role-to {
+      margin-left: -1px;
+    }
+    .item-row,
+    .col-heading {
+      border-bottom: 1px solid #ededed;
+      h3 {
+        margin: 0;
+      }
+    }
+    .item-row {
+      padding: 5px 10px 5px 5px;
+      margin-bottom: 20px;
+    }
+    .col-heading {
+      margin-bottom: 20px;
+      .col-add-role {
+        h3 {
+          display: none;
+        }
+      }
+    }
+    .col-name {
+      min-width: 165px;
+      padding: 0 5px 10px 0;
+      word-wrap: break-word;
+      input {
+        max-width: 150px;
+      }
+      .new-project {
+        margin-top: 2px;
+      }
+    }
+    .form-new-role {
+      .col-roles {
+        display: none;
+      }
+    }
+    .content-serviceaccount {
+      .form-new-role {
+        .col-roles {
+          display: block;
+        }
+      }
+    }
+    .input-name {
+      width: 150px;
+      margin-bottom: 5px;
+    }
+    .select-project {
+      width: 150px;
+    }
+    .select-role {
+      width: 150px;
+      small {
+        color: #999;
+      }
+      .active {
+        small {
+          color: #c0e0f0;
+        }
+      }
+    }
+  }
+}
+
+
+@media(min-width: @screen-sm-min) {
+  .membership {
+    .content-pane {
+      .col-add-role {
+        padding: 0;
+        min-width: 245px;
+      }
+      .item-row,
+      .col-heading {
+        border-bottom: none;
+        margin-bottom: none;
+      }
+      .item-row.highlight-hover:hover {
+        background-color: #fafafa;
+      }
+      .col-heading {
+        .col-add-role {
+          h3 {
+            display: block;
+          }
+          a {
+            display: block;
+            padding-left: 10px;
+          }
+        }
+      }
+      .col-name {
+        min-width: 180px;
+        input {
+          max-width: 175px;
+        }
+      }
+      .form-new-role {
+        .col-roles {
+          display: block;
+        }
+      }
+    }
+  }
+}
+
+
+// FIXME (bpeterse): to update in layout.attrs & eliminate the workaround here
+// fix for collapse of flex items in IE
+// https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored
+[flex-collapse-fix],
+.item-row,
+.col-heading,
+.col-name,
+.col-roles,
+.col-add-role {
+  //flex-shrink: 0;
+  flex-basis: auto;
+}

--- a/app/styles/_select.less
+++ b/app/styles/_select.less
@@ -20,10 +20,15 @@
         color: @dropdown-link-hover-color;
       }
     }
-    &.active > span {
-      background-color: @dropdown-link-active-bg !important;
-      border-color: @dropdown-link-active-border-color !important;
-      color: @dropdown-link-active-color;
+    &.active {
+      > span {
+        background-color: @dropdown-link-active-bg !important;
+        border-color: @dropdown-link-active-border-color !important;
+        color: @dropdown-link-active-color;
+      }
+      .text-muted {
+        color: #f5f5f5;
+      }
     }
   }
   .ui-select-choices-row-inner {

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -44,3 +44,5 @@
 @import "_patternfly-additions.less";
 @import "_container-terminal.less";
 @import "_kve.less";
+@import "_membership.less";
+@import "_action-chip.less";

--- a/app/views/directives/action-chip.html
+++ b/app/views/directives/action-chip.html
@@ -1,0 +1,44 @@
+<span class="action-chip">
+
+  <span
+    ng-if="key && !(keyHelp)"
+    class="item key truncate">
+    {{key}}
+  </span>
+
+  <a
+    ng-if="key && keyHelp"
+    href=""
+    class="item key truncate"
+    data-toggle="popover"
+    data-trigger="focus"
+    data-content="{{keyHelp}}">
+    {{key}}
+  </a>
+
+  <span
+    ng-if="value && !(valueHelp)"
+    class="item value truncate">
+    {{value}}
+  </span>
+
+  <a
+    ng-if="value && valueHelp"
+    href=""
+    class="item value truncate"
+    data-toggle="popover"
+    data-trigger="focus"
+    data-content="{{valueHelp}}">
+    {{value}}
+  </a>
+
+  <a
+    href=""
+    class="item action"
+    ng-if="showAction"
+    ng-click="action()"
+    ng-attr-title="actionTitle">
+    <i ng-class="icon || 'pficon pficon-close'"></i>
+  </a>
+
+</span>

--- a/app/views/membership.html
+++ b/app/views/membership.html
@@ -1,0 +1,301 @@
+<project-header class="top-header"></project-header>
+<project-page class="membership" ng-if="project">
+
+  <div class="middle-section">
+    <div class="middle-container">
+      <div class="middle-header">
+        <div class="container-fluid">
+          <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
+        </div>
+      </div>
+      <div class="middle-content" persist-tab-state>
+        <div class="container-fluid">
+          <div class="row">
+            <div class="col-md-12">
+              <h1>
+                <a
+                  class="pull-right btn btn-default"
+                  href=""
+                  ng-if="'rolebindings' | canI : 'update'"
+                  ng-click="toggleEditMode()">
+                  <span ng-if="!(mode.edit)">Edit Membership</span>
+                  <span ng-if="mode.edit">Done Editing</span>
+                </a>
+                 Membership
+              </h1>
+              <span class="learn-more-block">
+                <a ng-href="{{'roles' | helpLink}}">
+                  Learn more <i class="fa fa-external-link"></i>
+                </a>
+              </span>
+              <alerts alerts="alerts"></alerts>
+            </div>
+          </div>
+          <div  ng-if="!('rolebindings' | canI : 'list')">
+            <p>You do not have permission to view roles in this project.</p>
+          </div>
+          <uib-tabset
+            ng-if="'rolebindings' | canI : 'list'">
+            <uib-tab
+              ng-repeat="subjectKind in subjectKindsForUI | orderBy: 'sortOrder'"
+              active="selectedTab[subjectKind.name]"
+              select="selectTab(subjectKind.name)">
+              <uib-tab-heading>
+                {{subjectKind.name | startCase}}s&nbsp;({{subjectKind.subjects | hashSize}})
+              </uib-tab-heading>
+              <div ng-if="subjectKind.description">
+                <p>
+                  {{subjectKind.description}}
+                  <a
+                    ng-if="subjectKind.helpLinkKey"
+                    target="_blank"
+                    ng-href="{{subjectKind.helpLinkKey | helpLink}}"
+                    class="learn-more-inline">
+                    Learn more <i class="fa fa-external-link"></i>
+                  </a>
+                </p>
+              </div>
+              <div
+                column
+                class="content-pane"
+                ng-class="'content-' + subjectKind.name.toLowerCase()">
+
+                <div
+                  class="col-heading item-row"
+                  row mobile="column" tablet="column" flex-collapse-fix>
+                  <div row flex flex-collapse-fix>
+                    <div class="col-name" conceal="mobile">
+                      <h3>Name</h3>
+                    </div>
+                    <div class="col-roles" flex conceal="mobile">
+                      <h3>Roles</h3>
+                    </div>
+                  </div>
+                  <div class="col-add-role" flex-collapse-fix>
+                    <h3
+                      ng-show="mode.edit">
+                      Add another role
+                    </h3>
+                  </div>
+                </div>
+
+                <div ng-if="(subjectKind.subjects | hashSize) === 0">
+                  <p>
+                    <em>There are no {{ subjectKind.name | humanizeKind }}s with access to this project.</em>
+                  </p>
+                </div>
+                <div
+                  ng-repeat="subject in subjectKind.subjects"
+                  class="item-row highlight-hover"
+                  row mobile="column">
+                  <div class="col-name" row cross-axis="center">
+                    <a
+                      ng-if="subject.namespace"
+                      target="_blank"
+                      ng-href="project/{{project.metadata.name}}/browse/other?kind=ServiceAccount">
+                      <span>
+                        {{subject.namespace}} /
+                      </span>
+                      <strong>
+                        {{subject.name}}
+                      </strong>
+                    </a>
+                    <span ng-if="!subject.namespace">
+                      <strong>
+                        {{subject.name}}
+                      </strong>
+                      <span
+                        class="current-user"
+                        ng-if="subject.name === user.metadata.name">
+                        (you)
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="action-set"
+                    flex row tablet="column" mobile="column">
+                    <div
+                      class="col-roles"
+                      row tablet="column" flex wrap axis="start">
+                      <action-chip
+                        ng-repeat="role in subject.roles"
+                        key="role.metadata.name"
+                        key-help="roleHelp(role)"
+                        show-action="mode.edit"
+                        action="confirmRemove(subject.name, subjectKind.name, role.metadata.name)"
+                        action-title="remove role {{role}} from {{subject.name}}"></action-chip>
+                    </div>
+                    <div
+                      class="col-add-role">
+                      <div ng-show="mode.edit" row>
+                        <ui-select
+                          ng-if="filteredRoles.length"
+                          ng-model="subject.newRole"
+                          theme="bootstrap"
+                          search-enabled="true"
+                          title="Select a new role for {{subjectKind.name}}"
+                          class="select-role"
+                          flex>
+                          <ui-select-match
+                            placeholder="Select a role">
+                            <span ng-bind="subject.newRole.metadata.name"></span>
+                          </ui-select-match>
+                          <ui-select-choices
+                            repeat="role as role in filteredRoles | filter: excludeExistingRoles(subject.roles) | filter: $select.search | orderBy: 'metadata.name'">
+                            <div>{{ role.metadata.name }}</div>
+                            <div ng-if="role | annotation : 'description'">
+                              <small>{{role | annotation : 'description'}}</small>
+                            </div>
+                          </ui-select-choices>
+                        </ui-select>
+                        <a
+                          href=""
+                          ng-disabled="disableAddForm || (!subject.newRole)"
+                          ng-click="addRoleTo(subject.name, subjectKind.name, subject.newRole)"
+                          class="btn btn-default add-role-to">
+                          Add
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <ng-form
+                  class="new-binding"
+                  novalidate
+                  name="forms.newBindingForm"
+                  ng-if="newBinding">
+                  <div
+                    ng-if="mode.edit"
+                    class="item-row form-new-role" row mobile="column">
+                    <div class="col-name" column>
+                      <label
+                        ng-attr-for="newBindingName"
+                        class="sr-only">
+                        Name
+                      </label>
+                      <input
+                        type="text"
+                        class="form-control input-name"
+                        placeholder="Name"
+                        ng-model="newBinding.name">
+                      <div
+                        ng-if="newBinding.kind === 'ServiceAccount'"
+                        class="service-account-namespace hidden-sm hidden-md hidden-lg"
+                        aria-hidden="true">
+                        <ui-select
+                          ng-model="newBinding.namespace"
+                          theme="bootstrap"
+                          search-enabled="true"
+                          title="Select a project"
+                          class="select-role">
+                          <ui-select-match
+                            placeholder="Select a project">
+                            <span ng-bind="newBinding.namespace"></span>
+                          </ui-select-match>
+                          <ui-select-choices
+                            repeat="projectName in projects | filter: $select.search">
+                            <div>{{projectName}}</div>
+                          </ui-select-choices>
+                        </ui-select>
+                      </div>
+                    </div>
+                    <div
+                      class="action-set"
+                      flex row tablet="column" mobile="column">
+                      <div
+                        class="col-roles"
+                        row tablet="column" flex wrap axis="start">
+                        <div
+                          ng-if="newBinding.kind === 'ServiceAccount'"
+                          class="service-account-namespace hidden-xs">
+                          <ui-select
+                            ng-model="newBinding.namespace"
+                            theme="bootstrap"
+                            search-enabled="true"
+                            title="Select a project"
+                            class="select-project">
+                            <ui-select-match
+                              placeholder="Select a project">
+                              <span ng-bind="newBinding.namespace"></span>
+                            </ui-select-match>
+                            <ui-select-choices
+                              repeat="projectName in projects | filter: $select.search">
+                              <div>{{projectName}}</div>
+                            </ui-select-choices>
+                          </ui-select>
+                        </div>
+                      </div>
+                      <div class="col-add-role">
+                        <div ng-show="mode.edit" row>
+                          <ui-select
+                            ng-if="filteredRoles.length"
+                            ng-model="newBinding.newRole"
+                            theme="bootstrap"
+                            search-enabled="true"
+                            title="new {{subjectKind.name}} role"
+                            class="select-role"
+                            flex>
+                            <ui-select-match
+                              placeholder="Select a role">
+                              <span ng-bind="newBinding.newRole.metadata.name"></span>
+                            </ui-select-match>
+                            <ui-select-choices
+                              repeat="role as role in filteredRoles | filter: $select.search">
+                              <div>{{ role.metadata.name }}</div>
+                              <div ng-if="role | annotation : 'description'">
+                                <small>{{role | annotation : 'description'}}</small>
+                              </div>
+                            </ui-select-choices>
+                          </ui-select>
+                          <a
+                            href=""
+                            ng-disabled="disableAddForm || (!newBinding.name) || (!newBinding.newRole)"
+                            ng-click="addRoleTo(newBinding.name, newBinding.kind, newBinding.newRole, newBinding.namespace)"
+                            class="btn btn-default add-role-to">
+                            Add
+                          </a>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </ng-form>
+
+                <div
+                  ng-if="mode.edit"
+                  class="item-row"
+                  row mobile="column">
+                  <div class="col-name hidden-xs">&nbsp;</div>
+                  <div
+                    class="action-set"
+                    flex row tablet="column" mobile="column">
+                    <div class="col-roles hidden-xs" flex>&nbsp;</div>
+                    <div class="col-add-role" row>
+                      <input
+                        id="show-hidden-roles"
+                        type="checkbox"
+                        class="toggle-hidden"
+                        ng-click="showAllRoles($event)">
+                        &nbsp;
+                      <label for="show-hidden-roles">
+                        Show hidden roles
+                      </label>
+                      <a
+                        href=""
+                        class="action-inline"
+                        data-toggle="popover"
+                        data-trigger="focus"
+                        data-content="System roles are hidden by default and do not typically need to be managed.">
+                        <i class="pficon pficon-help"></i>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </uib-tab>
+          </uib-tabset>
+        </div>
+      </div>
+    </div>
+  </div>
+</project-page>

--- a/app/views/modals/confirm.html
+++ b/app/views/modals/confirm.html
@@ -1,8 +1,9 @@
 <div class="modal-resource-action">
   <div class="modal-body">
     <h1>{{message}}</h1>
-    <alerts ng-if="alerts" alerts="alerts" hide-close-button="true"></alerts>
     <p ng-if="details">{{details}}</p>
+    <p ng-if="detailsMarkup" ng-bind-html="detailsMarkup"></p>
+    <alerts ng-if="alerts" alerts="alerts" hide-close-button="true"></alerts>
   </div>
   <div class="modal-footer">
     <button class="btn btn-lg" ng-class="okButtonClass" type="button" ng-click="confirm()">{{okButtonText}}</button>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4905,6 +4905,27 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/directives/action-chip.html',
+    "<span class=\"action-chip\">\n" +
+    "<span ng-if=\"key && !(keyHelp)\" class=\"item key truncate\">\n" +
+    "{{key}}\n" +
+    "</span>\n" +
+    "<a ng-if=\"key && keyHelp\" href=\"\" class=\"item key truncate\" data-toggle=\"popover\" data-trigger=\"focus\" data-content=\"{{keyHelp}}\">\n" +
+    "{{key}}\n" +
+    "</a>\n" +
+    "<span ng-if=\"value && !(valueHelp)\" class=\"item value truncate\">\n" +
+    "{{value}}\n" +
+    "</span>\n" +
+    "<a ng-if=\"value && valueHelp\" href=\"\" class=\"item value truncate\" data-toggle=\"popover\" data-trigger=\"focus\" data-content=\"{{valueHelp}}\">\n" +
+    "{{value}}\n" +
+    "</a>\n" +
+    "<a href=\"\" class=\"item action\" ng-if=\"showAction\" ng-click=\"action()\" ng-attr-title=\"actionTitle\">\n" +
+    "<i ng-class=\"icon || 'pficon pficon-close'\"></i>\n" +
+    "</a>\n" +
+    "</span>"
+  );
+
+
   $templateCache.put('views/directives/annotations.html',
     "<div ng-if=\"annotations\" class=\"gutter-top-bottom\">\n" +
     "<a href=\"\" ng-click=\"toggleAnnotations()\" ng-if=\"annotations && !expandAnnotations\">Show annotations</a>\n" +
@@ -8212,6 +8233,194 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/membership.html',
+    "<project-header class=\"top-header\"></project-header>\n" +
+    "<project-page class=\"membership\" ng-if=\"project\">\n" +
+    "<div class=\"middle-section\">\n" +
+    "<div class=\"middle-container\">\n" +
+    "<div class=\"middle-header\">\n" +
+    "<div class=\"container-fluid\">\n" +
+    "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"middle-content\" persist-tab-state>\n" +
+    "<div class=\"container-fluid\">\n" +
+    "<div class=\"row\">\n" +
+    "<div class=\"col-md-12\">\n" +
+    "<h1>\n" +
+    "<a class=\"pull-right btn btn-default\" href=\"\" ng-if=\"'rolebindings' | canI : 'update'\" ng-click=\"toggleEditMode()\">\n" +
+    "<span ng-if=\"!(mode.edit)\">Edit Membership</span>\n" +
+    "<span ng-if=\"mode.edit\">Done Editing</span>\n" +
+    "</a>\n" +
+    "Membership\n" +
+    "</h1>\n" +
+    "<span class=\"learn-more-block\">\n" +
+    "<a ng-href=\"{{'roles' | helpLink}}\">\n" +
+    "Learn more <i class=\"fa fa-external-link\"></i>\n" +
+    "</a>\n" +
+    "</span>\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div ng-if=\"!('rolebindings' | canI : 'list')\">\n" +
+    "<p>You do not have permission to view roles in this project.</p>\n" +
+    "</div>\n" +
+    "<uib-tabset ng-if=\"'rolebindings' | canI : 'list'\">\n" +
+    "<uib-tab ng-repeat=\"subjectKind in subjectKindsForUI | orderBy: 'sortOrder'\" active=\"selectedTab[subjectKind.name]\" select=\"selectTab(subjectKind.name)\">\n" +
+    "<uib-tab-heading>\n" +
+    "{{subjectKind.name | startCase}}s&nbsp;({{subjectKind.subjects | hashSize}})\n" +
+    "</uib-tab-heading>\n" +
+    "<div ng-if=\"subjectKind.description\">\n" +
+    "<p>\n" +
+    "{{subjectKind.description}}\n" +
+    "<a ng-if=\"subjectKind.helpLinkKey\" target=\"_blank\" ng-href=\"{{subjectKind.helpLinkKey | helpLink}}\" class=\"learn-more-inline\">\n" +
+    "Learn more <i class=\"fa fa-external-link\"></i>\n" +
+    "</a>\n" +
+    "</p>\n" +
+    "</div>\n" +
+    "<div column class=\"content-pane\" ng-class=\"'content-' + subjectKind.name.toLowerCase()\">\n" +
+    "<div class=\"col-heading item-row\" row mobile=\"column\" tablet=\"column\" flex-collapse-fix>\n" +
+    "<div row flex flex-collapse-fix>\n" +
+    "<div class=\"col-name\" conceal=\"mobile\">\n" +
+    "<h3>Name</h3>\n" +
+    "</div>\n" +
+    "<div class=\"col-roles\" flex conceal=\"mobile\">\n" +
+    "<h3>Roles</h3>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"col-add-role\" flex-collapse-fix>\n" +
+    "<h3 ng-show=\"mode.edit\">\n" +
+    "Add another role\n" +
+    "</h3>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div ng-if=\"(subjectKind.subjects | hashSize) === 0\">\n" +
+    "<p>\n" +
+    "<em>There are no {{ subjectKind.name | humanizeKind }}s with access to this project.</em>\n" +
+    "</p>\n" +
+    "</div>\n" +
+    "<div ng-repeat=\"subject in subjectKind.subjects\" class=\"item-row highlight-hover\" row mobile=\"column\">\n" +
+    "<div class=\"col-name\" row cross-axis=\"center\">\n" +
+    "<a ng-if=\"subject.namespace\" target=\"_blank\" ng-href=\"project/{{project.metadata.name}}/browse/other?kind=ServiceAccount\">\n" +
+    "<span>\n" +
+    "{{subject.namespace}} /\n" +
+    "</span>\n" +
+    "<strong>\n" +
+    "{{subject.name}}\n" +
+    "</strong>\n" +
+    "</a>\n" +
+    "<span ng-if=\"!subject.namespace\">\n" +
+    "<strong>\n" +
+    "{{subject.name}}\n" +
+    "</strong>\n" +
+    "<span class=\"current-user\" ng-if=\"subject.name === user.metadata.name\">\n" +
+    "(you)\n" +
+    "</span>\n" +
+    "</span>\n" +
+    "</div>\n" +
+    "<div class=\"action-set\" flex row tablet=\"column\" mobile=\"column\">\n" +
+    "<div class=\"col-roles\" row tablet=\"column\" flex wrap axis=\"start\">\n" +
+    "<action-chip ng-repeat=\"role in subject.roles\" key=\"role.metadata.name\" key-help=\"roleHelp(role)\" show-action=\"mode.edit\" action=\"confirmRemove(subject.name, subjectKind.name, role.metadata.name)\" action-title=\"remove role {{role}} from {{subject.name}}\"></action-chip>\n" +
+    "</div>\n" +
+    "<div class=\"col-add-role\">\n" +
+    "<div ng-show=\"mode.edit\" row>\n" +
+    "<ui-select ng-if=\"filteredRoles.length\" ng-model=\"subject.newRole\" theme=\"bootstrap\" search-enabled=\"true\" title=\"Select a new role for {{subjectKind.name}}\" class=\"select-role\" flex>\n" +
+    "<ui-select-match placeholder=\"Select a role\">\n" +
+    "<span ng-bind=\"subject.newRole.metadata.name\"></span>\n" +
+    "</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"role as role in filteredRoles | filter: excludeExistingRoles(subject.roles) | filter: $select.search | orderBy: 'metadata.name'\">\n" +
+    "<div>{{ role.metadata.name }}</div>\n" +
+    "<div ng-if=\"role | annotation : 'description'\">\n" +
+    "<small>{{role | annotation : 'description'}}</small>\n" +
+    "</div>\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "<a href=\"\" ng-disabled=\"disableAddForm || (!subject.newRole)\" ng-click=\"addRoleTo(subject.name, subjectKind.name, subject.newRole)\" class=\"btn btn-default add-role-to\">\n" +
+    "Add\n" +
+    "</a>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<ng-form class=\"new-binding\" novalidate name=\"forms.newBindingForm\" ng-if=\"newBinding\">\n" +
+    "<div ng-if=\"mode.edit\" class=\"item-row form-new-role\" row mobile=\"column\">\n" +
+    "<div class=\"col-name\" column>\n" +
+    "<label ng-attr-for=\"newBindingName\" class=\"sr-only\">\n" +
+    "Name\n" +
+    "</label>\n" +
+    "<input type=\"text\" class=\"form-control input-name\" placeholder=\"Name\" ng-model=\"newBinding.name\">\n" +
+    "<div ng-if=\"newBinding.kind === 'ServiceAccount'\" class=\"service-account-namespace hidden-sm hidden-md hidden-lg\" aria-hidden=\"true\">\n" +
+    "<ui-select ng-model=\"newBinding.namespace\" theme=\"bootstrap\" search-enabled=\"true\" title=\"Select a project\" class=\"select-role\">\n" +
+    "<ui-select-match placeholder=\"Select a project\">\n" +
+    "<span ng-bind=\"newBinding.namespace\"></span>\n" +
+    "</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"projectName in projects | filter: $select.search\">\n" +
+    "<div>{{projectName}}</div>\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"action-set\" flex row tablet=\"column\" mobile=\"column\">\n" +
+    "<div class=\"col-roles\" row tablet=\"column\" flex wrap axis=\"start\">\n" +
+    "<div ng-if=\"newBinding.kind === 'ServiceAccount'\" class=\"service-account-namespace hidden-xs\">\n" +
+    "<ui-select ng-model=\"newBinding.namespace\" theme=\"bootstrap\" search-enabled=\"true\" title=\"Select a project\" class=\"select-project\">\n" +
+    "<ui-select-match placeholder=\"Select a project\">\n" +
+    "<span ng-bind=\"newBinding.namespace\"></span>\n" +
+    "</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"projectName in projects | filter: $select.search\">\n" +
+    "<div>{{projectName}}</div>\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"col-add-role\">\n" +
+    "<div ng-show=\"mode.edit\" row>\n" +
+    "<ui-select ng-if=\"filteredRoles.length\" ng-model=\"newBinding.newRole\" theme=\"bootstrap\" search-enabled=\"true\" title=\"new {{subjectKind.name}} role\" class=\"select-role\" flex>\n" +
+    "<ui-select-match placeholder=\"Select a role\">\n" +
+    "<span ng-bind=\"newBinding.newRole.metadata.name\"></span>\n" +
+    "</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"role as role in filteredRoles | filter: $select.search\">\n" +
+    "<div>{{ role.metadata.name }}</div>\n" +
+    "<div ng-if=\"role | annotation : 'description'\">\n" +
+    "<small>{{role | annotation : 'description'}}</small>\n" +
+    "</div>\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "<a href=\"\" ng-disabled=\"disableAddForm || (!newBinding.name) || (!newBinding.newRole)\" ng-click=\"addRoleTo(newBinding.name, newBinding.kind, newBinding.newRole, newBinding.namespace)\" class=\"btn btn-default add-role-to\">\n" +
+    "Add\n" +
+    "</a>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</ng-form>\n" +
+    "<div ng-if=\"mode.edit\" class=\"item-row\" row mobile=\"column\">\n" +
+    "<div class=\"col-name hidden-xs\">&nbsp;</div>\n" +
+    "<div class=\"action-set\" flex row tablet=\"column\" mobile=\"column\">\n" +
+    "<div class=\"col-roles hidden-xs\" flex>&nbsp;</div>\n" +
+    "<div class=\"col-add-role\" row>\n" +
+    "<input id=\"show-hidden-roles\" type=\"checkbox\" class=\"toggle-hidden\" ng-click=\"showAllRoles($event)\">\n" +
+    "&nbsp;\n" +
+    "<label for=\"show-hidden-roles\">\n" +
+    "Show hidden roles\n" +
+    "</label>\n" +
+    "<a href=\"\" class=\"action-inline\" data-toggle=\"popover\" data-trigger=\"focus\" data-content=\"System roles are hidden by default and do not typically need to be managed.\">\n" +
+    "<i class=\"pficon pficon-help\"></i>\n" +
+    "</a>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</uib-tab>\n" +
+    "</uib-tabset>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</project-page>"
+  );
+
+
   $templateCache.put('views/modals/confirm-replace.html',
     "<div class=\"modal-resource-action\">\n" +
     "<div class=\"modal-body\">\n" +
@@ -8240,8 +8449,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"modal-resource-action\">\n" +
     "<div class=\"modal-body\">\n" +
     "<h1>{{message}}</h1>\n" +
-    "<alerts ng-if=\"alerts\" alerts=\"alerts\" hide-close-button=\"true\"></alerts>\n" +
     "<p ng-if=\"details\">{{details}}</p>\n" +
+    "<p ng-if=\"detailsMarkup\" ng-bind-html=\"detailsMarkup\"></p>\n" +
+    "<alerts ng-if=\"alerts\" alerts=\"alerts\" hide-close-button=\"true\"></alerts>\n" +
     "</div>\n" +
     "<div class=\"modal-footer\">\n" +
     "<button class=\"btn btn-lg\" ng-class=\"okButtonClass\" type=\"button\" ng-click=\"confirm()\">{{okButtonText}}</button>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4464,6 +4464,7 @@ td.visible-print,th.visible-print{display:table-cell!important}
 .ui-select-bootstrap .ui-select-choices-row>span{border-color:transparent;border-style:solid;border-width:1px 0;line-height:1.66666667;padding:1px 10px}
 .ui-select-bootstrap .ui-select-choices-row>span:focus,.ui-select-bootstrap .ui-select-choices-row>span:hover{background-color:#def3ff;border-color:#bee1f4;color:#4d5258}
 .ui-select-bootstrap .ui-select-choices-row.active>span{background-color:#0088ce!important;border-color:#0088ce!important;color:#fff}
+.ui-select-bootstrap .ui-select-choices-row.active .text-muted{color:#f5f5f5}
 .ui-select-bootstrap .ui-select-choices-row-inner{min-height:24px;cursor:pointer}
 .ui-select-bootstrap .ui-select-match-text,.ui-select-bootstrap .ui-select-placeholder{font-weight:400}
 .ui-select-bootstrap .ui-select-match-text{padding-right:20px}
@@ -4552,7 +4553,7 @@ td.visible-print,th.visible-print{display:table-cell!important}
 .events-sidebar .right-content .event .event-details .event-reason{order:2}
 .events-sidebar .right-content .event .event-details .event-timestamp{text-align:right;margin-left:5px;min-width:100px}
 }
-.events-table td,.log-line-text{word-wrap:break-word;word-break:break-word;min-width:0}
+.events-table td,.log-line-text{word-break:break-word;min-width:0;word-wrap:break-word}
 .events-sidebar .right-content .event.highlight+.event{border-top:1px solid #d1d1d1}
 .events-badge{font-size:14px}
 .events-badge:hover{text-decoration:none}
@@ -4851,8 +4852,47 @@ kubernetes-topology-graph{height:700px}
 }
 .settings-item{margin:4px 8px 4px 0}
 .hide-if-empty:empty{display:none!important}
+.membership .content-pane .col-heading .col-add-role h3,.membership .content-pane .form-new-role .col-roles{display:none}
 .donut-title-med-pf{font-size:22.5px;font-weight:300}
 .terminal-font,kubernetes-container-terminal .terminal{font-family:"Monospace Regular","DejaVu Sans Mono",Menlo,Monaco,Consolas,monospace;line-height:1em;font-size:12px}
-@media (min-width:768px){.container-terminal-wrapper{background-color:#000}
-}
 .key-value-editor .key-value-editor-header{margin-bottom:5px}
+.membership .content-pane{max-width:1024px;margin-top:50px}
+.membership .content-pane .col-add-role{padding:10px 0;min-width:150px}
+.membership .content-pane .add-role-to{margin-left:-1px}
+.membership .content-pane .col-heading,.membership .content-pane .item-row{border-bottom:1px solid #ededed}
+.membership .content-pane .col-heading h3,.membership .content-pane .item-row h3{margin:0}
+.membership .content-pane .item-row{padding:5px 10px 5px 5px;margin-bottom:20px}
+.membership .content-pane .col-heading{margin-bottom:20px}
+.membership .content-pane .col-name{min-width:165px;padding:0 5px 10px 0;word-wrap:break-word}
+.membership .content-pane .col-name input{max-width:150px}
+.membership .content-pane .col-name .new-project{margin-top:2px}
+.membership .content-pane .content-serviceaccount .form-new-role .col-roles{display:block}
+.membership .content-pane .input-name{width:150px;margin-bottom:5px}
+.membership .content-pane .select-project,.membership .content-pane .select-role{width:150px}
+.membership .content-pane .select-role small{color:#999}
+.membership .content-pane .select-role .active small{color:#c0e0f0}
+@media (min-width:768px){.container-terminal-wrapper{background-color:#000}
+.membership .content-pane .col-heading .col-add-role h3,.membership .content-pane .form-new-role .col-roles{display:block}
+.membership .content-pane .col-add-role{padding:0;min-width:245px}
+.membership .content-pane .col-heading,.membership .content-pane .item-row{border-bottom:none;margin-bottom:none}
+.membership .content-pane .item-row.highlight-hover:hover{background-color:#fafafa}
+.membership .content-pane .col-heading .col-add-role a{display:block;padding-left:10px}
+.membership .content-pane .col-name{min-width:180px}
+.membership .content-pane .col-name input{max-width:175px}
+}
+.col-add-role,.col-heading,.col-name,.col-roles,.item-row,[flex-collapse-fix]{flex-basis:auto}
+.action-chip{margin:0 5px 2px 0;font-size:12px;display:flex;flex-direction:row}
+.action-chip .item{padding:.2em .6em .3em}
+.action-chip .item:first-child{border-top-left-radius:2px;border-bottom-left-radius:2px}
+.action-chip .item:last-child{border-top-right-radius:2px;border-bottom-right-radius:2px}
+.action-chip .item:nth-child(3){border-left:1px solid #f1f1f1}
+.action-chip .key{background-color:#ededed;color:#252525}
+.action-chip .value{background-color:#bbb;color:#FFF}
+.action-chip .action{background-color:#d1d1d1;color:#FFF}
+.action-chip .action:hover{background-color:#adadad}
+.action-chip .action i{margin-top:2px}
+.blue .action-chip .item:nth-child(3){border-left:1px solid #b2dcf3}
+.blue .action-chip .key{background-color:#bee1f4;color:#00659c}
+.blue .action-chip .value{background-color:#7dc3e8;color:#FFF}
+.blue .action-chip .action{background-color:#7dc3e8}
+.blue .action-chip .action:hover{background-color:#00659c}


### PR DESCRIPTION
@ajacobs21e @jwforres @spadgett @enj 

Tasks:
- [x] On remove, ensure a user/group/etc in two different `rolebindings` for the same role is removed from both `rolebindings`. 
- [x]  On add, if there are two `rolebindings` for the same role, only add to one of the `rolebindings`.
- [x] On add, check for duplicates,do not add a user/group/etc to a `rolebinding` if already present in the specified `rolebinding`
- [x] On delete, if all subjects are removed from the `rolebinding`, delete the `rolebinding`
- [x] Limit the # of roles a user can see by default, but provide checkbox to show all if desired
- [x] work with @enj on a `end-user` type of annotation to show/hide roles (for above checkbox task)
- [x] be sure to use the `description` annotation if present
- [x] handle both clusterRoles & local roles (namespaced)

Potential additional tasks (nice to have if they make sense):
- [x] ~~Show/hide the membership menu item based on the user's ability to manage rolebindings?~~ Future
- [x] Show/hide the "edit" functionality of the membership page based on the user's ability to manage rolebindings?
- [x] ~~For non-admin users, it may be nice to show a list of "what can I do" for the project, since they will not be able to see the `rolebindings`, and showing them `local roles` & `clusterroles` that they cannot interact with is not helpful~~ Future perhaps
- [x]  ~~On add, if user/group/etc is already a part of another role, can offer to update that role if it is sensible (ie, if in `view` and is added to `admin`, is not necessary for.~~ Not currently a "weight" or ranking available via api for roles
- [x] ~~create a new group, add users to group, assign group to a role?~~ nope. cluster admin only

Prototype UI screenshots:

First view hides many of the roles to keep the picker sane:
![screen shot 2016-09-20 at 10 43 09 am](https://cloud.githubusercontent.com/assets/280512/18679135/51b82560-7f2c-11e6-8996-c6e94f38a126.png)
Second view shows everything, it is reasonable someone will want to interact with these at some point:
![screen shot 2016-09-20 at 10 43 32 am](https://cloud.githubusercontent.com/assets/280512/18679134/51b13386-7f2c-11e6-93a4-7f2248694c24.png)


