### PR TITLE
Rename scope variables in DeploymentsController

### DIFF
--- a/app/views/deployments.html
+++ b/app/views/deployments.html
@@ -21,8 +21,8 @@
         <div class="container-fluid">
           <div class="row">
             <div class="col-md-12"
-                 ng-class="{ 'gutter-top': !(k8sDeployments | hashSize) && !(replicaSets | hashSize) }">
-              <h3 ng-if="(k8sDeployments | hashSize) || (replicaSets | hashSize)">Deployment Configurations</h3>
+                 ng-class="{ 'gutter-top': !(deployments | hashSize) && !(replicaSets | hashSize) }">
+              <h3 ng-if="(deployments | hashSize) || (replicaSets | hashSize)">Deployment Configurations</h3>
               <table class="table table-bordered table-hover table-mobile">
                 <thead>
                   <tr>
@@ -35,54 +35,54 @@
                 </thead>
                 <!-- message doesnt show right when there are both dcs and rcs and they are all filtered -->
                 <tbody ng-if="showEmptyMessage()">
-                  <!-- If there are no deployment configs, and if the only 'deployments' are just replication controllers -->
+                  <!-- If there are no deployment configs and no replication controllers owned by a deployment config -->
                   <tr><td colspan="5"><em>{{emptyMessage}}</em></td></tr>
                 </tbody>
-                <tbody ng-repeat="(deploymentConfigName, deploymentConfigDeployments) in deploymentsByDeploymentConfig" ng-if="deploymentConfigName && (deploymentConfigs[deploymentConfigName] || !unfilteredDeploymentConfigs[deploymentConfigName])">
-                  <!-- Deployment config with no deployments-->
-                  <tr ng-if="(deploymentConfigDeployments | hashSize) == 0 && deploymentConfigName">
+                <tbody ng-repeat="(dcName, replicationControllersForDC) in replicationControllersByDC" ng-if="dcName && (deploymentConfigs[dcName] || !unfilteredDeploymentConfigs[dcName])">
+                  <!-- Deployment config with no replication controllers -->
+                  <tr ng-if="(replicationControllersForDC | hashSize) == 0 && dcName">
                     <td data-title="Name">
-                      <a ng-if="deploymentConfigs[deploymentConfigName]" href="{{deploymentConfigName | navigateResourceURL : 'DeploymentConfig' : projectName}}">{{deploymentConfigName}}</a>
-                      <span ng-if="deploymentConfigs[deploymentConfigName].status.details.message" class="pficon pficon-warning-triangle-o" style="cursor: help;" data-toggle="popover" data-trigger="hover" dynamic-content="{{deploymentConfigs[deploymentConfigName].status.details.message}}"></span>
+                      <a ng-if="deploymentConfigs[dcName]" href="{{dcName | navigateResourceURL : 'DeploymentConfig' : projectName}}">{{dcName}}</a>
+                      <span ng-if="deploymentConfigs[dcName].status.details.message" class="pficon pficon-warning-triangle-o" style="cursor: help;" data-toggle="popover" data-trigger="hover" dynamic-content="{{deploymentConfigs[dcName].status.details.message}}"></span>
                     </td>
                     <td data-title="Last Version"><em>No deployments</em></td>
                     <td class="hidden-xs">&nbsp;</td>
                     <td class="hidden-xs">&nbsp;</td>
                     <td class="hidden-xs">&nbsp;</td>
                   </tr>
-                  <!-- Deployment config with deployments, or deployments from a deployment config which has since been deleted -->
-                  <tr ng-repeat="deployment in deploymentConfigDeployments | orderObjectsByDate : true | limitTo : 1" ng-if="deploymentConfigName">
+                  <!-- Deployment config with replication controllers, or replication controllers from a deployment config which has since been deleted -->
+                  <tr ng-repeat="replicationController in replicationControllersForDC | orderObjectsByDate : true | limitTo : 1" ng-if="dcName">
                     <td data-title="Name">
-                      <a href="{{deploymentConfigName | navigateResourceURL : 'DeploymentConfig' : deployment.metadata.namespace}}">{{deploymentConfigName}}</a>
-                      <!-- <span ng-if="deploymentConfigs[deploymentConfigName].status.details.message" class="pficon pficon-warning-triangle-o" style="cursor: help;" data-toggle="popover" data-trigger="hover" dynamic-content="{{deploymentConfigs[deploymentConfigName].status.details.message}}"></span> -->
-                      <span ng-if="deploymentConfigs && !deploymentConfigs[deploymentConfigName]" class="pficon pficon-warning-triangle-o" data-toggle="tooltip" title="This deployment config no longer exists" style="cursor: help;"></span>
+                      <a ng-href="{{replicationController | configURLForResource}}">{{dcName}}</a>
+                      <!-- <span ng-if="deploymentConfigs[dcName].status.details.message" class="pficon pficon-warning-triangle-o" style="cursor: help;" data-toggle="popover" data-trigger="hover" dynamic-content="{{deploymentConfigs[dcName].status.details.message}}"></span> -->
+                      <span ng-if="deploymentConfigs && !deploymentConfigs[dcName]" class="pficon pficon-warning-triangle-o" data-toggle="tooltip" title="This deployment config no longer exists" style="cursor: help;"></span>
                     </td>
                     <td data-title="Last Version">
                       <!-- Deployment number and link -->
-                      <span ng-if="deployment | annotation : 'deploymentVersion'">
-                        <a ng-href="{{deployment | navigateResourceURL}}">#{{deployment | annotation : 'deploymentVersion'}}</a>
+                      <span ng-if="replicationController | annotation : 'deploymentVersion'">
+                        <a ng-href="{{replicationController | navigateResourceURL}}">#{{replicationController | annotation : 'deploymentVersion'}}</a>
                       </span>
-                      <span ng-if="!(deployment | annotation : 'deploymentVersion')">
-                        <a ng-href="{{deployment | navigateResourceURL}}">{{deployment.metadata.name}}</a>
+                      <span ng-if="!(replicationController | annotation : 'deploymentVersion')">
+                        <a ng-href="{{replicationController | navigateResourceURL}}">{{replicationController.metadata.name}}</a>
                       </span>
                     </td>
                     <td data-title="Status">
                       <div row class="status">
-                        <status-icon status="deployment | deploymentStatus" disable-animation fixed-width="true"></status-icon>
+                        <status-icon status="replicationController | deploymentStatus" disable-animation fixed-width="true"></status-icon>
                         <span flex>
-                          {{deployment | deploymentStatus}}<span ng-if="(deployment | deploymentStatus) == 'Active' || (deployment | deploymentStatus) == 'Running'">,
-                          <span ng-if="deployment.spec.replicas !== deployment.status.replicas">{{deployment.status.replicas}}/</span>{{deployment.spec.replicas}} replica<span ng-if="deployment.spec.replicas != 1">s</span></span>
+                          {{replicationController | deploymentStatus}}<span ng-if="(replicationController | deploymentStatus) == 'Active' || (replicationController | deploymentStatus) == 'Running'">,
+                          <span ng-if="replicationController.spec.replicas !== replicationController.status.replicas">{{replicationController.status.replicas}}/</span>{{replicationController.spec.replicas}} replica<span ng-if="replicationController.spec.replicas != 1">s</span></span>
                         </span>
                       </div>
                       <!-- TODO would be nice to have the deploymentStatusReason in a popup, when there is one -->
                     </td>
                     <td data-title="Created">
-                      <relative-timestamp timestamp="deployment.metadata.creationTimestamp"></relative-timestamp>
+                      <relative-timestamp timestamp="replicationController.metadata.creationTimestamp"></relative-timestamp>
                     </td>
                     <td data-title="Trigger">
-                      <span ng-if="!deployment.causes.length">Unknown</span>
-                      <span ng-if="deployment.causes.length">
-                        <span ng-repeat="cause in deployment.causes">
+                      <span ng-if="!replicationController.causes.length">Unknown</span>
+                      <span ng-if="replicationController.causes.length">
+                        <span ng-repeat="cause in replicationController.causes">
                           <span ng-switch="cause.type">
                             <span ng-switch-when="ImageChange">
                               <span ng-if="cause.imageTrigger.from">
@@ -98,7 +98,7 @@
                   </tr>
                 </tbody>
               </table>
-              <div ng-if="k8sDeployments | hashSize">
+              <div ng-if="deployments | hashSize">
                 <h3>Deployments</h3>
                 <table class="table table-bordered table-hover table-mobile">
                   <thead>
@@ -110,22 +110,22 @@
                       <th>Strategy</th>
                     </tr>
                   </thead>
-                  <tbody ng-repeat="k8sDeployment in k8sDeployments | orderObjectsByDate : true">
+                  <tbody ng-repeat="deployment in deployments | orderObjectsByDate : true">
                     <tr>
                       <td data-title="Name">
-                        <a ng-href="{{k8sDeployment | navigateResourceURL}}">{{k8sDeployment.metadata.name}}</a>
+                        <a ng-href="{{deployment | navigateResourceURL}}">{{deployment.metadata.name}}</a>
                       </td>
                       <td data-title="Last Version">
-                        {{k8sDeployment | lastDeploymentRevision}}
+                        {{deployment | lastDeploymentRevision}}
                       </td>
                       <td data-title="Replicas">
-                        <span ng-if="k8sDeployment.status.replicas !== k8sDeployment.spec.replicas">{{k8sDeployment.status.replicas}}/</span>{{k8sDeployment.spec.replicas}} replica<span ng-if="k8sDeployment.spec.replicas != 1">s</span>
+                        <span ng-if="deployment.status.replicas !== deployment.spec.replicas">{{deployment.status.replicas}}/</span>{{deployment.spec.replicas}} replica<span ng-if="deployment.spec.replicas != 1">s</span>
                       </td>
                       <td data-title="Created">
-                        <relative-timestamp timestamp="k8sDeployment.metadata.creationTimestamp"></relative-timestamp>
+                        <relative-timestamp timestamp="deployment.metadata.creationTimestamp"></relative-timestamp>
                       </td>
                       <td data-title="Strategy">
-                        {{k8sDeployment.spec.strategy.type | sentenceCase}}
+                        {{deployment.spec.strategy.type | sentenceCase}}
                       </td>
                     </tr>
                   </tbody>
@@ -166,8 +166,8 @@
                       <th>Created</th>
                     </tr>
                   </thead>
-                  <tbody ng-if="(deploymentsByDeploymentConfig[''] | hashSize) === 0"><tr><td colspan="3"><em>No replication controllers to show</em></td></tr></tbody>
-                  <tbody ng-repeat="deployment in deploymentsByDeploymentConfig[''] | orderObjectsByDate : true">
+                  <tbody ng-if="(replicationControllersByDC[''] | hashSize) === 0"><tr><td colspan="3"><em>No replication controllers to show</em></td></tr></tbody>
+                  <tbody ng-repeat="deployment in replicationControllersByDC[''] | orderObjectsByDate : true">
                     <!-- We only show this if there are replication controllers but the active filter is hiding them, otherwise the RC table doesnt show
                          at all -->
                     <tr>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4341,7 +4341,7 @@ c.unwatchAll(g);
 });
 }));
 } ]), angular.module("openshiftConsole").controller("DeploymentsController", [ "$scope", "$filter", "$routeParams", "AlertMessageService", "DataService", "DeploymentsService", "LabelFilter", "Logger", "ProjectsService", function(a, b, c, d, e, f, g, h, i) {
-a.projectName = c.project, a.deployments = {}, a.unfilteredDeploymentConfigs = {}, a.unfilteredK8SDeployments = {}, a.deploymentsByDeploymentConfig = {}, a.labelSuggestions = {}, a.alerts = a.alerts || {}, a.emptyMessage = "Loading...", a.expandedDeploymentConfigRow = {}, a.unfilteredReplicaSets = {}, a.unfilteredReplicationControllers = {}, d.getAlerts().forEach(function(b) {
+a.projectName = c.project, a.replicationControllers = {}, a.unfilteredDeploymentConfigs = {}, a.unfilteredDeployments = {}, a.replicationControllersByDC = {}, a.labelSuggestions = {}, a.alerts = a.alerts || {}, a.emptyMessage = "Loading...", a.expandedDeploymentConfigRow = {}, a.unfilteredReplicaSets = {}, a.unfilteredReplicationControllers = {}, d.getAlerts().forEach(function(b) {
 a.alerts[b.name] = b.data;
 }), d.clearAlerts();
 var j = [];
@@ -4349,43 +4349,43 @@ i.get(c.project).then(_.spread(function(c, d) {
 function i() {
 var b = !g.getLabelSelector().isEmpty();
 if (!b) return void delete a.alerts.deployments;
-var c = _.isEmpty(a.unfilteredDeploymentConfigs) && _.isEmpty(a.unfilteredReplicationControllers) && _.isEmpty(a.unfilteredK8SDeployments) && _.isEmpty(a.unfilteredReplicaSets);
+var c = _.isEmpty(a.unfilteredDeploymentConfigs) && _.isEmpty(a.unfilteredReplicationControllers) && _.isEmpty(a.unfilteredDeployments) && _.isEmpty(a.unfilteredReplicaSets);
 if (c) return void delete a.alerts.deployments;
-var d = _.isEmpty(a.deploymentConfigs) && _.isEmpty(a.deploymentsByDeploymentConfig[""]) && _.isEmpty(a.k8sDeployments) && _.isEmpty(a.replicaSets);
+var d = _.isEmpty(a.deploymentConfigs) && _.isEmpty(a.replicationControllersByDC[""]) && _.isEmpty(a.deployments) && _.isEmpty(a.replicaSets);
 return d ? void (a.alerts.deployments = {
 type:"warning",
 details:"The active filters are hiding all deployments."
 }) :void delete a.alerts.deployments;
 }
 a.project = c, j.push(e.watch("replicationcontrollers", d, function(c, d, e) {
-a.deployments = c.by("metadata.name");
+a.replicationControllers = c.by("metadata.name");
 var j, k;
-if (e && (j = b("annotation")(e, "deploymentConfig"), k = e.metadata.name), a.deploymentsByDeploymentConfig = f.associateDeploymentsToDeploymentConfig(a.deployments, a.deploymentConfigs, !0), a.deploymentsByDeploymentConfig[""] && (a.unfilteredReplicationControllers = a.deploymentsByDeploymentConfig[""], g.addLabelSuggestionsFromResources(a.unfilteredReplicationControllers, a.labelSuggestions), g.setLabelSuggestions(a.labelSuggestions), a.deploymentsByDeploymentConfig[""] = g.getLabelSelector().select(a.deploymentsByDeploymentConfig[""])), i(), d) {
+if (e && (j = b("annotation")(e, "deploymentConfig"), k = e.metadata.name), a.replicationControllersByDC = f.associateDeploymentsToDeploymentConfig(a.replicationControllers, a.deploymentConfigs, !0), a.replicationControllersByDC[""] && (a.unfilteredReplicationControllers = a.replicationControllersByDC[""], g.addLabelSuggestionsFromResources(a.unfilteredReplicationControllers, a.labelSuggestions), g.setLabelSuggestions(a.labelSuggestions), a.replicationControllersByDC[""] = g.getLabelSelector().select(a.replicationControllersByDC[""])), i(), d) {
 if ("ADDED" === d || "MODIFIED" === d && [ "New", "Pending", "Running" ].indexOf(b("deploymentStatus")(e)) > -1) a.deploymentConfigDeploymentsInProgress[j] = a.deploymentConfigDeploymentsInProgress[j] || {}, a.deploymentConfigDeploymentsInProgress[j][k] = e; else if ("MODIFIED" === d) {
 var l = b("deploymentStatus")(e);
 "Complete" !== l && "Failed" !== l || delete a.deploymentConfigDeploymentsInProgress[j][k];
 }
-} else a.deploymentConfigDeploymentsInProgress = f.associateRunningDeploymentToDeploymentConfig(a.deploymentsByDeploymentConfig);
-e ? "DELETED" !== d && (e.causes = b("deploymentCauses")(e)) :angular.forEach(a.deployments, function(a) {
+} else a.deploymentConfigDeploymentsInProgress = f.associateRunningDeploymentToDeploymentConfig(a.replicationControllersByDC);
+e ? "DELETED" !== d && (e.causes = b("deploymentCauses")(e)) :angular.forEach(a.replicationControllers, function(a) {
 a.causes = b("deploymentCauses")(a);
-}), h.log("deployments (subscribe)", a.deployments);
+}), h.log("replicationControllers (subscribe)", a.replicationControllers);
 })), j.push(e.watch({
 group:"extensions",
 resource:"replicasets"
 }, d, function(b) {
 a.unfilteredReplicaSets = b.by("metadata.name"), g.addLabelSuggestionsFromResources(a.unfilteredReplicaSets, a.labelSuggestions), g.setLabelSuggestions(a.labelSuggestions), a.replicaSets = g.getLabelSelector().select(a.unfilteredReplicaSets), h.log("replicasets (subscribe)", a.replicaSets);
 })), j.push(e.watch("deploymentconfigs", d, function(b) {
-a.unfilteredDeploymentConfigs = b.by("metadata.name"), g.addLabelSuggestionsFromResources(a.unfilteredDeploymentConfigs, a.labelSuggestions), g.setLabelSuggestions(a.labelSuggestions), a.deploymentConfigs = g.getLabelSelector().select(a.unfilteredDeploymentConfigs), a.emptyMessage = "No deployment configurations to show", a.deploymentsByDeploymentConfig = f.associateDeploymentsToDeploymentConfig(a.deployments, a.deploymentConfigs, !0), a.deploymentsByDeploymentConfig[""] && (a.unfilteredReplicationControllers = a.deploymentsByDeploymentConfig[""], a.deploymentsByDeploymentConfig[""] = g.getLabelSelector().select(a.deploymentsByDeploymentConfig[""])), i(), h.log("deploymentconfigs (subscribe)", a.deploymentConfigs);
+a.unfilteredDeploymentConfigs = b.by("metadata.name"), g.addLabelSuggestionsFromResources(a.unfilteredDeploymentConfigs, a.labelSuggestions), g.setLabelSuggestions(a.labelSuggestions), a.deploymentConfigs = g.getLabelSelector().select(a.unfilteredDeploymentConfigs), a.emptyMessage = "No deployment configurations to show", a.replicationControllersByDC = f.associateDeploymentsToDeploymentConfig(a.replicationControllers, a.deploymentConfigs, !0), a.replicationControllersByDC[""] && (a.unfilteredReplicationControllers = a.replicationControllersByDC[""], a.replicationControllersByDC[""] = g.getLabelSelector().select(a.replicationControllersByDC[""])), i(), h.log("deploymentconfigs (subscribe)", a.deploymentConfigs);
 })), j.push(e.watch({
 group:"extensions",
 resource:"deployments"
 }, d, function(b) {
-a.unfilteredK8SDeployments = b.by("metadata.name"), g.addLabelSuggestionsFromResources(a.unfilteredK8SDeployments, a.labelSuggestions), g.setLabelSuggestions(a.labelSuggestions), a.k8sDeployments = g.getLabelSelector().select(a.unfilteredK8SDeployments), h.log("k8sDeployments (subscribe)", a.unfilteredK8SDeployments);
+a.unfilteredDeployments = b.by("metadata.name"), g.addLabelSuggestionsFromResources(a.unfilteredDeployments, a.labelSuggestions), g.setLabelSuggestions(a.labelSuggestions), a.deployments = g.getLabelSelector().select(a.unfilteredDeployments), h.log("deployments (subscribe)", a.unfilteredDeployments);
 })), a.showEmptyMessage = function() {
-return 0 === b("hashSize")(a.deploymentsByDeploymentConfig) || !(1 !== b("hashSize")(a.deploymentsByDeploymentConfig) || !a.deploymentsByDeploymentConfig[""]);
+return 0 === b("hashSize")(a.replicationControllersByDC) || !(1 !== b("hashSize")(a.replicationControllersByDC) || !a.replicationControllersByDC[""]);
 }, g.onActiveFiltersChanged(function(b) {
 a.$apply(function() {
-a.deploymentConfigs = b.select(a.unfilteredDeploymentConfigs), a.deploymentsByDeploymentConfig = f.associateDeploymentsToDeploymentConfig(a.deployments, a.deploymentConfigs, !0), a.deploymentsByDeploymentConfig[""] && (a.unfilteredReplicationControllers = a.deploymentsByDeploymentConfig[""], a.deploymentsByDeploymentConfig[""] = g.getLabelSelector().select(a.deploymentsByDeploymentConfig[""])), a.k8sDeployments = b.select(a.unfilteredK8SDeployments), a.replicaSets = b.select(a.unfilteredReplicaSets), i();
+a.deploymentConfigs = b.select(a.unfilteredDeploymentConfigs), a.replicationControllersByDC = f.associateDeploymentsToDeploymentConfig(a.replicationControllers, a.deploymentConfigs, !0), a.replicationControllersByDC[""] && (a.unfilteredReplicationControllers = a.replicationControllersByDC[""], a.replicationControllersByDC[""] = g.getLabelSelector().select(a.replicationControllersByDC[""])), a.deployments = b.select(a.unfilteredDeployments), a.replicaSets = b.select(a.unfilteredReplicaSets), i();
 });
 }), a.$on("$destroy", function() {
 e.unwatchAll(j);

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4301,8 +4301,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\">\n" +
-    "<div class=\"col-md-12\" ng-class=\"{ 'gutter-top': !(k8sDeployments | hashSize) && !(replicaSets | hashSize) }\">\n" +
-    "<h3 ng-if=\"(k8sDeployments | hashSize) || (replicaSets | hashSize)\">Deployment Configurations</h3>\n" +
+    "<div class=\"col-md-12\" ng-class=\"{ 'gutter-top': !(deployments | hashSize) && !(replicaSets | hashSize) }\">\n" +
+    "<h3 ng-if=\"(deployments | hashSize) || (replicaSets | hashSize)\">Deployment Configurations</h3>\n" +
     "<table class=\"table table-bordered table-hover table-mobile\">\n" +
     "<thead>\n" +
     "<tr>\n" +
@@ -4318,12 +4318,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<tr><td colspan=\"5\"><em>{{emptyMessage}}</em></td></tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat=\"(deploymentConfigName, deploymentConfigDeployments) in deploymentsByDeploymentConfig\" ng-if=\"deploymentConfigName && (deploymentConfigs[deploymentConfigName] || !unfilteredDeploymentConfigs[deploymentConfigName])\">\n" +
+    "<tbody ng-repeat=\"(dcName, replicationControllersForDC) in replicationControllersByDC\" ng-if=\"dcName && (deploymentConfigs[dcName] || !unfilteredDeploymentConfigs[dcName])\">\n" +
     "\n" +
-    "<tr ng-if=\"(deploymentConfigDeployments | hashSize) == 0 && deploymentConfigName\">\n" +
+    "<tr ng-if=\"(replicationControllersForDC | hashSize) == 0 && dcName\">\n" +
     "<td data-title=\"Name\">\n" +
-    "<a ng-if=\"deploymentConfigs[deploymentConfigName]\" href=\"{{deploymentConfigName | navigateResourceURL : 'DeploymentConfig' : projectName}}\">{{deploymentConfigName}}</a>\n" +
-    "<span ng-if=\"deploymentConfigs[deploymentConfigName].status.details.message\" class=\"pficon pficon-warning-triangle-o\" style=\"cursor: help\" data-toggle=\"popover\" data-trigger=\"hover\" dynamic-content=\"{{deploymentConfigs[deploymentConfigName].status.details.message}}\"></span>\n" +
+    "<a ng-if=\"deploymentConfigs[dcName]\" href=\"{{dcName | navigateResourceURL : 'DeploymentConfig' : projectName}}\">{{dcName}}</a>\n" +
+    "<span ng-if=\"deploymentConfigs[dcName].status.details.message\" class=\"pficon pficon-warning-triangle-o\" style=\"cursor: help\" data-toggle=\"popover\" data-trigger=\"hover\" dynamic-content=\"{{deploymentConfigs[dcName].status.details.message}}\"></span>\n" +
     "</td>\n" +
     "<td data-title=\"Last Version\"><em>No deployments</em></td>\n" +
     "<td class=\"hidden-xs\">&nbsp;</td>\n" +
@@ -4331,38 +4331,38 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<td class=\"hidden-xs\">&nbsp;</td>\n" +
     "</tr>\n" +
     "\n" +
-    "<tr ng-repeat=\"deployment in deploymentConfigDeployments | orderObjectsByDate : true | limitTo : 1\" ng-if=\"deploymentConfigName\">\n" +
+    "<tr ng-repeat=\"replicationController in replicationControllersForDC | orderObjectsByDate : true | limitTo : 1\" ng-if=\"dcName\">\n" +
     "<td data-title=\"Name\">\n" +
-    "<a href=\"{{deploymentConfigName | navigateResourceURL : 'DeploymentConfig' : deployment.metadata.namespace}}\">{{deploymentConfigName}}</a>\n" +
+    "<a ng-href=\"{{replicationController | configURLForResource}}\">{{dcName}}</a>\n" +
     "\n" +
-    "<span ng-if=\"deploymentConfigs && !deploymentConfigs[deploymentConfigName]\" class=\"pficon pficon-warning-triangle-o\" data-toggle=\"tooltip\" title=\"This deployment config no longer exists\" style=\"cursor: help\"></span>\n" +
+    "<span ng-if=\"deploymentConfigs && !deploymentConfigs[dcName]\" class=\"pficon pficon-warning-triangle-o\" data-toggle=\"tooltip\" title=\"This deployment config no longer exists\" style=\"cursor: help\"></span>\n" +
     "</td>\n" +
     "<td data-title=\"Last Version\">\n" +
     "\n" +
-    "<span ng-if=\"deployment | annotation : 'deploymentVersion'\">\n" +
-    "<a ng-href=\"{{deployment | navigateResourceURL}}\">#{{deployment | annotation : 'deploymentVersion'}}</a>\n" +
+    "<span ng-if=\"replicationController | annotation : 'deploymentVersion'\">\n" +
+    "<a ng-href=\"{{replicationController | navigateResourceURL}}\">#{{replicationController | annotation : 'deploymentVersion'}}</a>\n" +
     "</span>\n" +
-    "<span ng-if=\"!(deployment | annotation : 'deploymentVersion')\">\n" +
-    "<a ng-href=\"{{deployment | navigateResourceURL}}\">{{deployment.metadata.name}}</a>\n" +
+    "<span ng-if=\"!(replicationController | annotation : 'deploymentVersion')\">\n" +
+    "<a ng-href=\"{{replicationController | navigateResourceURL}}\">{{replicationController.metadata.name}}</a>\n" +
     "</span>\n" +
     "</td>\n" +
     "<td data-title=\"Status\">\n" +
     "<div row class=\"status\">\n" +
-    "<status-icon status=\"deployment | deploymentStatus\" disable-animation fixed-width=\"true\"></status-icon>\n" +
+    "<status-icon status=\"replicationController | deploymentStatus\" disable-animation fixed-width=\"true\"></status-icon>\n" +
     "<span flex>\n" +
-    "{{deployment | deploymentStatus}}<span ng-if=\"(deployment | deploymentStatus) == 'Active' || (deployment | deploymentStatus) == 'Running'\">,\n" +
-    "<span ng-if=\"deployment.spec.replicas !== deployment.status.replicas\">{{deployment.status.replicas}}/</span>{{deployment.spec.replicas}} replica<span ng-if=\"deployment.spec.replicas != 1\">s</span></span>\n" +
+    "{{replicationController | deploymentStatus}}<span ng-if=\"(replicationController | deploymentStatus) == 'Active' || (replicationController | deploymentStatus) == 'Running'\">,\n" +
+    "<span ng-if=\"replicationController.spec.replicas !== replicationController.status.replicas\">{{replicationController.status.replicas}}/</span>{{replicationController.spec.replicas}} replica<span ng-if=\"replicationController.spec.replicas != 1\">s</span></span>\n" +
     "</span>\n" +
     "</div>\n" +
     "\n" +
     "</td>\n" +
     "<td data-title=\"Created\">\n" +
-    "<relative-timestamp timestamp=\"deployment.metadata.creationTimestamp\"></relative-timestamp>\n" +
+    "<relative-timestamp timestamp=\"replicationController.metadata.creationTimestamp\"></relative-timestamp>\n" +
     "</td>\n" +
     "<td data-title=\"Trigger\">\n" +
-    "<span ng-if=\"!deployment.causes.length\">Unknown</span>\n" +
-    "<span ng-if=\"deployment.causes.length\">\n" +
-    "<span ng-repeat=\"cause in deployment.causes\">\n" +
+    "<span ng-if=\"!replicationController.causes.length\">Unknown</span>\n" +
+    "<span ng-if=\"replicationController.causes.length\">\n" +
+    "<span ng-repeat=\"cause in replicationController.causes\">\n" +
     "<span ng-switch=\"cause.type\">\n" +
     "<span ng-switch-when=\"ImageChange\">\n" +
     "<span ng-if=\"cause.imageTrigger.from\">\n" +
@@ -4378,7 +4378,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</tr>\n" +
     "</tbody>\n" +
     "</table>\n" +
-    "<div ng-if=\"k8sDeployments | hashSize\">\n" +
+    "<div ng-if=\"deployments | hashSize\">\n" +
     "<h3>Deployments</h3>\n" +
     "<table class=\"table table-bordered table-hover table-mobile\">\n" +
     "<thead>\n" +
@@ -4390,22 +4390,22 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<th>Strategy</th>\n" +
     "</tr>\n" +
     "</thead>\n" +
-    "<tbody ng-repeat=\"k8sDeployment in k8sDeployments | orderObjectsByDate : true\">\n" +
+    "<tbody ng-repeat=\"deployment in deployments | orderObjectsByDate : true\">\n" +
     "<tr>\n" +
     "<td data-title=\"Name\">\n" +
-    "<a ng-href=\"{{k8sDeployment | navigateResourceURL}}\">{{k8sDeployment.metadata.name}}</a>\n" +
+    "<a ng-href=\"{{deployment | navigateResourceURL}}\">{{deployment.metadata.name}}</a>\n" +
     "</td>\n" +
     "<td data-title=\"Last Version\">\n" +
-    "{{k8sDeployment | lastDeploymentRevision}}\n" +
+    "{{deployment | lastDeploymentRevision}}\n" +
     "</td>\n" +
     "<td data-title=\"Replicas\">\n" +
-    "<span ng-if=\"k8sDeployment.status.replicas !== k8sDeployment.spec.replicas\">{{k8sDeployment.status.replicas}}/</span>{{k8sDeployment.spec.replicas}} replica<span ng-if=\"k8sDeployment.spec.replicas != 1\">s</span>\n" +
+    "<span ng-if=\"deployment.status.replicas !== deployment.spec.replicas\">{{deployment.status.replicas}}/</span>{{deployment.spec.replicas}} replica<span ng-if=\"deployment.spec.replicas != 1\">s</span>\n" +
     "</td>\n" +
     "<td data-title=\"Created\">\n" +
-    "<relative-timestamp timestamp=\"k8sDeployment.metadata.creationTimestamp\"></relative-timestamp>\n" +
+    "<relative-timestamp timestamp=\"deployment.metadata.creationTimestamp\"></relative-timestamp>\n" +
     "</td>\n" +
     "<td data-title=\"Strategy\">\n" +
-    "{{k8sDeployment.spec.strategy.type | sentenceCase}}\n" +
+    "{{deployment.spec.strategy.type | sentenceCase}}\n" +
     "</td>\n" +
     "</tr>\n" +
     "</tbody>\n" +
@@ -4446,8 +4446,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<th>Created</th>\n" +
     "</tr>\n" +
     "</thead>\n" +
-    "<tbody ng-if=\"(deploymentsByDeploymentConfig[''] | hashSize) === 0\"><tr><td colspan=\"3\"><em>No replication controllers to show</em></td></tr></tbody>\n" +
-    "<tbody ng-repeat=\"deployment in deploymentsByDeploymentConfig[''] | orderObjectsByDate : true\">\n" +
+    "<tbody ng-if=\"(replicationControllersByDC[''] | hashSize) === 0\"><tr><td colspan=\"3\"><em>No replication controllers to show</em></td></tr></tbody>\n" +
+    "<tbody ng-repeat=\"deployment in replicationControllersByDC[''] | orderObjectsByDate : true\">\n" +
     "\n" +
     "<tr>\n" +
     "<td data-title=\"Name\">\n" +


### PR DESCRIPTION
Avoid confusion between k8s deployments and replication controllers by renaming some scope variables:

$scope.deployments -> $scope.replicationControllers
$scope.deploymentsByDeploymentConfig -> $scope.replicationControllersByDC
$scope.k8sDeployments -> $scope.deployments
$scope.unfilteredK8SDeployments -> $scope.unfilteredDeployments