### PR TITLE
Group pods by replica sets on the overview

### DIFF
--- a/app/scripts/directives/serviceGroupNotifications.js
+++ b/app/scripts/directives/serviceGroupNotifications.js
@@ -9,7 +9,7 @@ angular.module('openshiftConsole')
         childServices: '=',
         deploymentConfigsByService: '=',
         deploymentsByService: '=',
-        podsByDeployment: '=',
+        podsByOwnerUid: '=',
         collapsed: '='
       },
       templateUrl: 'views/directives/service-group-notifications.html',
@@ -76,9 +76,9 @@ angular.module('openshiftConsole')
           _.each(svcs, function(svc) {
             // Get notifications for deployments in this service group
             var svcName = _.get(svc, "metadata.name", '');
-            if ($scope.deploymentsByService && $scope.podsByDeployment) {
+            if ($scope.deploymentsByService && $scope.podsByOwnerUid) {
               _.each($scope.deploymentsByService[svcName], function(deployment) {
-                $filter('groupedPodWarnings')($scope.podsByDeployment[deployment.metadata.name], groupedPodWarnings);
+                $filter('groupedPodWarnings')($scope.podsByOwnerUid[deployment.metadata.uid], groupedPodWarnings);
               });
             }
           });
@@ -149,7 +149,7 @@ angular.module('openshiftConsole')
         $scope.$watch('deploymentConfigsByService', function() {
           setDCNotifications();
         });
-        $scope.$watchGroup(['podsByDeployment', 'deploymentsByService'], function() {
+        $scope.$watchGroup(['podsByOwnerUid', 'deploymentsByService'], function() {
           setDeploymentNotifications();
         });
       }

--- a/app/scripts/services/deployments.js
+++ b/app/scripts/services/deployments.js
@@ -367,24 +367,26 @@ angular.module("openshiftConsole")
       return scalableName === deployment.metadata.name;
     };
 
-    DeploymentsService.prototype.groupByService = function(/* deployments or deployment configs */ resources, services) {
+    // Group objects by service using the service selector and pod template labels.
+    // Objects should have spec.template.metadata.labels.
+    DeploymentsService.prototype.groupByService = function(objects, services) {
       var byService = {};
-      _.each(resources, function(resource) {
-        var selector = new LabelSelector(getLabels(resource));
+      _.each(objects, function(object) {
+        var selector = new LabelSelector(getLabels(object));
         var foundSvc = false;
         _.each(services, function(service) {
           var serviceSelector = new LabelSelector(service.spec.selector);
           if (serviceSelector.covers(selector)) {
             foundSvc = true;
             _.set(byService,
-                  [service.metadata.name, resource.metadata.name],
-                  resource);
+                  [service.metadata.name, object.metadata.name],
+                  object);
           }
         });
         if (!foundSvc) {
           _.set(byService,
-                  ['', resource.metadata.name],
-                  resource);
+                  ['', object.metadata.name],
+                  object);
         }
       });
       return byService;

--- a/app/views/overview.html
+++ b/app/views/overview.html
@@ -50,7 +50,7 @@
               </div>
 
               <!-- Unserviced DCs, RCs, and pods -->
-              <div row wrap ng-if="(monopodsByService[''] | hashSize) > 0 || (deploymentConfigsByService[''] | hashSize) > 0 || (deploymentsByService[''] | hashSize) > 0" class="unserviced-row">
+              <div row wrap ng-if="(monopodsByService[''] | hashSize) || (deploymentConfigsByService[''] | hashSize) || (deploymentsByService[''] | hashSize) || (replicaSetsByService[''] | hashSize)" class="unserviced-row">
                 <!-- unserviced DC -->
                 <div ng-repeat="(dcName, deploymentConfig) in deploymentConfigsByService[''] track by (deploymentConfig | uid)"
                     class="no-service"
@@ -66,6 +66,13 @@
                   <overview-replication-controller class="deployment-tile-wrapper"></overview-replication-controller>
                 </div>
                 <!-- /unserviced RC-->
+
+                <!-- unserviced RS -->
+                <div ng-repeat="deployment in replicaSetsByService[''] | orderObjectsByDate : true track by (deployment | uid)"
+                    class="no-service">
+                  <overview-replication-controller class="deployment-tile-wrapper"></overview-replication-controller>
+                </div>
+                <!-- /unserviced RS-->
 
                 <!-- unservice monopods -->
                 <div ng-repeat="pod in monopodsByService[''] | orderObjectsByDate : true track by (pod | uid)"

--- a/app/views/overview/_dc.html
+++ b/app/views/overview/_dc.html
@@ -43,8 +43,8 @@
       <deployment-donut
           rc="deployment"
           deployment-config="deploymentConfigs[dcName]"
-          pods="podsByDeployment[deployment.metadata.name]"
-          hpa="getHPA(deployment.metadata.name, dcName)"
+          pods="podsByOwnerUID[deployment.metadata.uid]"
+          hpa="getHPA(deploymentConfig) || getHPA(deployment)"
           limit-ranges="limitRanges"
           scalable="isScalableDeployment(deployment)"
           alerts="alerts">
@@ -92,7 +92,7 @@
       <!-- pause metrics updates when the service group is collapsed -->
       <deployment-metrics
         ng-if="showMetrics && !collapse"
-        pods="podsByDeployment[activeDeployment.metadata.name]"
+        pods="podsByOwnerUID[activeDeployment.metadata.uid]"
         containers="activeDeployment.spec.template.spec.containers"
         compact="true"
         class="overview-metrics">

--- a/app/views/overview/_rc.html
+++ b/app/views/overview/_rc.html
@@ -1,9 +1,9 @@
-<div class="deployment-tile" ng-if="deployment.kind === 'ReplicationController'">
+<div class="deployment-tile">
   <ng-include src="'views/overview/_service-header.html'"></ng-include>
   <div class="deployment-header">
     <div class="rc-header">
       <div>
-        Replication Controller
+        {{deployment.kind | humanizeKind : true}}
         <a ng-href="{{deployment | navigateResourceURL}}">{{deployment.metadata.name}}</a>
         <small class="overview-timestamp">
           <span class="hidden-xs">&ndash;</span>
@@ -19,8 +19,8 @@
       <deployment-donut
           rc="deployment"
           deployment-config="deploymentConfigs[dcName]"
-          pods="podsByDeployment[deployment.metadata.name]"
-          hpa="getHPA(deployment.metadata.name, dcName)"
+          pods="podsByOwnerUID[deployment.metadata.uid]"
+          hpa="getHPA(deployment)"
           limit-ranges="limitRanges"
           scalable="isScalableDeployment(deployment)"
           alerts="alerts">
@@ -31,7 +31,7 @@
     <div column class="deployment-details">
       <deployment-metrics
         ng-if="showMetrics && !collapse"
-        pods="podsByDeployment[deployment.metadata.name]"
+        pods="podsByOwnerUID[deployment.metadata.uid]"
         containers="deployment.spec.template.spec.containers"
         compact="true"
         class="overview-metrics">

--- a/app/views/overview/_service-group.html
+++ b/app/views/overview/_service-group.html
@@ -52,7 +52,7 @@
           deployments-by-service="deploymentsByService"
           child-services="childServices"
           service="service"
-          pods-by-deployment="podsByDeployment">
+          pods-by-owner-uid="podsByOwnerUID">
       </service-group-notifications>
       <div uib-collapse="collapse" class="service-group-body">
         <!--

--- a/app/views/overview/_service.html
+++ b/app/views/overview/_service.html
@@ -1,4 +1,4 @@
-<div ng-if="!(visibleDeploymentsByConfig | hashSize) && !(monopodsByService[service.metadata.name] | hashSize)" class="no-deployments-block">
+<div ng-if="!(visibleDeploymentsByConfig | hashSize) && !(visibleReplicaSets | hashSize) && !(monopodsByService[service.metadata.name] | hashSize)" class="no-deployments-block">
   <div column class="no-deployments-message">
     <ng-include src="'views/overview/_service-header.html'"></ng-include>
     <div class="pad-xxl">
@@ -13,11 +13,11 @@
 
 <div ng-attr-row="{{!service ? '' : undefined}}"
      ng-attr-wrap="{{!service ? '' : undefined}}"
-     ng-if="(visibleDeploymentsByConfig | hashSize) || (monopodsByService[service.metadata.name || ''] | hashSize)"
+     ng-if="(visibleDeploymentsByConfig | hashSize) || (visibleReplicaSets | hashSize) || (monopodsByService[service.metadata.name || ''] | hashSize)"
      class="deployment-block"
      ng-class="{
        'no-service': !service,
-       'service-multiple-targets': (rcTileCount + (monopodsByService[service.metadata.name] | hashSize) > 1)
+       'service-multiple-targets': rcTileCount + (visibleReplicaSets | hashSize) + (monopodsByService[service.metadata.name] | hashSize) > 1
      }">
   <div ng-repeat="(dcName, deployments) in visibleDeploymentsByConfig" class="deployment-tile-wrapper">
     <!-- visible deployments with a dc -->
@@ -28,7 +28,13 @@
     <div class="deployment-tile-wrapper" ng-if="!dcName.length" ng-repeat="deployment in deployments | orderObjectsByDate : true track by (deployment | uid)">
       <overview-replication-controller></overview-replication-controller>
     </div>
+
   </div>
+
+  <div class="deployment-tile-wrapper" ng-repeat="deployment in visibleReplicaSets track by (deployment | uid)">
+    <overview-replication-controller></overview-replication-controller>
+  </div>
+
   <!-- monopods -->
   <div ng-repeat="pod in monopodsByService[service.metadata.name || ''] | orderObjectsByDate : true track by (pod | uid)"
       class="deployment-tile-wrapper">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2733,6 +2733,18 @@ annotations:{
 labels:{}
 }, c.spec.restartPolicy = "Never", delete c.spec.host, delete c.spec.nodeName, c.status = {}, delete d.readinessProbe, delete d.livenessProbe, d.command = [ "sleep" ], d.args = [ "3600" ], c.spec.containers = [ d ], c) :null;
 },
+groupByOwnerUID:function(a, b) {
+var c = {}, d = {};
+return _.each(b, function(a) {
+d[a.metadata.uid] = new LabelSelector(a.spec.selector);
+}), _.each(a, function(a) {
+var e = !1;
+_.each(b, function(b) {
+var f = b.metadata.uid, g = d[f];
+g.matches(a) && (_.set(c, [ f, a.metadata.name ], a), e = !0);
+}), e || _.set(c, [ "", a.metadata.name ], a);
+}), c;
+},
 groupByReplicationController:function(a, b) {
 var c = {};
 return _.each(a, function(a) {
@@ -3343,63 +3355,57 @@ c.visibleDeploymentsByConfigAndService[b][d] = _.filter(_.values(a), K);
 });
 }
 }, M = function() {
-w = {}, x = {}, angular.forEach(v, function(a) {
+p && s && (c.replicaSetsByService = g.groupByService(s, p));
+}, N = function() {
+x = {}, _.each(w, function(a) {
 var b = a.spec.scaleRef.name, c = a.spec.scaleRef.kind;
-if (b && c) switch (c) {
-case "DeploymentConfig":
-w[b] = w[b] || [], w[b].push(a);
-break;
-
-case "ReplicationController":
-x[b] = x[b] || [], x[b].push(a);
-break;
-
-default:
-h.warn("Unexpected HPA scaleRef kind", c);
-}
-}), c.hpaByDC = w, c.hpaByRC = x;
-}, N = function(a) {
+b && c && (_.has(x, [ c, b ]) || _.set(x, [ c, b ], []), x[c][b].push(a));
+});
+}, O = function(a) {
 return "Succeeded" !== a.status.phase && "Terminated" !== a.status.phase && (!B(a, "openshift.io/deployer-pod-for.name") && (!A(a, "openshift.io/build.name") && "slave" !== B(a, "jenkins")));
-}, O = function() {
-s && r && (c.podsByDeployment = i.groupByReplicationController(s, r), c.monopodsByService = i.groupByService(c.podsByDeployment[""], p, N));
-}, P = {}, Q = function(a) {
-return !!P[a.metadata.name];
-}, R = function(a) {
+}, P = function() {
+if (t && r && s) {
+var a = _.toArray(r).concat(_.toArray(s));
+c.podsByOwnerUID = i.groupByOwnerUID(t, a), c.monopodsByService = i.groupByService(c.podsByOwnerUID[""], p, O);
+}
+}, Q = {}, R = function(a) {
+return !!Q[a.metadata.name];
+}, S = function(a) {
 var b = _.get(a, "metadata.name");
 if (!b) return !1;
 var d = _.get(c, [ "childServicesByParent", b ], []);
 return !_.isEmpty(d);
-}, S = function(a, b) {
+}, T = function(a, b) {
 var d = p[b];
-P[b] = d, c.childServicesByParent[a] = c.childServicesByParent[a] || [], c.childServicesByParent[a].push(d);
-}, T = function(a) {
+Q[b] = d, c.childServicesByParent[a] = c.childServicesByParent[a] || [], c.childServicesByParent[a].push(d);
+}, U = function(a) {
 var b = 0, d = _.get(a, "metadata.name", ""), e = _.get(c, [ "routesByService", d ], []);
 return _.isEmpty(e) || (b += 5), _.has(a, "metadata.labels.app") && (b += 3), l.isInfrastructure(a) && (b -= 5), b;
-}, U = function(a, b) {
-var c = T(a), d = T(b);
+}, V = function(a, b) {
+var c = U(a), d = U(b);
 return c === d ? a.metadata.name.localeCompare(b.metadata.name) :d - c;
-}, V = function() {
-p && o && (c.services = p, P = {}, c.childServicesByParent = {}, _.each(p, function(a, b) {
+}, W = function() {
+p && o && (c.services = p, Q = {}, c.childServicesByParent = {}, _.each(p, function(a, b) {
 var c = l.getDependentServices(a);
 _.each(c, function(a) {
-S(b, a);
+T(b, a);
 });
 }), c.topLevelServices = _.filter(p, function(a) {
-return !!R(a) || !Q(a) && !G(a);
-}).sort(U));
-}, W = function() {
+return !!S(a) || !R(a) && !G(a);
+}).sort(V));
+}, X = function() {
 p && o && (c.routeWarningsByService = {}, _.each(p, function(a) {
 _.each(c.routesByService[a.metadata.name], function(b) {
 var d = k.getRouteWarnings(b, a);
 _.set(c, [ "routeWarningsByService", a.metadata.name, b.metadata.name ], d);
 });
 }));
-}, X = function(a) {
+}, Y = function(a) {
 var b = C(_.get(a, "spec.output.to"), a.metadata.namespace);
 c.recentBuildsByOutputImage[b] = c.recentBuildsByOutputImage[b] || [], c.recentBuildsByOutputImage[b].push(a);
-}, Y = a("buildConfigForBuild"), Z = function(a) {
-if (t) {
-var b = Y(a), d = t[b];
+}, Z = a("buildConfigForBuild"), $ = function(a) {
+if (u) {
+var b = Z(a), d = u[b];
 if (d) {
 var f = e.usesDeploymentConfigs(d);
 _.each(f, function(b) {
@@ -3407,21 +3413,18 @@ c.recentPipelinesByDC[b] = c.recentPipelinesByDC[b] || [], c.recentPipelinesByDC
 });
 }
 }
-}, $ = function() {
-u && (c.recentPipelinesByDC = {}, c.recentBuildsByOutputImage = {}, _.each(e.interestingBuilds(u), function(a) {
-return z(a) ? void Z(a) :void X(a);
-}));
 }, aa = function() {
-var a = _.isEmpty(p) && _.isEmpty(c.monopodsByService) && _.isEmpty(r), b = p && s && r && q;
+v && (c.recentPipelinesByDC = {}, c.recentBuildsByOutputImage = {}, _.each(e.interestingBuilds(v), function(a) {
+return z(a) ? void $(a) :void Y(a);
+}));
+}, ba = function() {
+var a = _.isEmpty(p) && _.isEmpty(c.monopodsByService) && _.isEmpty(r) && _.isEmpty(s), b = p && t && r && q && s;
 c.renderOptions.showGetStarted = b && a, c.renderOptions.showLoading = !b && a;
 };
 c.viewPodsForDeployment = function(a) {
-_.isEmpty(c.podsByDeployment[a.metadata.name]) || m.toPodsForDeployment(a);
-}, c.getHPA = function(a, b) {
-var d = c.hpaByDC, e = c.hpaByRC;
-return d && e ? b ? (d[b] = d[b] || [], d[b]) :(e[a] = e[a] || [], e[a]) :null;
+_.isEmpty(c.podsByOwnerUID[a.metadata.uid]) || m.toPodsForDeployment(a);
 }, c.isScalableDeployment = function(a) {
-return g.isScalable(a, q, c.hpaByDC, c.hpaByRC, c.scalableDeploymentByConfig);
+return g.isScalable(a, q, _.get(x, "DeploymentConfig"), _.get(x, "ReplicationController"), c.scalableDeploymentByConfig);
 }, c.isDeploymentLatest = function(a) {
 var b = A(a, "deploymentConfig");
 if (!b) return !0;
@@ -3430,35 +3433,49 @@ var d = parseInt(A(a, "deploymentVersion"));
 return _.some(c.deploymentConfigs, function(a) {
 return a.metadata.name === b && a.status.latestVersion === d;
 });
+};
+var ca = [];
+c.getHPA = function(a) {
+if (!w) return null;
+var b = _.get(a, "kind"), c = _.get(a, "metadata.name");
+return _.get(x, [ b, c ], ca);
 }, window.OPENSHIFT_CONSTANTS.DISABLE_OVERVIEW_METRICS || n.isAvailable(!0).then(function(a) {
 c.showMetrics = a;
 });
-var ba = a("isIE")() || a("isEdge")();
+var da = a("isIE")() || a("isEdge")();
 j.get(b.project).then(_.spread(function(a, b) {
 c.project = a, c.projectContext = b, y.push(f.watch("pods", b, function(a) {
-s = a.by("metadata.name"), O(), aa(), h.log("pods", s);
+t = a.by("metadata.name"), P(), ba(), h.log("pods", t);
 })), y.push(f.watch("services", b, function(a) {
-c.services = p = a.by("metadata.name"), V(), O(), I(), L(), W(), aa(), h.log("services (list)", p);
-})), y.push(f.watch("builds", b, function(a) {
-u = a.by("metadata.name"), $(), aa(), h.log("builds (list)", u);
-})), y.push(f.watch("buildConfigs", b, function(a) {
-t = a.by("metadata.name"), $(), h.log("builds (list)", u);
-})), y.push(f.watch("routes", b, function(a) {
-o = a.by("metadata.name"), H(), V(), W(), h.log("routes (subscribe)", c.routesByService);
+c.services = p = a.by("metadata.name"), W(), P(), I(), L(), M(), X(), ba(), h.log("services (list)", p);
 }, {
-poll:ba,
+poll:da,
+pollInterval:6e4
+})), y.push(f.watch("builds", b, function(a) {
+v = a.by("metadata.name"), aa(), ba(), h.log("builds (list)", v);
+})), y.push(f.watch("buildConfigs", b, function(a) {
+u = a.by("metadata.name"), aa(), h.log("builds (list)", v);
+})), y.push(f.watch("routes", b, function(a) {
+o = a.by("metadata.name"), H(), W(), X(), h.log("routes (subscribe)", c.routesByService);
+}, {
+poll:da,
 pollInterval:6e4
 })), y.push(f.watch("replicationcontrollers", b, function(a) {
-c.deploymentsByName = r = a.by("metadata.name"), L(), O(), $(), aa(), h.log("replicationcontrollers (subscribe)", r);
+c.deploymentsByName = r = a.by("metadata.name"), L(), P(), aa(), ba(), h.log("replicationcontrollers (subscribe)", r);
 })), y.push(f.watch("deploymentconfigs", b, function(a) {
-q = a.by("metadata.name"), I(), L(), aa(), h.log("deploymentconfigs (subscribe)", c.deploymentConfigs);
+q = a.by("metadata.name"), I(), L(), ba(), h.log("deploymentconfigs (subscribe)", c.deploymentConfigs);
+})), y.push(f.watch({
+group:"extensions",
+resource:"replicasets"
+}, b, function(a) {
+s = a.by("metadata.name"), P(), M(), ba(), h.log("replicasets (subscribe)", c.replicaSets);
 })), y.push(f.watch({
 group:"extensions",
 resource:"horizontalpodautoscalers"
 }, b, function(a) {
-v = a.by("metadata.name"), M();
+w = a.by("metadata.name"), N();
 }, {
-poll:ba,
+poll:da,
 pollInterval:6e4
 })), f.list("limitranges", b, function(a) {
 c.limitRanges = a.by("metadata.name");
@@ -9512,7 +9529,7 @@ service:"=",
 childServices:"=",
 deploymentConfigsByService:"=",
 deploymentsByService:"=",
-podsByDeployment:"=",
+podsByOwnerUid:"=",
 collapsed:"="
 },
 templateUrl:"views/directives/service-group-notifications.html",
@@ -9552,8 +9569,8 @@ _.each(h, function(a, b) {
 b.indexOf("pod_warning") >= 0 && delete a[b];
 }), _.each(i, function(b) {
 var e = _.get(b, "metadata.name", "");
-c.deploymentsByService && c.podsByDeployment && _.each(c.deploymentsByService[e], function(b) {
-a("groupedPodWarnings")(c.podsByDeployment[b.metadata.name], d);
+c.deploymentsByService && c.podsByOwnerUid && _.each(c.deploymentsByService[e], function(b) {
+a("groupedPodWarnings")(c.podsByOwnerUid[b.metadata.uid], d);
 });
 }), _.each(d, function(a, d) {
 var g = _.head(a);
@@ -9594,7 +9611,7 @@ return !c.collapsed || "info" !== a.type;
 i = (c.childServices || []).concat([ c.service ]), j(), k();
 }), c.$watch("deploymentConfigsByService", function() {
 j();
-}), c.$watchGroup([ "podsByDeployment", "deploymentsByService" ], function() {
+}), c.$watchGroup([ "podsByOwnerUid", "deploymentsByService" ], function() {
 k();
 });
 }
@@ -9604,25 +9621,24 @@ return {
 restrict:"E",
 scope:!0,
 templateUrl:"views/overview/_service.html",
-link:function(a) {
-window.OPENSHIFT_CONSTANTS.DISABLE_OVERVIEW_METRICS || c.isAvailable(!0).then(function(b) {
-a.showMetrics = b;
-}), a.$watch("deploymentConfigsByService", function(a) {
-}), a.$watch("visibleDeploymentsByConfigAndService", function(b) {
-if (b) {
-var c = _.get(a, "service.metadata.name");
-a.activeDeploymentByConfig = {}, a.visibleDeploymentsByConfig = b[c], a.rcTileCount = 0, _.each(a.visibleDeploymentsByConfig, function(b, c) {
-c ? a.rcTileCount++ :a.rcTileCount += _.size(b);
+link:function(b) {
+window.OPENSHIFT_CONSTANTS.DISABLE_OVERVIEW_METRICS || c.isAvailable(!0).then(function(a) {
+b.showMetrics = a;
+});
+var d = a("annotation"), e = a("orderObjectsByDate"), f = function(a) {
+return _.get(a, "status.replicas") || !d(a, "deployment.kubernetes.io/revision");
+};
+b.$watch("replicaSetsByService", function(a) {
+var c = _.get(b, "service.metadata.name"), d = _.get(a, [ c ], []);
+b.visibleReplicaSets = e(_.filter(d, f), !0);
+}), b.$watch("visibleDeploymentsByConfigAndService", function(a) {
+if (a) {
+var c = _.get(b, "service.metadata.name");
+b.activeDeploymentByConfig = {}, b.visibleDeploymentsByConfig = a[c], b.rcTileCount = 0, _.each(b.visibleDeploymentsByConfig, function(a, c) {
+c ? b.rcTileCount++ :b.rcTileCount += _.size(a);
 });
 }
-}), a.viewPodsForDeployment = function(b) {
-_.isEmpty(a.podsByDeployment[b.metadata.name]) || d.toPodsForDeployment(b);
-}, a.getHPA = function(b, c) {
-var d = a.hpaByDC, e = a.hpaByRC;
-return d && e ? c ? (d[c] = d[c] || [], d[c]) :(e[b] = e[b] || [], e[b]) :null;
-}, a.isScalableDeployment = function(c) {
-return b.isScalable(c, a.deploymentConfigs, a.hpaByDC, a.hpaByRC, a.scalableDeploymentByConfig);
-};
+});
 }
 };
 } ]), angular.module("openshiftConsole").directive("overviewServiceGroup", [ "$filter", "$uibModal", "RoutesService", "ServicesService", function(a, b, c, d) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8021,7 +8021,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "\n" +
-    "<div row wrap ng-if=\"(monopodsByService[''] | hashSize) > 0 || (deploymentConfigsByService[''] | hashSize) > 0 || (deploymentsByService[''] | hashSize) > 0\" class=\"unserviced-row\">\n" +
+    "<div row wrap ng-if=\"(monopodsByService[''] | hashSize) || (deploymentConfigsByService[''] | hashSize) || (deploymentsByService[''] | hashSize) || (replicaSetsByService[''] | hashSize)\" class=\"unserviced-row\">\n" +
     "\n" +
     "<div ng-repeat=\"(dcName, deploymentConfig) in deploymentConfigsByService[''] track by (deploymentConfig | uid)\" class=\"no-service\" ng-if=\"deployments = visibleDeploymentsByConfigAndService[''][dcName]\"> \n" +
     "<overview-deployment-config class=\"deployment-tile-wrapper\"></overview-deployment-config>\n" +
@@ -8029,6 +8029,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "\n" +
     "<div ng-repeat=\"deployment in deploymentsByService[''] | orderObjectsByDate : true track by (deployment | uid)\" ng-if=\"!(deployment | annotation : 'deploymentConfig') || !deploymentConfigs[(deployment | annotation : 'deploymentConfig')]\" class=\"no-service\">\n" +
+    "<overview-replication-controller class=\"deployment-tile-wrapper\"></overview-replication-controller>\n" +
+    "</div>\n" +
+    "\n" +
+    "\n" +
+    "<div ng-repeat=\"deployment in replicaSetsByService[''] | orderObjectsByDate : true track by (deployment | uid)\" class=\"no-service\">\n" +
     "<overview-replication-controller class=\"deployment-tile-wrapper\"></overview-replication-controller>\n" +
     "</div>\n" +
     "\n" +
@@ -8085,7 +8090,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div row class=\"deployment-body\">\n" +
     "\n" +
     "<div column class=\"overview-donut\" ng-repeat=\"deployment in orderedDeployments track by (deployment | uid)\" ng-class=\"{ latest: isDeploymentLatest(deployment) }\" ng-if=\"!activeDeployment || !(isDeploymentLatest(deployment) && ((deployment | deploymentStatus) == 'Cancelled' || (deployment | deploymentStatus) == 'Failed'))\">\n" +
-    "<deployment-donut rc=\"deployment\" deployment-config=\"deploymentConfigs[dcName]\" pods=\"podsByDeployment[deployment.metadata.name]\" hpa=\"getHPA(deployment.metadata.name, dcName)\" limit-ranges=\"limitRanges\" scalable=\"isScalableDeployment(deployment)\" alerts=\"alerts\">\n" +
+    "<deployment-donut rc=\"deployment\" deployment-config=\"deploymentConfigs[dcName]\" pods=\"podsByOwnerUID[deployment.metadata.uid]\" hpa=\"getHPA(deploymentConfig) || getHPA(deployment)\" limit-ranges=\"limitRanges\" scalable=\"isScalableDeployment(deployment)\" alerts=\"alerts\">\n" +
     "</deployment-donut>\n" +
     "</div>\n" +
     "\n" +
@@ -8123,7 +8128,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div column class=\"deployment-details\" ng-if=\"activeDeployment && !inProgressDeployment\">\n" +
     "\n" +
     "\n" +
-    "<deployment-metrics ng-if=\"showMetrics && !collapse\" pods=\"podsByDeployment[activeDeployment.metadata.name]\" containers=\"activeDeployment.spec.template.spec.containers\" compact class=\"overview-metrics\">\n" +
+    "<deployment-metrics ng-if=\"showMetrics && !collapse\" pods=\"podsByOwnerUID[activeDeployment.metadata.uid]\" containers=\"activeDeployment.spec.template.spec.containers\" compact class=\"overview-metrics\">\n" +
     "</deployment-metrics>\n" +
     "<pod-template ng-if=\"!showMetrics\" pod-template=\"activeDeployment.spec.template\"></pod-template>\n" +
     "\n" +
@@ -8179,12 +8184,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/overview/_rc.html',
-    "<div class=\"deployment-tile\" ng-if=\"deployment.kind === 'ReplicationController'\">\n" +
+    "<div class=\"deployment-tile\">\n" +
     "<ng-include src=\"'views/overview/_service-header.html'\"></ng-include>\n" +
     "<div class=\"deployment-header\">\n" +
     "<div class=\"rc-header\">\n" +
     "<div>\n" +
-    "Replication Controller\n" +
+    "{{deployment.kind | humanizeKind : true}}\n" +
     "<a ng-href=\"{{deployment | navigateResourceURL}}\">{{deployment.metadata.name}}</a>\n" +
     "<small class=\"overview-timestamp\">\n" +
     "<span class=\"hidden-xs\">&ndash;</span>\n" +
@@ -8197,13 +8202,13 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div row class=\"deployment-body\">\n" +
     "\n" +
     "<div column class=\"overview-donut\" ng-class=\"{ latest: isDeploymentLatest(deployment) }\">\n" +
-    "<deployment-donut rc=\"deployment\" deployment-config=\"deploymentConfigs[dcName]\" pods=\"podsByDeployment[deployment.metadata.name]\" hpa=\"getHPA(deployment.metadata.name, dcName)\" limit-ranges=\"limitRanges\" scalable=\"isScalableDeployment(deployment)\" alerts=\"alerts\">\n" +
+    "<deployment-donut rc=\"deployment\" deployment-config=\"deploymentConfigs[dcName]\" pods=\"podsByOwnerUID[deployment.metadata.uid]\" hpa=\"getHPA(deployment)\" limit-ranges=\"limitRanges\" scalable=\"isScalableDeployment(deployment)\" alerts=\"alerts\">\n" +
     "</deployment-donut>\n" +
     "</div>\n" +
     "\n" +
     "\n" +
     "<div column class=\"deployment-details\">\n" +
-    "<deployment-metrics ng-if=\"showMetrics && !collapse\" pods=\"podsByDeployment[deployment.metadata.name]\" containers=\"deployment.spec.template.spec.containers\" compact class=\"overview-metrics\">\n" +
+    "<deployment-metrics ng-if=\"showMetrics && !collapse\" pods=\"podsByOwnerUID[deployment.metadata.uid]\" containers=\"deployment.spec.template.spec.containers\" compact class=\"overview-metrics\">\n" +
     "</deployment-metrics>\n" +
     "<pod-template ng-if=\"!showMetrics\" pod-template=\"deployment.spec.template\"></pod-template>\n" +
     "</div>\n" +
@@ -8255,7 +8260,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "\n" +
-    "<service-group-notifications ng-if=\"service\" collapsed=\"collapse\" deployment-configs-by-service=\"deploymentConfigsByService\" deployments-by-service=\"deploymentsByService\" child-services=\"childServices\" service=\"service\" pods-by-deployment=\"podsByDeployment\">\n" +
+    "<service-group-notifications ng-if=\"service\" collapsed=\"collapse\" deployment-configs-by-service=\"deploymentConfigsByService\" deployments-by-service=\"deploymentsByService\" child-services=\"childServices\" service=\"service\" pods-by-owner-uid=\"podsByOwnerUID\">\n" +
     "</service-group-notifications>\n" +
     "<div uib-collapse=\"collapse\" class=\"service-group-body\">\n" +
     "\n" +
@@ -8320,7 +8325,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/overview/_service.html',
-    "<div ng-if=\"!(visibleDeploymentsByConfig | hashSize) && !(monopodsByService[service.metadata.name] | hashSize)\" class=\"no-deployments-block\">\n" +
+    "<div ng-if=\"!(visibleDeploymentsByConfig | hashSize) && !(visibleReplicaSets | hashSize) && !(monopodsByService[service.metadata.name] | hashSize)\" class=\"no-deployments-block\">\n" +
     "<div column class=\"no-deployments-message\">\n" +
     "<ng-include src=\"'views/overview/_service-header.html'\"></ng-include>\n" +
     "<div class=\"pad-xxl\">\n" +
@@ -8332,9 +8337,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-attr-row=\"{{!service ? '' : undefined}}\" ng-attr-wrap=\"{{!service ? '' : undefined}}\" ng-if=\"(visibleDeploymentsByConfig | hashSize) || (monopodsByService[service.metadata.name || ''] | hashSize)\" class=\"deployment-block\" ng-class=\"{\n" +
+    "<div ng-attr-row=\"{{!service ? '' : undefined}}\" ng-attr-wrap=\"{{!service ? '' : undefined}}\" ng-if=\"(visibleDeploymentsByConfig | hashSize) || (visibleReplicaSets | hashSize) || (monopodsByService[service.metadata.name || ''] | hashSize)\" class=\"deployment-block\" ng-class=\"{\n" +
     "       'no-service': !service,\n" +
-    "       'service-multiple-targets': (rcTileCount + (monopodsByService[service.metadata.name] | hashSize) > 1)\n" +
+    "       'service-multiple-targets': rcTileCount + (visibleReplicaSets | hashSize) + (monopodsByService[service.metadata.name] | hashSize) > 1\n" +
     "     }\">\n" +
     "<div ng-repeat=\"(dcName, deployments) in visibleDeploymentsByConfig\" class=\"deployment-tile-wrapper\">\n" +
     "\n" +
@@ -8344,6 +8349,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"deployment-tile-wrapper\" ng-if=\"!dcName.length\" ng-repeat=\"deployment in deployments | orderObjectsByDate : true track by (deployment | uid)\">\n" +
     "<overview-replication-controller></overview-replication-controller>\n" +
     "</div>\n" +
+    "</div>\n" +
+    "<div class=\"deployment-tile-wrapper\" ng-repeat=\"deployment in visibleReplicaSets track by (deployment | uid)\">\n" +
+    "<overview-replication-controller></overview-replication-controller>\n" +
     "</div>\n" +
     "\n" +
     "<div ng-repeat=\"pod in monopodsByService[service.metadata.name || ''] | orderObjectsByDate : true track by (pod | uid)\" class=\"deployment-tile-wrapper\">\n" +


### PR DESCRIPTION
This adds replica sets to the overview. It does not group replica sets by deployment.

https://trello.com/c/HGvCTI96

<img width="1073" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/18682717/490a4f60-7f3b-11e6-9586-62cb5357dc5a.png">

@jwforres PTAL