### PR TITLE
Bug 1378703: No need to show error about editing again when bc is deleted

### DIFF
--- a/app/scripts/controllers/edit/buildConfig.js
+++ b/app/scripts/controllers/edit/buildConfig.js
@@ -198,13 +198,13 @@ angular.module('openshiftConsole')
             // If we found the item successfully, watch for changes on it
             watches.push(DataService.watchObject("buildconfigs", $routeParams.buildconfig, context, function(buildConfig, action) {
               if (action === 'MODIFIED') {
-                $scope.alerts["background_update"] = {
+                $scope.alerts["updated/deleted"] = {
                   type: "warning",
                   message: "This build configuration has changed since you started editing it. You'll need to copy any changes you've made and edit again."
                 };
               }
               if (action === "DELETED") {
-                $scope.alerts["deleted"] = {
+                $scope.alerts["updated/deleted"] = {
                   type: "warning",
                   message: "This build configuration has been deleted."
                 };

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5151,10 +5151,10 @@ value:a.destinationDir
 })) :(a.imageSourceFromObjects = [], a.sourceImages.forEach(function(b) {
 a.imageSourceFromObjects.push(b.from);
 }))), a.options.forcePull = !!a.buildStrategy.forcePull, a.sources.binary && (a.options.binaryAsFile = a.buildConfig.spec.source.binary.asFile ? a.buildConfig.spec.source.binary.asFile :""), "Docker" === a.strategyType && (a.options.noCache = !!a.buildConfig.spec.strategy.dockerStrategy.noCache, a.buildFromTypes.push("None")), l.push(c.watchObject("buildconfigs", b.buildconfig, f, function(b, c) {
-"MODIFIED" === c && (a.alerts.background_update = {
+"MODIFIED" === c && (a.alerts["updated/deleted"] = {
 type:"warning",
 message:"This build configuration has changed since you started editing it. You'll need to copy any changes you've made and edit again."
-}), "DELETED" === c && (a.alerts.deleted = {
+}), "DELETED" === c && (a.alerts["updated/deleted"] = {
 type:"warning",
 message:"This build configuration has been deleted."
 }, a.disableInputs = !0), a.buildConfig = b;


### PR DESCRIPTION
Wasn't sure if we shall do it this way(deleting the opposing alert) or just nuke all alerts... but would rather go with this one since its safer.

@spadgett PTAL 