### PR TITLE
Added a Makefile to allow for interaction from the Origin CI tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+# Pull in dependencies
+#
+# Examples:
+#   make install
+install:
+	hack/install-deps.sh
+.PHONY: install
+
+# Clean up all dependencies
+#
+# Args:
+#   GRUNT_FLAGS: Extra flags to pass to 'grunt test'
+#
+# Example:
+#   make clean
+#   make test GRUNT_FLAGS='--stack'
+clean:
+	grunt clean $(GRUNT_FLAGS)
+	hack/clean-deps.sh
+.PHONY: clean
+
+# Run `grunt build`
+#
+# Args:
+#   GRUNT_FLAGS: Extra flags to pass to 'grunt build'
+#
+# Examples:
+#   make build
+#   make build GRUNT_FLAGS='--verbose'
+build: install
+	grunt build $(GRUNT_FLAGS)
+.PHONY: build
+
+# Run all tests
+#
+# Args:
+#   GRUNT_FLAGS: Extra flags to pass to 'grunt test'
+#
+# Examples:
+#   make test
+#   make test GRUNT_FLAGS='--gruntfile=~/special/Gruntfile.js'
+test: build
+	hack/verify-dist.sh
+	hack/test-integration-headless.sh
+	grunt test $(GRUNT_FLAGS)
+.PHONY: test


### PR DESCRIPTION
The Origin CI tooling will expect the following Makefile targets:
 - build
 - install
 - test

The basic Makefile in this commit provides these targets.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>