### PR TITLE
Move overview deployment log link beside cancel action

### DIFF
--- a/app/scripts/directives/overview/dc.js
+++ b/app/scripts/directives/overview/dc.js
@@ -11,7 +11,6 @@ angular.module('openshiftConsole')
       link: function($scope) {
         var orderByDate = $filter('orderObjectsByDate');
         var deploymentIsInProgress = $filter('deploymentIsInProgress');
-        var anyDeploymentInProgress = $filter('anyDeploymentIsInProgress');
 
         $scope.$watch('deploymentConfigs', function(deploymentConfigs) {
           $scope.deploymentConfig = _.get(deploymentConfigs, $scope.dcName);
@@ -20,11 +19,11 @@ angular.module('openshiftConsole')
         $scope.$watch('deployments', function(deployments) {
           $scope.orderedDeployments = orderByDate(deployments, true);
           $scope.activeDeployment = _.get($scope, ['scalableDeploymentByConfig', $scope.dcName]);
-          $scope.anyDeploymentInProgress = anyDeploymentInProgress(deployments);
+          $scope.inProgressDeployment = _.find($scope.orderedDeployments, deploymentIsInProgress);
         });
 
         $scope.cancelDeployment = function() {
-          var deployment = _.find($scope.orderedDeployments, deploymentIsInProgress);
+          var deployment = $scope.inProgressDeployment;
           if (!deployment) {
             return;
           }

--- a/app/views/overview/_dc.html
+++ b/app/views/overview/_dc.html
@@ -1,23 +1,29 @@
-<div class="deployment-tile" ng-class="{ 'deployment-in-progress': anyDeploymentInProgress }">
+<div class="deployment-tile" ng-class="{ 'deployment-in-progress': inProgressDeployment }">
   <ng-include src="'views/overview/_service-header.html'"></ng-include>
   <div class="deployment-header">
     <div class="rc-header">
       <div>
         Deployment
         <a ng-href="{{deploymentConfig | navigateResourceURL}}">{{dcName}}</a>
-        <small class="overview-timestamp" ng-if="activeDeployment && !anyDeploymentInProgress">
+        <small class="overview-timestamp" ng-if="activeDeployment && !inProgressDeployment">
           <span class="hidden-xs">&ndash;</span>
           <relative-timestamp timestamp="activeDeployment.metadata.creationTimestamp"></relative-timestamp>
         </small>
       </div>
       <div>
         <image-names
-            ng-if="activeDeployment && !anyDeploymentInProgress && showMetrics"
+            ng-if="activeDeployment && !inProgressDeployment && showMetrics"
             pod-template="activeDeployment.spec.template">
         </image-names>
-        <span ng-if="anyDeploymentInProgress" class="small">
+        <span ng-if="inProgressDeployment" class="small">
           {{deploymentConfig.spec.strategy.type}} <ellipsis-pulser color="dark" size="sm" display="inline" msg="deployment in progress"></ellipsis-pulser>
-          <a href="" ng-click="cancelDeployment()" role="button">Cancel</a>
+          <span ng-if="'deploymentconfigs/log' | canI : 'get'" class="deployment-log-link">
+            <a ng-href="{{inProgressDeployment | navigateResourceURL}}?tab=logs">View Log</a>
+            <span ng-if="'replicationcontrollers' | canI: 'update'" class="action-divider">|</span>
+          </span>
+          <span ng-if="'replicationcontrollers' | canI : 'update'" class="deployment-log-link">
+            <a href="" ng-click="cancelDeployment()" role="button">Cancel</a>
+          </span>
         </span>
       </div>
     </div>
@@ -47,7 +53,7 @@
     <!-- /all visible deployments -->
 
     <!-- deployment in progress (connecting arrow) -->
-    <div column class="overview-donut-connector" ng-class="{'contains-deployment-status-msg':deployments.length === 1}" ng-if="anyDeploymentInProgress">
+    <div column class="overview-donut-connector" ng-class="{'contains-deployment-status-msg':deployments.length === 1}" ng-if="inProgressDeployment">
       <div ng-if="deployments.length > 1" class="deployment-connector-arrow">
 
       </div>
@@ -55,15 +61,12 @@
         <status-icon status="deployments[0] | deploymentStatus" class="mar-right-xs"></status-icon>
         Deployment&nbsp;#{{deployments[0] | annotation : 'deploymentVersion'}}
         {{deployments[0] | deploymentStatus | lowercase}}
-        <div ng-if="'deploymentconfigs/log' | canI : 'get'" class="deployment-log-link">
-          <a ng-href="{{deployments[0] | navigateResourceURL}}?tab=logs">View Log</a>
-        </div>
       </div>
     </div>
     <!-- /deployment in progress (connecting arrow) -->
 
     <!-- cancelled/failed state -->
-    <div column class="overview-unsuccessful-state" ng-if="!activeDeployment && !anyDeploymentInProgress" ng-switch="deployments[0] | deploymentStatus">
+    <div column class="overview-unsuccessful-state" ng-if="!activeDeployment && !inProgressDeployment" ng-switch="deployments[0] | deploymentStatus">
       <div ng-switch-when="Cancelled">
         <span class="deployment-status-msg">
           <i class="fa fa-ban" aria-hidden="true"></i>
@@ -84,7 +87,7 @@
     <!-- /cancelled/failed state -->
 
     <!-- succeeded state -->
-    <div column class="deployment-details" ng-if="activeDeployment && !anyDeploymentInProgress">
+    <div column class="deployment-details" ng-if="activeDeployment && !inProgressDeployment">
       <!-- metrics or pod template -->
       <!-- pause metrics updates when the service group is collapsed -->
       <deployment-metrics

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -9738,13 +9738,13 @@ restrict:"E",
 scope:!0,
 templateUrl:"views/overview/_dc.html",
 link:function(d) {
-var e = a("orderObjectsByDate"), f = a("deploymentIsInProgress"), g = a("anyDeploymentIsInProgress");
+var e = a("orderObjectsByDate"), f = a("deploymentIsInProgress");
 d.$watch("deploymentConfigs", function(a) {
 d.deploymentConfig = _.get(a, d.dcName);
 }), d.$watch("deployments", function(a) {
-d.orderedDeployments = e(a, !0), d.activeDeployment = _.get(d, [ "scalableDeploymentByConfig", d.dcName ]), d.anyDeploymentInProgress = g(a);
+d.orderedDeployments = e(a, !0), d.activeDeployment = _.get(d, [ "scalableDeploymentByConfig", d.dcName ]), d.inProgressDeployment = _.find(d.orderedDeployments, f);
 }), d.cancelDeployment = function() {
-var a = _.find(d.orderedDeployments, f);
+var a = d.inProgressDeployment;
 if (a) {
 var e = a.metadata.name, g = b.open({
 animation:!0,

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8049,24 +8049,30 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/overview/_dc.html',
-    "<div class=\"deployment-tile\" ng-class=\"{ 'deployment-in-progress': anyDeploymentInProgress }\">\n" +
+    "<div class=\"deployment-tile\" ng-class=\"{ 'deployment-in-progress': inProgressDeployment }\">\n" +
     "<ng-include src=\"'views/overview/_service-header.html'\"></ng-include>\n" +
     "<div class=\"deployment-header\">\n" +
     "<div class=\"rc-header\">\n" +
     "<div>\n" +
     "Deployment\n" +
     "<a ng-href=\"{{deploymentConfig | navigateResourceURL}}\">{{dcName}}</a>\n" +
-    "<small class=\"overview-timestamp\" ng-if=\"activeDeployment && !anyDeploymentInProgress\">\n" +
+    "<small class=\"overview-timestamp\" ng-if=\"activeDeployment && !inProgressDeployment\">\n" +
     "<span class=\"hidden-xs\">&ndash;</span>\n" +
     "<relative-timestamp timestamp=\"activeDeployment.metadata.creationTimestamp\"></relative-timestamp>\n" +
     "</small>\n" +
     "</div>\n" +
     "<div>\n" +
-    "<image-names ng-if=\"activeDeployment && !anyDeploymentInProgress && showMetrics\" pod-template=\"activeDeployment.spec.template\">\n" +
+    "<image-names ng-if=\"activeDeployment && !inProgressDeployment && showMetrics\" pod-template=\"activeDeployment.spec.template\">\n" +
     "</image-names>\n" +
-    "<span ng-if=\"anyDeploymentInProgress\" class=\"small\">\n" +
+    "<span ng-if=\"inProgressDeployment\" class=\"small\">\n" +
     "{{deploymentConfig.spec.strategy.type}} <ellipsis-pulser color=\"dark\" size=\"sm\" display=\"inline\" msg=\"deployment in progress\"></ellipsis-pulser>\n" +
+    "<span ng-if=\"'deploymentconfigs/log' | canI : 'get'\" class=\"deployment-log-link\">\n" +
+    "<a ng-href=\"{{inProgressDeployment | navigateResourceURL}}?tab=logs\">View Log</a>\n" +
+    "<span ng-if=\"'replicationcontrollers' | canI: 'update'\" class=\"action-divider\">|</span>\n" +
+    "</span>\n" +
+    "<span ng-if=\"'replicationcontrollers' | canI : 'update'\" class=\"deployment-log-link\">\n" +
     "<a href=\"\" ng-click=\"cancelDeployment()\" role=\"button\">Cancel</a>\n" +
+    "</span>\n" +
     "</span>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -8084,20 +8090,17 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "\n" +
     "\n" +
-    "<div column class=\"overview-donut-connector\" ng-class=\"{'contains-deployment-status-msg':deployments.length === 1}\" ng-if=\"anyDeploymentInProgress\">\n" +
+    "<div column class=\"overview-donut-connector\" ng-class=\"{'contains-deployment-status-msg':deployments.length === 1}\" ng-if=\"inProgressDeployment\">\n" +
     "<div ng-if=\"deployments.length > 1\" class=\"deployment-connector-arrow\">\n" +
     "</div>\n" +
     "<div ng-if=\"deployments.length === 1\" class=\"deployment-status-msg\">\n" +
     "<status-icon status=\"deployments[0] | deploymentStatus\" class=\"mar-right-xs\"></status-icon>\n" +
     "Deployment&nbsp;#{{deployments[0] | annotation : 'deploymentVersion'}} {{deployments[0] | deploymentStatus | lowercase}}\n" +
-    "<div ng-if=\"'deploymentconfigs/log' | canI : 'get'\" class=\"deployment-log-link\">\n" +
-    "<a ng-href=\"{{deployments[0] | navigateResourceURL}}?tab=logs\">View Log</a>\n" +
-    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "\n" +
     "\n" +
-    "<div column class=\"overview-unsuccessful-state\" ng-if=\"!activeDeployment && !anyDeploymentInProgress\" ng-switch=\"deployments[0] | deploymentStatus\">\n" +
+    "<div column class=\"overview-unsuccessful-state\" ng-if=\"!activeDeployment && !inProgressDeployment\" ng-switch=\"deployments[0] | deploymentStatus\">\n" +
     "<div ng-switch-when=\"Cancelled\">\n" +
     "<span class=\"deployment-status-msg\">\n" +
     "<i class=\"fa fa-ban\" aria-hidden=\"true\"></i>\n" +
@@ -8117,7 +8120,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "\n" +
     "\n" +
-    "<div column class=\"deployment-details\" ng-if=\"activeDeployment && !anyDeploymentInProgress\">\n" +
+    "<div column class=\"deployment-details\" ng-if=\"activeDeployment && !inProgressDeployment\">\n" +
     "\n" +
     "\n" +
     "<deployment-metrics ng-if=\"showMetrics && !collapse\" pods=\"podsByDeployment[activeDeployment.metadata.name]\" containers=\"activeDeployment.spec.template.spec.containers\" compact class=\"overview-metrics\">\n" +


### PR DESCRIPTION
This lets you view deployment logs for any running deployment, not just the first.

First deployment:

<img width="552" alt="screen shot 2016-09-20 at 3 08 50 pm" src="https://cloud.githubusercontent.com/assets/1167259/18685164/de5b26da-7f44-11e6-940f-555aa75ee72e.png">

Later deployments:

<img width="543" alt="screen shot 2016-09-20 at 3 11 16 pm" src="https://cloud.githubusercontent.com/assets/1167259/18685166/e112e32c-7f44-11e6-83e9-b55452c4ae03.png">

Also add a `canI` test for the cancel action.

@jwforres PTAL