### PR TITLE
Improve loading message position on browse pages

### DIFF
--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -10,7 +10,6 @@
               <span ng-if="buildConfig | isJenkinsPipelineStrategy" class="pad-top-md"><span class="label label-warning">Technology Preview</span></span>
             </div>
             <alerts alerts="alerts"></alerts>
-            <div ng-if="!loaded">Loading...</div>
             <h1>
               {{buildConfigName}}
               <span class="pficon pficon-warning-triangle-o"
@@ -65,6 +64,7 @@
         </div><!-- /middle-header-->
         <div class="middle-content">
           <div class="container-fluid">
+            <div ng-if="!loaded">Loading...</div>
             <div class="row" ng-if="loaded">
               <div class="col-md-12" ng-class="{ 'hide-tabs' : !buildConfig }">
                 <uib-tabset>

--- a/app/views/browse/build.html
+++ b/app/views/browse/build.html
@@ -11,7 +11,7 @@
               <span ng-if="build | isJenkinsPipelineStrategy" class="pad-top-md"><span class="label label-warning">Technology Preview</span></span>
             </div>
             <alerts alerts="alerts"></alerts>
-            <div ng-if="!loaded">Loading...</div>
+            <div ng-if="!loaded" class="mar-top-xl">Loading...</div>
             <div ng-if="build">
               <h1>
                 {{build.metadata.name}}

--- a/app/views/browse/deployment-config.html
+++ b/app/views/browse/deployment-config.html
@@ -8,7 +8,6 @@
           <div class="container-fluid">
             <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
             <alerts alerts="alerts"></alerts>
-            <div ng-if="!loaded">Loading...</div>
             <div>
               <h1>
                 {{deploymentConfigName}}
@@ -83,6 +82,7 @@
         </div><!-- /middle-header-->
         <div class="middle-content">
           <div class="container-fluid">
+            <div ng-if="!loaded">Loading...</div>
             <div class="row" ng-if="loaded">
               <div class="col-md-12" ng-class="{ 'hide-tabs' : !deploymentConfig }">
                 <uib-tabset>

--- a/app/views/browse/deployment.html
+++ b/app/views/browse/deployment.html
@@ -8,7 +8,6 @@
         <div class="container-fluid">
           <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
           <alerts alerts="alerts"></alerts>
-          <div ng-if="!loaded">Loading...</div>
           <div>
             <h1>
               {{name}}
@@ -65,6 +64,7 @@
       </div><!-- /middle-header-->
       <div class="middle-content">
         <div class="container-fluid">
+          <div ng-if="!loaded">Loading...</div>
           <div class="row" ng-if="loaded">
             <div class="col-md-12" ng-class="{ 'hide-tabs' : !deployment }">
               <uib-tabset>

--- a/app/views/browse/image.html
+++ b/app/views/browse/image.html
@@ -8,7 +8,7 @@
         <div class="container-fluid">
           <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
           <alerts alerts="alerts"></alerts>
-          <div ng-if="!loaded">Loading...</div>
+          <div ng-if="!imageStream" class="mar-top-xl">Loading...</div>
           <div ng-if="imageStream">
             <h1>
               {{imageStream.metadata.name}}:{{tagName}}
@@ -18,6 +18,7 @@
       </div><!-- /middle-header-->
       <div class="middle-content gutter-top">
         <div class="container-fluid">
+          <div ng-if="imageStream && !image">Loading...</div>
           <div class="row" ng-if="image">
             <div class="col-md-12">
               <registry-image-pull settings="settings" names="[ imageStream.metadata.name + ':' + tagName ]">

--- a/app/views/browse/imagestream.html
+++ b/app/views/browse/imagestream.html
@@ -8,7 +8,7 @@
         <div class="container-fluid">
           <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
           <alerts alerts="alerts"></alerts>
-          <div ng-if="!loaded">Loading...</div>
+          <div ng-if="!imageStream" class="mar-top-xl">Loading...</div>
           <div ng-if="imageStream">
             <h1>
               {{imageStream.metadata.name}}

--- a/app/views/browse/pod.html
+++ b/app/views/browse/pod.html
@@ -8,7 +8,7 @@
           <div class="container-fluid">
             <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
             <alerts alerts="alerts"></alerts>
-            <div ng-if="!loaded">Loading...</div>
+            <div ng-if="!loaded" class="mar-top-xl">Loading...</div>
             <div ng-if="pod">
               <h1>
                 {{pod.metadata.name}}

--- a/app/views/browse/route.html
+++ b/app/views/browse/route.html
@@ -8,7 +8,7 @@
         <div class="container-fluid">
           <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
           <alerts alerts="alerts"></alerts>
-          <div ng-if="!loaded">Loading...</div>
+          <div ng-if="!loaded" class="mar-top-xl">Loading...</div>
           <div ng-if="route">
             <h1>
               {{route.metadata.name}}

--- a/app/views/browse/service.html
+++ b/app/views/browse/service.html
@@ -8,7 +8,7 @@
         <div class="container-fluid">
           <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
           <alerts alerts="alerts"></alerts>
-          <div ng-if="!loaded">Loading...</div>
+          <div ng-if="!loaded" class="mar-top-xl">Loading...</div>
           <div ng-if="service">
             <h1>
               {{service.metadata.name}}

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1465,7 +1465,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"buildConfig | isJenkinsPipelineStrategy\" class=\"pad-top-md\"><span class=\"label label-warning\">Technology Preview</span></span>\n" +
     "</div>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
-    "<div ng-if=\"!loaded\">Loading...</div>\n" +
     "<h1>\n" +
     "{{buildConfigName}}\n" +
     "<span class=\"pficon pficon-warning-triangle-o\" ng-if=\"paused\" aria-hidden=\"true\" data-toggle=\"tooltip\" data-original-title=\"Building from build configuration {{buildConfig.metadata.name}} has been paused.\">\n" +
@@ -1504,6 +1503,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<div ng-if=\"!loaded\">Loading...</div>\n" +
     "<div class=\"row\" ng-if=\"loaded\">\n" +
     "<div class=\"col-md-12\" ng-class=\"{ 'hide-tabs' : !buildConfig }\">\n" +
     "<uib-tabset>\n" +
@@ -1841,7 +1841,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"build | isJenkinsPipelineStrategy\" class=\"pad-top-md\"><span class=\"label label-warning\">Technology Preview</span></span>\n" +
     "</div>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
-    "<div ng-if=\"!loaded\">Loading...</div>\n" +
+    "<div ng-if=\"!loaded\" class=\"mar-top-xl\">Loading...</div>\n" +
     "<div ng-if=\"build\">\n" +
     "<h1>\n" +
     "{{build.metadata.name}}\n" +
@@ -1940,7 +1940,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-fluid\">\n" +
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
-    "<div ng-if=\"!loaded\">Loading...</div>\n" +
     "<div>\n" +
     "<h1>\n" +
     "{{deploymentConfigName}}\n" +
@@ -1994,6 +1993,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<div ng-if=\"!loaded\">Loading...</div>\n" +
     "<div class=\"row\" ng-if=\"loaded\">\n" +
     "<div class=\"col-md-12\" ng-class=\"{ 'hide-tabs' : !deploymentConfig }\">\n" +
     "<uib-tabset>\n" +
@@ -2189,7 +2189,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-fluid\">\n" +
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
-    "<div ng-if=\"!loaded\">Loading...</div>\n" +
     "<div>\n" +
     "<h1>\n" +
     "{{name}}\n" +
@@ -2234,6 +2233,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<div ng-if=\"!loaded\">Loading...</div>\n" +
     "<div class=\"row\" ng-if=\"loaded\">\n" +
     "<div class=\"col-md-12\" ng-class=\"{ 'hide-tabs' : !deployment }\">\n" +
     "<uib-tabset>\n" +
@@ -2405,7 +2405,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-fluid\">\n" +
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
-    "<div ng-if=\"!loaded\">Loading...</div>\n" +
+    "<div ng-if=\"!imageStream\" class=\"mar-top-xl\">Loading...</div>\n" +
     "<div ng-if=\"imageStream\">\n" +
     "<h1>\n" +
     "{{imageStream.metadata.name}}:{{tagName}}\n" +
@@ -2415,6 +2415,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content gutter-top\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<div ng-if=\"imageStream && !image\">Loading...</div>\n" +
     "<div class=\"row\" ng-if=\"image\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<registry-image-pull settings=\"settings\" names=\"[ imageStream.metadata.name + ':' + tagName ]\">\n" +
@@ -2459,7 +2460,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-fluid\">\n" +
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
-    "<div ng-if=\"!loaded\">Loading...</div>\n" +
+    "<div ng-if=\"!imageStream\" class=\"mar-top-xl\">Loading...</div>\n" +
     "<div ng-if=\"imageStream\">\n" +
     "<h1>\n" +
     "{{imageStream.metadata.name}}\n" +
@@ -2695,7 +2696,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-fluid\">\n" +
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
-    "<div ng-if=\"!loaded\">Loading...</div>\n" +
+    "<div ng-if=\"!loaded\" class=\"mar-top-xl\">Loading...</div>\n" +
     "<div ng-if=\"pod\">\n" +
     "<h1>\n" +
     "{{pod.metadata.name}}\n" +
@@ -2943,7 +2944,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-fluid\">\n" +
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
-    "<div ng-if=\"!loaded\">Loading...</div>\n" +
+    "<div ng-if=\"!loaded\" class=\"mar-top-xl\">Loading...</div>\n" +
     "<div ng-if=\"route\">\n" +
     "<h1>\n" +
     "{{route.metadata.name}}\n" +
@@ -3230,7 +3231,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-fluid\">\n" +
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
-    "<div ng-if=\"!loaded\">Loading...</div>\n" +
+    "<div ng-if=\"!loaded\" class=\"mar-top-xl\">Loading...</div>\n" +
     "<div ng-if=\"service\">\n" +
     "<h1>\n" +
     "{{service.metadata.name}}\n" +


### PR DESCRIPTION
Avoid having the header jump after the page loads and keep a consistent top margin below the breadcrumbs when there's no header.

@jwforres PTAL