### PR TITLE
update latest release cli download link

### DIFF
--- a/app/scripts/constants.js
+++ b/app/scripts/constants.js
@@ -26,7 +26,7 @@ window.OPENSHIFT_CONSTANTS = {
   },
   // Maps links names to URL's where the CLI tools can be downloaded, may point directly to files or to external pages in a CDN, for example.
   CLI: {
-    "Latest Release":          "https://github.com/openshift/origin/releases/latest"
+    "Latest Release":          "https://access.redhat.com/downloads/content/290"
   },
   // The default CPU target percentage for horizontal pod autoscalers created or edited in the web console.
   // This value is set in the HPA when the input is left blank.

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -22,7 +22,7 @@ application_health:"https://docs.openshift.com/container-platform/3.3/dev_guide/
 "default":"https://docs.openshift.com/container-platform/3.3/welcome/index.html"
 },
 CLI:{
-"Latest Release":"https://github.com/openshift/origin/releases/latest"
+"Latest Release":"https://access.redhat.com/downloads/content/290"
 },
 DEFAULT_HPA_CPU_TARGET_PERCENT:80,
 DISABLE_OVERVIEW_METRICS:!1,


### PR DESCRIPTION
Related Bugzilla:
https://bugzilla.redhat.com/show_bug.cgi?id=1381151

Reverts CLI download link to the one used in 3.2

@jwforres @fabianofranz @spadgett 