### PR TITLE
Bug 1388428 - Get SA list even if the SA to which the secret be linked is defined

### DIFF
--- a/app/scripts/controllers/createSecret.js
+++ b/app/scripts/controllers/createSecret.js
@@ -33,8 +33,10 @@ angular.module('openshiftConsole')
         $scope.context = context;
         $scope.breadcrumbs[0].title = $filter('displayName')(project);
 
-        $scope.postCreateAction = function(newSecret, creationAlert) {
-          AlertMessageService.addAlert(creationAlert);
+        $scope.postCreateAction = function(newSecret, creationAlerts) {
+          _.each(creationAlerts, function(alert) {
+            AlertMessageService.addAlert(alert);
+          });
           Navigate.toResourceList('secrets', $scope.projectName);
         };
         $scope.cancel = function() {

--- a/app/scripts/controllers/modals/createSecretModal.js
+++ b/app/scripts/controllers/modals/createSecretModal.js
@@ -11,10 +11,12 @@
 angular.module('openshiftConsole')
   .controller('CreateSecretModalController', function ($scope, $uibModalInstance) {
 
-    $scope.postCreateAction = function(newSecret, creationAlert) {
+    $scope.postCreateAction = function(newSecret, creationAlerts) {
       $uibModalInstance.close(newSecret);
       // Add creation alert into scope
-      $scope.alerts[creationAlert.name] = creationAlert.data;
+      _.each(creationAlerts, function(alert) {
+        $scope.alerts[alert.name] = alert.data;
+      });
     };
 
     $scope.cancel = function() {

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5994,7 +5994,9 @@ link:"project/" + c.projectName + "/browse/secrets"
 title:"Create Secret"
 } ], i.get(b.project).then(_.spread(function(b, d) {
 c.project = b, c.context = d, c.breadcrumbs[0].title = a("displayName")(b), c.postCreateAction = function(a, b) {
-e.addAlert(b), h.toResourceList("secrets", c.projectName);
+_.each(b, function(a) {
+e.addAlert(a);
+}), h.toResourceList("secrets", c.projectName);
 }, c.cancel = function() {
 h.toResourceList("secrets", c.projectName);
 };
@@ -7849,7 +7851,9 @@ n("An error occurred attaching the persistent volume claim to the " + a("humaniz
 }));
 } ]), angular.module("openshiftConsole").controller("CreateSecretModalController", [ "$scope", "$uibModalInstance", function(a, b) {
 a.postCreateAction = function(c, d) {
-b.close(c), a.alerts[d.name] = d.data;
+b.close(c), _.each(d, function(b) {
+a.alerts[b.name] = b.data;
+});
 }, a.cancel = function() {
 b.dismiss("cancel");
 };
@@ -7985,7 +7989,7 @@ a.hideBuild = c(b);
 },
 templateUrl:"views/directives/_build-close.html"
 };
-} ]), angular.module("openshiftConsole").directive("createSecret", [ "DataService", "AuthorizationService", function(a, b) {
+} ]), angular.module("openshiftConsole").directive("createSecret", [ "DataService", "AuthorizationService", "$filter", function(a, b, c) {
 return {
 restrict:"E",
 scope:{
@@ -7996,8 +8000,8 @@ postCreateAction:"&",
 cancel:"&"
 },
 templateUrl:"views/directives/create-secret.html",
-link:function(c, d) {
-c.alerts = {}, c.secretAuthTypeMap = {
+link:function(d) {
+d.alerts = {}, d.secretAuthTypeMap = {
 image:{
 label:"Image Secret",
 authTypes:[ {
@@ -8018,50 +8022,50 @@ id:"kubernetes.io/ssh-auth",
 label:"SSH Key"
 } ]
 }
-}, c.secretTypes = _.keys(c.secretAuthTypeMap), c.type ? c.newSecret = {
-type:c.type,
-authType:c.secretAuthTypeMap[c.type].authTypes[0].id,
+}, d.secretTypes = _.keys(d.secretAuthTypeMap), d.type ? d.newSecret = {
+type:d.type,
+authType:d.secretAuthTypeMap[d.type].authTypes[0].id,
 data:{},
-linkSecret:!_.isEmpty(c.serviceAccountToLink),
-pickedServiceAccountToLink:c.serviceAccountToLink || ""
-} :c.newSecret = {
+linkSecret:!_.isEmpty(d.serviceAccountToLink),
+pickedServiceAccountToLink:d.serviceAccountToLink || ""
+} :d.newSecret = {
 type:"source",
 authType:"kubernetes.io/basic-auth",
 data:{},
 linkSecret:!1,
 pickedServiceAccountToLink:""
-}, c.add = {
+}, d.add = {
 gitconfig:!1,
 cacert:!1
-}, !c.serviceAccountToLink && b.canI("serviceaccounts", "list") && b.canI("serviceaccounts", "update") && a.list("serviceaccounts", c, function(a) {
-c.serviceAccounts = a.by("metadata.name"), c.serviceAccountsNames = _.keys(c.serviceAccounts);
+}, b.canI("serviceaccounts", "list") && b.canI("serviceaccounts", "update") && a.list("serviceaccounts", d, function(a) {
+d.serviceAccounts = a.by("metadata.name"), d.serviceAccountsNames = _.keys(d.serviceAccounts);
 });
 var e = function(a, b) {
-var d = {
+var c = {
 apiVersion:"v1",
 kind:"Secret",
 metadata:{
-name:c.newSecret.data.secretName
+name:d.newSecret.data.secretName
 },
 type:b,
 data:{}
 };
 switch (b) {
 case "kubernetes.io/basic-auth":
-a.passwordToken ? d.data = {
+a.passwordToken ? c.data = {
 password:window.btoa(a.passwordToken)
-} :d.type = "Opaque", a.username && (d.data.username = window.btoa(a.username)), a.gitconfig && (d.data[".gitconfig"] = window.btoa(a.gitconfig)), a.cacert && (d.data["ca.crt"] = window.btoa(a.cacert));
+} :c.type = "Opaque", a.username && (c.data.username = window.btoa(a.username)), a.gitconfig && (c.data[".gitconfig"] = window.btoa(a.gitconfig)), a.cacert && (c.data["ca.crt"] = window.btoa(a.cacert));
 break;
 
 case "kubernetes.io/ssh-auth":
-d.data = {
+c.data = {
 "ssh-privatekey":window.btoa(a.privateKey)
-}, a.gitconfig && (d.data[".gitconfig"] = window.btoa(a.gitconfig));
+}, a.gitconfig && (c.data[".gitconfig"] = window.btoa(a.gitconfig));
 break;
 
 case "kubernetes.io/dockerconfigjson":
 var e = window.btoa(a.dockerConfig);
-JSON.parse(a.dockerConfig).auths ? d.data[".dockerconfigjson"] = e :(d.type = "kubernetes.io/dockercfg", d.data[".dockercfg"] = e);
+JSON.parse(a.dockerConfig).auths ? c.data[".dockerconfigjson"] = e :(c.type = "kubernetes.io/dockercfg", c.data[".dockercfg"] = e);
 break;
 
 case "kubernetes.io/dockercfg":
@@ -8071,80 +8075,80 @@ username:a.dockerUsername,
 password:a.dockerPassword,
 email:a.dockerMail,
 auth:f
-}, d.data[".dockercfg"] = window.btoa(JSON.stringify(g));
+}, c.data[".dockercfg"] = window.btoa(JSON.stringify(g));
 }
-return d;
-}, f = function(b) {
-var e = angular.copy(c.serviceAccounts[c.newSecret.pickedServiceAccountToLink]);
-switch (c.newSecret.type) {
+return c;
+}, f = function(b, e) {
+var f = angular.copy(d.serviceAccounts[d.newSecret.pickedServiceAccountToLink]);
+switch (d.newSecret.type) {
 case "source":
-e.secrets.push({
+f.secrets.push({
 name:b.metadata.name
 });
 break;
 
 case "image":
-e.imagePullSecrets.push({
+f.imagePullSecrets.push({
 name:b.metadata.name
 });
 }
-var f = c.serviceAccountToLink ? {
+var g = d.serviceAccountToLink ? {
 errorNotification:!1
 } :{};
-a.update("serviceaccounts", c.newSecret.pickedServiceAccountToLink, e, c, f).then(function(a) {
-var d = {
-name:"createAndLink",
+a.update("serviceaccounts", d.newSecret.pickedServiceAccountToLink, f, d, g).then(function(a) {
+e.push({
+name:"create",
 data:{
 type:"success",
 message:"Secret " + b.metadata.name + " was created and linked with service account " + a.metadata.name + "."
 }
-};
-c.postCreateAction({
+}), d.postCreateAction({
 newSecret:b,
-creationAlert:d
+creationAlert:e
 });
 }, function(a) {
-c.alerts = {
+e.push({
 name:"createAndLink",
 data:{
 type:"error",
-message:"An error occurred while linking the secret with service account.",
-details:d("getErrorDetails")(a)
+message:"An error occurred while linking the secret with service account " + d.newSecret.pickedServiceAccountToLink + ".",
+details:c("getErrorDetails")(a)
 }
-};
+}), d.postCreateAction({
+newSecret:b,
+creationAlert:e
+});
 });
 }, g = _.debounce(function() {
 try {
-JSON.parse(c.newSecret.data.dockerConfig), c.invalidConfigFormat = !1;
+JSON.parse(d.newSecret.data.dockerConfig), d.invalidConfigFormat = !1;
 } catch (a) {
-c.invalidConfigFormat = !0;
+d.invalidConfigFormat = !0;
 }
 }, 300, {
 leading:!0
 });
-c.aceChanged = g, c.create = function() {
-c.alerts = {};
-var g = e(c.newSecret.data, c.newSecret.authType);
-a.create("secrets", null, g, c).then(function(a) {
-if (c.newSecret.linkSecret && c.newSecret.pickedServiceAccountToLink && b.canI("serviceaccounts", "update")) f(a); else {
-var d = {
+d.aceChanged = g, d.create = function() {
+d.alerts = {};
+var g = e(d.newSecret.data, d.newSecret.authType);
+a.create("secrets", null, g, d).then(function(a) {
+var c = [ {
 name:"create",
 data:{
 type:"success",
 message:"Secret " + g.metadata.name + " was created."
 }
-};
-c.postCreateAction({
+} ];
+d.newSecret.linkSecret && d.serviceAccountsNames.contains(d.newSecret.pickedServiceAccountToLink) && b.canI("serviceaccounts", "update") ? f(a, c) :d.postCreateAction({
 newSecret:a,
-creationAlert:d
+creationAlert:c
 });
-}
 }, function(a) {
 var b = a.data || {};
-return "AlreadyExists" === b.reason ? void (c.nameTaken = !0) :void (c.alerts.create = {
+return "AlreadyExists" === b.reason ? void (d.nameTaken = !0) :void (d.alerts.create = {
 type:"error",
 message:"An error occurred while creating the secret.",
-details:d("getErrorDetails")(a)
+details:c("getErrorDetails")(a)
 });
 });
 };


### PR DESCRIPTION
Even if the `$scope.serviceAccountToLink` is defined(`builder` for the BC editor, `default` for the DC editor), we shall list the SAs so we can update the appropriate one, or have an alert which will inform that the SA which the secret should be link with is is not available.
The other approach could be to GET the `$scope.serviceAccountToLink` and if the request fails we can inform user user in the 'create secret' form that the linking with the SA wont be possible and only create the secret.
Anyway I think just informing the user that the created secret was not linked with the SA we determined for him(`builder` for the BC editor, `default` for the DC editor) is better since not linking the created secret with SA wont do any magic, unless there is a option enabled in the cluster, that will use those linked secrets automatically, which is disabled by default.
@spadgett PTAL
