### PR TITLE
Use consistent close icon

### DIFF
--- a/app/views/directives/_edit-command.html
+++ b/app/views/directives/_edit-command.html
@@ -27,7 +27,7 @@
         </span>
         <a href="" ng-click="removeArg($index)" class="input-group-addon action-button remove-arg" title="Remove argument">
           <span class="sr-only">Remove argument</span>
-          <i class="fa fa-times" aria-hidden="true"></i>
+          <i class="pficon pficon-close" aria-hidden="true"></i>
         </a>
       </span>
     </span>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4607,7 +4607,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "<a href=\"\" ng-click=\"removeArg($index)\" class=\"input-group-addon action-button remove-arg\" title=\"Remove argument\">\n" +
     "<span class=\"sr-only\">Remove argument</span>\n" +
-    "<i class=\"fa fa-times\" aria-hidden=\"true\"></i>\n" +
+    "<i class=\"pficon pficon-close\" aria-hidden=\"true\"></i>\n" +
     "</a>\n" +
     "</span>\n" +
     "</span>\n" +


### PR DESCRIPTION
updating the close btn icon, from `fa-times` to `pficon-close` so we are consistent with the close btn icon that we use on other places, eg: `key-value-editor`  or `osc-source-secrets` directives ...
