### PR TITLE
Fix typos automatically

### DIFF
--- a/app/scripts/controllers/pod.js
+++ b/app/scripts/controllers/pod.js
@@ -150,7 +150,7 @@ angular.module('openshiftConsole')
      *  Will set the newTerm's isVisible/isUsed to true, while hiding the previous
      */
     $scope.onTerminalSelectChange = function(newTerm) {
-      // Make all terminals invisible (Becuase we don't have a pointer to the terminal that is currently visible)
+      // Make all terminals invisible (Because we don't have a pointer to the terminal that is currently visible)
       _.each($scope.containerTerminals, function(term) {
         term.isVisible = false;
       });

--- a/app/scripts/directives/logViewer.js
+++ b/app/scripts/directives/logViewer.js
@@ -59,7 +59,7 @@ angular.module('openshiftConsole')
           '$scope',
           function($scope) {
             // cached node's are set by the directive's postLink fn after render (see link: func below)
-            // A jQuery wrapped verison is cached in var of same name w/$
+            // A jQuery wrapped version is cached in var of same name w/$
             var cachedLogNode;
             var cachedScrollableNode;
             var $cachedScrollableNode;

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -319,7 +319,7 @@
                                   <span class="help action-inline">
                                     <a href ng-switch="buildConfig.spec.runPolicy">
                                       <i ng-switch-when="Serial" class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Builds triggered from this Build Configuration will run one at the time, in the order they have been triggered."></i>
-                                      <i ng-switch-when="Parallel" class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Builds triggered from this Build Configuration will run all at the same time. The order in which they will finish is not guranteed."></i>
+                                      <i ng-switch-when="Parallel" class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Builds triggered from this Build Configuration will run all at the same time. The order in which they will finish is not guaranteed."></i>
                                       <i ng-switch-when="SerialLatestOnly" class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Builds triggered from this Build Configuration will run one at the time. When a currently running build completes, the next build that will run is the latest build created. Other queued builds will be cancelled."></i>
                                       <i ng-switch-default class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Builds triggered from this Build Configuration will run using the {{buildConfig.spec.runPolicy | sentenceCase}} policy."></i>
                                     </a>

--- a/app/views/deployments.html
+++ b/app/views/deployments.html
@@ -33,7 +33,7 @@
                     <th>Trigger</th>
                   </tr>
                 </thead>
-                <!-- message doesnt show right when there are both dcs and rcs and they are all filtered -->
+                <!-- message doesn't show right when there are both dcs and rcs and they are all filtered -->
                 <tbody ng-if="showEmptyMessage()">
                   <!-- If there are no deployment configs and no replication controllers owned by a deployment config -->
                   <tr><td colspan="5"><em>{{emptyMessage}}</em></td></tr>
@@ -173,7 +173,7 @@
                   </thead>
                   <tbody ng-if="(replicationControllersByDC[''] | hashSize) === 0"><tr><td colspan="3"><em>No replication controllers to show</em></td></tr></tbody>
                   <tbody ng-repeat="deployment in replicationControllersByDC[''] | orderObjectsByDate : true">
-                    <!-- We only show this if there are replication controllers but the active filter is hiding them, otherwise the RC table doesnt show
+                    <!-- We only show this if there are replication controllers but the active filter is hiding them, otherwise the RC table doesn't show
                          at all -->
                     <tr>
                       <td data-title="Name">

--- a/app/views/directives/osc-persistent-volume-claim.html
+++ b/app/views/directives/osc-persistent-volume-claim.html
@@ -86,7 +86,7 @@
       </div>
       <div class="has-error" ng-show="persistentVolumeClaimForm.capacity.$error.pattern && persistentVolumeClaimForm.capacity.$touched && !claimDisabled">
         <span class="help-block">
-          Must be a postive integer.
+          Must be a positive integer.
         </span>
       </div>
       </fieldset>

--- a/app/views/edit/build-config.html
+++ b/app/views/edit/build-config.html
@@ -531,7 +531,7 @@
                       </div>
                       <div ng-switch="updatedBuildConfig.spec.runPolicy">
                         <div class="help-block" ng-switch-when="Serial">Builds triggered from this Build Configuration will run one at the time, in the order they have been triggered.</div>
-                        <div class="help-block" ng-switch-when="Parallel">Builds triggered from this Build Configuration will run all at the same time. The order in which they will finish is not guranteed.</div>
+                        <div class="help-block" ng-switch-when="Parallel">Builds triggered from this Build Configuration will run all at the same time. The order in which they will finish is not guaranteed.</div>
                         <div class="help-block" ng-switch-when="SerialLatestOnly">Builds triggered from this Build Configuration will run one at the time. When a currently running build completes, the next build that will run is the latest build created. Other queued builds will be cancelled.</div>
                         <div class="help-block" ng-switch-default>Builds triggered from this Build Configuration will run using the {{updatedBuildConfig.spec.runPolicy | sentenceCase}} policy.</div>
                       </div>

--- a/app/views/monitoring.html
+++ b/app/views/monitoring.html
@@ -241,7 +241,7 @@
                     <div ng-repeat-end ng-if="expanded.replicaSets[replicaSet.metadata.name]" class="list-group-expanded-section" ng-class="{'expanded': expanded.replicaSets[replicaSet.metadata.name]}">
                       Logs are not available for replica sets.
                       <span ng-if="podsByOwnerUID[replicaSet.metadata.uid] | hashSize">
-                        To see applicaiton logs, view the logs for one of the replica set's
+                        To see application logs, view the logs for one of the replica set's
                         <a href="" ng-click="viewPodsForReplicaSet(replicaSet)">pods</a>.
                       </span>
                       <div class="mar-top-lg" ng-if="metricsAvailable">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1755,7 +1755,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"help action-inline\">\n" +
     "<a href ng-switch=\"buildConfig.spec.runPolicy\">\n" +
     "<i ng-switch-when=\"Serial\" class=\"pficon pficon-help\" data-toggle=\"tooltip\" aria-hidden=\"true\" data-original-title=\"Builds triggered from this Build Configuration will run one at the time, in the order they have been triggered.\"></i>\n" +
-    "<i ng-switch-when=\"Parallel\" class=\"pficon pficon-help\" data-toggle=\"tooltip\" aria-hidden=\"true\" data-original-title=\"Builds triggered from this Build Configuration will run all at the same time. The order in which they will finish is not guranteed.\"></i>\n" +
+    "<i ng-switch-when=\"Parallel\" class=\"pficon pficon-help\" data-toggle=\"tooltip\" aria-hidden=\"true\" data-original-title=\"Builds triggered from this Build Configuration will run all at the same time. The order in which they will finish is not guaranteed.\"></i>\n" +
     "<i ng-switch-when=\"SerialLatestOnly\" class=\"pficon pficon-help\" data-toggle=\"tooltip\" aria-hidden=\"true\" data-original-title=\"Builds triggered from this Build Configuration will run one at the time. When a currently running build completes, the next build that will run is the latest build created. Other queued builds will be cancelled.\"></i>\n" +
     "<i ng-switch-default class=\"pficon pficon-help\" data-toggle=\"tooltip\" aria-hidden=\"true\" data-original-title=\"Builds triggered from this Build Configuration will run using the {{buildConfig.spec.runPolicy | sentenceCase}} policy.\"></i>\n" +
     "</a>\n" +
@@ -6362,7 +6362,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"has-error\" ng-show=\"persistentVolumeClaimForm.capacity.$error.pattern && persistentVolumeClaimForm.capacity.$touched && !claimDisabled\">\n" +
     "<span class=\"help-block\">\n" +
-    "Must be a postive integer.\n" +
+    "Must be a positive integer.\n" +
     "</span>\n" +
     "</div>\n" +
     "</fieldset>\n" +
@@ -7399,7 +7399,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div ng-switch=\"updatedBuildConfig.spec.runPolicy\">\n" +
     "<div class=\"help-block\" ng-switch-when=\"Serial\">Builds triggered from this Build Configuration will run one at the time, in the order they have been triggered.</div>\n" +
-    "<div class=\"help-block\" ng-switch-when=\"Parallel\">Builds triggered from this Build Configuration will run all at the same time. The order in which they will finish is not guranteed.</div>\n" +
+    "<div class=\"help-block\" ng-switch-when=\"Parallel\">Builds triggered from this Build Configuration will run all at the same time. The order in which they will finish is not guaranteed.</div>\n" +
     "<div class=\"help-block\" ng-switch-when=\"SerialLatestOnly\">Builds triggered from this Build Configuration will run one at the time. When a currently running build completes, the next build that will run is the latest build created. Other queued builds will be cancelled.</div>\n" +
     "<div class=\"help-block\" ng-switch-default>Builds triggered from this Build Configuration will run using the {{updatedBuildConfig.spec.runPolicy | sentenceCase}} policy.</div>\n" +
     "</div>\n" +
@@ -8271,7 +8271,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-repeat-end ng-if=\"expanded.replicaSets[replicaSet.metadata.name]\" class=\"list-group-expanded-section\" ng-class=\"{'expanded': expanded.replicaSets[replicaSet.metadata.name]}\">\n" +
     "Logs are not available for replica sets.\n" +
     "<span ng-if=\"podsByOwnerUID[replicaSet.metadata.uid] | hashSize\">\n" +
-    "To see applicaiton logs, view the logs for one of the replica set's\n" +
+    "To see application logs, view the logs for one of the replica set's\n" +
     "<a href=\"\" ng-click=\"viewPodsForReplicaSet(replicaSet)\">pods</a>.\n" +
     "</span>\n" +
     "<div class=\"mar-top-lg\" ng-if=\"metricsAvailable\">\n" +


### PR DESCRIPTION
Some are just comments, some should up in the UI.

The changes were made with:

```bash
 # Install tool:
go get -u github.com/client9/misspell/cmd/misspell

 # And now fix typos:
git ls-files | \
  `# ignore some paths` \
  grep -vE '^(dist\.java/|dist/styles/|dist/scripts/vendor\.js)' | \
  `# fix spelling in-place` \
  xargs misspell -w
```