### PR TITLE
Update filter to immitate future annotation behavior

### DIFF
--- a/app/scripts/services/membership/membership.js
+++ b/app/scripts/services/membership/membership.js
@@ -119,9 +119,13 @@ angular
       return _.filter(roles, function(item) {
         // image-puller & image-pusher ok, other system: prob no
         return (_.isEqual(item.metadata.name, 'system:image-puller')   ||
-                _.isEqual(item.metadata.name, 'system:image-pusher') ) ||
+                _.isEqual(item.metadata.name, 'system:image-pusher')   ||
+                _.isEqual(item.metadata.name, 'system:image-builder')  ||
+                _.isEqual(item.metadata.name, 'system:deployer')     ) ||
                 ! _.startsWith(item.metadata.name, 'cluster-') &&
-                ! _.startsWith(item.metadata.name, 'system:');
+                ! _.startsWith(item.metadata.name, 'system:') &&
+                ! _.startsWith(item.metadata.name, 'registry-') &&
+                ! _.startsWith(item.metadata.name, 'self-');
       });
     };
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2721,7 +2721,7 @@ return _.sortBy(e, "sortOrder");
 return _.sortBy(a, "metadata.name");
 }, g = function(a) {
 return _.filter(a, function(a) {
-return _.isEqual(a.metadata.name, "system:image-puller") || _.isEqual(a.metadata.name, "system:image-pusher") || !_.startsWith(a.metadata.name, "cluster-") && !_.startsWith(a.metadata.name, "system:");
+return _.isEqual(a.metadata.name, "system:image-puller") || _.isEqual(a.metadata.name, "system:image-pusher") || _.isEqual(a.metadata.name, "system:image-builder") || _.isEqual(a.metadata.name, "system:deployer") || !_.startsWith(a.metadata.name, "cluster-") && !_.startsWith(a.metadata.name, "system:") && !_.startsWith(a.metadata.name, "registry-") && !_.startsWith(a.metadata.name, "self-");
 });
 }, h = function(a) {
 return _.reduce(a, function(a, b) {


### PR DESCRIPTION
@jwforres @spadgett 

Re: https://github.com/openshift/origin/pull/11328
Fixes issue #712 

Since the above annotations didn't make DCUT, this PR updates the temp filter we are using to match the 8 roles agreed upon in discussion.

![screen shot 2016-10-24 at 12 18 20 pm](https://cloud.githubusercontent.com/assets/280512/19653959/8a4d4b4e-99e4-11e6-8167-2bf61c081215.png)
