### PR TITLE
Bug 1388337 - Clear lifecycle hooks when changing strategy from Recreate to Rolling

### DIFF
--- a/app/scripts/controllers/edit/deploymentConfig.js
+++ b/app/scripts/controllers/edit/deploymentConfig.js
@@ -183,7 +183,6 @@ angular.module('openshiftConsole')
       modalInstance.result.then(function () {
         // Move parameters that belong to the origial strategy to the picked one.
         $scope.strategyData[pickedStrategyParams] = $scope.strategyData[getParamsPropertyName($scope.originalStrategy)];
-        $scope.paramsMoved = getParamsPropertyName($scope.originalStrategy);
       }, function() {
         // Create empty parameters for the newly picked strategy
         $scope.strategyData[pickedStrategyParams] = {};
@@ -263,7 +262,7 @@ angular.module('openshiftConsole')
       });
 
       // Remove parameters of previously set strategy, if user moved 
-      if ($scope.paramsMoved && isRollingRecreateSwitch()) {
+      if (isRollingRecreateSwitch()) {
         delete $scope.strategyData[getParamsPropertyName($scope.originalStrategy)];
       }
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -6642,7 +6642,7 @@ cancelButtonText:"No"
 }
 });
 d.result.then(function() {
-a.strategyData[b] = a.strategyData[p(a.originalStrategy)], a.paramsMoved = p(a.originalStrategy);
+a.strategyData[b] = a.strategyData[p(a.originalStrategy)];
 }, function() {
 a.strategyData[b] = {};
 });
@@ -6691,7 +6691,7 @@ var d = _.find(a.updatedDeploymentConfig.spec.template.spec.containers, {
 name:c
 });
 d.env = n.compactEntries(b.env);
-}), a.paramsMoved && q() && delete a.strategyData[p(a.originalStrategy)], "Custom" !== a.strategyData.type ? _.each([ "pre", "mid", "post" ], function(b) {
+}), q() && delete a.strategyData[p(a.originalStrategy)], "Custom" !== a.strategyData.type ? _.each([ "pre", "mid", "post" ], function(b) {
 _.has(a.strategyData, [ a.strategyParamsPropertyName, b, "execNewPod", "env" ]) && (a.strategyData[a.strategyParamsPropertyName][b].execNewPod.env = n.compactEntries(a.strategyData[a.strategyParamsPropertyName][b].execNewPod.env));
 }) :_.has(a, "strategyData.customParams.environment") && (a.strategyData.customParams.environment = n.compactEntries(a.strategyData.customParams.environment)), a.updatedDeploymentConfig.spec.template.spec.imagePullSecrets = a.pullSecrets, a.updatedDeploymentConfig.spec.strategy = a.strategyData, a.updatedDeploymentConfig.spec.triggers = t(), d.update("deploymentconfigs", a.updatedDeploymentConfig.metadata.name, a.updatedDeploymentConfig, a.context).then(function() {
 l.addAlert({


### PR DESCRIPTION
@spadgett talked to @mfojtik && @kargakis regarding this and we agreed that when  switching between rolling<->recreate strategy it doesnt make sense to preserve the old params.
PTAL