### PR TITLE
Fall back to container status to get image ID

### DIFF
--- a/app/scripts/directives/overview/imageNames.js
+++ b/app/scripts/directives/overview/imageNames.js
@@ -1,12 +1,32 @@
 'use strict';
 
 angular.module('openshiftConsole')
-  .directive('imageNames', function() {
+  .directive('imageNames', function($filter, PodsService) {
     return {
       restrict: 'E',
       scope: {
-        podTemplate: '='
+        podTemplate: '=',
+        pods: '='
       },
-      templateUrl: 'views/overview/_image-names.html'
+      templateUrl: 'views/overview/_image-names.html',
+      link: function($scope) {
+        var imageSHA = $filter('imageSHA');
+        var updateImageDetails = function() {
+          var firstContainer = _.get($scope, 'podTemplate.spec.containers[0]');
+          if (!firstContainer) {
+            return;
+          }
+
+          var sha = imageSHA(firstContainer.image);
+          if (sha) {
+            $scope.imageIDs = [ sha ];
+            return;
+          }
+
+          $scope.imageIDs = PodsService.getImageIDs($scope.pods, firstContainer.name);
+        };
+
+        $scope.$watchGroup(['podTemplate', 'pods'], updateImageDetails);
+      }
     };
   });

--- a/app/scripts/services/pods.js
+++ b/app/scripts/services/pods.js
@@ -3,6 +3,23 @@
 angular.module("openshiftConsole")
   .factory("PodsService", function() {
     return {
+      getImageIDs: function(pods, containerName) {
+        var imageIDs = {};
+        _.each(pods, function(pod) {
+          var id;
+          var containerStatuses = _.get(pod, 'status.containerStatuses', []);
+          var containerStatus = _.find(containerStatuses, { name: containerName });
+          if (containerStatus && containerStatus.imageID) {
+            // Strip the SHA prefix if present. Example imageID:
+            //   docker://sha256:eb96a0f8f2d3e0c2447e45b6b309f9e5d436ccc8eac2817a5ccc9fa022c4ce85
+            id = containerStatus.imageID.replace(/^docker:\/\/sha256:/, '');
+            imageIDs[id] = true;
+          }
+        });
+
+        return _.keys(imageIDs);
+      },
+
       // Generates a copy of pod for debugging crash loops.
       generateDebugPod: function(pod, containerName) {
         // Copy the pod and make some changes for debugging.

--- a/app/views/monitoring.html
+++ b/app/views/monitoring.html
@@ -172,11 +172,10 @@
                           <div class="list-view-pf-additional-info">
                             <div class="list-view-pf-additional-info-item">
                               <span class="pficon fa-fw pficon-image"></span>
-                              <span>{{deployment.spec.template.spec.containers[0].image | imageStreamName}}</span>
-                              <span ng-if="sha = (deployment.spec.template.spec.containers[0].image | imageSHA)" title="{{sha}}">
-                                <span>@</span><span class="hash">{{sha | stripSHAPrefix | limitTo: 7}}</span>
-                              </span>
-                              <span ng-if="deployment.spec.template.spec.containers.length > 1"> and {{deployment.spec.template.spec.containers.length - 1}} other image<span ng-if="deployment.spec.template.spec.containers.length > 2">s</span></span>
+                              <image-names
+                                  pod-template="deployment.spec.template"
+                                  pods="podsByDeployment[deployment.metadata.name]">
+                              </image-names>
                             </div>
                           </div>
                         </div>
@@ -248,11 +247,7 @@
                           <div class="list-view-pf-additional-info">
                             <div class="list-view-pf-additional-info-item">
                               <span class="pficon fa-fw pficon-image"></span>
-                              <span>{{pod.spec.containers[0].image | imageStreamName}}</span>
-                              <span ng-if="sha = (pod.spec.containers[0].image | imageSHA)" title="{{sha}}">
-                                <span>@</span><span class="hash">{{sha | stripSHAPrefix | limitTo: 7}}</span>
-                              </span>
-                              <span ng-if="pod.spec.containers.length > 1" class="mar-left-xs">and {{pod.spec.containers.length - 1}} other image<span ng-if="pod.spec.containers.length > 2">s</span></span>
+                              <image-names pod-template="pod" pods="[pod]"></image-names>
                             </div>
                           </div>
                         </div>

--- a/app/views/overview/_dc.html
+++ b/app/views/overview/_dc.html
@@ -11,11 +11,14 @@
         </small>
       </div>
       <div>
-        <image-names
-            ng-if="activeDeployment && !inProgressDeployment && showMetrics"
-            pod-template="activeDeployment.spec.template">
-        </image-names>
-        <span ng-if="inProgressDeployment" class="small">
+        <div class="small truncate">
+          <image-names
+              ng-if="activeDeployment && !inProgressDeployment && showMetrics"
+              pod-template="activeDeployment.spec.template"
+              pods="podsByDeployment[activeDeployment.metadata.name]">
+          </image-names>
+        </div>
+        <div ng-if="inProgressDeployment" class="small">
           {{deploymentConfig.spec.strategy.type}} <ellipsis-pulser color="dark" size="sm" display="inline" msg="deployment in progress"></ellipsis-pulser>
           <span ng-if="'deploymentconfigs/log' | canI : 'get'" class="deployment-log-link">
             <a ng-href="{{inProgressDeployment | navigateResourceURL}}?tab=logs">View Log</a>
@@ -24,7 +27,7 @@
           <span ng-if="'replicationcontrollers' | canI : 'update'" class="deployment-log-link">
             <a href="" ng-click="cancelDeployment()" role="button">Cancel</a>
           </span>
-        </span>
+        </div>
       </div>
     </div>
     <div column flex class="shield" ng-if="activeDeployment"

--- a/app/views/overview/_image-names.html
+++ b/app/views/overview/_image-names.html
@@ -1,7 +1,5 @@
-<div class="small">
-  <span>{{podTemplate.spec.containers[0].image | imageStreamName}}</span>
-  <span ng-if="sha = (podTemplate.spec.containers[0].image | imageSHA)" title="{{sha}}">
-    <span class="hash">{{sha | stripSHAPrefix | limitTo: 7}}</span>
-  </span>
-  <span ng-if="podTemplate.spec.containers.length > 1"> and {{podTemplate.spec.containers.length - 1}} other image<span ng-if="podTemplate.spec.containers.length > 2">s</span></span>
-</div>
+<span>{{podTemplate.spec.containers[0].image | imageStreamName}}</span>
+<span ng-repeat="id in imageIDs" title="{{id}}">
+  <span class="hash">{{id | stripSHAPrefix | limitTo: 7}}</span><span ng-if="!$last">,</span>
+</span>
+<span ng-if="podTemplate.spec.containers.length > 1"> and {{podTemplate.spec.containers.length - 1}} other image<span ng-if="podTemplate.spec.containers.length > 2">s</span></span>

--- a/app/views/overview/_pod.html
+++ b/app/views/overview/_pod.html
@@ -9,7 +9,9 @@
         <relative-timestamp timestamp="pod.metadata.creationTimestamp"></relative-timestamp>
       </small>
     </div>
-    <image-names ng-if="showMetrics" pod-template="pod"></image-names>
+    <div class="small truncate">
+      <image-names ng-if="showMetrics" pod-template="pod" pods="[pod]"></image-names>
+    </div>
   </div>
   <div row class="deployment-body">
     <div column class="overview-donut">

--- a/app/views/overview/_rc.html
+++ b/app/views/overview/_rc.html
@@ -10,7 +10,13 @@
           <relative-timestamp timestamp="deployment.metadata.creationTimestamp"></relative-timestamp>
         </small>
       </div>
-      <image-names ng-if="showMetrics" pod-template="deployment.spec.template"></image-names>
+      <div class="small truncate">
+        <image-names
+            ng-if="showMetrics"
+            pod-template="deployment.spec.template"
+            pods="podsByDeployment[deployment.metadata.name]">
+        </image-names>
+      </div>
     </div>
   </div>
   <div row class="deployment-body">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2720,6 +2720,15 @@ getHPAWarnings:s
 };
 } ]), angular.module("openshiftConsole").factory("PodsService", function() {
 return {
+getImageIDs:function(a, b) {
+var c = {};
+return _.each(a, function(a) {
+var d, e = _.get(a, "status.containerStatuses", []), f = _.find(e, {
+name:b
+});
+f && f.imageID && (d = f.imageID.replace(/^docker:\/\/sha256:/, ""), c[d] = !0);
+}), _.keys(c);
+},
 generateDebugPod:function(a, b) {
 var c = angular.copy(a), d = _.find(c.spec.containers, {
 name:b
@@ -9799,15 +9808,26 @@ message:"Deployment " + e + " no longer exists."
 };
 }
 };
-} ]), angular.module("openshiftConsole").directive("imageNames", function() {
+} ]), angular.module("openshiftConsole").directive("imageNames", [ "$filter", "PodsService", function(a, b) {
 return {
 restrict:"E",
 scope:{
-podTemplate:"="
+podTemplate:"=",
+pods:"="
 },
-templateUrl:"views/overview/_image-names.html"
+templateUrl:"views/overview/_image-names.html",
+link:function(c) {
+var d = a("imageSHA"), e = function() {
+var a = _.get(c, "podTemplate.spec.containers[0]");
+if (a) {
+var e = d(a.image);
+return e ? void (c.imageIDs = [ e ]) :void (c.imageIDs = b.getImageIDs(c.pods, a.name));
+}
 };
-}), angular.module("openshiftConsole").directive("istagSelect", [ "DataService", function(a) {
+c.$watchGroup([ "podTemplate", "pods" ], e);
+}
+};
+} ]), angular.module("openshiftConsole").directive("istagSelect", [ "DataService", function(a) {
 return {
 require:"^form",
 restrict:"E",

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7731,11 +7731,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"list-view-pf-additional-info\">\n" +
     "<div class=\"list-view-pf-additional-info-item\">\n" +
     "<span class=\"pficon fa-fw pficon-image\"></span>\n" +
-    "<span>{{deployment.spec.template.spec.containers[0].image | imageStreamName}}</span>\n" +
-    "<span ng-if=\"sha = (deployment.spec.template.spec.containers[0].image | imageSHA)\" title=\"{{sha}}\">\n" +
-    "<span>@</span><span class=\"hash\">{{sha | stripSHAPrefix | limitTo: 7}}</span>\n" +
-    "</span>\n" +
-    "<span ng-if=\"deployment.spec.template.spec.containers.length > 1\"> and {{deployment.spec.template.spec.containers.length - 1}} other image<span ng-if=\"deployment.spec.template.spec.containers.length > 2\">s</span></span>\n" +
+    "<image-names pod-template=\"deployment.spec.template\" pods=\"podsByDeployment[deployment.metadata.name]\">\n" +
+    "</image-names>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -7792,11 +7789,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"list-view-pf-additional-info\">\n" +
     "<div class=\"list-view-pf-additional-info-item\">\n" +
     "<span class=\"pficon fa-fw pficon-image\"></span>\n" +
-    "<span>{{pod.spec.containers[0].image | imageStreamName}}</span>\n" +
-    "<span ng-if=\"sha = (pod.spec.containers[0].image | imageSHA)\" title=\"{{sha}}\">\n" +
-    "<span>@</span><span class=\"hash\">{{sha | stripSHAPrefix | limitTo: 7}}</span>\n" +
-    "</span>\n" +
-    "<span ng-if=\"pod.spec.containers.length > 1\" class=\"mar-left-xs\">and {{pod.spec.containers.length - 1}} other image<span ng-if=\"pod.spec.containers.length > 2\">s</span></span>\n" +
+    "<image-names pod-template=\"pod\" pods=\"[pod]\"></image-names>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -8062,9 +8055,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</small>\n" +
     "</div>\n" +
     "<div>\n" +
-    "<image-names ng-if=\"activeDeployment && !inProgressDeployment && showMetrics\" pod-template=\"activeDeployment.spec.template\">\n" +
+    "<div class=\"small truncate\">\n" +
+    "<image-names ng-if=\"activeDeployment && !inProgressDeployment && showMetrics\" pod-template=\"activeDeployment.spec.template\" pods=\"podsByDeployment[activeDeployment.metadata.name]\">\n" +
     "</image-names>\n" +
-    "<span ng-if=\"inProgressDeployment\" class=\"small\">\n" +
+    "</div>\n" +
+    "<div ng-if=\"inProgressDeployment\" class=\"small\">\n" +
     "{{deploymentConfig.spec.strategy.type}} <ellipsis-pulser color=\"dark\" size=\"sm\" display=\"inline\" msg=\"deployment in progress\"></ellipsis-pulser>\n" +
     "<span ng-if=\"'deploymentconfigs/log' | canI : 'get'\" class=\"deployment-log-link\">\n" +
     "<a ng-href=\"{{inProgressDeployment | navigateResourceURL}}?tab=logs\">View Log</a>\n" +
@@ -8073,7 +8068,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"'replicationcontrollers' | canI : 'update'\" class=\"deployment-log-link\">\n" +
     "<a href=\"\" ng-click=\"cancelDeployment()\" role=\"button\">Cancel</a>\n" +
     "</span>\n" +
-    "</span>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div column flex class=\"shield\" ng-if=\"activeDeployment\" ng-class=\"{ 'shield-lg': (activeDeployment | annotation: 'deploymentVersion').length > 3 }\">\n" +
@@ -8135,13 +8130,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/overview/_image-names.html',
-    "<div class=\"small\">\n" +
     "<span>{{podTemplate.spec.containers[0].image | imageStreamName}}</span>\n" +
-    "<span ng-if=\"sha = (podTemplate.spec.containers[0].image | imageSHA)\" title=\"{{sha}}\">\n" +
-    "<span class=\"hash\">{{sha | stripSHAPrefix | limitTo: 7}}</span>\n" +
+    "<span ng-repeat=\"id in imageIDs\" title=\"{{id}}\">\n" +
+    "<span class=\"hash\">{{id | stripSHAPrefix | limitTo: 7}}</span><span ng-if=\"!$last\">,</span>\n" +
     "</span>\n" +
-    "<span ng-if=\"podTemplate.spec.containers.length > 1\"> and {{podTemplate.spec.containers.length - 1}} other image<span ng-if=\"podTemplate.spec.containers.length > 2\">s</span></span>\n" +
-    "</div>"
+    "<span ng-if=\"podTemplate.spec.containers.length > 1\"> and {{podTemplate.spec.containers.length - 1}} other image<span ng-if=\"podTemplate.spec.containers.length > 2\">s</span></span>"
   );
 
 
@@ -8157,7 +8150,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<relative-timestamp timestamp=\"pod.metadata.creationTimestamp\"></relative-timestamp>\n" +
     "</small>\n" +
     "</div>\n" +
-    "<image-names ng-if=\"showMetrics\" pod-template=\"pod\"></image-names>\n" +
+    "<div class=\"small truncate\">\n" +
+    "<image-names ng-if=\"showMetrics\" pod-template=\"pod\" pods=\"[pod]\"></image-names>\n" +
+    "</div>\n" +
     "</div>\n" +
     "<div row class=\"deployment-body\">\n" +
     "<div column class=\"overview-donut\">\n" +
@@ -8191,7 +8186,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<relative-timestamp timestamp=\"deployment.metadata.creationTimestamp\"></relative-timestamp>\n" +
     "</small>\n" +
     "</div>\n" +
-    "<image-names ng-if=\"showMetrics\" pod-template=\"deployment.spec.template\"></image-names>\n" +
+    "<div class=\"small truncate\">\n" +
+    "<image-names ng-if=\"showMetrics\" pod-template=\"deployment.spec.template\" pods=\"podsByDeployment[deployment.metadata.name]\">\n" +
+    "</image-names>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div row class=\"deployment-body\">\n" +


### PR DESCRIPTION
If the image ID is not in the pod template, fall back to the container
statuses for running pods to get the ID on the overview and monitoring
pages.

Fixes https://github.com/openshift/origin/issues/10962
@jwforres PTAL