### PR TITLE
Truncate imageStreamName like we do for dockerImageReference.

### DIFF
--- a/app/styles/_mixins.less
+++ b/app/styles/_mixins.less
@@ -103,3 +103,24 @@
     display: inline-block !important;
   }
 }
+
+// Truncate or word-break long strings within tables
+// Wrap when < 768 & truncate when > 769
+.td-long-string {
+  @media (max-width: @screen-xs-max) {
+    .word-break();
+  }
+  @media (min-width: @screen-sm-min) {
+    max-width: 170px;
+    .text-overflow();
+  }
+  @media (min-width: @screen-md-min) {
+    max-width: 260px
+  }
+  @media (min-width: @screen-lg-min) {
+    max-width: 370px
+  }
+  @media (min-width: @screen-xlg-min) {
+    max-width: 540px
+  }
+}

--- a/app/styles/_tables.less
+++ b/app/styles/_tables.less
@@ -46,14 +46,6 @@
   border-top: none;
 }
 
-.table .pull-spec {
-  max-width: 700px;
-
-  @media (max-width: @screen-md-max) {
-    max-width: 315px;
-  }
-}
-
 .data-toolbar, .table-toolbar {
   .vertical-divider {
     // Controls are stacked at mobile, so hide the divider.

--- a/app/views/browse/imagestream.html
+++ b/app/views/browse/imagestream.html
@@ -72,20 +72,20 @@
                     <td data-title="From">
                       <!-- this value can get long when its an ImageStreamImage. Use max width and class truncate to elide some
                            of the SHA1 for long values. They can still be copied even when elided. -->
-                      <div style="max-width: 400px;" class="truncate">
+
                         <span ng-if="!tag.spec.from"><em>pushed</em></span>
-                        <span ng-if="tag.spec.from">
-                          <span ng-if="!tag.spec.from._imageStreamName">
-                            {{tag.spec.from.name}}
-                          </span>
-                          <span ng-if="tag.spec.from._imageStreamName">
-                            <span ng-if="tag.spec.from._imageStreamName === imageStream.metadata.name">{{tag.spec.from._completeName}}</span>
-                            <span ng-if="tag.spec.from._imageStreamName !== imageStream.metadata.name" >
-                              <a ng-href="{{tag.spec.from._imageStreamName | navigateResourceURL : 'ImageStream' : (tag.spec.from.namespace || imageStream.metadata.namespace)}}"><span ng-if="tag.spec.from.namespace && tag.spec.from.namespace !== imageStream.metadata.namespace" >{{tag.spec.from.namespace}}/</span>{{tag.spec.from._imageStreamName}}</a>{{tag.spec.from._nameConnector}}{{tag.spec.from._idOrTag}}
+                        <div ng-if="tag.spec.from" ng-attr-title="{{tag.spec.from.name}}" class="td-long-string">
+                            <span ng-if="!tag.spec.from._imageStreamName">
+                              {{tag.spec.from.name}}
                             </span>
-                          </span>
-                        </span>
-                      </div>
+                            <span ng-if="tag.spec.from._imageStreamName">
+                              <span ng-if="tag.spec.from._imageStreamName === imageStream.metadata.name">{{tag.spec.from._completeName}}</span>
+                              <span ng-if="tag.spec.from._imageStreamName !== imageStream.metadata.name" >
+                                <a ng-href="{{tag.spec.from._imageStreamName | navigateResourceURL : 'ImageStream' : (tag.spec.from.namespace || imageStream.metadata.namespace)}}"><span ng-if="tag.spec.from.namespace && tag.spec.from.namespace !== imageStream.metadata.namespace" >{{tag.spec.from.namespace}}/</span>{{tag.spec.from._imageStreamName}}</a>{{tag.spec.from._nameConnector}}{{tag.spec.from._idOrTag}}
+                              </span>
+                            </span>
+                        </div>
+
                     </td>
                     <td data-title="Latest Image">
                       <div ng-if="!tag.status">
@@ -117,13 +117,9 @@
                       <!-- dockerImageReference values can get long. Use max width and class truncate to elide some of the SHA1 for long values.
                            They can still be copied even when elided. -->
                       <div ng-if="tag.status.items.length && tag.status.items[0].dockerImageReference">
-                        <div ng-attr-title="{{tag.status.items[0].dockerImageReference}}" class="word-break visible-xs-block">
+                        <div ng-attr-title="{{tag.status.items[0].dockerImageReference}}" class="td-long-string">
                           {{tag.status.items[0].dockerImageReference}}
                         </div>
-                        <div class="pull-spec truncate hidden-xs"
-                         ng-attr-title="{{tag.status.items[0].dockerImageReference}}">
-                          {{tag.status.items[0].dockerImageReference}}
-                        </div>                      
                       </div>
                     </td>
                   </tr>
@@ -139,15 +135,9 @@
                       <relative-timestamp timestamp="item.created"></relative-timestamp>
                     </td>
                     <td data-title="Pull Spec">
-                      <div ng-if="item.dockerImageReference">
-                        <div ng-attr-title="{{item.dockerImageReference}}" class="word-break visible-xs-block">
-                          {{item.dockerImageReference}}
-                        </div>
-                        <div class="pull-spec truncate hidden-xs"
-                         ng-attr-title="{{item.dockerImageReference}}">
-                          {{item.dockerImageReference}}
-                        </div>                      
-                      </div>                      
+                      <div ng-if="item.dockerImageReference" ng-attr-title="{{item.dockerImageReference}}" class="td-long-string">
+                        {{item.dockerImageReference}}
+                      </div>
                     </td>
                   </tr>
                 </tbody>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2583,9 +2583,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<td data-title=\"Tag\"><a href=\"{{imageStream | navigateResourceURL}}/{{tag.name}}\">{{tag.name}}</a></td>\n" +
     "<td data-title=\"From\">\n" +
     "\n" +
-    "<div style=\"max-width: 400px\" class=\"truncate\">\n" +
     "<span ng-if=\"!tag.spec.from\"><em>pushed</em></span>\n" +
-    "<span ng-if=\"tag.spec.from\">\n" +
+    "<div ng-if=\"tag.spec.from\" ng-attr-title=\"{{tag.spec.from.name}}\" class=\"td-long-string\">\n" +
     "<span ng-if=\"!tag.spec.from._imageStreamName\">\n" +
     "{{tag.spec.from.name}}\n" +
     "</span>\n" +
@@ -2593,7 +2592,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"tag.spec.from._imageStreamName === imageStream.metadata.name\">{{tag.spec.from._completeName}}</span>\n" +
     "<span ng-if=\"tag.spec.from._imageStreamName !== imageStream.metadata.name\">\n" +
     "<a ng-href=\"{{tag.spec.from._imageStreamName | navigateResourceURL : 'ImageStream' : (tag.spec.from.namespace || imageStream.metadata.namespace)}}\"><span ng-if=\"tag.spec.from.namespace && tag.spec.from.namespace !== imageStream.metadata.namespace\">{{tag.spec.from.namespace}}/</span>{{tag.spec.from._imageStreamName}}</a>{{tag.spec.from._nameConnector}}{{tag.spec.from._idOrTag}}\n" +
-    "</span>\n" +
     "</span>\n" +
     "</span>\n" +
     "</div>\n" +
@@ -2626,10 +2624,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<td data-title=\"Pull Spec\">\n" +
     "\n" +
     "<div ng-if=\"tag.status.items.length && tag.status.items[0].dockerImageReference\">\n" +
-    "<div ng-attr-title=\"{{tag.status.items[0].dockerImageReference}}\" class=\"word-break visible-xs-block\">\n" +
-    "{{tag.status.items[0].dockerImageReference}}\n" +
-    "</div>\n" +
-    "<div class=\"pull-spec truncate hidden-xs\" ng-attr-title=\"{{tag.status.items[0].dockerImageReference}}\">\n" +
+    "<div ng-attr-title=\"{{tag.status.items[0].dockerImageReference}}\" class=\"td-long-string\">\n" +
     "{{tag.status.items[0].dockerImageReference}}\n" +
     "</div>\n" +
     "</div>\n" +
@@ -2647,13 +2642,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<relative-timestamp timestamp=\"item.created\"></relative-timestamp>\n" +
     "</td>\n" +
     "<td data-title=\"Pull Spec\">\n" +
-    "<div ng-if=\"item.dockerImageReference\">\n" +
-    "<div ng-attr-title=\"{{item.dockerImageReference}}\" class=\"word-break visible-xs-block\">\n" +
+    "<div ng-if=\"item.dockerImageReference\" ng-attr-title=\"{{item.dockerImageReference}}\" class=\"td-long-string\">\n" +
     "{{item.dockerImageReference}}\n" +
-    "</div>\n" +
-    "<div class=\"pull-spec truncate hidden-xs\" ng-attr-title=\"{{item.dockerImageReference}}\">\n" +
-    "{{item.dockerImageReference}}\n" +
-    "</div>\n" +
     "</div>\n" +
     "</td>\n" +
     "</tr>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3256,8 +3256,6 @@ to{transform:rotate(359deg)}
 .persistent-secondary:hover .nav-pf-persistent-secondary{display:block;z-index:1031}
 .collapsed .persistent-secondary:hover .nav-pf-persistent-secondary{left:75px}
 .collapsed.collapsed-secondary-nav-pf .persistent-secondary:hover .nav-pf-persistent-secondary{left:0}
-@media (min-width:1200px){.collapsed.collapsed-secondary-nav-pf .persistent-secondary:hover .nav-pf-persistent-secondary,.hidden-icons-pf .collapsed.collapsed-secondary-nav-pf .persistent-secondary:hover .nav-pf-persistent-secondary{left:0}
-}
 .secondary-visible-pf.collapsed .persistent-secondary:hover .nav-pf-persistent-secondary{display:block}
 .layout-pf-fixed-with-footer .nav-pf-persistent-secondary{bottom:37px}
 .nav-pf-persistent-secondary .persistent-secondary-header{color:#fff;font-size:17px;margin:18px 20px 10px}
@@ -3298,7 +3296,17 @@ to{transform:rotate(359deg)}
 .word-break{overflow-wrap:break-word;min-width:0}
 .pre-wrap{white-space:pre-wrap}
 .visible-xlg-inline-block{display:none!important}
+@media (max-width:767px){.td-long-string{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
+}
+@media (min-width:768px){.td-long-string{max-width:170px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+}
+@media (min-width:992px){.td-long-string{max-width:260px}
+}
+@media (min-width:1200px){.collapsed.collapsed-secondary-nav-pf .persistent-secondary:hover .nav-pf-persistent-secondary,.hidden-icons-pf .collapsed.collapsed-secondary-nav-pf .persistent-secondary:hover .nav-pf-persistent-secondary{left:0}
+.td-long-string{max-width:370px}
+}
 @media (min-width:1600px){.visible-xlg-inline-block{display:inline-block!important}
+.td-long-string{max-width:540px}
 }
 .btn-file{position:relative;overflow:hidden}
 .btn-file input[type=file]{position:absolute;top:0;right:0;min-width:100%;min-height:100%;font-size:100px;text-align:right;filter:alpha(opacity=0);opacity:0;cursor:inherit;display:block}
@@ -4621,9 +4629,6 @@ body,html{margin:0;padding:0}
 .table th .pficon-help:not(:first-child){margin-left:5px}
 .table>tbody+tbody{border-top-width:1px}
 .table-borderless>tbody>tr>td,.table-borderless>tbody>tr>th,.table-borderless>tfoot>tr>td,.table-borderless>tfoot>tr>th,.table-borderless>thead>tr>td{border-top:none}
-.table .pull-spec{max-width:700px}
-@media (max-width:1199px){.table .pull-spec{max-width:315px}
-}
 .data-toolbar .vertical-divider,.table-toolbar .vertical-divider{display:none}
 @media (min-width:768px){.data-toolbar .vertical-divider,.table-toolbar .vertical-divider{border-left:1px solid #bbb;display:inline-block;height:27px;margin:0 7px;vertical-align:middle;width:1px}
 }


### PR DESCRIPTION
- for @screen-*-min widths set a max-width
- max-width determined by minimum space needed, when
<img width="370" alt="screen shot 2016-10-25 at 12 24 42 pm" src="https://cloud.githubusercontent.com/assets/1874151/19695442/433b85a4-9ab1-11e6-838b-ff9131e827eb.png">
<img width="634" alt="screen shot 2016-10-25 at 12 24 07 pm" src="https://cloud.githubusercontent.com/assets/1874151/19695443/43436b70-9ab1-11e6-862c-6ffda3f67e4e.png">
<img width="808" alt="screen shot 2016-10-25 at 12 23 57 pm" src="https://cloud.githubusercontent.com/assets/1874151/19695440/433a0b34-9ab1-11e6-818a-8b240233eca5.png">
<img width="1067" alt="screen shot 2016-10-25 at 12 23 49 pm" src="https://cloud.githubusercontent.com/assets/1874151/19695444/4346a4f2-9ab1-11e6-9534-5389a4c2726c.png">
<img width="1229" alt="screen shot 2016-10-25 at 12 23 39 pm" src="https://cloud.githubusercontent.com/assets/1874151/19695441/433ab8ea-9ab1-11e6-9d9f-aa92c4aad0b7.png">




 both imageStreamName and dockerImageReference fields need truncating
Fixes bug 1383623