### PR TITLE
Open template description links and other `linky` links in a new window

### DIFF
--- a/app/views/create/next-steps.html
+++ b/app/views/create/next-steps.html
@@ -50,7 +50,7 @@
 
             <div class="template-message" ng-if="templateMessage.length">
               <span class="pficon pficon-info" aria-hidden="true"></span>
-              <div class="resource-description" ng-bind-html="templateMessage | linky"></div>
+              <div class="resource-description" ng-bind-html="templateMessage | linky : '_blank'"></div>
             </div>
 
             <div class="row" ng-controller="TasksController">

--- a/app/views/directives/osc-image-summary.html
+++ b/app/views/directives/osc-image-summary.html
@@ -1,5 +1,5 @@
 <h1>{{ name || (resource | displayName) }}</h1>
-<div class="resource-description" ng-bind-html="resource | description | linky"></div>
+<div class="resource-description" ng-bind-html="resource | description | linky : '_blank'"></div>
 <div class="resource-metadata">
   <div ng-show="resource | annotation:'provider'">Provider: {{ resource | annotation:'provider' }}</div>
   <div ng-show="resource.metadata.namespace && resource.metadata.namespace !=='openshift'">Namespace: {{ resource.metadata.namespace }}</div>

--- a/app/views/projects.html
+++ b/app/views/projects.html
@@ -110,7 +110,7 @@
                     <p class="projects-instructions" ng-if="canCreate === false">
                       <span ng-if="!newProjectMessage">A cluster admin can create a project for you by running the command
                         <code>oadm new-project &lt;projectname&gt; --admin={{user.metadata.name || '&lt;YourUsername&gt;'}}</code></span>
-                      <span ng-if="newProjectMessage" ng-bind-html="newProjectMessage | linky" class="projects-instructions-link"></span>
+                      <span ng-if="newProjectMessage" ng-bind-html="newProjectMessage | linky : '_blank'" class="projects-instructions-link"></span>
                     </p>
                     <p class="projects-instructions">
                       A project admin can add you to a role on a project by running the command
@@ -131,7 +131,7 @@
                     <p class="projects-instructions" ng-if="canCreate === false">
                       <span ng-if="!newProjectMessage">A cluster admin can create a project for you by running the command<br>
                         <code>oadm new-project &lt;projectname&gt; --admin={{user.metadata.name || '&lt;YourUsername&gt;'}}</code></span>
-                        <span ng-if="newProjectMessage" ng-bind-html="newProjectMessage | linky" class="projects-instructions-link"></span>
+                        <span ng-if="newProjectMessage" ng-bind-html="newProjectMessage | linky : '_blank'" class="projects-instructions-link"></span>
                     </p>
                   </div>
                 </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4524,7 +4524,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"template-message\" ng-if=\"templateMessage.length\">\n" +
     "<span class=\"pficon pficon-info\" aria-hidden=\"true\"></span>\n" +
-    "<div class=\"resource-description\" ng-bind-html=\"templateMessage | linky\"></div>\n" +
+    "<div class=\"resource-description\" ng-bind-html=\"templateMessage | linky : '_blank'\"></div>\n" +
     "</div>\n" +
     "<div class=\"row\" ng-controller=\"TasksController\">\n" +
     "<div ng-if=\"!pendingTasks(tasks()).length && erroredTasks(tasks()).length\" class=\"col-md-12\">\n" +
@@ -6554,7 +6554,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/directives/osc-image-summary.html',
     "<h1>{{ name || (resource | displayName) }}</h1>\n" +
-    "<div class=\"resource-description\" ng-bind-html=\"resource | description | linky\"></div>\n" +
+    "<div class=\"resource-description\" ng-bind-html=\"resource | description | linky : '_blank'\"></div>\n" +
     "<div class=\"resource-metadata\">\n" +
     "<div ng-show=\"resource | annotation:'provider'\">Provider: {{ resource | annotation:'provider' }}</div>\n" +
     "<div ng-show=\"resource.metadata.namespace && resource.metadata.namespace !=='openshift'\">Namespace: {{ resource.metadata.namespace }}</div>\n" +
@@ -10302,7 +10302,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p class=\"projects-instructions\" ng-if=\"canCreate === false\">\n" +
     "<span ng-if=\"!newProjectMessage\">A cluster admin can create a project for you by running the command\n" +
     "<code>oadm new-project &lt;projectname&gt; --admin={{user.metadata.name || '&lt;YourUsername&gt;'}}</code></span>\n" +
-    "<span ng-if=\"newProjectMessage\" ng-bind-html=\"newProjectMessage | linky\" class=\"projects-instructions-link\"></span>\n" +
+    "<span ng-if=\"newProjectMessage\" ng-bind-html=\"newProjectMessage | linky : '_blank'\" class=\"projects-instructions-link\"></span>\n" +
     "</p>\n" +
     "<p class=\"projects-instructions\">\n" +
     "A project admin can add you to a role on a project by running the command\n" +
@@ -10322,7 +10322,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p class=\"projects-instructions\" ng-if=\"canCreate === false\">\n" +
     "<span ng-if=\"!newProjectMessage\">A cluster admin can create a project for you by running the command<br>\n" +
     "<code>oadm new-project &lt;projectname&gt; --admin={{user.metadata.name || '&lt;YourUsername&gt;'}}</code></span>\n" +
-    "<span ng-if=\"newProjectMessage\" ng-bind-html=\"newProjectMessage | linky\" class=\"projects-instructions-link\"></span>\n" +
+    "<span ng-if=\"newProjectMessage\" ng-bind-html=\"newProjectMessage | linky : '_blank'\" class=\"projects-instructions-link\"></span>\n" +
     "</p>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
This is consistent with how we handle help links and other external links in the web console.

https://code.angularjs.org/1.3.19/docs/api/ngSanitize/filter/linky

@jwforres PTAL
@luciddreamz FYI