### PR TITLE
update latest release cli download link

### DIFF
--- a/app/scripts/constants.js
+++ b/app/scripts/constants.js
@@ -31,7 +31,7 @@ window.OPENSHIFT_CONSTANTS = {
   },
   // Maps links names to URL's where the CLI tools can be downloaded, may point directly to files or to external pages in a CDN, for example.
   CLI: {
-    "Latest Release":          "https://github.com/openshift/origin/releases/latest"
+    "Latest Release":          "https://access.redhat.com/downloads/content/290"
   },
   // The default CPU target percentage for horizontal pod autoscalers created or edited in the web console.
   // This value is set in the HPA when the input is left blank.

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -27,7 +27,7 @@ creating_secrets:"https://docs.openshift.org/latest/dev_guide/secrets.html#creat
 "default":"https://docs.openshift.org/latest/welcome/index.html"
 },
 CLI:{
-"Latest Release":"https://github.com/openshift/origin/releases/latest"
+"Latest Release":"https://access.redhat.com/downloads/content/290"
 },
 DEFAULT_HPA_CPU_TARGET_PERCENT:80,
 DISABLE_OVERVIEW_METRICS:!1,


### PR DESCRIPTION
Related Bugzilla:
https://bugzilla.redhat.com/show_bug.cgi?id=1381151

Reverts CLI download link to the one used in 3.2

cc @jwforres @fabianofranz @spadgett 