### PR TITLE
Added link for attach storage to deployment pages

### DIFF
--- a/app/views/browse/deployment-config.html
+++ b/app/views/browse/deployment-config.html
@@ -138,6 +138,9 @@
                             <span ng-if="!('deploymentconfigs' | canI : 'update')">none</span>
                           </p>
                           <volumes volumes="deploymentConfig.spec.template.spec.volumes" namespace="project.metadata.name"></volumes>
+                          <p ng-if="deploymentConfig.spec.template.spec.volumes.length && 'deploymentconfigs' | canI : 'update' ">
+                            <a ng-href="project/{{project.metadata.name}}/attach-pvc?kind=DeploymentConfig&name={{deploymentConfig.metadata.name}}">Attach storage</a>
+                          </p>
                         </div>
 
                         <!-- Autoscaling -->

--- a/app/views/browse/deployment.html
+++ b/app/views/browse/deployment.html
@@ -158,6 +158,9 @@
                           <span ng-if="!('deploymentconfigs' | canI : 'update')">none</span>
                         </p>
                         <volumes volumes="deployment.spec.template.spec.volumes" namespace="project.metadata.name"></volumes>
+                        <p ng-if="deployment.spec.template.spec.volumes.length && 'deploymentconfigs' | canI : 'update'">
+                          <a ng-href="project/{{project.metadata.name}}/attach-pvc?kind=Deployment&name={{deployment.metadata.name}}&group=extensions">Attach storage</a>
+                        </p>
                       </div>
                       <div class="col-lg-6">
                         <h3>Autoscaling</h3>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2046,6 +2046,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"!('deploymentconfigs' | canI : 'update')\">none</span>\n" +
     "</p>\n" +
     "<volumes volumes=\"deploymentConfig.spec.template.spec.volumes\" namespace=\"project.metadata.name\"></volumes>\n" +
+    "<p ng-if=\"deploymentConfig.spec.template.spec.volumes.length && 'deploymentconfigs' | canI : 'update' \">\n" +
+    "<a ng-href=\"project/{{project.metadata.name}}/attach-pvc?kind=DeploymentConfig&name={{deploymentConfig.metadata.name}}\">Attach storage</a>\n" +
+    "</p>\n" +
     "</div>\n" +
     "\n" +
     "<div class=\"col-lg-6\">\n" +
@@ -2318,6 +2321,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"!('deploymentconfigs' | canI : 'update')\">none</span>\n" +
     "</p>\n" +
     "<volumes volumes=\"deployment.spec.template.spec.volumes\" namespace=\"project.metadata.name\"></volumes>\n" +
+    "<p ng-if=\"deployment.spec.template.spec.volumes.length && 'deploymentconfigs' | canI : 'update'\">\n" +
+    "<a ng-href=\"project/{{project.metadata.name}}/attach-pvc?kind=Deployment&name={{deployment.metadata.name}}&group=extensions\">Attach storage</a>\n" +
+    "</p>\n" +
     "</div>\n" +
     "<div class=\"col-lg-6\">\n" +
     "<h3>Autoscaling</h3>\n" +


### PR DESCRIPTION
For more transparency and better user experience, I have added an additional link to attach storage from the deployment/volumes screen