### PR TITLE
Fix overview image-names for replica set change

### DIFF
--- a/app/views/overview/_dc.html
+++ b/app/views/overview/_dc.html
@@ -15,7 +15,7 @@
           <image-names
               ng-if="activeDeployment && !inProgressDeployment && showMetrics"
               pod-template="activeDeployment.spec.template"
-              pods="podsByDeployment[activeDeployment.metadata.name]">
+              pods="podsByOwnerUID[activeDeployment.metadata.uid]">
           </image-names>
         </div>
         <div ng-if="inProgressDeployment" class="small">

--- a/app/views/overview/_rc.html
+++ b/app/views/overview/_rc.html
@@ -14,7 +14,7 @@
         <image-names
             ng-if="showMetrics"
             pod-template="deployment.spec.template"
-            pods="podsByDeployment[deployment.metadata.name]">
+            pods="podsByOwnerUID[deployment.metadata.uid]">
         </image-names>
       </div>
     </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8051,7 +8051,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div>\n" +
     "<div class=\"small truncate\">\n" +
-    "<image-names ng-if=\"activeDeployment && !inProgressDeployment && showMetrics\" pod-template=\"activeDeployment.spec.template\" pods=\"podsByDeployment[activeDeployment.metadata.name]\">\n" +
+    "<image-names ng-if=\"activeDeployment && !inProgressDeployment && showMetrics\" pod-template=\"activeDeployment.spec.template\" pods=\"podsByOwnerUID[activeDeployment.metadata.uid]\">\n" +
     "</image-names>\n" +
     "</div>\n" +
     "<div ng-if=\"inProgressDeployment\" class=\"small\">\n" +
@@ -8182,7 +8182,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</small>\n" +
     "</div>\n" +
     "<div class=\"small truncate\">\n" +
-    "<image-names ng-if=\"showMetrics\" pod-template=\"deployment.spec.template\" pods=\"podsByDeployment[deployment.metadata.name]\">\n" +
+    "<image-names ng-if=\"showMetrics\" pod-template=\"deployment.spec.template\" pods=\"podsByOwnerUID[deployment.metadata.uid]\">\n" +
     "</image-names>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
@jwforres PTAL

#565 broke #578 even though there were no merge conflicts since it changed `podsByDeployment` to `podsByOwnerUID`.