### PR TITLE
Improving display of data-toolbar and table-toolbar to resolve bugs

### DIFF
--- a/app/styles/_data-toolbar.less
+++ b/app/styles/_data-toolbar.less
@@ -3,45 +3,38 @@
 ---------------------------------------------------------------------------- */
 
 .data-toolbar {
-  .flex(@columns: 1 1 0%);
-  .flex-direction(@direction: column);
-  .flex-display(@display: flex);
-  .flex-wrap(@wrap: wrap);
   padding: 5px 0;
   @media (min-width: @screen-sm-min) {
-    .flex-direction(@direction: row);
+    .flex-display(@display: flex);
   }
   // Set min-widths to prevent clipping when option lengths are known
   &.other-resources-toolbar .data-toolbar-dropdown {
-    min-width: 250px;
+    min-width: 210px;
   }
   .checkbox {
     margin-bottom: 0;
     margin-top: 10px;
-    width: 100%;
-    @media (min-width: 900px) {
+    @media (min-width: @screen-sm-min) {
       .flex(@columns: 1 1 0%);
+      margin-left: 20px;
       margin-top: 3px;
       text-align: right;
-      width: auto;
     }
   }
-  .data-toolbar-dropdown {
-    min-width: 160px;
-  }
   .data-toolbar-filter {
-    min-width: 75px;
     @media (min-width: @screen-sm-min) {
-      // Set flex rules so that filter expands in IE11
-      .flex-display(@display: flex);
-      .flex(@columns: 1 1 auto);
+      .flex(@columns: 1 1 0%);
+    }
+    @media (min-width: @screen-md-min) {
+      max-width: 600px;
+    }
+    .filter .navbar-filter-widget .label-filter .selectize-control .selectize-input {
+      &, & input {
+        font-size: @font-size-base;
+      }
     }
     .form-group {
       margin-bottom: 0;
-      min-width: 75px;
-      input {
-        width: 100%;
-      }
     }
   }
   // TODO:  remove this rule with https://github.com/openshift/origin-web-console/issues/220
@@ -52,27 +45,13 @@
       .flex(@columns: 0 1 auto);
     }
   }
-}
-
-project-filter {
-    // Set flex rules so that filter expands in IE11
-  .flex-display(@display: flex);
-  .flex(@columns: 1 0 0%);
-  .flex-direction(@direction: column);
-  @media (max-width: @screen-xs-max) {
-    min-width: initial;
-  }
-  .filter .navbar-filter-widget .label-filter  {
-    width: 100%;
+  .vertical-divider + .data-toolbar-filter {
+    margin-top: 10px;
     @media (min-width: @screen-sm-min) {
-      min-width: 50%;
-      width: auto;
-    }
-    @media (min-width: @screen-md-min) {
-      min-width: 30%;
+      margin-top: 0;
     }
   }
-  .label-filtering-remove-all {
-    background-color: @brand-primary !important;
-  }
+}
+.selectize-dropdown {
+  font-size: @font-size-base;
 }

--- a/app/styles/_tables.less
+++ b/app/styles/_tables.less
@@ -66,7 +66,7 @@
       //   https://www.patternfly.org/styles/color-palette/
       border-left: 1px solid #bbbbbb;
       display: inline-block;
-      height: 25px;
+      height: 27px;
       margin: 0 7px;
       vertical-align: middle;
       width: 1px;
@@ -75,8 +75,11 @@
 }
 
 .table-toolbar {
-  .filter-controls input {
-    width: 100%;
+  .filter-controls {
+    margin-bottom: 10px;
+    input {
+      width: 100%;
+    }
   }
   .sort-label {
     margin-right: 4px;
@@ -92,8 +95,11 @@
       // Inline controls at wider widths.
       display: inline-block;
     }
-    .filter-controls input {
-      width: 300px;
+    .filter-controls {
+      margin-bottom: 0;
+      input {
+        width: 300px;
+      }
     }
   }
 }

--- a/app/views/directives/_project-filter.html
+++ b/app/views/directives/_project-filter.html
@@ -1,4 +1,4 @@
-<div class="filter navbar-collapse-3 navbar-filter-widget-collapse">
+<div class="filter">
   <div class="form-group">
     <label ng-if="!renderOptions || !renderOptions.hideFilterWidget" class="control-label sr-only">Filter by labels</label>
     <div class="navbar-filter-widget"></div>

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "microplugin": "0.0.3",
     "selectize": "0.12.1",
     "messenger": "1.4.1",
-    "kubernetes-label-selector": "1.2.0",
+    "kubernetes-label-selector": "1.3.0",
     "kubernetes-topology-graph": "0.0.23",
     "kubernetes-container-terminal": "1.0.1",
     "registry-image-widgets": "0.0.2",

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4781,7 +4781,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/directives/_project-filter.html',
-    "<div class=\"filter navbar-collapse-3 navbar-filter-widget-collapse\">\n" +
+    "<div class=\"filter\">\n" +
     "<div class=\"form-group\">\n" +
     "<label ng-if=\"!renderOptions || !renderOptions.hideFilterWidget\" class=\"control-label sr-only\">Filter by labels</label>\n" +
     "<div class=\"navbar-filter-widget\"></div>\n" +

--- a/dist/scripts/vendor.js
+++ b/dist/scripts/vendor.js
@@ -38656,7 +38656,7 @@ var e = d._existingLabels;
 if (!e[c]) return void a({});
 for (var f = 0; f < e[c].length; f++) b.push(e[c][f]);
 a(b);
-}), d._labelFilterOperatorSelectizeInput.css("display", "inline-flex");
+}), d._labelFilterOperatorSelectizeInput.css("display", "inline-block");
 var e = d._labelFilterOperatorSelectize.getValue();
 e ? c.focus() :d._labelFilterOperatorSelectize.focus();
 },
@@ -38691,7 +38691,7 @@ type:"not in",
 label:"not in ..."
 } ],
 onItemAdd:function(a, b) {
-return "exists" == a || "does not exist" == a ? void d._labelFilterAddBtn.removeClass("disabled").prop("disabled", !1).focus() :(d._labelFilterValuesSelectizeInput.css("display", "inline-flex"), void d._labelFilterValuesSelectize.focus());
+return "exists" == a || "does not exist" == a ? void d._labelFilterAddBtn.removeClass("disabled").prop("disabled", !1).focus() :(d._labelFilterValuesSelectizeInput.css("display", "inline-block"), void d._labelFilterValuesSelectize.focus());
 },
 onItemRemove:function(a) {
 d._labelFilterValuesSelectizeInput.hide(), d._labelFilterValuesSelectize.clear(), d._labelFilterAddBtn.addClass("disabled").prop("disabled", !0);

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3545,6 +3545,7 @@ label.checkbox{font-weight:400}
 .osc-form span.fa.visible-xs-inline{margin-right:10px}
 .osc-form .flow{border-top:1px solid rgba(0,0,0,.15);display:table;margin-top:40px;width:100%}
 .osc-form .flow>.flow-block{display:inline-block}
+.catalog-fluid,.navbar-pf-alt .navbar-header{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex}
 .osc-form .flow>.flow-block .action,.osc-form .flow>.flow-block.right{font-size:11px;font-weight:400}
 .osc-form .flow>.flow-block>ul.list-inline{margin-bottom:0}
 .osc-form .flow>.flow-block>ul.list-inline>li{font-size:11px;text-align:left}
@@ -3569,7 +3570,7 @@ label.checkbox{font-weight:400}
 .catalog .tile-image h3 small,.catalog .tile-template h3 small{vertical-align:1px}
 .catalog .tile-image a.tag,.catalog .tile-template a.tag{text-decoration:none}
 .catalog .tile-image a.tag:hover,.catalog .tile-template a.tag:hover{color:#000;background:#dfdfdf;text-decoration:none}
-.catalog-fluid{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column}
+.catalog-fluid{display:flex;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column}
 @media (min-width:992px){.catalog-fluid .tile-image:nth-child(odd),.catalog-fluid .tile-template:nth-child(odd){margin-right:20px}
 }
 @media (min-width:768px){.catalog-fluid{-webkit-flex-direction:row;-moz-flex-direction:row;-ms-flex-direction:row;flex-direction:row;-webkit-flex-wrap:wrap;-moz-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-justify-content:flex-start;-moz-justify-content:flex-start;justify-content:flex-start;-ms-flex-pack:start}
@@ -3693,6 +3694,7 @@ labels+.resource-details{margin-top:10px}
 [flex].page-header{margin-top:21px}
 .resource-details h3{padding-bottom:10px;border-bottom:1px solid #eee}
 .build-config-summary .meta,h1 small.meta{font-size:12px}
+.data-toolbar .data-toolbar-filter .filter .navbar-filter-widget .label-filter .selectize-control .selectize-input,.data-toolbar .data-toolbar-filter .filter .navbar-filter-widget .label-filter .selectize-control .selectize-input input,.selectize-dropdown{font-size:13px}
 @media (max-width:480px){.build-config-summary .meta,h1 small.meta{display:block;margin-top:5px}
 }
 .ace-bordered{border:1px solid #8b8d8f}
@@ -3707,29 +3709,20 @@ labels+.resource-details{margin-top:10px}
 copy-to-clipboard .input-group{max-width:300px}
 .strong{font-weight:700}
 .tech-preview-header{justify-content:space-between}
-.data-toolbar{-webkit-flex:1 1 0%;-moz-flex:1 1 0%;-ms-flex:1 1 0%;flex:1 1 0%;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex-wrap:wrap;-moz-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;padding:5px 0}
-@media (min-width:768px){.data-toolbar{-webkit-flex-direction:row;-moz-flex-direction:row;-ms-flex-direction:row;flex-direction:row}
+.data-toolbar{padding:5px 0}
+.data-toolbar.other-resources-toolbar .data-toolbar-dropdown{min-width:210px}
+.data-toolbar .checkbox{margin-bottom:0;margin-top:10px}
+@media (min-width:768px){.data-toolbar{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex}
+.data-toolbar .checkbox{-webkit-flex:1 1 0%;-moz-flex:1 1 0%;-ms-flex:1 1 0%;flex:1 1 0%;margin-left:20px;margin-top:3px;text-align:right}
+.data-toolbar .data-toolbar-filter{-webkit-flex:1 1 0%;-moz-flex:1 1 0%;-ms-flex:1 1 0%;flex:1 1 0%}
 }
-.data-toolbar.other-resources-toolbar .data-toolbar-dropdown{min-width:250px}
-.data-toolbar .checkbox{margin-bottom:0;margin-top:10px;width:100%}
-@media (min-width:900px){.data-toolbar .checkbox{-webkit-flex:1 1 0%;-moz-flex:1 1 0%;-ms-flex:1 1 0%;flex:1 1 0%;margin-top:3px;text-align:right;width:auto}
-}
-.data-toolbar .data-toolbar-filter .form-group input,project-filter .filter .navbar-filter-widget .label-filter{width:100%}
-.data-toolbar .data-toolbar-dropdown{min-width:160px}
-.data-toolbar .data-toolbar-filter{min-width:75px}
-@media (min-width:768px){.data-toolbar .data-toolbar-filter{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex:1 1 auto;-moz-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto}
-}
-.navbar-pf-alt .navbar-header,project-filter{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex}
-.data-toolbar .data-toolbar-filter .form-group{margin-bottom:0;min-width:75px}
+.data-toolbar .data-toolbar-filter .form-group{margin-bottom:0}
 .data-toolbar .data-toolbar-views{-webkit-flex:0 1 auto;-moz-flex:0 1 auto;-ms-flex:0 1 auto;flex:0 1 auto;text-align:right}
 @media (min-width:1200px){.data-toolbar .data-toolbar-views{-webkit-flex:0 1 auto;-moz-flex:0 1 auto;-ms-flex:0 1 auto;flex:0 1 auto}
 }
-project-filter{display:flex;-webkit-flex:1 0 0%;-moz-flex:1 0 0%;-ms-flex:1 0 0%;flex:1 0 0%;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column}
-@media (max-width:767px){project-filter{min-width:initial}
+.data-toolbar .vertical-divider+.data-toolbar-filter{margin-top:10px}
+@media (min-width:768px){.data-toolbar .vertical-divider+.data-toolbar-filter{margin-top:0}
 }
-@media (min-width:768px){project-filter .filter .navbar-filter-widget .label-filter{min-width:50%;width:auto}
-}
-project-filter .label-filtering-remove-all{background-color:#39a5dc!important}
 .ellipsis-pulser{padding:10px;text-align:center}
 .ellipsis-pulser.ellipsis-dark .dot.pulse:after,.ellipsis-pulser.ellipsis-dark .dot.pulse:before{background:#333}
 .ellipsis-pulser.ellipsis-dark .ellipsis-msg{color:#333}
@@ -3773,7 +3766,7 @@ h2+.list-view-pf{margin-top:20px}
 .list-view-pf-description{-ms-flex:1 0 55%;flex:1 0 55%}
 .list-view-pf-main-info{padding-bottom:10px;padding-top:10px}
 .list-view-pf .list-group-item-heading small{overflow:hidden;text-overflow:ellipsis;color:#9c9c9c}
-@media (min-width:992px){project-filter .filter .navbar-filter-widget .label-filter{min-width:30%}
+@media (min-width:992px){.data-toolbar .data-toolbar-filter{max-width:600px}
 .list-view-pf .list-group-item-heading,.list-view-pf .list-group-item-text{-ms-flex:1 0 auto;flex:1 0 auto;margin:0;padding:0 20px 0 0;width:50%}
 .list-view-pf-additional-info{width:40%}
 .list-view-pf-description{width:60%}
@@ -4570,14 +4563,16 @@ body,html{margin:0;padding:0}
 @media (max-width:1199px){.table .pull-spec{max-width:315px}
 }
 .data-toolbar .vertical-divider,.table-toolbar .vertical-divider{display:none}
-@media (min-width:768px){.data-toolbar .vertical-divider,.table-toolbar .vertical-divider{border-left:1px solid #bbb;display:inline-block;height:25px;margin:0 7px;vertical-align:middle;width:1px}
+@media (min-width:768px){.data-toolbar .vertical-divider,.table-toolbar .vertical-divider{border-left:1px solid #bbb;display:inline-block;height:27px;margin:0 7px;vertical-align:middle;width:1px}
 }
+.table-toolbar .filter-controls{margin-bottom:10px}
 .table-toolbar .filter-controls input{width:100%}
 .table-toolbar .sort-label{margin-right:4px;vertical-align:-1px}
 .table-toolbar .sort-controls{display:inline-block}
 @media (min-width:768px){.table-toolbar{padding-bottom:20px}
 .table-toolbar.gutter-bottom-2x{padding-bottom:40px}
 .table-toolbar .filter-controls,.table-toolbar .sort-group{display:inline-block}
+.table-toolbar .filter-controls{margin-bottom:0}
 .table-toolbar .filter-controls input{width:300px}
 .tile h3 .tile-timestamp{float:right!important;float:right}
 }

--- a/dist/styles/vendor.css
+++ b/dist/styles/vendor.css
@@ -128,7 +128,7 @@ ul.messenger-theme-flat .messenger-spinner{display:block;position:absolute;left:
 .selectize-control.plugin-drag_drop.multi>.selectize-input>div.ui-sortable-placeholder{visibility:visible!important;background:#f2f2f2!important;background:rgba(0,0,0,.06)!important;border:0!important;box-shadow:inset 0 0 12px 4px #fff}
 .selectize-control.plugin-drag_drop .ui-sortable-placeholder::after{content:'!';visibility:hidden}
 .selectize-control.plugin-drag_drop .ui-sortable-helper{box-shadow:0 2px 5px rgba(0,0,0,.2)}
-.selectize-dropdown-header{position:relative;padding:7px;border-bottom:1px solid #b7b7b7;background:#f4f4f4;border-radius:1px 1px 0 0}
+.selectize-dropdown-header{position:relative;padding:7px;border-bottom:1px solid #bbb;background:#f5f5f5;border-radius:1px 1px 0 0}
 .selectize-dropdown-header-close{position:absolute;right:7px;top:50%;color:#303030;opacity:.4;margin-top:-12px;line-height:20px;font-size:20px!important}
 .selectize-dropdown-header-close:hover{color:#000}
 .selectize-dropdown.plugin-optgroup_columns .optgroup{border-right:1px solid #f2f2f2;border-top:0 none;float:left;box-sizing:border-box}
@@ -136,33 +136,33 @@ ul.messenger-theme-flat .messenger-spinner{display:block;position:absolute;left:
 .selectize-dropdown.plugin-optgroup_columns .optgroup:before{display:none}
 .selectize-dropdown.plugin-optgroup_columns .optgroup-header{border-top:0 none}
 .selectize-control.plugin-remove_button [data-value]{position:relative;padding-right:24px!important}
-.selectize-control.plugin-remove_button [data-value] .remove{z-index:1;position:absolute;top:0;right:0;bottom:0;width:17px;text-align:center;font-weight:700;font-size:12px;color:inherit;text-decoration:none;vertical-align:middle;display:inline-block;border-radius:0 2px 2px 0;box-sizing:border-box}
-.selectize-control,.selectize-input{position:relative}
+.selectize-control.plugin-remove_button [data-value] .remove{z-index:1;position:absolute;top:0;right:0;bottom:0;width:17px;text-align:center;font-weight:700;font-size:12px;color:inherit;text-decoration:none;vertical-align:middle;display:inline-block;padding:2px 0 0;border-left:1px solid #bbb;border-radius:0 2px 2px 0;box-sizing:border-box}
 .selectize-control.plugin-remove_button [data-value] .remove:hover{background:rgba(0,0,0,.05)}
 .selectize-control.plugin-remove_button [data-value].active .remove{border-left-color:#00578d}
 .selectize-control.plugin-remove_button .disabled [data-value] .remove:hover{background:0 0}
 .selectize-control.plugin-remove_button .disabled [data-value] .remove{border-left-color:#fff}
+.selectize-control.plugin-remove_button .remove-single{position:absolute;right:28px;top:6px;font-size:23px}
+.selectize-control,.selectize-input{position:relative}
 .selectize-dropdown,.selectize-input,.selectize-input input{color:#303030;font-family:inherit;font-size:13px;line-height:18px;-webkit-font-smoothing:inherit}
 .selectize-control.single .selectize-input.input-active,.selectize-input{background:#fff;cursor:text;display:inline-block}
-.selectize-input{border:1px solid #b7b7b7;padding:7px 10px;display:inline-block;width:100%;overflow:hidden;z-index:1;box-sizing:border-box;box-shadow:inset 0 1px 1px rgba(0,0,0,.1);border-radius:1px}
+.selectize-input{border:1px solid #bbb;padding:7px 10px;display:inline-block;width:100%;overflow:hidden;z-index:1;box-sizing:border-box;box-shadow:inset 0 1px 1px rgba(0,0,0,.1);border-radius:1px}
 .selectize-control.multi .selectize-input.has-items{padding:5px 10px 2px}
 .selectize-input.full{background-color:#fff}
 .selectize-input.disabled,.selectize-input.disabled *{cursor:default!important}
 .selectize-input.focus{box-shadow:inset 0 1px 2px rgba(0,0,0,.15)}
 .selectize-input.dropdown-active{border-radius:1px 1px 0 0}
 .selectize-input>*{vertical-align:baseline;display:-moz-inline-stack;display:inline-block;zoom:1}
-.selectize-control.multi .selectize-input>div{cursor:pointer;margin:0 3px 3px 0;padding:2px 6px;background:#006e9c;color:#fff;border:0 solid #b7b7b7}
+.selectize-control.multi .selectize-input>div{cursor:pointer;margin:0 3px 3px 0;padding:2px 6px;background:#006e9c;color:#fff;border:0 solid #bbb}
 .selectize-control.multi .selectize-input>div.active{background:#92c836;color:#fff;border:0 solid #00578d}
 .selectize-control.multi .selectize-input.disabled>div,.selectize-control.multi .selectize-input.disabled>div.active{color:#fff;background:#9b9b9b;border:0 solid #fff}
 .selectize-input>input{display:inline-block!important;padding:0!important;min-height:0!important;max-height:none!important;max-width:100%!important;margin:0 1px!important;text-indent:0!important;border:0!important;background:0 0!important;line-height:inherit!important;-webkit-user-select:auto!important;box-shadow:none!important}
 .selectize-input>input::-ms-clear{display:none}
 .selectize-input>input:focus{outline:0!important}
 .selectize-input::after{content:' ';display:block;clear:left}
-.filter .navbar-filter-widget:after,ul.registry-image-layers li{clear:both}
 .selectize-input.dropdown-active::before{content:' ';display:block;position:absolute;background:0 0;height:1px;bottom:0;left:0;right:0}
-.selectize-dropdown{position:absolute;background:#fff;box-sizing:border-box;box-shadow:0 1px 3px rgba(0,0,0,.1);border-radius:0 0 1px 1px}
+.selectize-dropdown{position:absolute;background:#fff;box-sizing:border-box;border-radius:0 0 1px 1px}
 .selectize-dropdown [data-selectable]{cursor:pointer;overflow:hidden}
-.selectize-dropdown [data-selectable] .highlight{background:rgba(125,168,208,.2);border-radius:1px}
+.selectize-dropdown [data-selectable] .highlight{border-radius:1px}
 .selectize-dropdown .optgroup:first-child .optgroup-header{border-top:0 none}
 .selectize-dropdown .optgroup-header{color:#303030;background:#fff;cursor:default;padding-top:9px;font-weight:700;font-size:.85em}
 .selectize-dropdown .active{background-color:#f5fafd;color:#495c68}
@@ -180,51 +180,45 @@ ul.messenger-theme-flat .messenger-spinner{display:block;position:absolute;left:
 .selectize-control.multi .selectize-input.disabled [data-value]{color:#999;text-shadow:none;background:0 0;box-shadow:none}
 .selectize-control.multi .selectize-input.disabled [data-value],.selectize-control.multi .selectize-input.disabled [data-value] .remove{border-color:#e6e6e6}
 .selectize-control.multi .selectize-input.disabled [data-value] .remove{background:0 0}
-.selectize-control.multi .selectize-input [data-value]{box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 1px rgba(255,255,255,.03)}
 .selectize-control.multi .selectize-input [data-value].active{background-color:#0085d4;background-image:linear-gradient(to bottom,#008fd8,#0075cf);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff008fd8', endColorstr='#ff0075cf', GradientType=0)}
-.selectize-control.single .selectize-input{box-shadow:0 1px 0 rgba(0,0,0,.05),inset 0 1px 0 rgba(255,255,255,.8);background-color:#f9f9f9;background-color:rgba(0,0,0,0);background-image:linear-gradient(to bottom,transparent,transparent);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#00000000', GradientType=0)}
+.selectize-control.single .selectize-input{box-shadow:0 1px 0 rgba(0,0,0,.05),inset 0 1px 0 rgba(255,255,255,.8);background-color:#f9f9f9;background-image:linear-gradient(to bottom,#fefefe,#f2f2f2);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#fffefefe', endColorstr='#fff2f2f2', GradientType=0)}
 .selectize-dropdown .optgroup{border-top:1px solid transparent}
 .selectize-dropdown .optgroup:first-child{border-top:0 none}
-.selectize-control.plugin-remove_button [data-value]{font-size:12px}
-.selectize-control.plugin-remove_button [data-value] .remove{border-left:1px solid #005c83;padding:0}
-.selectize-control.multi .selectize-input [data-value]{padding:0 6px;margin:0 3px 0 0;text-shadow:0 1px 0 rgba(0,0,0,.2);border-radius:2px;background-color:#006e9c;background-image:linear-gradient(to bottom,#006e9c,#006e9c);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff006e9c', endColorstr='#ff006e9c', GradientType=0)}
-.selectize-control.multi .selectize-input [data-value]+[data-value]{margin-top:3px}
-.selectize-control.single .selectize-input,.selectize-dropdown.single{border-color:#b7b7b7}
+.selectize-control.multi .selectize-input [data-value]{box-shadow:none;line-height:18px;margin:2px 4px 2px 0;padding:0 6px;text-shadow:0 1px 0 rgba(0,0,0,.2);border-radius:2px;background-color:#006e9c!important;background-image:linear-gradient(to bottom,#006e9c,#006e9c)!important;background-repeat:repeat-x!important;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff006e9c', endColorstr='#ff006e9c', GradientType=0)!important}
+.selectize-control.plugin-remove_button .selectize-input .remove{border-left:0;padding:1px 0 0}
+.selectize-control.single .selectize-input,.selectize-dropdown.single{border-color:#bbb}
 .selectize-dropdown .optgroup-header,.selectize-dropdown [data-selectable]{padding:5px 20px 5px 7px;word-break:break-all;word-break:break-word;overflow-wrap:break-word}
-.filter{display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;-webkit-flex-flow:row nowrap;-ms-flex-flow:row nowrap;flex-flow:row nowrap;-webkit-align-items:stretch;-ms-flex-align:stretch;align-items:stretch;min-width:220px}
-.filter .navbar-filter-widget{display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex:1 1 0%;-ms-flex:1 1 0%;flex:1 1 0%;-webkit-flex-flow:row nowrap;-ms-flex-flow:row nowrap;flex-flow:row nowrap;-webkit-align-items:stretch;-ms-flex-align:stretch;align-items:stretch;min-width:0}
-.filter .navbar-filter-widget:after,.filter .navbar-filter-widget:before{content:" ";display:table}
-.filter .navbar-filter-widget .label-filter{background:#fff;-webkit-flex:0 1 auto;-ms-flex:0 1 auto;flex:0 1 auto;min-width:0;min-height:27px;border:1px solid #b7b7b7;border-radius:1px}
-.filter .navbar-filter-widget .label-filter.filter-active{border-color:#66afe9;outline:0;box-shadow:inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(102,175,233,.6)}
-.filter .navbar-filter-widget .label-filter .selectize-control{display:-webkit-inline-flex;display:-ms-inline-flexbox;display:inline-flex}
-.filter .navbar-filter-widget .label-filter .selectize-control .item{word-break:break-all;word-break:break-word;overflow-wrap:break-word;max-width:100%}
-.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input{background:0 0;vertical-align:middle;padding:2px 8px;border:0;box-shadow:none;font-size:12px;-webkit-flex:0 1 auto;-ms-flex:0 1 auto;flex:0 1 auto;min-width:160px;width:100%}
+.filter{display:table;width:100%}
+.filter .navbar-filter-widget{display:table-row}
+.filter .navbar-filter-widget .label-filter{background:#fff;border:1px solid #bbb;box-shadow:inset 0 1px 1px rgba(0,0,0,.075);border-radius:1px;display:table-cell;transition:"border-color ease-in-out .15s, box-shadow ease-in-out .15s";width:100%}
+.filter .navbar-filter-widget .label-filter.filter-active{border-color:#0088ce;outline:0;box-shadow:inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(0,136,206,.6)}
+.filter .navbar-filter-widget .label-filter:hover{border-color:#7dc3e8}
+.filter .navbar-filter-widget .label-filter .selectize-control{display:inline-block}
+.filter .navbar-filter-widget .label-filter .selectize-control .item{max-width:100%;word-break:break-all;word-break:break-word;overflow-wrap:break-word}
+.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input{background:0 0;border:0;box-shadow:none;-ms-flex:0 1 auto;flex:0 1 auto;font-size:12px;line-height:22px;padding:0 6px;vertical-align:middle;width:100%}
 .filter .navbar-filter-widget .label-filter .selectize-control .selectize-input.full{min-width:0}
 .filter .navbar-filter-widget .label-filter .selectize-control .selectize-input.full:after{border:0}
-.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input input{font-size:12px;height:21px}
-.filter .navbar-filter-widget .label-filter-add.btn{border-left:0;border-radius:0;font-size:12px;opacity:1;height:27px;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;-webkit-justify-content:center;-ms-flex-pack:center;justify-content:center}
-.filter .navbar-filter-widget .label-filter-add.btn.disabled{opacity:.75}
-.selectize-dropdown{z-index:9999;font-size:12px;margin:0 0 0 -1px;width:100%!important;border:1px solid #b7b7b7}
-.active-filters{line-height:0;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column}
-.active-filters .label-filter-active-filters{display:-webkit-inline-flex;display:-ms-inline-flexbox;display:inline-flex;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;padding-bottom:3px}
-.active-filters .label-filter-active-filters .label{-webkit-align-items:center;-ms-flex-align:center;align-items:center;background:#006e9c;border-radius:2px;display:-webkit-inline-flex;display:-ms-inline-flexbox;display:inline-flex;-webkit-flex:0 1 auto;-ms-flex:0 1 auto;flex:0 1 auto;font-size:12px;font-weight:400;line-height:13px;padding-bottom:.3em;padding-top:.3em;text-shadow:0 1px 0 rgba(0,0,0,.2);word-break:break-all;word-break:break-word;overflow-wrap:break-word;white-space:normal;margin:2px 3px 2px 0}
+.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input input{font-size:12px;height:22px;margin-left:0!important;margin-right:0!important}
+.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input input::-webkit-input-placeholder{font-style:italic;color:#999}
+.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input input::-moz-placeholder{font-style:italic;color:#999;opacity:1}
+.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input input:-ms-input-placeholder{font-style:italic;color:#999}
+.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input input::placeholder{color:#999;font-style:italic}
+.filter .navbar-filter-widget .label-filter-add.btn{border-left:0;border-radius:1px;display:table-cell}
+.selectize-dropdown{border:1px solid #bbb;box-shadow:0 6px 12px rgba(0,0,0,.175);font-size:12px;margin:1px 0 0 -1px;min-width:40%;padding:5px 0;z-index:9999}
+@media (min-width:768px){.selectize-dropdown{min-width:0;width:auto!important;white-space:nowrap}
+}
+.selectize-dropdown [data-selectable]{border-bottom:1px solid transparent;border-top:1px solid transparent;line-height:1.66666667;padding:1px 10px}
+.selectize-dropdown [data-selectable].active{background:#def3ff;border-color:#bee1f4;color:#4d5258}
+.selectize-dropdown [data-selectable] .highlight{background:0 0;font-weight:700}
+.active-filters{line-height:0;display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column}
+.active-filters .label-filter-active-filters{display:-ms-inline-flexbox;display:inline-flex;-ms-flex-wrap:wrap;flex-wrap:wrap}
+.active-filters .label-filter-active-filters .label{-ms-flex-align:center;align-items:center;background:#006e9c;border-radius:2px;display:-ms-inline-flexbox;display:inline-flex;-ms-flex:0 1 auto;flex:0 1 auto;font-size:12px;font-weight:400;line-height:13px;padding:.3em 6px;margin:3px 3px 0 0;text-shadow:0 1px 0 rgba(0,0,0,.2);word-break:break-all;word-break:break-word;overflow-wrap:break-word;white-space:normal}
 [overflow-hidden],[truncate]{overflow:hidden}
 .active-filters .label-filter-active-filters .label:hover{background:#006e9c}
-.active-filters .label-filter-active-filters .label i.fa-times{font-size:11px;padding-left:5px}
-.active-filters .label-filter-active-filters .label-filter-clear{display:-webkit-inline-flex;display:-ms-inline-flexbox;display:inline-flex;margin:2px 5px 2px 0;-webkit-align-items:center;-ms-flex-align:center;align-items:center}
-.active-filters .label-filter-active-filters .label-filter-clear .label-filtering-remove-all{margin:0}
+.active-filters .label-filter-active-filters .label i.fa-times{font-size:10px;padding-left:10px}
+.active-filters .label-filter-active-filters .label-filter-clear{display:-ms-inline-flexbox;display:inline-flex;margin:3px 3px 0 0;-ms-flex-align:center;align-items:center}
+.active-filters .label-filter-active-filters .label-filter-clear .label-filtering-remove-all{background:#39a5dc;margin:0}
 .active-filters .label-filter-active-filters .label-filter-clear .label-filtering-remove-all i.fa.fa-filter{padding-right:5px}
-@media (min-width:768px){.filter .active-filters{margin-top:0}
-.filter .selectize-control{display:inline-block}
-.selectize-dropdown{width:auto!important;white-space:nowrap}
-.label-filter-key .selectize-input.not-full{width:auto}
-}
-.navbar-filter-widget-collapse .form-group{margin-bottom:0;-webkit-flex:1 1 0%;-ms-flex:1 1 0%;flex:1 1 0%;min-width:0}
-.filter .navbar-filter-widget .label-filter-add.btn{margin-right:0;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex:0 0 auto;-ms-flex:0 0 auto;flex:0 0 auto;-webkit-align-items:stretch;-ms-flex-align:stretch;align-items:stretch}
-@media (max-width:767px){.selectize-dropdown{left:0!important;margin:0}
-.filter .navbar-filter-widget .label-filter{min-width:initial;width:84%}
-.filter .navbar-filter-widget .selectize-input{width:auto!important}
-}
 kubernetes-topology-graph{display:block;user-select:none}
 .kube-topology g{font-family:PatternFlyIcons-webfont;font-size:18px;text-anchor:middle;cursor:pointer}
 .kube-topology g text{stroke:none;stroke-width:0px}
@@ -259,6 +253,7 @@ dl.registry-image-tags .registry-image-tag:after{content:' ';white-space:pre}
 .registry-image-pull .fa-info-circle{font-size:15px;color:#888;padding:0px 5px}
 registry-image-layers{border:1px solid #d1d1d1;display:block;overflow-y:auto;max-height:200px}
 ul.registry-image-layers{list-style:none;background-image:-webkit-linear-gradient(top,#fff 12px,#d3d3d3 15px);background-image:-moz-linear-gradient(top,#fff 12px,#d3d3d3 15px);background-image:-o-linear-gradient(top,#fff 12px,#d3d3d3 15px);background-image:linear-gradient(top,#fff 12px,#d3d3d3 15px);background-size:2px 100%;background-repeat:no-repeat;margin:8px 10px 15px 15px;padding-left:0px;font-size:13px}
+ul.registry-image-layers li{clear:both}
 ul.registry-image-layers li:before{content:"\F111";font-family:FontAwesome;font-size:19px;line-height:19px;float:left;display:block;color:#09f;position:relative;left:-7px;top:1px;padding-bottom:9px}
 ul.registry-image-layers li.hint-add:before{color:#555753}
 ul.registry-image-layers li.hint-run:before{color:#4e9a06}


### PR DESCRIPTION
Fixes #545 and #546 and other visual defects in data-toolbar and table-toolbar.

Note:  this PR changes the display of label-filters so that they're more easily adapted to their context so that we don't have to do so much overriding when a label-filter goes in to a new context **and** to make the differing toolbars more consistent.  Visuals should make this easier to digest, so here goes a bunch of screenshots:

1400px
![builds-1400px](https://cloud.githubusercontent.com/assets/895728/18969904/267a058e-865d-11e6-9cf4-c688a7e5ddcf.png)
1200px
![builds-1200px](https://cloud.githubusercontent.com/assets/895728/18969903/2679b82c-865d-11e6-8739-bf3d8129ad6e.png)
768px
![builds-768px](https://cloud.githubusercontent.com/assets/895728/18969902/26795a94-865d-11e6-9946-12eeca8b8c79.png)
480px
![builds-480px](https://cloud.githubusercontent.com/assets/895728/18969905/267c2f26-865d-11e6-98ae-ddc0b8f22ec6.png)

1400px
![other-1400px](https://cloud.githubusercontent.com/assets/895728/18969945/532740d8-865d-11e6-87f6-1ada7e76093f.png)
1200px
![other-1200px](https://cloud.githubusercontent.com/assets/895728/18969946/53295364-865d-11e6-95f3-cd1c195372f3.png)
768px
![other-768px](https://cloud.githubusercontent.com/assets/895728/18969954/5ceb87f0-865d-11e6-8192-5a893fcbfb31.png)
480px
![other-480px](https://cloud.githubusercontent.com/assets/895728/18969953/5ce96f10-865d-11e6-9a83-947969e8b67b.png)

1400px
![monitoring-1400px](https://cloud.githubusercontent.com/assets/895728/18970012/97a7d768-865d-11e6-896e-0b1f00712834.png)
1200px
![monitoring-1200px](https://cloud.githubusercontent.com/assets/895728/18970016/9ded6502-865d-11e6-8239-957ee690b4db.png)
768px
![monitoring-768px](https://cloud.githubusercontent.com/assets/895728/18970017/9dedc18c-865d-11e6-836e-91dea1c0f6fa.png)
480px
![monitoring-480px](https://cloud.githubusercontent.com/assets/895728/18970279/a3847d60-865e-11e6-9f4d-7c417509534d.png)


1400px
![events-1400px](https://cloud.githubusercontent.com/assets/895728/18970086/d83eef5a-865d-11e6-891f-87d0b02762b0.png)
1200px
![events-1200px](https://cloud.githubusercontent.com/assets/895728/18970094/e32748ae-865d-11e6-84ea-c834c6f0cb44.png)
768px
![events-768px](https://cloud.githubusercontent.com/assets/895728/18970092/e324299e-865d-11e6-83a8-b62e9340e104.png)
480px
![events-480px](https://cloud.githubusercontent.com/assets/895728/18970093/e324b184-865d-11e6-8ea1-612d391a3fbd.png)

In addition, the label-filters now look more consistent with other widgets (fixes issues in #545).
Note:  due to a limitation of selectize, the [label-filter dropdowns do **not** look exactly like other dropdowns](https://github.com/kubernetes-ui/label-selector/pull/26#issuecomment-249599329).

![other-filter-1](https://cloud.githubusercontent.com/assets/895728/18970159/287a20de-865e-11e6-9494-5c0a9a2ad9f5.png)
![other-filter-2](https://cloud.githubusercontent.com/assets/895728/18970158/2876ecc0-865e-11e6-8d2c-f9da9518c89e.png)
![other-filter-3](https://cloud.githubusercontent.com/assets/895728/18970160/287b649e-865e-11e6-939e-bca6e346bb45.png)

@jwforres, PTAL