### PR TITLE
Fix display of unserviced deployment configs

### DIFF
--- a/app/scripts/directives/overview/dc.js
+++ b/app/scripts/directives/overview/dc.js
@@ -16,9 +16,12 @@ angular.module('openshiftConsole')
           $scope.deploymentConfig = _.get(deploymentConfigs, $scope.dcName);
         });
 
+        $scope.$watch('scalableReplicationControllerByDC', function(replicationControllers) {
+          $scope.activeReplicationController = _.get($scope, ['scalableReplicationControllerByDC', $scope.dcName]);
+        });
+
         $scope.$watch('replicationControllers', function(replicationControllers) {
           $scope.orderedReplicationControllers = orderByDate(replicationControllers, true);
-          $scope.activeReplicationController = _.get($scope, ['scalableReplicationControllerByDC', $scope.dcName]);
           $scope.inProgressDeployment = _.find($scope.orderedReplicationControllers, deploymentIsInProgress);
         });
 

--- a/app/views/overview.html
+++ b/app/views/overview.html
@@ -54,7 +54,7 @@
                 <!-- unserviced DC -->
                 <div ng-repeat="(dcName, deploymentConfig) in deploymentConfigsByService[''] track by (deploymentConfig | uid)"
                     class="no-service"
-                    ng-if="deployments = visibleRCByDCAndService[''][dcName]"> <!-- Must be an ng-if, an ng-init will not re-evaluate properly -->
+                    ng-if="replicationControllers = visibleRCByDCAndService[''][dcName]"> <!-- Must be an ng-if, an ng-init will not re-evaluate properly -->
                   <overview-deployment-config class="overview-tile-wrapper"></overview-deployment-config>
                 </div>
                 <!-- /unserviced DC -->

--- a/app/views/overview/_dc.html
+++ b/app/views/overview/_dc.html
@@ -45,7 +45,7 @@
         ng-if="!activeReplicationController || !(isDeploymentLatest(replicationController) && ((replicationController | deploymentStatus) == 'Cancelled' || (replicationController | deploymentStatus) == 'Failed'))">
       <deployment-donut
           rc="replicationController"
-          deployment-config="deploymentConfigs[dcName]"
+          deployment-config="deploymentConfig"
           pods="podsByOwnerUID[replicationController.metadata.uid]"
           hpa="getHPA(deploymentConfig) || getHPA(replicationController)"
           limit-ranges="limitRanges"

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10635,8 +10635,10 @@ link:function(d) {
 var e = a("orderObjectsByDate"), f = a("deploymentIsInProgress");
 d.$watch("deploymentConfigs", function(a) {
 d.deploymentConfig = _.get(a, d.dcName);
+}), d.$watch("scalableReplicationControllerByDC", function(a) {
+d.activeReplicationController = _.get(d, [ "scalableReplicationControllerByDC", d.dcName ]);
 }), d.$watch("replicationControllers", function(a) {
-d.orderedReplicationControllers = e(a, !0), d.activeReplicationController = _.get(d, [ "scalableReplicationControllerByDC", d.dcName ]), d.inProgressDeployment = _.find(d.orderedReplicationControllers, f);
+d.orderedReplicationControllers = e(a, !0), d.inProgressDeployment = _.find(d.orderedReplicationControllers, f);
 }), d.cancelDeployment = function() {
 var a = d.inProgressDeployment;
 if (a) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8487,7 +8487,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<div row wrap ng-if=\"hasUnservicedContent()\" class=\"unserviced-row\">\n" +
     "\n" +
-    "<div ng-repeat=\"(dcName, deploymentConfig) in deploymentConfigsByService[''] track by (deploymentConfig | uid)\" class=\"no-service\" ng-if=\"deployments = visibleRCByDCAndService[''][dcName]\"> \n" +
+    "<div ng-repeat=\"(dcName, deploymentConfig) in deploymentConfigsByService[''] track by (deploymentConfig | uid)\" class=\"no-service\" ng-if=\"replicationControllers = visibleRCByDCAndService[''][dcName]\"> \n" +
     "<overview-deployment-config class=\"overview-tile-wrapper\"></overview-deployment-config>\n" +
     "</div>\n" +
     "\n" +
@@ -8566,7 +8566,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div row class=\"overview-tile-body\">\n" +
     "\n" +
     "<div column class=\"overview-donut\" ng-repeat=\"replicationController in orderedReplicationControllers track by (replicationController | uid)\" ng-class=\"{ latest: isDeploymentLatest(replicationController) }\" ng-if=\"!activeReplicationController || !(isDeploymentLatest(replicationController) && ((replicationController | deploymentStatus) == 'Cancelled' || (replicationController | deploymentStatus) == 'Failed'))\">\n" +
-    "<deployment-donut rc=\"replicationController\" deployment-config=\"deploymentConfigs[dcName]\" pods=\"podsByOwnerUID[replicationController.metadata.uid]\" hpa=\"getHPA(deploymentConfig) || getHPA(replicationController)\" limit-ranges=\"limitRanges\" quotas=\"quotas\" cluster-quotas=\"clusterQuotas\" scalable=\"isScalableReplicationController(replicationController)\" alerts=\"alerts\">\n" +
+    "<deployment-donut rc=\"replicationController\" deployment-config=\"deploymentConfig\" pods=\"podsByOwnerUID[replicationController.metadata.uid]\" hpa=\"getHPA(deploymentConfig) || getHPA(replicationController)\" limit-ranges=\"limitRanges\" quotas=\"quotas\" cluster-quotas=\"clusterQuotas\" scalable=\"isScalableReplicationController(replicationController)\" alerts=\"alerts\">\n" +
     "</deployment-donut>\n" +
     "</div>\n" +
     "\n" +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1382895

The `$watch` wasn't getting updates for unserviced deployment configs. It worked on page refresh because the watch is always called once even for `undefined`, which set `activeReplicationController`. Missed the unserviced deployment config `ng-repeat` on the variable renames.

@jwforres PTAL