### PR TITLE
Improve display of metrics usage values on overview

### DIFF
--- a/app/scripts/directives/deploymentMetrics.js
+++ b/app/scripts/directives/deploymentMetrics.js
@@ -176,7 +176,17 @@ angular.module('openshiftConsole')
           return point.value === null || point.value === undefined;
         }
 
-        scope.formatUsage = d3.format('.2r');
+        scope.formatUsage = function(usage) {
+          if (usage < 0.01) {
+            return '0';
+          }
+
+          if (usage < 1) {
+            return d3.format('.1r')(usage);
+          }
+
+          return d3.format('.2r')(usage);
+        };
 
         function averages(metric) {
           var label;

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -9488,7 +9488,9 @@ return d3.round(b, 2) + " " + a.units;
 }
 };
 };
-b.formatUsage = d3.format(".2r"), b.$watch("options", function() {
+b.formatUsage = function(a) {
+return a < .01 ? "0" :a < 1 ? d3.format(".1r")(a) :d3.format(".2r")(a);
+}, b.$watch("options", function() {
 z = {}, x = null, delete b.metricsError, r();
 }, !0), s = a(r, u, !1), b.updateInView = function(a) {
 A = !a, a && (!y || Date.now() > y + u) && r();


### PR DESCRIPTION
Fix how small metrics values look on the overview (regression from 1.3).

* Show "0" instead of very small values like "0.0006 KiB/s"
* Only round to one significant digit if less than 1 ("0.02" instead of "0.023")

@jwforres PTAL