### PR TITLE
Standalone secrets page

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -219,6 +219,9 @@
         <script src="scripts/controllers/replicaSet.js"></script>
         <script src="scripts/controllers/services.js"></script>
         <script src="scripts/controllers/service.js"></script>
+        <script src="scripts/controllers/secrets.js"></script>
+        <script src="scripts/controllers/secret.js"></script>
+        <script src="scripts/controllers/createSecret.js"></script>
         <script src="scripts/controllers/routes.js"></script>
         <script src="scripts/controllers/route.js"></script>
         <script src="scripts/controllers/storage.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -243,6 +243,20 @@ angular
         controller: 'StorageController',
         reloadOnSearch: false
       })
+      .when('/project/:project/browse/secrets/:secret', {
+        templateUrl: 'views/browse/secret.html',
+        controller: 'SecretController',
+        reloadOnSearch: false
+      })
+      .when('/project/:project/browse/secrets', {
+        templateUrl: 'views/secrets.html',
+        controller: 'SecretsController',
+        reloadOnSearch: false
+      })
+      .when('/project/:project/create-secret', {
+        templateUrl: 'views/create-secret.html',
+        controller: 'CreateSecretController'
+      })
       .when('/project/:project/browse/other', {
         templateUrl: 'views/other-resources.html',
         controller: 'OtherResourcesController',

--- a/app/scripts/constants.js
+++ b/app/scripts/constants.js
@@ -159,6 +159,10 @@ window.OPENSHIFT_CONSTANTS = {
               href: "/quota"
             },
             {
+              label: "Secrets",
+              href: "/browse/secrets"
+            },
+            {
               label: "Other Resources",
               href: "/browse/other"
             }

--- a/app/scripts/controllers/create/createFromImage.js
+++ b/app/scripts/controllers/create/createFromImage.js
@@ -14,6 +14,7 @@ angular.module("openshiftConsole")
       MetricsService,
       HPAService,
       QuotaService,
+      SecretsService,
       TaskList,
       failureObjectNameFilter,
       $filter,
@@ -42,6 +43,7 @@ angular.module("openshiftConsole")
         title: imageName
       }
     ];
+    $scope.alerts = {};
 
     var appLabel = {name: 'app', value: ''};
 
@@ -67,12 +69,20 @@ angular.module("openshiftConsole")
           scope.buildConfig = {
             buildOnSourceChange: true,
             buildOnImageChange: true,
-            buildOnConfigChange: true
+            buildOnConfigChange: true,
+            secrets: {
+              gitSecret: [{name: ""}],
+              pullSecret: [{name: ""}],
+              pushSecret: [{name: ""}]
+            }
           };
           scope.buildConfigEnvVars = [];
           scope.deploymentConfig = {
             deployOnNewImage: true,
-            deployOnConfigChange: true
+            deployOnConfigChange: true,
+            secrets: {
+              pullSecrets: [{name: ""}]
+            }
           };
           scope.DCEnvVarsFromImage;
           scope.DCEnvVarsFromUser = [];
@@ -122,6 +132,15 @@ angular.module("openshiftConsole")
           // Warn if metrics aren't configured when setting autoscaling options.
           MetricsService.isAvailable().then(function(available) {
             $scope.metricsWarning = !available;
+          });
+
+          DataService.list("secrets", context, function(secrets) {
+            var secretsByType = SecretsService.groupSecretsByType(secrets);
+            var secretNamesByType =_.mapValues(secretsByType, function(secrets) {return _.map(secrets, 'metadata.name')});
+            // Add empty option to the image/source secrets
+            $scope.secretsByType = _.each(secretNamesByType, function(secretsArray) {
+              secretsArray.unshift("");
+            });
           });
 
           DataService.get("imagestreams", scope.imageName, {namespace: (scope.namespace || $routeParams.project)}).then(function(imageStream){

--- a/app/scripts/controllers/createSecret.js
+++ b/app/scripts/controllers/createSecret.js
@@ -1,0 +1,44 @@
+'use strict';
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:CreateSecretController
+ * @description
+ * # CreateSecretController
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('CreateSecretController', function ($filter, $routeParams, $scope, $window, AlertMessageService, ApplicationGenerator, DataService, Navigate, ProjectsService) {
+    $scope.alerts = {};
+    $scope.projectName = $routeParams.project;
+
+    $scope.breadcrumbs = [
+      {
+        title: $scope.projectName,
+        link: "project/" + $scope.projectName
+      },
+      {
+         title: "Secrets",
+         link: "project/" + $scope.projectName + "/browse/secrets"
+      },
+      {
+        title: "Create Secret"
+      }
+    ];
+
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+        $scope.context = context;
+        $scope.breadcrumbs[0].title = $filter('displayName')(project);
+
+        $scope.postCreateAction = function(newSecret, creationAlert) {
+          AlertMessageService.addAlert(creationAlert);
+          Navigate.toResourceList('secrets', $scope.projectName);
+        };
+        $scope.cancel = function() {
+          Navigate.toResourceList('secrets', $scope.projectName);
+        };
+    }));
+  });

--- a/app/scripts/controllers/edit/buildConfig.js
+++ b/app/scripts/controllers/edit/buildConfig.js
@@ -140,8 +140,9 @@ angular.module('openshiftConsole')
 
             DataService.list("secrets", context, function(secrets) {
               var secretsByType = SecretsService.groupSecretsByType(secrets);
+              var secretNamesByType =_.mapValues(secretsByType, function(secrets) {return _.map(secrets, 'metadata.name')});
               // Add empty option to the image/source secrets
-              $scope.secrets.secretsByType = _.each(secretsByType, function(secretsArray) {
+              $scope.secrets.secretsByType = _.each(secretNamesByType, function(secretsArray) {
                 secretsArray.unshift("");
               });
               loadBuildConfigSecrets();

--- a/app/scripts/controllers/modals/createSecretModal.js
+++ b/app/scripts/controllers/modals/createSecretModal.js
@@ -14,7 +14,7 @@ angular.module('openshiftConsole')
     $scope.postCreateAction = function(newSecret, creationAlert) {
       $uibModalInstance.close(newSecret);
       // Add creation alert into scope
-      _.extend($scope.alerts, creationAlert);
+      $scope.alerts[creationAlert.name] = creationAlert.data;
     };
 
     $scope.cancel = function() {

--- a/app/scripts/controllers/secret.js
+++ b/app/scripts/controllers/secret.js
@@ -1,0 +1,58 @@
+'use strict';
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:SecretController
+ * @description
+ * # SecretController
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('SecretController', function ($routeParams, $filter, $scope, AlertMessageService, DataService, ProjectsService, SecretsService) {
+    $scope.projectName = $routeParams.project;
+    $scope.secretName = $routeParams.secret;
+    $scope.view = {
+      showSecret: false
+    };
+
+    $scope.alerts = $scope.alerts || {};
+    $scope.emptyMessage = "Loading...";
+
+    $scope.breadcrumbs = [
+      {
+        title: "Secrets",
+        link: "project/" + $routeParams.project + "/browse/secrets"
+      },
+      {
+        title: $scope.secretName
+      }
+    ];
+
+    AlertMessageService.getAlerts().forEach(function(alert) {
+      $scope.alerts[alert.name] = alert.data;
+    });
+
+    AlertMessageService.clearAlerts();
+
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+        $scope.context = context;
+
+        DataService.get("secrets", $scope.secretName, context).then(
+          function(secret) {
+            $scope.secret = secret;
+            $scope.decodedSecretData = SecretsService.decodeSecretData($scope.secret.data);
+            $scope.loaded = true;
+          },
+          function(e) {
+            $scope.loaded = true;
+            $scope.alerts["load"] = {
+              type: "error",
+              message: "The secret details could not be loaded.",
+              details: "Reason: " + $filter('getErrorDetails')(e)
+            };
+          });
+    }));
+  });

--- a/app/scripts/controllers/secrets.js
+++ b/app/scripts/controllers/secrets.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:SecretsController
+ * @description
+ * # ProjectController
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('SecretsController', function ($routeParams, $scope, AlertMessageService, DataService, ProjectsService, SecretsService) {
+    $scope.projectName = $routeParams.project;
+    $scope.secretsByType = {};
+    $scope.alerts = $scope.alerts || {};
+
+    AlertMessageService.getAlerts().forEach(function(alert) {
+      $scope.alerts[alert.name] = alert.data;
+    });
+
+    AlertMessageService.clearAlerts();
+
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+        $scope.context = context;
+
+        DataService.list("secrets", context, function(secrets) {
+          $scope.secretsByType = SecretsService.groupSecretsByType(secrets);
+          $scope.loaded = true;
+        });
+    }));
+  });

--- a/app/scripts/directives/createSecret.js
+++ b/app/scripts/directives/createSecret.js
@@ -2,7 +2,7 @@
 
 angular.module("openshiftConsole")
 
-  .directive("createSecret", function() {
+  .directive("createSecret", function(DataService, AuthorizationService) {
     return {
       restrict: 'E',
       scope: {
@@ -13,7 +13,7 @@ angular.module("openshiftConsole")
         cancel: '&'
       },
       templateUrl: 'views/directives/create-secret.html',
-      controller: function($scope, $filter, DataService) {
+      link: function($scope, $filter) {
         $scope.alerts = {};
 
         $scope.secretAuthTypeMap = {
@@ -55,26 +55,33 @@ angular.module("openshiftConsole")
         //                                  - if in BC the 'builder' SA if picked automatically
         //                                  - if in DC the 'deployer' SA if picked automatically
         //                                  - else the user will have to pick the SA and type of linking
-        //   - linkAs                      user specifies how he wants to link the secret with SA
-        //                                  - as a 'secrets'
-        //                                  - as a 'imagePullSecret'
-        $scope.newSecret = {
-          type: $scope.type,
-          authType: $scope.secretAuthTypeMap[$scope.type].authTypes[0].id,
-          data: {},
-          linkSecret: false,
-          pickedServiceAccountToLink: $scope.serviceAccountToLink || "",
-          linkAs: {
-            secrets: $scope.type === 'source',
-            imagePullSecrets: $scope.type === 'image'
-          }
-        };
+        if ($scope.type) {
+          $scope.newSecret = {
+            type: $scope.type,
+            authType: $scope.secretAuthTypeMap[$scope.type].authTypes[0].id,
+            data: {},
+            linkSecret: !_.isEmpty($scope.serviceAccountToLink),
+            pickedServiceAccountToLink: $scope.serviceAccountToLink || "",
+          };
+        } else {
+          $scope.newSecret = {
+            type: "source",
+            authType: "kubernetes.io/basic-auth",
+            data: {},
+            linkSecret: false,
+            pickedServiceAccountToLink: "",
+          };
+        }
         $scope.addGitconfig = false;
+        $scope.addCaCert = false;
 
-        DataService.list("serviceaccounts", $scope, function(result) {
-          $scope.serviceAccounts = result.by('metadata.name');
-          $scope.serviceAccountsNames = _.keys($scope.serviceAccounts);
-        });
+        // List SA only if $scope.serviceAccountToLink is not defined so user has to pick one.
+        if (!$scope.serviceAccountToLink && AuthorizationService.canI('serviceaccounts', 'list') && AuthorizationService.canI('serviceaccounts', 'update')) {
+          DataService.list("serviceaccounts", $scope, function(result) {
+            $scope.serviceAccounts = result.by('metadata.name');
+            $scope.serviceAccountsNames = _.keys($scope.serviceAccounts);
+          });
+        }
 
         var constructSecretObject = function(data, authType) {
           var secret = {
@@ -89,12 +96,20 @@ angular.module("openshiftConsole")
 
           switch (authType) {
             case "kubernetes.io/basic-auth":
-              secret.data = {password: window.btoa(data.password)};
+              // If the password/token is not entered either .gitconfig or ca.crt has to be provided
+              if (data.passwordToken) {
+                secret.data = {password: window.btoa(data.passwordToken)};
+              } else {
+                secret.type = "Opaque";
+              }
               if (data.username) {
                 secret.data.username = window.btoa(data.username);
               }
               if (data.gitconfig) {
                 secret.data[".gitconfig"] = window.btoa(data.gitconfig);
+              }
+              if (data.cacert) {
+                secret.data["ca.crt"] = window.btoa(data.cacert);
               }
               break;
             case "kubernetes.io/ssh-auth":
@@ -129,25 +144,33 @@ angular.module("openshiftConsole")
 
         var linkSecretToServiceAccount = function(secret) {
           var updatedSA = angular.copy($scope.serviceAccounts[$scope.newSecret.pickedServiceAccountToLink]);
-          if ($scope.newSecret.linkAs.secrets) {
+          switch ($scope.newSecret.type) {
+          case 'source':
             updatedSA.secrets.push({name: secret.metadata.name});
-          }
-          if ($scope.newSecret.linkAs.imagePullSecrets) {
+            break;
+          case 'image':
             updatedSA.imagePullSecrets.push({name: secret.metadata.name});
+            break;
           }
-          DataService.update('serviceaccounts', $scope.newSecret.pickedServiceAccountToLink, updatedSA, $scope).then(function(sa) {
+          // Don't show any error related to linking to SA when linking is done automatically 
+          var options = $scope.serviceAccountToLink ? {errorNotification: false} : {};
+          DataService.update('serviceaccounts', $scope.newSecret.pickedServiceAccountToLink, updatedSA, $scope, options).then(function(sa) {
             var alert = {
-              createAndLink: {
+              name: 'createAndLink',
+              data: {
                 type: "success",
                 message: "Secret " + secret.metadata.name + " was created and linked with service account " + sa.metadata.name + "."
               }
             };
             $scope.postCreateAction({newSecret: secret, creationAlert: alert});
           }, function(result){
-            $scope.alerts["createAndLink"] = {
-              type: "error",
-              message: "An error occurred while linking the secret with service account.",
-              details: $filter('getErrorDetails')(result)
+            $scope.alerts = {
+              name: 'createAndLink',
+              data: {
+                type: "error",
+                message: "An error occurred while linking the secret with service account.",
+                details: $filter('getErrorDetails')(result)
+              }
             };
           });
         };
@@ -156,11 +179,12 @@ angular.module("openshiftConsole")
           $scope.alerts = {};
           var newSecret = constructSecretObject($scope.newSecret.data, $scope.newSecret.authType);
           DataService.create('secrets', null, newSecret, $scope).then(function(secret) { // Success
-            if ($scope.newSecret.linkSecret && $scope.newSecret.pickedServiceAccountToLink) {
+            if ($scope.newSecret.linkSecret && $scope.newSecret.pickedServiceAccountToLink && AuthorizationService.canI('serviceaccounts', 'update')) {
               linkSecretToServiceAccount(secret);
             } else {
               var alert = {
-                create: {
+                name: 'create',
+                data: {
                   type: "success",
                   message: "Secret " + newSecret.metadata.name + " was created."
                 }

--- a/app/scripts/directives/deployImage.js
+++ b/app/scripts/directives/deployImage.js
@@ -12,6 +12,7 @@ angular.module("openshiftConsole")
                                      ProjectsService,
                                      QuotaService,
                                      TaskList,
+                                     SecretsService,
                                      keyValueEditorUtils) {
     return {
       restrict: 'E',
@@ -35,6 +36,16 @@ angular.module("openshiftConsole")
           name: 'app',
           value: ''
         }];
+        $scope.pullSecrets = [{name: ''}];
+
+        DataService.list("secrets", {namespace: $scope.project}, function(secrets) {
+          var secretsByType = SecretsService.groupSecretsByType(secrets);
+          var secretNamesByType =_.mapValues(secretsByType, function(secrets) {return _.map(secrets, 'metadata.name');});
+          // Add empty option to the image/source secrets
+          $scope.secretsByType = _.each(secretNamesByType, function(secretsArray) {
+            secretsArray.unshift("");
+          });
+        });
 
         var stripTag = $filter('stripTag');
         var stripSHA = $filter('stripSHA');
@@ -73,7 +84,8 @@ angular.module("openshiftConsole")
             ports: $scope.ports,
             volumes: $scope.volumes,
             env: keyValueEditorUtils.mapEntries(keyValueEditorUtils.compactEntries($scope.env)),
-            labels: _.extend(systemLabels, userLabels)
+            labels: _.extend(systemLabels, userLabels),
+            pullSecrets: $scope.pullSecrets
           });
         }
 

--- a/app/scripts/directives/oscSecrets.js
+++ b/app/scripts/directives/oscSecrets.js
@@ -19,6 +19,9 @@ angular.module("openshiftConsole")
       link: function($scope) {
 
         $scope.canAddSourceSecret = function() {
+          if (!$scope.allowMultipleSecrets) {
+            return false;
+          }
           var lastSecret = _.last($scope.pickedSecrets);
           if (!lastSecret) {
             return false;
@@ -56,8 +59,9 @@ angular.module("openshiftConsole")
           modalInstance.result.then(function(newSecret) {
             DataService.list("secrets", {namespace: $scope.namespace}, function(secrets) {
               var secretsByType = SecretsService.groupSecretsByType(secrets);
+              var secretNamesByType =_.mapValues(secretsByType, function(secrets) {return _.map(secrets, 'metadata.name');});
               // Add empty option to the image/source secrets
-              $scope.secretsByType = _.each(secretsByType, function(secretsArray) {
+              $scope.secretsByType = _.each(secretNamesByType, function(secretsArray) {
                 secretsArray.unshift("");
               });
               $scope.setLastSecretsName(newSecret.metadata.name);

--- a/app/scripts/directives/oscSourceSecrets.js
+++ b/app/scripts/directives/oscSourceSecrets.js
@@ -76,8 +76,9 @@ angular.module("openshiftConsole")
           modalInstance.result.then(function(newSecret) {
             DataService.list("secrets", {namespace: $scope.namespace}, function(secrets) {
               var secretsByType = SecretsService.groupSecretsByType(secrets);
+              var secretNamesByType =_.mapValues(secretsByType, function(secrets) {return _.map(secrets, 'metadata.name');});
               // Add empty option to the image/source secrets
-              $scope.secretsByType = _.each(secretsByType, function(secretsArray) {
+              $scope.secretsByType = _.each(secretNamesByType, function(secretsArray) {
                 secretsArray.unshift("");
               });
               $scope.setLastSecretsName(newSecret.metadata.name);

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -183,6 +183,9 @@ angular.module('openshiftConsole')
       'services': [
         {group: '', resource: 'services', verbs: ['update', 'create', 'delete']}
       ],
+      'secrets': [
+        {group: '', resource: 'secrets', verbs: ['update', 'delete']}
+      ],
       'projects': [
         {group: '', resource: 'projects', verbs: ['delete', 'update']}
       ]

--- a/app/scripts/services/applicationGenerator.js
+++ b/app/scripts/services/applicationGenerator.js
@@ -237,8 +237,11 @@ angular.module("openshiftConsole")
           }
         );
       }
-      if(input.deploymentConfig.deployOnConfigChange){
+      if (input.deploymentConfig.deployOnConfigChange) {
         deploymentConfig.spec.triggers.push({type: "ConfigChange"});
+      }
+      if (_.get(input, 'deploymentConfig.secrets.pullSecrets[0].name')) {
+        deploymentConfig.spec.template.spec.imagePullSecrets = input.deploymentConfig.secrets.pullSecrets;
       }
       return deploymentConfig;
     };
@@ -349,6 +352,15 @@ angular.module("openshiftConsole")
           triggers: triggers
         }
       };
+      if (_.get(input, 'buildConfig.secrets.gitSecret[0].name')) {
+        bc.spec.source.sourceSecret = _.first(input.buildConfig.secrets.gitSecret);
+      }
+      if (_.get(input, 'buildConfig.secrets.pullSecret[0].name')) {
+        bc.spec.strategy.sourceStrategy.pullSecret = _.first(input.buildConfig.secrets.pullSecret);
+      }
+      if (_.get(input, 'buildConfig.secrets.pushSecret[0].name')) {
+        bc.spec.output.pushSecret = _.first(input.buildConfig.secrets.pushSecret);
+      }
 
       // Add contextDir only if specified.
       if (input.buildConfig.contextDir) {

--- a/app/scripts/services/images.js
+++ b/app/scripts/services/images.js
@@ -182,6 +182,9 @@ angular.module("openshiftConsole")
         },
         status: {}
       };
+      if(_.first(config.pullSecrets).name){
+        deploymentConfig.spec.template.spec.imagePullSecrets = config.pullSecrets;
+      }
 
       resources.push(deploymentConfig);
 

--- a/app/scripts/services/navigate.js
+++ b/app/scripts/services/navigate.js
@@ -179,6 +179,7 @@ angular.module("openshiftConsole")
               .segmentCoded(name);
             break;
           case "Service":
+          case "Secret":
           case "Route":
           case "Pod":
           case "PersistentVolumeClaim":
@@ -237,6 +238,7 @@ angular.module("openshiftConsole")
           'replicasets': 'deployments',
           'replicationcontrollers': 'deployments',
           'routes': 'routes',
+          'secrets': 'secrets',
           'services': 'services',
           'persistentvolumeclaims': 'storage'
         };

--- a/app/scripts/services/secrets.js
+++ b/app/scripts/services/secrets.js
@@ -14,18 +14,65 @@ angular.module("openshiftConsole")
           case 'kubernetes.io/basic-auth':
           case 'kubernetes.io/ssh-auth':
           case 'Opaque':
-            secretsByType.source.push(secret.metadata.name);
+            secretsByType.source.push(secret);
             break;
           case 'kubernetes.io/dockercfg':
           case 'kubernetes.io/dockerconfigjson':
-            secretsByType.image.push(secret.metadata.name);
+            secretsByType.image.push(secret);
             break;
         }
       });      
       return secretsByType;
     };
 
+    var decodeDockercfg = function(encodedData) {
+      var decodedSecretData = {};
+      var decodedData = JSON.parse(window.atob(encodedData));
+      _.each(decodedData, function(data, serverName) {
+        decodedSecretData[serverName] = {
+          username: data.username,
+          password: data.password,
+          email: data.email
+        };
+      });
+      return decodedSecretData;
+    };
+
+    var decodeDockerconfigjson = function(encodedData) {
+      var decodedSecretData = {};
+      var decodedData = JSON.parse(window.atob(encodedData));
+      _.each(decodedData.auths, function(data, serverName) {
+        var usernamePassword = window.atob(data.auth).split(":");
+        decodedSecretData[serverName] = {
+          username: usernamePassword[0],
+          password: usernamePassword[1],
+          email: data.email
+        };
+      });
+      return decodedSecretData;
+    };
+
+    var decodeSecretData = function(secretData) {
+      return _.mapValues(secretData, function(data, paramName) {
+        switch (paramName) {
+          case ".dockercfg":
+            return decodeDockercfg(data);
+          case ".dockerconfigjson":
+            return decodeDockerconfigjson(data);
+          case "username":
+          case "password":
+          case ".gitconfig":
+          case "ssh-privatekey":
+          case "ca.crt":
+            return window.atob(data);
+          default:
+            return data;
+        }
+      });
+    };
+
     return {
-      groupSecretsByType: groupSecretsByType
+      groupSecretsByType: groupSecretsByType,
+      decodeSecretData: decodeSecretData
     };
   });

--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -1077,10 +1077,21 @@ a.disabled-link {
   }
   .modal-body {
     padding: 0px 18px;
-    .create-secret-editor {
-      height: 150px;
-    }
   }
+}
+
+.secret-data {
+  max-width: 450px;
+  max-height: 150px;
+  @media (max-width: @screen-sm-max) {
+    // The `table-responsive` div adds a 100% border. Make sure the table is at
+    // least 100% to avoid a white block at some screen sizes.
+    max-width: 100%;
+  }
+}
+
+.create-secret-editor {
+  height: 150px;
 }
 
 .edit-yaml {

--- a/app/views/_config-file-params.html
+++ b/app/views/_config-file-params.html
@@ -1,0 +1,10 @@
+<div ng-repeat="(serverName, data) in secretData" class="image-source-item">
+  <h4>{{serverName}}</h4>
+  <dt>Username:</dt>
+  <dd class="word-break">{{data.username}}</dd>
+  <dt>Password:</dt>
+  <dd ng-if="view.showSecret" class="word-break">{{data.password}}</dd>
+  <dd ng-if="!view.showSecret">*****</dd>
+  <dt>Email:</dt>
+  <dd class="word-break">{{data.email}}</dd>
+</div>

--- a/app/views/browse/secret.html
+++ b/app/views/browse/secret.html
@@ -1,0 +1,152 @@
+<project-header class="top-header"></project-header>
+<project-page>
+  <!-- Middle section -->
+  <div class="middle-section">
+    <div class="middle-container">
+      <div class="middle-header">
+        <div class="container-fluid">
+          <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
+          <alerts alerts="alerts"></alerts>
+          <div ng-if="!loaded" class="mar-top-xl">Loading...</div>
+          <div ng-if="loaded">
+            <h1>
+              <div class="pull-right dropdown" ng-hide="!('secrets' | canIDoAny)">
+                <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
+                  Actions
+                  <span class="caret"></span>
+                </button>
+                <a href=""
+                   class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
+                   data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+                <ul class="dropdown-menu actions action-link">
+                  <li ng-if="'secrets' | canI : 'update'">
+                    <a ng-href="{{secret | editYamlURL}}" role="button">Edit YAML</a>
+                  </li>
+                  <li ng-if="'secrets' | canI : 'delete'">
+                    <delete-link
+                      kind="Secret"
+                      resource-name="{{secret.metadata.name}}"
+                      project-name="{{secret.metadata.namespace}}"
+                      alerts="alerts">
+                    </delete-link>
+                  </li>
+                </ul>
+              </div>
+              {{secret.metadata.name}}
+              <small class="meta">created <relative-timestamp timestamp="secret.metadata.creationTimestamp"></relative-timestamp></small>
+            </h1>
+          </div>
+        </div>
+      </div><!-- /middle-header-->
+      <div class="middle-content gutter-top">
+        <div class="container-fluid">
+          <div ng-if="secret" class="row">
+            <div class="col-sm-12">
+              <div class="resource-details secret-details">
+                <dl class="dl-horizontal left">
+                  <dt>Type:</dt>
+                  <dd>{{secret.type}}</dd>
+
+                  <div ng-repeat="(secretDataName, secretData) in decodedSecretData" class="image-source-item">
+                    <div ng-switch="secretDataName">
+                      <div ng-switch-when=".dockercfg">
+                        <ng-include src=" 'views/_config-file-params.html' "></ng-include>
+                      </div>
+
+                      <div ng-switch-when=".dockerconfigjson">
+                        <ng-include src=" 'views/_config-file-params.html' "></ng-include>
+                      </div>
+
+                      <div ng-switch-when="username">
+                        <dt>Username:</dt>
+                        <dd class="word-break">{{decodedSecretData.username}}</dd>
+                      </div>
+
+                      <div ng-switch-when="password">
+                        <dt>Password:</dt>
+                        <dd ng-if="view.showSecret" class="word-break">{{secretData}}</dd>
+                        <dd ng-if="!view.showSecret">*****</dd>
+                      </div>
+
+                      <div ng-switch-when="ssh-privatekey">
+                        <dt>SSH Private Key:</dt>
+                        <dd ng-if="view.showSecret" class="gutter-bottom">
+                          <div ui-ace="{
+                            theme: 'dreamweaver',
+                            highlightActiveLine: false,
+                            showGutter: false,
+                            rendererOptions: {
+                              fadeFoldWidgets: true,
+                              highlightActiveLine: false,
+                              showPrintMargin: false
+                            },
+                            advanced: {
+                              highlightActiveLine: false
+                            }
+                          }" readonly ng-model="secretData" class="ace-bordered ace-read-only ace-inline secret-data"></div>
+                        </dd>
+                        <dd ng-if="!view.showSecret">*****</dd>
+                      </div>
+
+                      <div ng-switch-when="ca.crt">
+                        <dt>CA Certificate:</dt>
+                        <dd ng-if="view.showSecret" class="gutter-bottom">
+                          <div ui-ace="{
+                            theme: 'dreamweaver',
+                            highlightActiveLine: false,
+                            showGutter: false,
+                            rendererOptions: {
+                              fadeFoldWidgets: true,
+                              highlightActiveLine: false,
+                              showPrintMargin: false
+                            },
+                            advanced: {
+                              highlightActiveLine: false
+                            }
+                          }" readonly ng-model="secretData" class="ace-bordered ace-read-only ace-inline secret-data"></div>
+                        </dd>
+                        <dd ng-if="!view.showSecret">*****</dd>
+                      </div>
+
+                      <div ng-switch-when=".gitconfig">
+                        <dt>Git Configuration File:</dt>
+                        <dd ng-if="view.showSecret" class="gutter-bottom">
+                          <div ui-ace="{
+                            mode: 'ini',
+                            theme: 'dreamweaver',
+                            highlightActiveLine: false,
+                            showGutter: false,
+                            rendererOptions: {
+                              fadeFoldWidgets: true,
+                              highlightActiveLine: false,
+                              showPrintMargin: false
+                            },
+                            advanced: {
+                              highlightActiveLine: false
+                            }
+                          }" readonly ng-model="secretData" class="ace-bordered ace-read-only ace-inline secret-data"></div>
+                        </dd>
+                        <dd ng-if="!view.showSecret">*****</dd>
+                      </div>
+
+                      <div ng-switch-default>
+                        <dt>{{secretDataName}}:</dt>
+                        <dd ng-if="view.showSecret" class="word-break gutter-bottom" >{{secretData}}</dd>
+                        <dd ng-if="!view.showSecret">*****</dd>
+                      </div>
+
+                    </div>
+                  </div>
+                </dl>
+              </div>
+              <div class="gutter-bottom">
+                <a href="" ng-click="view.showSecret = !view.showSecret">{{view.showSecret ? "Hide" : "Reveal"}} secret contents</a>
+              </div>
+              <annotations annotations="secret.metadata.annotations"></annotations>
+            </div><!-- /col-* -->
+          </div>
+        </div>
+      </div><!-- /middle-content -->
+    </div><!-- /middle-container -->
+  </div><!-- /middle-section -->
+</project-page>

--- a/app/views/create-secret.html
+++ b/app/views/create-secret.html
@@ -1,0 +1,36 @@
+<default-header class="top-header"></default-header>
+<div class="wrap no-sidebar">
+  <div class="sidebar-left collapse navbar-collapse navbar-collapse-2">
+    <navbar-utility-mobile></navbar-utility-mobile>
+  </div>
+  <div class="middle surface-shaded">
+    <!-- Middle section -->
+    <div class="middle-section">
+      <div class="middle-container">
+        <div class="middle-content">
+          <div class="container surface-shaded">
+            <div ng-if="!project">Loading...</div>
+            <div class="row" ng-if="project">
+              <div class="col-md-10 col-md-offset-1">
+                <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
+                <alerts alerts="alerts"></alerts>
+                <div class="mar-top-xl">
+                  <h1>Create Secret</h1>
+                  <div class="help-block">
+                    Secrets allow you to authenticate to a private Git repository or a private image registry.
+                  </div>
+                  <create-secret
+                    namespace="projectName"
+                    alerts="alerts"
+                    post-create-action="postCreateAction(newSecret, creationAlert)"
+                    cancel="cancel()">
+                  </create-secret>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div><!-- /middle-content -->
+      </div><!-- /middle-container -->
+    </div><!-- /middle-section -->
+  </div><!-- /middle -->
+</div><!-- /wrap -->

--- a/app/views/create/fromimage.html
+++ b/app/views/create/fromimage.html
@@ -134,7 +134,20 @@
                                   spellcheck="false"
                                   class="form-control">
                               </div>
-                              <div class="help-block">Optional subdirectory for the application source code, used as the context directory for the build.</div> </div>
+                              <div class="help-block">Optional subdirectory for the application source code, used as the context directory for the build.</div>
+                            </div>
+
+                            <div class="form-group">
+                              <osc-secrets model="buildConfig.secrets.gitSecret"
+                                          namespace="projectName"
+                                          display-type="source"
+                                          type="source"
+                                          service-account-to-link="builder"
+                                          secrets-by-type="secretsByType"
+                                          alerts="alerts"
+                                          allow-multiple-secrets="false">
+                              </osc-secrets>
+                            </div>
 
                             <!-- Only show routing options if the image has exposed ports. -->
                             <osc-form-section
@@ -209,6 +222,28 @@
                                 key-validator="[a-zA-Z][a-zA-Z0-9_]*"
                                 key-validator-error-tooltip="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."
                                 add-row-link="Add environment variable"></key-value-editor>
+                              <div class="form-group">
+                                <osc-secrets model="buildConfig.secrets.pullSecret"
+                                            namespace="projectName"
+                                            display-type="pull"
+                                            type="image"
+                                            secrets-by-type="secretsByType"
+                                            service-account-to-link="builder"
+                                            alerts="alerts"
+                                            allow-multiple-secrets="false">
+                                </osc-secrets>
+                              </div>
+                              <div class="form-group">
+                                <osc-secrets model="buildConfig.secrets.pushSecret"
+                                            namespace="projectName"
+                                            display-type="push"
+                                            type="image"
+                                            service-account-to-link="builder"
+                                            secrets-by-type="secretsByType"
+                                            alerts="alerts"
+                                            allow-multiple-secrets="false">
+                                </osc-secrets>
+                              </div>
                             </osc-form-section>
 
                             <!-- /build config -->
@@ -234,6 +269,15 @@
                                   Deployment configuration changes
                                 </label>
                                 </div>
+                                <osc-secrets model="deploymentConfig.secrets.pullSecrets"
+                                            namespace="projectName"
+                                            display-type="pull"
+                                            type="image"
+                                            secrets-by-type="secretsByType"
+                                            service-account-to-link="default"
+                                            alerts="alerts"
+                                            allow-multiple-secrets="true">
+                                </osc-secrets>
                                 <div>
                                   <h3>Environment Variables (Runtime only) <span class="help action-inline">
                                     <a href="" data-toggle="tooltip"
@@ -381,7 +425,7 @@
                           </div>
                           <alerts alerts="alerts"></alerts>
                           <div class="gutter-top">
-                            <a href="" ng-click="advancedOptions = !advancedOptions" role="button">{{advancedOptions ? 'Hide' : 'Show'}} advanced routing, build, and deployment options</a>
+                            <a href="" ng-click="advancedOptions = !advancedOptions" role="button">{{advancedOptions ? 'Hide' : 'Show'}} advanced routing, build, deployment and source options</a>
                           </div>
                           <div class="buttons gutter-bottom" ng-class="{'gutter-top': !alerts.length}">
                             <!-- unable to use form.valid.  need to fix validators in labels and key values directive -->

--- a/app/views/directives/create-secret.html
+++ b/app/views/directives/create-secret.html
@@ -11,288 +11,284 @@
     </ui-select>
   </div>
 
-  <div class="form-group">
-    <label for="secretName" class="required">Secret Name</label>
-      <span ng-class="{'has-error': nameTaken || (secretForm.secretName.$error.pattern && secretForm.secretName.$touched)}">
-        <input class="form-control"
-          id="secretName"
-          name="secretName"
-          ng-model="newSecret.data.secretName"
-          type="text"
-          autocorrect="off"
-          autocapitalize="off"
-          spellcheck="false"
-          aria-describedby="secret-name-help"
-          ng-maxlength="253"
-          ng-pattern="/^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/"
-          required>
-      </span>
-      <div class="has-error" ng-show="nameTaken">
-        <span class="help-block">
-          This name is already in use. Please choose a different name.
+  <div ng-if="newSecret.type">
+    <div class="form-group">
+      <label for="secretName" class="required">Secret Name</label>
+        <span ng-class="{'has-error': nameTaken || (secretForm.secretName.$error.pattern && secretForm.secretName.$touched)}">
+          <input class="form-control"
+            id="secretName"
+            name="secretName"
+            ng-model="newSecret.data.secretName"
+            type="text"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            aria-describedby="secret-name-help"
+            ng-maxlength="253"
+            ng-pattern="/^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/"
+            required>
         </span>
-      </div>
-      <div class="has-error" ng-show="secretForm.secretName.$error.pattern && secretForm.secretName.$touched">
-        <span class="help-block">
-          Secret name must consist of lower-case letters, numbers, periods, and
-          hyphens. It must start and end with a letter or number.
-        </span>
-      </div>
-      <div class="help-block" id="secret-name-help">
-        Unique name of the new secret.
-      </div>
-  </div>
-  <div class="form-group">
-    <label for="authentificationType">Authetication Type</label>
-    <ui-select required ng-model="newSecret.authType" search-enabled="false">
-      <ui-select-match>{{$select.selected.label}}</ui-select-match>
-      <ui-select-choices repeat="type.id as type in secretAuthTypeMap[newSecret.type].authTypes">
-        {{type.label}}
-      </ui-select-choices>
-    </ui-select>
-  </div>
-
-  <div ng-if="newSecret.authType === 'kubernetes.io/basic-auth'">
-    <div class="form-group">
-      <label for="username">Username</label>
-      <div>
-        <input class="form-control"
-          id="username"
-          name="username"
-          ng-model="newSecret.data.username"
-          type="text"
-          autocorrect="off"
-          autocapitalize="off"
-          spellcheck="false"
-          aria-describedby="username-help">
-      </div>
-      <div class="help-block" id="username-help">
-        Optional username for SCM servers authentication.
-      </div>
-    </div>
-
-    <div class="form-group">
-      <label for="passwordToken" class="required">Password or Token</label>
-      <div>
-        <input class="form-control"
-          id="passwordToken"
-          name="passwordToken"
-          ng-model="newSecret.data.passwordToken"
-          autocorrect="off"
-          autocapitalize="off"
-          spellcheck="false"
-          aria-describedby="password-token-help"
-          type="password"
-          required>
-      </div>
-      <div class="help-block" id="password-token-help">
-        Password or token for SCM servers authentication.
-      </div>
-    </div>
-  </div>
-
-  <div ng-if="newSecret.authType === 'kubernetes.io/ssh-auth'">
-    <div class="form-group" id="private-key">
-      <label for="privateKey" class="required">SSH Private Key</label>
-      <osc-file-input 
-        id="private-key-file-input"
-        model="newSecret.data.privateKey"
-        drop-zone-id="private-key"
-        dragging="false"
-        help-text="Upload your private SSH key file."
-        show-values="false"></osc-file-input>
-      <div ui-ace="{
-        theme: 'eclipse',
-        onLoad: aceLoaded,
-        rendererOptions: {
-          fadeFoldWidgets: true,
-          showPrintMargin: false 
-        }
-      }" ng-model="newSecret.data.privateKey" class="create-secret-editor ace-bordered" id="private-key-editor" required></div>
-      <div class="help-block">
-        Private SSH key file for SCM servers authentication.
-      </div>
-    </div>
-  </div>
-  
-  <div ng-if="newSecret.type === 'source'">
-    <div class="form-group">
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" ng-model="addGitconfig">
-          Use a custom .gitconfig file
-        </label>
-      </div>
-    </div>
-
-    <div class="form-group" ng-if="addGitconfig" id="gitconfig" ng-show="addGitconfig">
-      <label class="required" for="gitconfig">Git Configuration File</label>
-      <osc-file-input 
-        id="gitconfig-file-input"
-        model="newSecret.data.gitconfig"
-        drop-zone-id="gitconfig"
-        dragging="false"
-        help-text="Upload your .gitconfig or  file."
-        show-values="false"
-        required="true"></osc-file-input>
-      <div ui-ace="{
-        mode: 'ini',
-        theme: 'eclipse',
-        onLoad: aceLoaded,
-        rendererOptions: {
-          fadeFoldWidgets: true,
-          showPrintMargin: false 
-        }
-      }" ng-model="newSecret.data.gitconfig" class="create-secret-editor ace-bordered" id="gitconfig-editor"></div>
-    </div>
-  </div>
-
-  <div ng-if="newSecret.authType === 'kubernetes.io/dockercfg'">
-    <div class="form-group">
-      <label for="dockerServer" class="required">Image Registry Server Address</label>
-      <div>
-        <input class="form-control"
-          id="dockerServer"
-          name="dockerServer"
-          ng-model="newSecret.data.dockerServer"
-          type="text"
-          autocorrect="off"
-          autocapitalize="off"
-          spellcheck="false"
-          required>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <label for="dockerUsername" class="required">Username</label>
-      <div>
-        <input class="form-control"
-          id="dockerUsername"
-          name="dockerUsername"
-          ng-model="newSecret.data.dockerUsername"
-          type="text"
-          autocorrect="off"
-          autocapitalize="off"
-          spellcheck="false"
-          required>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <label for="dockerPassword" class="required">Password</label>
-      <div>
-        <input class="form-control"
-          id="dockerPassword"
-          name="dockerPassword"
-          ng-model="newSecret.data.dockerPassword"
-          type="password"
-          autocorrect="off"
-          autocapitalize="off"
-          spellcheck="false"
-          required>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <label for="dockerEmail" class="required">Email</label>
-      <div>
-        <input class="form-control"
-          type="email"
-          id="dockerEmail"
-          name="dockerEmail"
-          ng-model="newSecret.data.dockerMail"
-          autocorrect="off"
-          autocapitalize="off"
-          spellcheck="false"
-          required>
-      </div>
-    </div>
-  </div>
-
-  <div ng-if="newSecret.authType === 'kubernetes.io/dockerconfigjson'">
-    <div class="form-group" id="docker-config">
-      <label for="dockerConfig" class="required">Configuration File</label>
-      <osc-file-input
-        if="dockercfg-file-input"
-        model="newSecret.data.dockerConfig"
-        drop-zone-id="docker-config"
-        dragging="false"
-        help-text="Upload a .dockercfg or .docker/config.json file"
-        show-values="false"
-        required="true"></osc-file-input>
-      <div ui-ace="{
-        mode: 'json',
-        theme: 'eclipse',
-        onLoad: aceLoaded,
-        rendererOptions: {
-          fadeFoldWidgets: true,
-          showPrintMargin: false 
-        }
-      }" ng-model="newSecret.data.dockerConfig" class="create-secret-editor ace-bordered" id="dockerconfig-editor" required></div>
-      <div class="help-block">
-        File with credentials and other configuration for connecting to a secured image registry.
-      </div>
-    </div>
-  </div>
-
-  <div ng-if="'serviceaccounts' | canI : 'update'">
-    <div class="form-group">
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" ng-model="newSecret.linkSecret">
-          Use this secret automatically for other builds.
-        </label>
-      </div>
-    </div>
-
-    <div ng-if="!serviceAccountToLink && newSecret.linkSecret">
-      <div class="form-group">
-        <label for="serviceAccount" class="required">Service Account</label>
-        <ui-select required ng-model="newSecret.pickedServiceAccountToLink">
-          <ui-select-match placeholder="Service Account Name">{{$select.selected}}</ui-select-match>
-          <ui-select-choices repeat="sa in (serviceAccountsNames | filter : $select.search)">
-            <div ng-bind-html="sa | highlight : $select.search"></div>
-          </ui-select-choices>
-        </ui-select>
-      </div>
-
-      <div class="form-group" >
-        <label class="required">Link as</label>
-
-        <div class="form-group">
-          <div class="checkbox">
-            <label>
-              <input type="checkbox" ng-model="newSecret.linkAs.secrets" ng-checked="newSecret.linkAs.secrets">
-              Link with {{newSecret.pickedServiceAccountToLink}} service account as a <b>source</b> secret.
-              <span class="help action-inline">
-                <a href="">
-                  <i class="pficon pficon-help" aria-hidden="true"
-                  data-toggle="tooltip" data-original-title="Pods using this service account will mount the content of secret into their containers for pulling sources during build time.">
-                </i>
-                </a>
-              </span>
-            </label>
-          </div>
+        <div class="has-error" ng-show="nameTaken">
+          <span class="help-block">
+            This name is already in use. Please choose a different name.
+          </span>
         </div>
+        <div class="has-error" ng-show="secretForm.secretName.$error.pattern && secretForm.secretName.$touched">
+          <span class="help-block">
+            Secret name must consist of lower-case letters, numbers, periods, and
+            hyphens. It must start and end with a letter or number.
+          </span>
+        </div>
+        <div class="help-block" id="secret-name-help">
+          Unique name of the new secret.
+        </div>
+    </div>
+    <div class="form-group">
+      <label for="authentificationType">Authetication Type</label>
+      <ui-select required ng-model="newSecret.authType" search-enabled="false">
+        <ui-select-match>{{$select.selected.label}}</ui-select-match>
+        <ui-select-choices repeat="type.id as type in secretAuthTypeMap[newSecret.type].authTypes">
+          {{type.label}}
+        </ui-select-choices>
+      </ui-select>
+    </div>
 
-        <div class="form-group">
-          <div class="checkbox">
-            <label>
-              <input type="checkbox" ng-model="newSecret.linkAs.imagePullSecrets" ng-checked="newSecret.linkAs.imagePullSecrets">
-              Link with {{newSecret.pickedServiceAccountToLink}} service account as a <b>image pull</b> secret.
-              <span class="help action-inline">
-                <a href="">
-                  <i class="pficon pficon-help" aria-hidden="true"
-                  data-toggle="tooltip" data-original-title="Pods using this service account will use provided creadentials to pull images for the pod’s containers.">
-                </i>
-                </a>
-              </span>
-            </label>
-          </div>
+    <div ng-if="newSecret.authType === 'kubernetes.io/basic-auth'">
+      <div class="form-group">
+        <label for="username">Username</label>
+        <div>
+          <input class="form-control"
+            id="username"
+            name="username"
+            ng-model="newSecret.data.username"
+            type="text"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            aria-describedby="username-help">
+        </div>
+        <div class="help-block" id="username-help">
+          Optional username for Git authentication.
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label for="passwordToken">Password or Token</label>
+        <div>
+          <input class="form-control"
+            id="passwordToken"
+            name="passwordToken"
+            ng-model="newSecret.data.passwordToken"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            aria-describedby="password-token-help"
+            type="password"
+            ng-required="!newSecret.data.cacert && !newSecret.data.gitconfig">
+        </div>
+        <div class="help-block" id="password-token-help">
+          Password or token for Git authentication.
+        </div>
+      </div>
+
+
+      <div class="form-group">
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" ng-model="addCaCert">
+            Use a custom ca.crt file
+          </label>
+        </div>
+      </div>
+      <div class="form-group" ng-if="addCaCert" id="cacert">
+        <label class="required" for="cacert">CA Certificate File</label>
+        <osc-file-input
+          id="cacert-file-input"
+          model="newSecret.data.cacert"
+          drop-zone-id="cacert"
+          dragging="false"
+          help-text="Upload your ca.cert file."
+          show-values="false"
+          ng-required="!newSecret.data.gitconfig || !newSecret.data.passwordToken"></osc-file-input>
+        <div ui-ace="{
+          mode: 'txt',
+          theme: 'eclipse',
+          onLoad: aceLoaded,
+          rendererOptions: {
+            fadeFoldWidgets: true,
+            showPrintMargin: false
+          }
+        }" ng-model="newSecret.data.cacert" class="create-secret-editor ace-bordered" id="cacert-editor"></div>
+      </div>
+
+
+    </div>
+
+    <div ng-if="newSecret.authType === 'kubernetes.io/ssh-auth'">
+      <div class="form-group" id="private-key">
+        <label for="privateKey" class="required">SSH Private Key</label>
+        <osc-file-input 
+          id="private-key-file-input"
+          model="newSecret.data.privateKey"
+          drop-zone-id="private-key"
+          dragging="false"
+          help-text="Upload your private SSH key file."
+          show-values="false"></osc-file-input>
+        <div ui-ace="{
+          theme: 'eclipse',
+          onLoad: aceLoaded,
+          rendererOptions: {
+            fadeFoldWidgets: true,
+            showPrintMargin: false 
+          }
+        }" ng-model="newSecret.data.privateKey" class="create-secret-editor ace-bordered" id="private-key-editor" required></div>
+        <div class="help-block">
+          Private SSH key file for Git authentication.
+        </div>
+      </div>
+    </div>
+    
+    <div ng-if="newSecret.type === 'source'">
+      <div class="form-group">
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" ng-model="addGitconfig">
+            Use a custom .gitconfig file
+          </label>
+        </div>
+      </div>
+
+      <div class="form-group" ng-if="addGitconfig" id="gitconfig" ng-show="addGitconfig">
+        <label class="required" for="gitconfig">Git Configuration File</label>
+        <osc-file-input 
+          id="gitconfig-file-input"
+          model="newSecret.data.gitconfig"
+          drop-zone-id="gitconfig"
+          dragging="false"
+          help-text="Upload your .gitconfig or  file."
+          show-values="false"
+          ng-required="!newSecret.data.cacert || !newSecret.data.passwordToken"></osc-file-input>
+        <div ui-ace="{
+          mode: 'ini',
+          theme: 'eclipse',
+          onLoad: aceLoaded,
+          rendererOptions: {
+            fadeFoldWidgets: true,
+            showPrintMargin: false 
+          }
+        }" ng-model="newSecret.data.gitconfig" class="create-secret-editor ace-bordered" id="gitconfig-editor"></div>
+      </div>
+    </div>
+
+    <div ng-if="newSecret.authType === 'kubernetes.io/dockercfg'">
+      <div class="form-group">
+        <label for="dockerServer" class="required">Image Registry Server Address</label>
+        <div>
+          <input class="form-control"
+            id="dockerServer"
+            name="dockerServer"
+            ng-model="newSecret.data.dockerServer"
+            type="text"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            required>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label for="dockerUsername" class="required">Username</label>
+        <div>
+          <input class="form-control"
+            id="dockerUsername"
+            name="dockerUsername"
+            ng-model="newSecret.data.dockerUsername"
+            type="text"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            required>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label for="dockerPassword" class="required">Password</label>
+        <div>
+          <input class="form-control"
+            id="dockerPassword"
+            name="dockerPassword"
+            ng-model="newSecret.data.dockerPassword"
+            type="password"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            required>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label for="dockerEmail" class="required">Email</label>
+        <div>
+          <input class="form-control"
+            type="email"
+            id="dockerEmail"
+            name="dockerEmail"
+            ng-model="newSecret.data.dockerMail"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            required>
+        </div>
+      </div>
+    </div>
+
+    <div ng-if="newSecret.authType === 'kubernetes.io/dockerconfigjson'">
+      <div class="form-group" id="docker-config">
+        <label for="dockerConfig" class="required">Configuration File</label>
+        <osc-file-input
+          if="dockercfg-file-input"
+          model="newSecret.data.dockerConfig"
+          drop-zone-id="docker-config"
+          dragging="false"
+          help-text="Upload a .dockercfg or .docker/config.json file"
+          show-values="false"
+          required="true"></osc-file-input>
+        <div ui-ace="{
+          mode: 'json',
+          theme: 'eclipse',
+          onLoad: aceLoaded,
+          rendererOptions: {
+            fadeFoldWidgets: true,
+            showPrintMargin: false 
+          }
+        }" ng-model="newSecret.data.dockerConfig" class="create-secret-editor ace-bordered" id="dockerconfig-editor" required></div>
+        <div class="help-block">
+          File with credentials and other configuration for connecting to a secured image registry.
+        </div>
+      </div>
+    </div>
+    <div ng-if="('serviceaccounts' | canI : 'update') && !serviceAccountToLink">
+      <div class="form-group">
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" ng-model="newSecret.linkSecret">
+            Link secret to a service account.
+          </label>
         </div>
         <div class="help-block">
-          Linking a secret enables a service account to automatically use that secret for some forms of authentication.
           <a href="{{'managing_secrets' | helpLink}}" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a>
+        </div>
+      </div>
+
+      <div ng-if="newSecret.linkSecret">
+        <div class="form-group">
+          <label class="required">Service Account</label>
+          <ui-select required ng-model="newSecret.pickedServiceAccountToLink">
+            <ui-select-match placeholder="Service Account Name">{{$select.selected}}</ui-select-match>
+            <ui-select-choices repeat="sa in (serviceAccountsNames | filter : $select.search)">
+              <div ng-bind-html="sa | highlight : $select.search"></div>
+            </ui-select-choices>
+          </ui-select>
         </div>
       </div>
     </div>

--- a/app/views/directives/deploy-image.html
+++ b/app/views/directives/deploy-image.html
@@ -143,6 +143,15 @@
             <span class="help-block">This name is already in use within the project. Please choose a different name.</span>
           </div>
         </div>
+        <osc-secrets model="pullSecrets"
+                    namespace="project"
+                    display-type="pull"
+                    type="image"
+                    secrets-by-type="secretsByType"
+                    service-account-to-link="default"
+                    alerts="alerts"
+                    allow-multiple-secrets="true">
+        </osc-secrets>
         <osc-form-section
             header="Environment Variables"
             about-title="Environment Variables"
@@ -166,8 +175,6 @@
             can-toggle="false"
             help-text="Each label is applied to each created resource.">
         </label-editor>
-
-        <alerts alerts="alerts"></alerts>
 
         <div class="button-group gutter-bottom" ng-class="{'gutter-top': !alerts.length}">
           <button type="submit"

--- a/app/views/directives/from-file.html
+++ b/app/views/directives/from-file.html
@@ -26,8 +26,6 @@
         }" ng-model="editorContent" class="editor ace-bordered yaml-mode" id="add-component-editor" required></div>
       </div>
 
-      <alerts alerts="alerts"></alerts>
-
       <div class="buttons gutter-bottom" ng-class="{'gutter-top': !alerts.length}">
         <button
           type="submit"

--- a/app/views/directives/osc-secrets.html
+++ b/app/views/directives/osc-secrets.html
@@ -15,7 +15,7 @@
           <div ng-if="allowMultipleSecrets">
             <div class="basic-secrets">
               <div class="secret-name">
-                <label ng-if="$first" class="picker-label">{{displayType | startCase}} Secret</label>
+                <label ng-if="$first" class="picker-label">{{displayType | startCase}} Secrets</label>
                 <ui-select ng-model="pickedSecret.name">
                   <ui-select-match placeholder="Secret name">{{$select.selected}}</ui-select-match>
                   <ui-select-choices repeat="secret in (secretsByType[type] | filter : $select.search)">

--- a/app/views/edit/deployment-config.html
+++ b/app/views/edit/deployment-config.html
@@ -302,6 +302,13 @@
                             </div>
                           </div>
 
+                          <div class="checkbox form-group">
+                            <label>
+                              <input type="checkbox" ng-model="triggers.hasConfigTrigger">
+                              Automatically start new deployment when the deployment configuration changes
+                            </label>
+                          </div>
+
                           <div ng-if="view.advancedImageOptions">
                             <div class="gutter-top">
                               <osc-secrets model="pullSecrets"

--- a/app/views/secrets.html
+++ b/app/views/secrets.html
@@ -1,0 +1,82 @@
+<project-header class="top-header"></project-header>
+<project-page>
+
+  <!-- Middle section -->
+  <div class="middle-section">
+    <div class="middle-container">
+      <div class="middle-header header-light">
+        <div class="container-fluid">
+          <div class="page-header page-header-bleed-right page-header-bleed-left">
+            <div class="pull-right" ng-if="project && ('secrets' | canI : 'create')">
+              <a ng-href="project/{{project.metadata.name}}/create-secret" class="btn btn-default">Create Secret</a>
+            </div>
+            <h1>Secrets</h1>
+          </div>
+          <alerts alerts="alerts"></alerts>
+        </div>
+      </div><!-- /middle-header-->
+      <div class="middle-content">
+        <div class="container-fluid">
+          <div ng-if="!loaded">Loading...</div>
+          <div ng-if="loaded" class="row">
+            <div class="col-md-12">
+              <h3>Source Secrets</h3>
+              <table class="table table-bordered table-hover table-mobile secrets-table">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th>Created</th>
+                  </tr>
+                </thead>
+                <!-- message doesnt show right when there are both dcs and rcs and they are all filtered -->
+                <tbody ng-if="secretsByType.source.length === 0">
+                  <!-- If there are no deployment configs and no replication controllers owned by a deployment config -->
+                  <tr><td colspan="3"><em>No secrets</em></td></tr>
+                </tbody>
+                <tbody ng-repeat="secret in secretsByType.source | orderBy : 'name'">
+                  <tr ng-if="secret">
+                    <td data-title="Name">
+                      <a ng-href="{{secret | navigateResourceURL}}">{{secret.metadata.name}}</a>
+                    </td>
+                    <td data-title="Type">
+                      {{secret.type}}
+                    </td>
+                    <td data-title="Created">
+                      <relative-timestamp timestamp="secret.metadata.creationTimestamp"></relative-timestamp>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <div ng-if="secretsByType.images.length !== 0">
+                <h3>Image Secrets</h3>
+                <table class="table table-bordered table-hover table-mobile secrets-table">
+                  <thead>
+                    <tr>
+                      <th>Name</th>
+                      <th>Type</th>
+                      <th>Created</th>
+                    </tr>
+                  </thead>
+                  <tbody ng-repeat="secret in secretsByType.image | orderBy : 'name'">
+                    <tr>
+                      <td data-title="Name">
+                        <a ng-href="{{secret | navigateResourceURL}}">{{secret.metadata.name}}</a>
+                      </td>
+                      <td data-title="Type">
+                        {{secret.type}}
+                      </td>
+                      <td data-title="Created">
+                        <relative-timestamp timestamp="secret.metadata.creationTimestamp"></relative-timestamp>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div><!-- /col-* -->
+          </div>
+        </div>
+      </div><!-- /middle-content -->
+    </div><!-- /middle-container -->
+  </div><!-- /middle-section -->
+</project-page>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -107,6 +107,20 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/_config-file-params.html',
+    "<div ng-repeat=\"(serverName, data) in secretData\" class=\"image-source-item\">\n" +
+    "<h4>{{serverName}}</h4>\n" +
+    "<dt>Username:</dt>\n" +
+    "<dd class=\"word-break\">{{data.username}}</dd>\n" +
+    "<dt>Password:</dt>\n" +
+    "<dd ng-if=\"view.showSecret\" class=\"word-break\">{{data.password}}</dd>\n" +
+    "<dd ng-if=\"!view.showSecret\">*****</dd>\n" +
+    "<dt>Email:</dt>\n" +
+    "<dd class=\"word-break\">{{data.email}}</dd>\n" +
+    "</div>"
+  );
+
+
   $templateCache.put('views/_deployment-config-metadata.html',
     "<div ng-if=\"deploymentConfigId != ''\" class=\"metadata\">\n" +
     "<span>Created from deployment config {{deploymentConfigId}}</span>\n" +
@@ -3234,6 +3248,147 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/browse/secret.html',
+    "<project-header class=\"top-header\"></project-header>\n" +
+    "<project-page>\n" +
+    "\n" +
+    "<div class=\"middle-section\">\n" +
+    "<div class=\"middle-container\">\n" +
+    "<div class=\"middle-header\">\n" +
+    "<div class=\"container-fluid\">\n" +
+    "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
+    "<div ng-if=\"!loaded\" class=\"mar-top-xl\">Loading...</div>\n" +
+    "<div ng-if=\"loaded\">\n" +
+    "<h1>\n" +
+    "<div class=\"pull-right dropdown\" ng-hide=\"!('secrets' | canIDoAny)\">\n" +
+    "<button type=\"button\" class=\"dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs\" data-toggle=\"dropdown\">\n" +
+    "Actions\n" +
+    "<span class=\"caret\"></span>\n" +
+    "</button>\n" +
+    "<a href=\"\" class=\"dropdown-toggle actions-dropdown-kebab visible-xs-inline\" data-toggle=\"dropdown\"><i class=\"fa fa-ellipsis-v\"></i><span class=\"sr-only\">Actions</span></a>\n" +
+    "<ul class=\"dropdown-menu actions action-link\">\n" +
+    "<li ng-if=\"'secrets' | canI : 'update'\">\n" +
+    "<a ng-href=\"{{secret | editYamlURL}}\" role=\"button\">Edit YAML</a>\n" +
+    "</li>\n" +
+    "<li ng-if=\"'secrets' | canI : 'delete'\">\n" +
+    "<delete-link kind=\"Secret\" resource-name=\"{{secret.metadata.name}}\" project-name=\"{{secret.metadata.namespace}}\" alerts=\"alerts\">\n" +
+    "</delete-link>\n" +
+    "</li>\n" +
+    "</ul>\n" +
+    "</div>\n" +
+    "{{secret.metadata.name}}\n" +
+    "<small class=\"meta\">created <relative-timestamp timestamp=\"secret.metadata.creationTimestamp\"></relative-timestamp></small>\n" +
+    "</h1>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"middle-content gutter-top\">\n" +
+    "<div class=\"container-fluid\">\n" +
+    "<div ng-if=\"secret\" class=\"row\">\n" +
+    "<div class=\"col-sm-12\">\n" +
+    "<div class=\"resource-details secret-details\">\n" +
+    "<dl class=\"dl-horizontal left\">\n" +
+    "<dt>Type:</dt>\n" +
+    "<dd>{{secret.type}}</dd>\n" +
+    "<div ng-repeat=\"(secretDataName, secretData) in decodedSecretData\" class=\"image-source-item\">\n" +
+    "<div ng-switch=\"secretDataName\">\n" +
+    "<div ng-switch-when=\".dockercfg\">\n" +
+    "<ng-include src=\" 'views/_config-file-params.html' \"></ng-include>\n" +
+    "</div>\n" +
+    "<div ng-switch-when=\".dockerconfigjson\">\n" +
+    "<ng-include src=\" 'views/_config-file-params.html' \"></ng-include>\n" +
+    "</div>\n" +
+    "<div ng-switch-when=\"username\">\n" +
+    "<dt>Username:</dt>\n" +
+    "<dd class=\"word-break\">{{decodedSecretData.username}}</dd>\n" +
+    "</div>\n" +
+    "<div ng-switch-when=\"password\">\n" +
+    "<dt>Password:</dt>\n" +
+    "<dd ng-if=\"view.showSecret\" class=\"word-break\">{{secretData}}</dd>\n" +
+    "<dd ng-if=\"!view.showSecret\">*****</dd>\n" +
+    "</div>\n" +
+    "<div ng-switch-when=\"ssh-privatekey\">\n" +
+    "<dt>SSH Private Key:</dt>\n" +
+    "<dd ng-if=\"view.showSecret\" class=\"gutter-bottom\">\n" +
+    "<div ui-ace=\"{\n" +
+    "                            theme: 'dreamweaver',\n" +
+    "                            highlightActiveLine: false,\n" +
+    "                            showGutter: false,\n" +
+    "                            rendererOptions: {\n" +
+    "                              fadeFoldWidgets: true,\n" +
+    "                              highlightActiveLine: false,\n" +
+    "                              showPrintMargin: false\n" +
+    "                            },\n" +
+    "                            advanced: {\n" +
+    "                              highlightActiveLine: false\n" +
+    "                            }\n" +
+    "                          }\" readonly ng-model=\"secretData\" class=\"ace-bordered ace-read-only ace-inline secret-data\"></div>\n" +
+    "</dd>\n" +
+    "<dd ng-if=\"!view.showSecret\">*****</dd>\n" +
+    "</div>\n" +
+    "<div ng-switch-when=\"ca.crt\">\n" +
+    "<dt>CA Certificate:</dt>\n" +
+    "<dd ng-if=\"view.showSecret\" class=\"gutter-bottom\">\n" +
+    "<div ui-ace=\"{\n" +
+    "                            theme: 'dreamweaver',\n" +
+    "                            highlightActiveLine: false,\n" +
+    "                            showGutter: false,\n" +
+    "                            rendererOptions: {\n" +
+    "                              fadeFoldWidgets: true,\n" +
+    "                              highlightActiveLine: false,\n" +
+    "                              showPrintMargin: false\n" +
+    "                            },\n" +
+    "                            advanced: {\n" +
+    "                              highlightActiveLine: false\n" +
+    "                            }\n" +
+    "                          }\" readonly ng-model=\"secretData\" class=\"ace-bordered ace-read-only ace-inline secret-data\"></div>\n" +
+    "</dd>\n" +
+    "<dd ng-if=\"!view.showSecret\">*****</dd>\n" +
+    "</div>\n" +
+    "<div ng-switch-when=\".gitconfig\">\n" +
+    "<dt>Git Configuration File:</dt>\n" +
+    "<dd ng-if=\"view.showSecret\" class=\"gutter-bottom\">\n" +
+    "<div ui-ace=\"{\n" +
+    "                            mode: 'ini',\n" +
+    "                            theme: 'dreamweaver',\n" +
+    "                            highlightActiveLine: false,\n" +
+    "                            showGutter: false,\n" +
+    "                            rendererOptions: {\n" +
+    "                              fadeFoldWidgets: true,\n" +
+    "                              highlightActiveLine: false,\n" +
+    "                              showPrintMargin: false\n" +
+    "                            },\n" +
+    "                            advanced: {\n" +
+    "                              highlightActiveLine: false\n" +
+    "                            }\n" +
+    "                          }\" readonly ng-model=\"secretData\" class=\"ace-bordered ace-read-only ace-inline secret-data\"></div>\n" +
+    "</dd>\n" +
+    "<dd ng-if=\"!view.showSecret\">*****</dd>\n" +
+    "</div>\n" +
+    "<div ng-switch-default>\n" +
+    "<dt>{{secretDataName}}:</dt>\n" +
+    "<dd ng-if=\"view.showSecret\" class=\"word-break gutter-bottom\">{{secretData}}</dd>\n" +
+    "<dd ng-if=\"!view.showSecret\">*****</dd>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</dl>\n" +
+    "</div>\n" +
+    "<div class=\"gutter-bottom\">\n" +
+    "<a href=\"\" ng-click=\"view.showSecret = !view.showSecret\">{{view.showSecret ? \"Hide\" : \"Reveal\"}} secret contents</a>\n" +
+    "</div>\n" +
+    "<annotations annotations=\"secret.metadata.annotations\"></annotations>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</project-page>"
+  );
+
+
   $templateCache.put('views/browse/service.html',
     "<project-header class=\"top-header\"></project-header>\n" +
     "<project-page>\n" +
@@ -3779,6 +3934,42 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/create-secret.html',
+    "<default-header class=\"top-header\"></default-header>\n" +
+    "<div class=\"wrap no-sidebar\">\n" +
+    "<div class=\"sidebar-left collapse navbar-collapse navbar-collapse-2\">\n" +
+    "<navbar-utility-mobile></navbar-utility-mobile>\n" +
+    "</div>\n" +
+    "<div class=\"middle surface-shaded\">\n" +
+    "\n" +
+    "<div class=\"middle-section\">\n" +
+    "<div class=\"middle-container\">\n" +
+    "<div class=\"middle-content\">\n" +
+    "<div class=\"container surface-shaded\">\n" +
+    "<div ng-if=\"!project\">Loading...</div>\n" +
+    "<div class=\"row\" ng-if=\"project\">\n" +
+    "<div class=\"col-md-10 col-md-offset-1\">\n" +
+    "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
+    "<div class=\"mar-top-xl\">\n" +
+    "<h1>Create Secret</h1>\n" +
+    "<div class=\"help-block\">\n" +
+    "Secrets allow you to authenticate to a private Git repository or a private image registry.\n" +
+    "</div>\n" +
+    "<create-secret namespace=\"projectName\" alerts=\"alerts\" post-create-action=\"postCreateAction(newSecret, creationAlert)\" cancel=\"cancel()\">\n" +
+    "</create-secret>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>"
+  );
+
+
   $templateCache.put('views/create.html',
     "<default-header class=\"top-header\"></default-header>\n" +
     "<div class=\"wrap no-sidebar\">\n" +
@@ -4011,7 +4202,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div>\n" +
     "<input id=\"contextdir\" ng-model=\"buildConfig.contextDir\" type=\"text\" placeholder=\"/\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck class=\"form-control\">\n" +
     "</div>\n" +
-    "<div class=\"help-block\">Optional subdirectory for the application source code, used as the context directory for the build.</div> </div>\n" +
+    "<div class=\"help-block\">Optional subdirectory for the application source code, used as the context directory for the build.</div>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\">\n" +
+    "<osc-secrets model=\"buildConfig.secrets.gitSecret\" namespace=\"projectName\" display-type=\"source\" type=\"source\" service-account-to-link=\"builder\" secrets-by-type=\"secretsByType\" alerts=\"alerts\" allow-multiple-secrets=\"false\">\n" +
+    "</osc-secrets>\n" +
+    "</div>\n" +
     "\n" +
     "<osc-form-section header=\"Routing\" about-title=\"Routing\" about=\"Routing is a way to make your application publicly visible. Otherwise you may only be able to access your application by its IP address, if allowed by the system administrator.\" expand=\"true\" can-toggle=\"false\" ng-if=\"routing.portOptions.length\">\n" +
     "<div class=\"form-group checkbox\">\n" +
@@ -4060,6 +4256,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</a>\n" +
     "</span></h3>\n" +
     "<key-value-editor entries=\"buildConfigEnvVars\" key-placeholder=\"name\" value-placeholder=\"value\" key-validator=\"[a-zA-Z][a-zA-Z0-9_]*\" key-validator-error-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" add-row-link=\"Add environment variable\"></key-value-editor>\n" +
+    "<div class=\"form-group\">\n" +
+    "<osc-secrets model=\"buildConfig.secrets.pullSecret\" namespace=\"projectName\" display-type=\"pull\" type=\"image\" secrets-by-type=\"secretsByType\" service-account-to-link=\"builder\" alerts=\"alerts\" allow-multiple-secrets=\"false\">\n" +
+    "</osc-secrets>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\">\n" +
+    "<osc-secrets model=\"buildConfig.secrets.pushSecret\" namespace=\"projectName\" display-type=\"push\" type=\"image\" service-account-to-link=\"builder\" secrets-by-type=\"secretsByType\" alerts=\"alerts\" allow-multiple-secrets=\"false\">\n" +
+    "</osc-secrets>\n" +
+    "</div>\n" +
     "</osc-form-section>\n" +
     "\n" +
     "<osc-form-section header=\"Deployment Configuration\" about-title=\"Deployment Configuration\" about=\"Deployment configurations describe how your application is configured\n" +
@@ -4078,6 +4282,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Deployment configuration changes\n" +
     "</label>\n" +
     "</div>\n" +
+    "<osc-secrets model=\"deploymentConfig.secrets.pullSecrets\" namespace=\"projectName\" display-type=\"pull\" type=\"image\" secrets-by-type=\"secretsByType\" service-account-to-link=\"default\" alerts=\"alerts\" allow-multiple-secrets=\"true\">\n" +
+    "</osc-secrets>\n" +
     "<div>\n" +
     "<h3>Environment Variables (Runtime only) <span class=\"help action-inline\">\n" +
     "<a href=\"\" data-toggle=\"tooltip\" data-original-title=\"Environment variables are used to configure and pass information to running containers.  These environment variables will only be available at runtime.\">\n" +
@@ -4159,7 +4365,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"gutter-top\">\n" +
-    "<a href=\"\" ng-click=\"advancedOptions = !advancedOptions\" role=\"button\">{{advancedOptions ? 'Hide' : 'Show'}} advanced routing, build, and deployment options</a>\n" +
+    "<a href=\"\" ng-click=\"advancedOptions = !advancedOptions\" role=\"button\">{{advancedOptions ? 'Hide' : 'Show'}} advanced routing, build, deployment and source options</a>\n" +
     "</div>\n" +
     "<div class=\"buttons gutter-bottom\" ng-class=\"{'gutter-top': !alerts.length}\">\n" +
     "\n" +
@@ -4936,6 +5142,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
     "</div>\n" +
+    "<div ng-if=\"newSecret.type\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"secretName\" class=\"required\">Secret Name</label>\n" +
     "<span ng-class=\"{'has-error': nameTaken || (secretForm.secretName.$error.pattern && secretForm.secretName.$touched)}\">\n" +
@@ -4971,17 +5178,38 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<input class=\"form-control\" id=\"username\" name=\"username\" ng-model=\"newSecret.data.username\" type=\"text\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck aria-describedby=\"username-help\">\n" +
     "</div>\n" +
     "<div class=\"help-block\" id=\"username-help\">\n" +
-    "Optional username for SCM servers authentication.\n" +
+    "Optional username for Git authentication.\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"form-group\">\n" +
-    "<label for=\"passwordToken\" class=\"required\">Password or Token</label>\n" +
+    "<label for=\"passwordToken\">Password or Token</label>\n" +
     "<div>\n" +
-    "<input class=\"form-control\" id=\"passwordToken\" name=\"passwordToken\" ng-model=\"newSecret.data.passwordToken\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck aria-describedby=\"password-token-help\" type=\"password\" required>\n" +
+    "<input class=\"form-control\" id=\"passwordToken\" name=\"passwordToken\" ng-model=\"newSecret.data.passwordToken\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck aria-describedby=\"password-token-help\" type=\"password\" ng-required=\"!newSecret.data.cacert && !newSecret.data.gitconfig\">\n" +
     "</div>\n" +
     "<div class=\"help-block\" id=\"password-token-help\">\n" +
-    "Password or token for SCM servers authentication.\n" +
+    "Password or token for Git authentication.\n" +
     "</div>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\">\n" +
+    "<div class=\"checkbox\">\n" +
+    "<label>\n" +
+    "<input type=\"checkbox\" ng-model=\"addCaCert\">\n" +
+    "Use a custom ca.crt file\n" +
+    "</label>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\" ng-if=\"addCaCert\" id=\"cacert\">\n" +
+    "<label class=\"required\" for=\"cacert\">CA Certificate File</label>\n" +
+    "<osc-file-input id=\"cacert-file-input\" model=\"newSecret.data.cacert\" drop-zone-id=\"cacert\" dragging=\"false\" help-text=\"Upload your ca.cert file.\" show-values=\"false\" ng-required=\"!newSecret.data.gitconfig || !newSecret.data.passwordToken\"></osc-file-input>\n" +
+    "<div ui-ace=\"{\n" +
+    "          mode: 'txt',\n" +
+    "          theme: 'eclipse',\n" +
+    "          onLoad: aceLoaded,\n" +
+    "          rendererOptions: {\n" +
+    "            fadeFoldWidgets: true,\n" +
+    "            showPrintMargin: false\n" +
+    "          }\n" +
+    "        }\" ng-model=\"newSecret.data.cacert\" class=\"create-secret-editor ace-bordered\" id=\"cacert-editor\"></div>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"newSecret.authType === 'kubernetes.io/ssh-auth'\">\n" +
@@ -4989,15 +5217,15 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<label for=\"privateKey\" class=\"required\">SSH Private Key</label>\n" +
     "<osc-file-input id=\"private-key-file-input\" model=\"newSecret.data.privateKey\" drop-zone-id=\"private-key\" dragging=\"false\" help-text=\"Upload your private SSH key file.\" show-values=\"false\"></osc-file-input>\n" +
     "<div ui-ace=\"{\n" +
-    "        theme: 'eclipse',\n" +
-    "        onLoad: aceLoaded,\n" +
-    "        rendererOptions: {\n" +
-    "          fadeFoldWidgets: true,\n" +
-    "          showPrintMargin: false \n" +
-    "        }\n" +
-    "      }\" ng-model=\"newSecret.data.privateKey\" class=\"create-secret-editor ace-bordered\" id=\"private-key-editor\" required></div>\n" +
+    "          theme: 'eclipse',\n" +
+    "          onLoad: aceLoaded,\n" +
+    "          rendererOptions: {\n" +
+    "            fadeFoldWidgets: true,\n" +
+    "            showPrintMargin: false \n" +
+    "          }\n" +
+    "        }\" ng-model=\"newSecret.data.privateKey\" class=\"create-secret-editor ace-bordered\" id=\"private-key-editor\" required></div>\n" +
     "<div class=\"help-block\">\n" +
-    "Private SSH key file for SCM servers authentication.\n" +
+    "Private SSH key file for Git authentication.\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -5012,16 +5240,16 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"form-group\" ng-if=\"addGitconfig\" id=\"gitconfig\" ng-show=\"addGitconfig\">\n" +
     "<label class=\"required\" for=\"gitconfig\">Git Configuration File</label>\n" +
-    "<osc-file-input id=\"gitconfig-file-input\" model=\"newSecret.data.gitconfig\" drop-zone-id=\"gitconfig\" dragging=\"false\" help-text=\"Upload your .gitconfig or  file.\" show-values=\"false\" required></osc-file-input>\n" +
+    "<osc-file-input id=\"gitconfig-file-input\" model=\"newSecret.data.gitconfig\" drop-zone-id=\"gitconfig\" dragging=\"false\" help-text=\"Upload your .gitconfig or  file.\" show-values=\"false\" ng-required=\"!newSecret.data.cacert || !newSecret.data.passwordToken\"></osc-file-input>\n" +
     "<div ui-ace=\"{\n" +
-    "        mode: 'ini',\n" +
-    "        theme: 'eclipse',\n" +
-    "        onLoad: aceLoaded,\n" +
-    "        rendererOptions: {\n" +
-    "          fadeFoldWidgets: true,\n" +
-    "          showPrintMargin: false \n" +
-    "        }\n" +
-    "      }\" ng-model=\"newSecret.data.gitconfig\" class=\"create-secret-editor ace-bordered\" id=\"gitconfig-editor\"></div>\n" +
+    "          mode: 'ini',\n" +
+    "          theme: 'eclipse',\n" +
+    "          onLoad: aceLoaded,\n" +
+    "          rendererOptions: {\n" +
+    "            fadeFoldWidgets: true,\n" +
+    "            showPrintMargin: false \n" +
+    "          }\n" +
+    "        }\" ng-model=\"newSecret.data.gitconfig\" class=\"create-secret-editor ace-bordered\" id=\"gitconfig-editor\"></div>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"newSecret.authType === 'kubernetes.io/dockercfg'\">\n" +
@@ -5055,71 +5283,40 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<label for=\"dockerConfig\" class=\"required\">Configuration File</label>\n" +
     "<osc-file-input if=\"dockercfg-file-input\" model=\"newSecret.data.dockerConfig\" drop-zone-id=\"docker-config\" dragging=\"false\" help-text=\"Upload a .dockercfg or .docker/config.json file\" show-values=\"false\" required></osc-file-input>\n" +
     "<div ui-ace=\"{\n" +
-    "        mode: 'json',\n" +
-    "        theme: 'eclipse',\n" +
-    "        onLoad: aceLoaded,\n" +
-    "        rendererOptions: {\n" +
-    "          fadeFoldWidgets: true,\n" +
-    "          showPrintMargin: false \n" +
-    "        }\n" +
-    "      }\" ng-model=\"newSecret.data.dockerConfig\" class=\"create-secret-editor ace-bordered\" id=\"dockerconfig-editor\" required></div>\n" +
+    "          mode: 'json',\n" +
+    "          theme: 'eclipse',\n" +
+    "          onLoad: aceLoaded,\n" +
+    "          rendererOptions: {\n" +
+    "            fadeFoldWidgets: true,\n" +
+    "            showPrintMargin: false \n" +
+    "          }\n" +
+    "        }\" ng-model=\"newSecret.data.dockerConfig\" class=\"create-secret-editor ace-bordered\" id=\"dockerconfig-editor\" required></div>\n" +
     "<div class=\"help-block\">\n" +
     "File with credentials and other configuration for connecting to a secured image registry.\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-if=\"'serviceaccounts' | canI : 'update'\">\n" +
+    "<div ng-if=\"('serviceaccounts' | canI : 'update') && !serviceAccountToLink\">\n" +
     "<div class=\"form-group\">\n" +
     "<div class=\"checkbox\">\n" +
     "<label>\n" +
     "<input type=\"checkbox\" ng-model=\"newSecret.linkSecret\">\n" +
-    "Use this secret automatically for other builds.\n" +
+    "Link secret to a service account.\n" +
     "</label>\n" +
     "</div>\n" +
+    "<div class=\"help-block\">\n" +
+    "<a href=\"{{'managing_secrets' | helpLink}}\" target=\"_blank\"><span class=\"learn-more-inline\">Learn more&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></span></a>\n" +
     "</div>\n" +
-    "<div ng-if=\"!serviceAccountToLink && newSecret.linkSecret\">\n" +
+    "</div>\n" +
+    "<div ng-if=\"newSecret.linkSecret\">\n" +
     "<div class=\"form-group\">\n" +
-    "<label for=\"serviceAccount\" class=\"required\">Service Account</label>\n" +
+    "<label class=\"required\">Service Account</label>\n" +
     "<ui-select required ng-model=\"newSecret.pickedServiceAccountToLink\">\n" +
     "<ui-select-match placeholder=\"Service Account Name\">{{$select.selected}}</ui-select-match>\n" +
     "<ui-select-choices repeat=\"sa in (serviceAccountsNames | filter : $select.search)\">\n" +
     "<div ng-bind-html=\"sa | highlight : $select.search\"></div>\n" +
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
-    "</div>\n" +
-    "<div class=\"form-group\">\n" +
-    "<label class=\"required\">Link as</label>\n" +
-    "<div class=\"form-group\">\n" +
-    "<div class=\"checkbox\">\n" +
-    "<label>\n" +
-    "<input type=\"checkbox\" ng-model=\"newSecret.linkAs.secrets\" ng-checked=\"newSecret.linkAs.secrets\">\n" +
-    "Link with {{newSecret.pickedServiceAccountToLink}} service account as a <b>source</b> secret.\n" +
-    "<span class=\"help action-inline\">\n" +
-    "<a href=\"\">\n" +
-    "<i class=\"pficon pficon-help\" aria-hidden=\"true\" data-toggle=\"tooltip\" data-original-title=\"Pods using this service account will mount the content of secret into their containers for pulling sources during build time.\">\n" +
-    "</i>\n" +
-    "</a>\n" +
-    "</span>\n" +
-    "</label>\n" +
-    "</div>\n" +
-    "</div>\n" +
-    "<div class=\"form-group\">\n" +
-    "<div class=\"checkbox\">\n" +
-    "<label>\n" +
-    "<input type=\"checkbox\" ng-model=\"newSecret.linkAs.imagePullSecrets\" ng-checked=\"newSecret.linkAs.imagePullSecrets\">\n" +
-    "Link with {{newSecret.pickedServiceAccountToLink}} service account as a <b>image pull</b> secret.\n" +
-    "<span class=\"help action-inline\">\n" +
-    "<a href=\"\">\n" +
-    "<i class=\"pficon pficon-help\" aria-hidden=\"true\" data-toggle=\"tooltip\" data-original-title=\"Pods using this service account will use provided creadentials to pull images for the pod’s containers.\">\n" +
-    "</i>\n" +
-    "</a>\n" +
-    "</span>\n" +
-    "</label>\n" +
-    "</div>\n" +
-    "</div>\n" +
-    "<div class=\"help-block\">\n" +
-    "Linking a secret enables a service account to automatically use that secret for some forms of authentication.\n" +
-    "<a href=\"{{'managing_secrets' | helpLink}}\" target=\"_blank\"><span class=\"learn-more-inline\">Learn more&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></span></a>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -5261,12 +5458,13 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"help-block\">This name is already in use within the project. Please choose a different name.</span>\n" +
     "</div>\n" +
     "</div>\n" +
+    "<osc-secrets model=\"pullSecrets\" namespace=\"project\" display-type=\"pull\" type=\"image\" secrets-by-type=\"secretsByType\" service-account-to-link=\"default\" alerts=\"alerts\" allow-multiple-secrets=\"true\">\n" +
+    "</osc-secrets>\n" +
     "<osc-form-section header=\"Environment Variables\" about-title=\"Environment Variables\" about=\"Environment variables are used to configure and pass information to running containers.\" expand=\"true\" can-toggle=\"false\" class=\"first-section\">\n" +
     "<key-value-editor entries=\"env\" key-placeholder=\"Name\" key-validator=\"[A-Za-z_][A-Za-z0-9_]*\" key-validator-error=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" value-placeholder=\"Value\" add-row-link=\"Add environment variable\"></key-value-editor>\n" +
     "</osc-form-section>\n" +
     "<label-editor labels=\"labels\" system-labels=\"systemLabels\" expand=\"true\" can-toggle=\"false\" help-text=\"Each label is applied to each created resource.\">\n" +
     "</label-editor>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"button-group gutter-bottom\" ng-class=\"{'gutter-top': !alerts.length}\">\n" +
     "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-click=\"create()\" value=\"\" ng-disabled=\"form.$invalid || nameTaken || disableInputs\">Create</button>\n" +
     "<a class=\"btn btn-default btn-lg\" href=\"#\" back>Cancel</a>\n" +
@@ -5655,7 +5853,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "          }\n" +
     "        }\" ng-model=\"editorContent\" class=\"editor ace-bordered yaml-mode\" id=\"add-component-editor\" required></div>\n" +
     "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"buttons gutter-bottom\" ng-class=\"{'gutter-top': !alerts.length}\">\n" +
     "<button type=\"submit\" ng-click=\"create()\" ng-disabled=\"editorErrorAnnotation || !editorContent\" class=\"btn btn-primary btn-lg\">\n" +
     "Create\n" +
@@ -6717,7 +6914,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"allowMultipleSecrets\">\n" +
     "<div class=\"basic-secrets\">\n" +
     "<div class=\"secret-name\">\n" +
-    "<label ng-if=\"$first\" class=\"picker-label\">{{displayType | startCase}} Secret</label>\n" +
+    "<label ng-if=\"$first\" class=\"picker-label\">{{displayType | startCase}} Secrets</label>\n" +
     "<ui-select ng-model=\"pickedSecret.name\">\n" +
     "<ui-select-match placeholder=\"Secret name\">{{$select.selected}}</ui-select-match>\n" +
     "<ui-select-choices repeat=\"secret in (secretsByType[type] | filter : $select.search)\">\n" +
@@ -7743,6 +7940,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<input class=\"form-control\" id=\"imageName\" name=\"imageName\" ng-model=\"containerConfig.image\" type=\"text\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck required>\n" +
     "</div>\n" +
     "</div>\n" +
+    "</div>\n" +
+    "<div class=\"checkbox form-group\">\n" +
+    "<label>\n" +
+    "<input type=\"checkbox\" ng-model=\"triggers.hasConfigTrigger\">\n" +
+    "Automatically start new deployment when the deployment configuration changes\n" +
+    "</label>\n" +
     "</div>\n" +
     "<div ng-if=\"view.advancedImageOptions\">\n" +
     "<div class=\"gutter-top\">\n" +
@@ -9993,6 +10196,91 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</tbody>\n" +
     "</table>\n" +
     "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</project-page>"
+  );
+
+
+  $templateCache.put('views/secrets.html',
+    "<project-header class=\"top-header\"></project-header>\n" +
+    "<project-page>\n" +
+    "\n" +
+    "<div class=\"middle-section\">\n" +
+    "<div class=\"middle-container\">\n" +
+    "<div class=\"middle-header header-light\">\n" +
+    "<div class=\"container-fluid\">\n" +
+    "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
+    "<div class=\"pull-right\" ng-if=\"project && ('secrets' | canI : 'create')\">\n" +
+    "<a ng-href=\"project/{{project.metadata.name}}/create-secret\" class=\"btn btn-default\">Create Secret</a>\n" +
+    "</div>\n" +
+    "<h1>Secrets</h1>\n" +
+    "</div>\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"middle-content\">\n" +
+    "<div class=\"container-fluid\">\n" +
+    "<div ng-if=\"!loaded\">Loading...</div>\n" +
+    "<div ng-if=\"loaded\" class=\"row\">\n" +
+    "<div class=\"col-md-12\">\n" +
+    "<h3>Source Secrets</h3>\n" +
+    "<table class=\"table table-bordered table-hover table-mobile secrets-table\">\n" +
+    "<thead>\n" +
+    "<tr>\n" +
+    "<th>Name</th>\n" +
+    "<th>Type</th>\n" +
+    "<th>Created</th>\n" +
+    "</tr>\n" +
+    "</thead>\n" +
+    "\n" +
+    "<tbody ng-if=\"secretsByType.source.length === 0\">\n" +
+    "\n" +
+    "<tr><td colspan=\"3\"><em>No secrets</em></td></tr>\n" +
+    "</tbody>\n" +
+    "<tbody ng-repeat=\"secret in secretsByType.source | orderBy : 'name'\">\n" +
+    "<tr ng-if=\"secret\">\n" +
+    "<td data-title=\"Name\">\n" +
+    "<a ng-href=\"{{secret | navigateResourceURL}}\">{{secret.metadata.name}}</a>\n" +
+    "</td>\n" +
+    "<td data-title=\"Type\">\n" +
+    "{{secret.type}}\n" +
+    "</td>\n" +
+    "<td data-title=\"Created\">\n" +
+    "<relative-timestamp timestamp=\"secret.metadata.creationTimestamp\"></relative-timestamp>\n" +
+    "</td>\n" +
+    "</tr>\n" +
+    "</tbody>\n" +
+    "</table>\n" +
+    "<div ng-if=\"secretsByType.images.length !== 0\">\n" +
+    "<h3>Image Secrets</h3>\n" +
+    "<table class=\"table table-bordered table-hover table-mobile secrets-table\">\n" +
+    "<thead>\n" +
+    "<tr>\n" +
+    "<th>Name</th>\n" +
+    "<th>Type</th>\n" +
+    "<th>Created</th>\n" +
+    "</tr>\n" +
+    "</thead>\n" +
+    "<tbody ng-repeat=\"secret in secretsByType.image | orderBy : 'name'\">\n" +
+    "<tr>\n" +
+    "<td data-title=\"Name\">\n" +
+    "<a ng-href=\"{{secret | navigateResourceURL}}\">{{secret.metadata.name}}</a>\n" +
+    "</td>\n" +
+    "<td data-title=\"Type\">\n" +
+    "{{secret.type}}\n" +
+    "</td>\n" +
+    "<td data-title=\"Created\">\n" +
+    "<relative-timestamp timestamp=\"secret.metadata.creationTimestamp\"></relative-timestamp>\n" +
+    "</td>\n" +
+    "</tr>\n" +
+    "</tbody>\n" +
+    "</table>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3677,7 +3677,10 @@ a.disabled-link:active,a.disabled-link:focus,a.disabled-link:hover{color:#bbb;te
 .create-secret-modal{background-color:#F5F5F5}
 .create-secret-modal .modal-footer{margin-top:0px}
 .create-secret-modal .modal-body{padding:0px 18px}
-.create-secret-modal .modal-body .create-secret-editor{height:150px}
+.secret-data{max-width:450px;max-height:150px}
+@media (max-width:991px){.secret-data{max-width:100%}
+}
+.create-secret-editor{height:150px}
 .edit-yaml h1{line-height:1.3}
 .edit-yaml .editor{line-height:1.5;width:100%;min-height:140px;height:50vh}
 .edit-yaml .editor .ace_gutter{color:#8b8d8f}


### PR DESCRIPTION
@spadgett FYI here is the work I done sofar on the stadalone secrets page + adding select-boxes to add secrets into the BC that will be generated in the `From Image` page. The only two thing I'm missing is the select boxes for adding secrets into the DC on the `From Image` && `Deploy Image` pages, since I need some work from https://github.com/openshift/origin-web-console/pull/656 to be merged, mainly the ability to add multiple secrets with the `osc-secrets` directive. Once thats in, will update the this PR
