### PR TITLE
Let c3.js pick y-axis values

### DIFF
--- a/app/scripts/directives/podMetrics.js
+++ b/app/scripts/directives/podMetrics.js
@@ -44,8 +44,6 @@ angular.module('openshiftConsole')
             chartPrefix: "memory-",
             convert: ConversionService.bytesToMiB,
             containerMetric: true,
-            // The sparkline y-axis will always extend to at least this value.
-            smallestYAxisMax: 100,
             datasets: [
               {
                 id: "memory/usage",
@@ -62,9 +60,6 @@ angular.module('openshiftConsole')
             chartPrefix: "cpu-",
             convert: _.round,
             containerMetric: true,
-            // The sparkline y-axis will always extend to at least this value.
-            // Avoid spikey charts when rounding very small CPU usage values.
-            smallestYAxisMax: 10,
             datasets: [
               {
                 id: "cpu/usage_rate",
@@ -81,9 +76,6 @@ angular.module('openshiftConsole')
             chartPrefix: "network-",
             chartType: "spline",
             convert: ConversionService.bytesToKiB,
-            // The sparkline y-axis will always extend to at least this value.
-            // Avoid spikey charts when rounding very small network usage values.
-            smallestYAxisMax: 1,
             datasets: [
               {
                 id: "network/tx_rate",
@@ -323,16 +315,6 @@ angular.module('openshiftConsole')
 
           // Sparkline
 
-          // Use a reasonable y-axis max value for small data values like 1
-          // millicore or 0.1 KiB/s. If left undefined, c3 will generate one
-          // that fits the data. Setting a value avoids weird spikes when when
-          // CPU or network usage is very low since we round to the nearest
-          // millicore or one decimal place for KiB/s.
-          var yAxisMax;
-          if (largestValue < metric.smallestYAxisMax) {
-            yAxisMax = metric.smallestYAxisMax;
-          }
-
           var sparklineConfig, sparklineData = {
             type: metric.chartType || 'spline',
             x: 'dates',
@@ -343,7 +325,6 @@ angular.module('openshiftConsole')
 
           if (!sparklineByMetric[chartId]) {
             sparklineConfig = createSparklineConfig(metric);
-            sparklineConfig.axis.y.max = yAxisMax;
             sparklineConfig.data = sparklineData;
             if (metric.chartDataColors) {
               sparklineConfig.color = { pattern: metric.chartDataColors };
@@ -357,9 +338,6 @@ angular.module('openshiftConsole')
             });
           } else {
             sparklineByMetric[chartId].load(sparklineData);
-            sparklineByMetric[chartId].axis.max({
-              y: yAxisMax
-            });
           }
         }
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10179,19 +10179,15 @@ Available:"#d1d1d1"
 u[g] = c3.generate(j);
 })));
 }), a.totalUsed = _.round(a.totalUsed, 1);
-var g, h = [ b ].concat(_.values(d));
-f < a.smallestYAxisMax && (g = a.smallestYAxisMax);
-var i, j = {
+var g, h = [ b ].concat(_.values(d)), i = {
 type:a.chartType || "spline",
 x:"dates",
 columns:h
-}, l = a.chartPrefix + "sparkline";
-v[l] ? (v[l].load(j), v[l].axis.max({
-y:g
-})) :(i = C(a), i.axis.y.max = g, i.data = j, a.chartDataColors && (i.color = {
+}, j = a.chartPrefix + "sparkline";
+v[j] ? v[j].load(i) :(g = C(a), g.data = i, a.chartDataColors && (g.color = {
 pattern:a.chartDataColors
 }), c(function() {
-A || (v[l] = c3.generate(i));
+A || (v[j] = c3.generate(g));
 }));
 }
 }
@@ -10262,7 +10258,6 @@ units:"MiB",
 chartPrefix:"memory-",
 convert:g.bytesToMiB,
 containerMetric:!0,
-smallestYAxisMax:100,
 datasets:[ {
 id:"memory/usage",
 label:"Memory",
@@ -10274,7 +10269,6 @@ units:"millicores",
 chartPrefix:"cpu-",
 convert:_.round,
 containerMetric:!0,
-smallestYAxisMax:10,
 datasets:[ {
 id:"cpu/usage_rate",
 label:"CPU",
@@ -10286,7 +10280,6 @@ units:"KiB/s",
 chartPrefix:"network-",
 chartType:"spline",
 convert:g.bytesToKiB,
-smallestYAxisMax:1,
 datasets:[ {
 id:"network/tx_rate",
 label:"Sent",


### PR DESCRIPTION
c3.js has no API to unset an axis max value once set. Passing undefined
or null does not reset the value from when the chart was initialized.
Avoid this problem by letting c3.js pick the y-axis values in all cases.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1386708
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1386823

@jwforres PTAL