### PR TITLE
Use pod UID instead of name to get pod metrics

### DIFF
--- a/app/scripts/services/metrics.js
+++ b/app/scripts/services/metrics.js
@@ -3,8 +3,7 @@
 angular.module("openshiftConsole")
   .factory("MetricsService", function($filter, $http, $q, $rootScope, APIDiscovery) {
     var POD_GAUGE_TEMPLATE = "/gauges/{containerName}%2F{podUID}%2F{metric}/data";
-    // Used in compact view.
-    var POD_STACKED_TEMPLATE = "/gauges/data?stacked=true&tags=descriptor_name:{metric},type:{type},pod_name:{podName}";
+    var POD_STACKED_TEMPLATE = "/gauges/data?stacked=true&tags=descriptor_name:{metric},type:{type},pod_id:{podUID}";
 
     var metricsURL;
     function getMetricsURL() {
@@ -69,7 +68,7 @@ angular.module("openshiftConsole")
         if (config.stacked) {
           template = metricsURL + POD_STACKED_TEMPLATE;
           return URI.expand(template, {
-            podName: config.pod.metadata.name,
+            podUID: config.pod.metadata.uid,
             metric: config.metric,
             type: type
           }).toString();

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2850,7 +2850,7 @@ function k(a) {
 return f().then(function(b) {
 var c, d = j(a.metric);
 return a.stacked ? (c = b + p, URI.expand(c, {
-podName:a.pod.metadata.name,
+podUID:a.pod.metadata.uid,
 metric:a.metric,
 type:d
 }).toString()) :(c = b + o, URI.expand(c, {
@@ -2860,7 +2860,7 @@ metric:a.metric
 }).toString());
 });
 }
-var l, m, n, o = "/gauges/{containerName}%2F{podUID}%2F{metric}/data", p = "/gauges/data?stacked=true&tags=descriptor_name:{metric},type:{type},pod_name:{podName}", q = function(a) {
+var l, m, n, o = "/gauges/{containerName}%2F{podUID}%2F{metric}/data", p = "/gauges/data?stacked=true&tags=descriptor_name:{metric},type:{type},pod_id:{podUID}", q = function(a) {
 return f().then(function(c) {
 return !!c && (!a || (!!m || !n && b.get(c).then(function() {
 return m = !0, !0;


### PR DESCRIPTION
Avoids a problem where a new pod with the same name will show metrics for a previously-deleted pod.

https://bugzilla.redhat.com/show_bug.cgi?id=1386838

(The problem with deployment name mentioned in the bug was previously fixed by #541.)

@jwforres PTAL