### PR TITLE
Use a monospace font for template messages

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -676,15 +676,11 @@ label.checkbox {
   border-style: solid;
   border-width: 1px;
   color: black;
-  padding: 21px;
-  .pficon-info {
-    float: left;
-    font-size: 18px;
-    margin-right: 6px;
-    color: #31708f;
-  }
   .resource-description {
     margin-bottom: 0;
+    font-family: @font-family-monospace;
+    // Consistent font-size with the CLI examples in code blocks below the template message.
+    font-size: (@font-size-base - 1);
   }
 }
 

--- a/app/views/create/next-steps.html
+++ b/app/views/create/next-steps.html
@@ -48,7 +48,7 @@
               </div>
             </div>
 
-            <div class="template-message" ng-if="templateMessage.length">
+            <div class="alert alert-info template-message" ng-if="templateMessage.length">
               <span class="pficon pficon-info" aria-hidden="true"></span>
               <div class="resource-description" ng-bind-html="templateMessage | linky"></div>
             </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4522,7 +4522,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"template-message\" ng-if=\"templateMessage.length\">\n" +
+    "<div class=\"alert alert-info template-message\" ng-if=\"templateMessage.length\">\n" +
     "<span class=\"pficon pficon-info\" aria-hidden=\"true\"></span>\n" +
     "<div class=\"resource-description\" ng-bind-html=\"templateMessage | linky\"></div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3355,7 +3355,7 @@ to{opacity:0}
 .components.components-group .connector{display:inline-block;position:absolute;top:48%;left:-5px}
 .components.components-group .connector i{color:#ccc;-webkit-transform:rotate(137deg);-ms-transform:rotate(137deg);-o-transform:rotate(137deg);transform:rotate(137deg);font-size:9px;position:absolute}
 .components.components-group .connector:before{content:'\f111';font:normal normal normal 6px/1 FontAwesome;display:inline-block;color:#fff;position:absolute;left:2px;top:1px}
-.edit-yaml .editor,.environment-variables.table.table-bordered>tbody>tr>td:last-child .env-var-value,.hash{font-family:Menlo,Monaco,Consolas,monospace}
+.edit-yaml .editor,.environment-variables.table.table-bordered>tbody>tr>td:last-child .env-var-value,.hash,.template-message .resource-description{font-family:Menlo,Monaco,Consolas,monospace}
 .components .components-panel{background-color:#fff;border:1px solid #ddd;position:relative}
 .components .components-panel.deployment-block.none,.components .components-panel.service.none{background-color:transparent}
 @media (min-width:768px){.components.components-group .osc-object-active .connector i{color:#00a8e1}
@@ -3585,9 +3585,9 @@ label.checkbox{font-weight:400}
 .osc-form .template-options .list-unstyled .help-block{margin:0 0 5px 2px}
 .osc-form .template-options .form-group{width:100%;max-width:600px}
 .osc-form .template-options .help-block{margin-bottom:5px}
-.next-steps .tile,.template-message .resource-description{margin-bottom:0}
 @media (max-width:767px){.compute-resource .inline-select{margin-top:5px}
 }
+.next-steps .tile{margin-bottom:0}
 .next-steps .tile.tile-status{margin-top:0}
 .command-args textarea{resize:none}
 .command-args .drag-handle{cursor:move}
@@ -3604,9 +3604,9 @@ label.checkbox{font-weight:400}
 .env-variable-list li .value,.label-list li .value{max-width:500px}
 .env-variable-list li .btn,.label-list li .btn{vertical-align:top}
 .label+.label{margin-left:3px}
-.template-message{background-color:#d9edf7;border-color:#31708f;border-style:solid;border-width:1px;color:#000;padding:21px}
+.template-message{background-color:#d9edf7;border-color:#31708f;border-style:solid;border-width:1px;color:#000}
 .attention-message,.tasks,div.code,pre.code{background-color:#fff}
-.template-message .pficon-info{float:left;font-size:18px;margin-right:6px;color:#31708f}
+.template-message .resource-description{margin-bottom:0;font-size:12px}
 .resource-metadata,.tasks{margin-bottom:20px}
 .resource-description{margin-bottom:20px;white-space:pre-wrap;overflow-wrap:break-word;min-width:0}
 .action-inline{margin-left:5px;font-size:11px}


### PR DESCRIPTION
This preserves plain text formatting in the message. Also use alert styles so that the message text does not wrap below the icon.

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/19663039/17c5891e-9a08-11e6-87ac-eef37a584162.png)

@jwforres PTAL
@luciddreamz CC