### PR TITLE
Bug 1388446 - Refactor osc-secret and osc-source-secret style

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -464,56 +464,6 @@ label.checkbox {
   }
 }
 
-.osc-secrets-form {
-  .basic-secrets {
-    .remove-secret {
-      display: inline-block;
-      margin-left: 7px;
-      vertical-align: 8px;
-    }
-    .secret-name {
-      width: 95%;
-      display: inline-block;
-    }
-  }
-  .advanced-secrets {
-    margin-bottom: 5px;
-    .remove-secret {
-      display: inline-block;
-      margin-left: 7px;
-      vertical-align: 2px;
-    }
-    .directory {
-      width: 90%;
-      display: inline-block;
-    }
-  }
-  @media (max-width: @screen-xs-max) {
-    .basic-secrets {
-      .secret-name {
-        width: 90%;
-        display: inline-block;
-      }
-    }
-    .remove-secret {
-      vertical-align: 2px;
-    }
-  }
-  .remove-btn {
-    color: #333;
-    opacity: 0.65;
-    font-size: 15px;
-    vertical-align: middle;
-    &:hover {
-      opacity: 1;
-      text-decoration: none;
-    }
-    &:focus {
-      text-decoration: none;
-    }
-  }
-}
-
 .lifecycle-hook {
   padding-bottom: 20px;
   &:first-of-type {
@@ -984,30 +934,6 @@ a.disabled-link {
 // Disable numeric highlighting in YAML and Dockerfile modes because of bugs
 .editor.yaml-mode .ace_constant.ace_numeric, .ace_editor.dockerfile-mode .ace_constant.ace_numeric {
   color: inherit;
-}
-
-.create-secret-modal {
-  background-color: #F5F5F5;
-  .modal-footer{
-    margin-top: 0px
-  }
-  .modal-body {
-    padding: 0px 18px;
-  }
-}
-
-.secret-data {
-  max-width: 450px;
-  max-height: 150px;
-  @media (max-width: @screen-sm-max) {
-    // The `table-responsive` div adds a 100% border. Make sure the table is at
-    // least 100% to avoid a white block at some screen sizes.
-    max-width: 100%;
-  }
-}
-
-.create-secret-editor {
-  height: 150px;
 }
 
 .edit-yaml {

--- a/app/styles/_secrets.less
+++ b/app/styles/_secrets.less
@@ -1,0 +1,92 @@
+.osc-secrets-form {
+  .advanced-secrets,
+  .basic-secrets {
+    .input-labels,
+    .help-blocks {
+      display: table;
+      padding-right: 30px;
+      position: relative;
+      width: 100%;
+      .input-label,
+      .help-block {
+        width: 100%;
+        float: left;
+        padding-right: 5px;
+      }
+    }
+    .secret-row {
+      display: table;
+      padding-right: 30px;
+      position: relative;
+      width: 100%;
+      padding-bottom: 5px;
+      .secret-name {
+        float: left;
+        padding-right: 5px;
+        width: 100%;
+      }
+      .remove-secret {
+        position: absolute;
+        right: 0;
+        top: 0;
+        width: 30px;
+      }
+    }
+  }
+
+  .advanced-secrets {
+    .input-labels,
+    .help-blocks {
+      .input-label,
+      .help-block {
+        width: 50%;
+      }
+    }
+    .secret-row {
+      .secret-name,
+      .destination-dir {
+        width: 50%;
+        display: inline-block;
+      }
+    }
+  }
+
+  .remove-btn {
+    color: #333;
+    margin-left: 5px;
+    opacity: 0.65;
+    font-size: 15px;
+    vertical-align: middle;
+    &:hover {
+      opacity: 1;
+      text-decoration: none;
+    }
+    &:focus {
+      text-decoration: none;
+    }
+  }
+}
+
+.create-secret-modal {
+  background-color: #F5F5F5;
+  .modal-footer{
+    margin-top: 0px
+  }
+  .modal-body {
+    padding: 0px 18px;
+  }
+}
+
+.secret-data {
+  max-width: 450px;
+  max-height: 150px;
+  @media (max-width: @screen-sm-max) {
+    // The `table-responsive` div adds a 100% border. Make sure the table is at
+    // least 100% to avoid a white block at some screen sizes.
+    max-width: 100%;
+  }
+}
+
+.create-secret-editor {
+  height: 150px;
+}

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -32,6 +32,7 @@
 @import "_responsive-utilities.less";
 @import "_scrollbars.less";
 @import "_select.less";
+@import "_secrets.less";
 @import "_sidebar.less";
 @import "_substructure.less";
 @import "_tables.less";

--- a/app/views/directives/osc-secrets.html
+++ b/app/views/directives/osc-secrets.html
@@ -1,10 +1,14 @@
 <ng-form name="secretsForm" class="osc-secrets-form">
-  <div ng-repeat="pickedSecret in pickedSecrets">
-    <div class="form-group">
-      <div class="row picked-secret">
-        <div class="col-lg-12">
-          <div ng-if="!allowMultipleSecrets">
-            <label class="picker-label">{{displayType | startCase}} Secret</label>
+  <div class="form-group">
+    <div class="basic-secrets">
+      <div class="input-labels">
+        <label class="input-label">
+          {{displayType | startCase}} Secret
+        </label>
+      </div>
+      <div ng-repeat="pickedSecret in pickedSecrets">
+        <div class="secret-row">
+          <div class="secret-name">
             <ui-select ng-disabled="disableInput" ng-model="pickedSecret.name">
               <ui-select-match placeholder="Secret name">{{$select.selected}}</ui-select-match>
               <ui-select-choices repeat="secret in (secretsByType[type] | filter : $select.search)">
@@ -12,37 +16,26 @@
               </ui-select-choices>
             </ui-select>
           </div>
-          <div ng-if="allowMultipleSecrets">
-            <div class="basic-secrets">
-              <div class="secret-name">
-                <label ng-if="$first" class="picker-label">{{displayType | startCase}} Secrets</label>
-                <ui-select ng-disabled="disableInput" ng-model="pickedSecret.name">
-                  <ui-select-match placeholder="Secret name">{{$select.selected}}</ui-select-match>
-                  <ui-select-choices repeat="secret in (secretsByType[type] | filter : $select.search)">
-                    <div ng-bind-html="secret | highlight : $select.search"></div>
-                  </ui-select-choices>
-                </ui-select>
-              </div>
-              <div class="remove-secret">
-                <label class="sr-only">Remove Build Secret</label>
-                <a class="pficon pficon-close remove-btn" aria-label="Delete row" role="button" ng-click="removeSecret($index)" href=""></a>
-              </div>
-            </div>
+          <div class="remove-secret">
+            <a ng-click="removeSecret($index)"  href="" role="button" class="remove-btn">
+              <span class="pficon pficon-close" aria-hidden="true"></span>
+              <span class="sr-only">Remove build secret</span>
+            </a>
           </div>
-          <div ng-if="$last" ng-switch="displayType">
-            <div class="help-block" ng-switch-when="source">
-              Secret with credentials for pulling your source code.
-              <a href="{{'git_secret' | helpLink}}" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a>
-            </div>
-            <div class="help-block" ng-switch-when="pull">
-              Secret for authentication when pulling images from a secured registry.
-              <a href="{{'pull_secret' | helpLink}}" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a>
-            </div>
-            <div class="help-block" ng-switch-when="push">
-              Secret for authentication when pushing images to a secured registry.
-              <a href="{{'pull_secret' | helpLink}}" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a>
-            </div>
-          </div>
+        </div>
+      </div>
+      <div class="help-blocks" ng-switch="displayType">
+        <div class="help-block" ng-switch-when="source">
+          Secret with credentials for pulling your source code.
+          <a href="{{'git_secret' | helpLink}}" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a>
+        </div>
+        <div class="help-block" ng-switch-when="pull">
+          Secret for authentication when pulling images from a secured registry.
+          <a href="{{'pull_secret' | helpLink}}" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a>
+        </div>
+        <div class="help-block" ng-switch-when="push">
+          Secret for authentication when pushing images to a secured registry.
+          <a href="{{'pull_secret' | helpLink}}" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a>
         </div>
       </div>
     </div>
@@ -60,5 +53,4 @@
       role="button"
       ng-click="openCreateSecretModal()">Create new secret</a>
   </div>
-    
 </ng-form>

--- a/app/views/directives/osc-source-secrets.html
+++ b/app/views/directives/osc-source-secrets.html
@@ -1,103 +1,96 @@
 <ng-form name="secretsForm" class="osc-secrets-form">  
-  <div ng-if="strategyType !== 'Custom'"> 
-    <div ng-repeat="pickedSecret in pickedSecrets">
-      <div class="form-group">
-        <div class="row advanced-secrets">
-          <div class="col-lg-6">
-            <label class="picker-label" ng-if="$first">Build Secret</label>
-            <ui-select ng-required="pickedSecret.destinationDir" ng-model="pickedSecret.secret.name">
-              <ui-select-match placeholder="Secret name">{{$select.selected}}</ui-select-match>
-              <ui-select-choices repeat="secret in (secretsByType[type] | filter : $select.search)">
-                <div ng-bind-html="secret | highlight : $select.search"></div>
-              </ui-select-choices>
-            </ui-select>
-          </div>
 
-          <div class="col-lg-6">
-            <div class="directory">
-              <label for="destinationDir" ng-if="$first">
-                Destination Directory
-              </label>
-              <div>
-                <input class="form-control"
-                  id="destinationDir"
-                  name="destinationDir"
-                  ng-model="pickedSecret.destinationDir"
-                  type="text"
-                  placeholder="/"
-                  autocorrect="off"
-                  autocapitalize="off"
-                  spellcheck="false">
-              </div>
+  <div ng-if="strategyType !== 'Custom'">
+    <div class="form-group">
+      <div class="advanced-secrets">
+        <div class="input-labels">
+          <label class="input-label">
+            Build Secret
+          </label>
+          <label class="input-label">
+            Destination Directory
+          </label>
+        </div>
+        <div ng-repeat="pickedSecret in pickedSecrets">
+          <div class="secret-row">
+            <div class="secret-name">
+              <ui-select ng-required="pickedSecret.destinationDir" ng-model="pickedSecret.secret.name">
+                <ui-select-match placeholder="Secret name">{{$select.selected}}</ui-select-match>
+                <ui-select-choices repeat="secret in (secretsByType[type] | filter : $select.search)">
+                  <div ng-bind-html="secret | highlight : $select.search"></div>
+                </ui-select-choices>
+              </ui-select>
+            </div>
+            <div class="destination-dir">
+              <input class="form-control"
+                id="destinationDir"
+                name="destinationDir"
+                ng-model="pickedSecret.destinationDir"
+                type="text"
+                placeholder="/"
+                autocorrect="off"
+                autocapitalize="off"
+                spellcheck="false">
             </div>
             <div class="remove-secret">
-              <a ng-click="removeSecret($index)" href="" role="button">
-                <span class="pficon pficon-close remove-btn" aria-hidden="true"></span>
+              <a ng-click="removeSecret($index)"  href="" role="button" class="remove-btn">
+                <span class="pficon pficon-close" aria-hidden="true"></span>
                 <span class="sr-only">Remove build secret</span>
               </a>
             </div>
           </div>
         </div>
-        <div class="row" ng-if="$last">
-          <div class="col-lg-6">
+        <div class="help-blocks">
             <div class="help-block">Source secret to copy into the builder pod at build time.</div>
-          </div>
-          <div class="col-lg-6">
-            <div class="directory">
-              <div class="help-block">Directory where the files will be available at build time.</div>
-            </div>
-          </div>
+            <div class="help-block">Directory where the files will be available at build time.</div>
         </div>
       </div>
     </div>
   </div>
 
   <div ng-if="strategyType === 'Custom'">
-    <div ng-repeat="pickedSecret in pickedSecrets">
-      <div class="form-group">
-        <div class="row advanced-secrets">
-          <div class="col-lg-6">
-            <label class="picker-label" ng-if="$first">Build Secret</label>
-            <ui-select ng-required="pickedSecret.mountPath" ng-model="pickedSecret.secretSource.name">
-              <ui-select-match placeholder="Secret name">{{$select.selected}}</ui-select-match>
-              <ui-select-choices repeat="secret in (secretsByType[type] | filter : $select.search)">
-                <div ng-bind-html="secret | highlight : $select.search"></div>
-              </ui-select-choices>
-            </ui-select>
-          </div>
-
-          <div class="col-lg-6">
-            <div class="directory">
-              <label for="mountPath" ng-if="$first">
-                Mount path
-              </label>
-              <div>
-                <input class="form-control"
-                  id="mountPath"
-                  name="mountPath"
-                  ng-model="pickedSecret.mountPath"
-                  type="text"
-                  placeholder="/"
-                  autocorrect="off"
-                  autocapitalize="off"
-                  spellcheck="false">
-              </div>
+    <div class="form-group">
+      <div class="advanced-secrets">
+        <div class="input-labels">
+          <label class="input-label">
+            Build Secret
+          </label>
+          <label class="input-label">
+            Mount path
+          </label>
+        </div>
+        <div ng-repeat="pickedSecret in pickedSecrets">
+          <div class="secret-row">
+            <div class="secret-name">
+              <ui-select ng-required="pickedSecret.mountPath" ng-model="pickedSecret.secretSource.name">
+                <ui-select-match placeholder="Secret name">{{$select.selected}}</ui-select-match>
+                <ui-select-choices repeat="secret in (secretsByType[type] | filter : $select.search)">
+                  <div ng-bind-html="secret | highlight : $select.search"></div>
+                </ui-select-choices>
+              </ui-select>
+            </div>
+            <div class="destination-dir">
+              <input class="form-control"
+                id="mountPath"
+                name="mountPath"
+                ng-model="pickedSecret.mountPath"
+                type="text"
+                placeholder="/"
+                autocorrect="off"
+                autocapitalize="off"
+                spellcheck="false">
             </div>
             <div class="remove-secret">
-              <label class="sr-only">Remove Build Secret</label>
-              <a class="pficon pficon-close remove-btn" aria-label="Delete row" role="button" ng-click="removeSecret($index)" href=""></a>
+              <a ng-click="removeSecret($index)"  href="" role="button" class="remove-btn">
+                <span class="pficon pficon-close" aria-hidden="true"></span>
+                <span class="sr-only">Remove build secret</span>
+              </a>
             </div>
           </div>
         </div>
-        <div class="row" ng-if="$last">
-          <div class="col-lg-6">
+        <div class="help-blocks">
             <div class="help-block">Source secret to mount into the builder pod at build time.</div>
-          </div>
-          <div class="col-lg-6">
-            <div class="directory">
-              <div class="help-block">Path at which to mount the secret.</div>
-            </div>
-          </div>
+            <div class="help-block">Path at which to mount the secret.</div>
         </div>
       </div>
     </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6999,23 +6999,16 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/directives/osc-secrets.html',
     "<ng-form name=\"secretsForm\" class=\"osc-secrets-form\">\n" +
-    "<div ng-repeat=\"pickedSecret in pickedSecrets\">\n" +
     "<div class=\"form-group\">\n" +
-    "<div class=\"row picked-secret\">\n" +
-    "<div class=\"col-lg-12\">\n" +
-    "<div ng-if=\"!allowMultipleSecrets\">\n" +
-    "<label class=\"picker-label\">{{displayType | startCase}} Secret</label>\n" +
-    "<ui-select ng-disabled=\"disableInput\" ng-model=\"pickedSecret.name\">\n" +
-    "<ui-select-match placeholder=\"Secret name\">{{$select.selected}}</ui-select-match>\n" +
-    "<ui-select-choices repeat=\"secret in (secretsByType[type] | filter : $select.search)\">\n" +
-    "<div ng-bind-html=\"secret | highlight : $select.search\"></div>\n" +
-    "</ui-select-choices>\n" +
-    "</ui-select>\n" +
-    "</div>\n" +
-    "<div ng-if=\"allowMultipleSecrets\">\n" +
     "<div class=\"basic-secrets\">\n" +
+    "<div class=\"input-labels\">\n" +
+    "<label class=\"input-label\">\n" +
+    "{{displayType | startCase}} Secret\n" +
+    "</label>\n" +
+    "</div>\n" +
+    "<div ng-repeat=\"pickedSecret in pickedSecrets\">\n" +
+    "<div class=\"secret-row\">\n" +
     "<div class=\"secret-name\">\n" +
-    "<label ng-if=\"$first\" class=\"picker-label\">{{displayType | startCase}} Secrets</label>\n" +
     "<ui-select ng-disabled=\"disableInput\" ng-model=\"pickedSecret.name\">\n" +
     "<ui-select-match placeholder=\"Secret name\">{{$select.selected}}</ui-select-match>\n" +
     "<ui-select-choices repeat=\"secret in (secretsByType[type] | filter : $select.search)\">\n" +
@@ -7024,12 +7017,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</ui-select>\n" +
     "</div>\n" +
     "<div class=\"remove-secret\">\n" +
-    "<label class=\"sr-only\">Remove Build Secret</label>\n" +
-    "<a class=\"pficon pficon-close remove-btn\" aria-label=\"Delete row\" role=\"button\" ng-click=\"removeSecret($index)\" href=\"\"></a>\n" +
+    "<a ng-click=\"removeSecret($index)\" href=\"\" role=\"button\" class=\"remove-btn\">\n" +
+    "<span class=\"pficon pficon-close\" aria-hidden=\"true\"></span>\n" +
+    "<span class=\"sr-only\">Remove build secret</span>\n" +
+    "</a>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-if=\"$last\" ng-switch=\"displayType\">\n" +
+    "<div class=\"help-blocks\" ng-switch=\"displayType\">\n" +
     "<div class=\"help-block\" ng-switch-when=\"source\">\n" +
     "Secret with credentials for pulling your source code.\n" +
     "<a href=\"{{'git_secret' | helpLink}}\" target=\"_blank\"><span class=\"learn-more-inline\">Learn more&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></span></a>\n" +
@@ -7041,8 +7036,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"help-block\" ng-switch-when=\"push\">\n" +
     "Secret for authentication when pushing images to a secured registry.\n" +
     "<a href=\"{{'pull_secret' | helpLink}}\" target=\"_blank\"><span class=\"learn-more-inline\">Learn more&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></span></a>\n" +
-    "</div>\n" +
-    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -7061,11 +7054,19 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   $templateCache.put('views/directives/osc-source-secrets.html',
     "<ng-form name=\"secretsForm\" class=\"osc-secrets-form\">\n" +
     "<div ng-if=\"strategyType !== 'Custom'\">\n" +
-    "<div ng-repeat=\"pickedSecret in pickedSecrets\">\n" +
     "<div class=\"form-group\">\n" +
-    "<div class=\"row advanced-secrets\">\n" +
-    "<div class=\"col-lg-6\">\n" +
-    "<label class=\"picker-label\" ng-if=\"$first\">Build Secret</label>\n" +
+    "<div class=\"advanced-secrets\">\n" +
+    "<div class=\"input-labels\">\n" +
+    "<label class=\"input-label\">\n" +
+    "Build Secret\n" +
+    "</label>\n" +
+    "<label class=\"input-label\">\n" +
+    "Destination Directory\n" +
+    "</label>\n" +
+    "</div>\n" +
+    "<div ng-repeat=\"pickedSecret in pickedSecrets\">\n" +
+    "<div class=\"secret-row\">\n" +
+    "<div class=\"secret-name\">\n" +
     "<ui-select ng-required=\"pickedSecret.destinationDir\" ng-model=\"pickedSecret.secret.name\">\n" +
     "<ui-select-match placeholder=\"Secret name\">{{$select.selected}}</ui-select-match>\n" +
     "<ui-select-choices repeat=\"secret in (secretsByType[type] | filter : $select.search)\">\n" +
@@ -7073,42 +7074,38 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
     "</div>\n" +
-    "<div class=\"col-lg-6\">\n" +
-    "<div class=\"directory\">\n" +
-    "<label for=\"destinationDir\" ng-if=\"$first\">\n" +
-    "Destination Directory\n" +
-    "</label>\n" +
-    "<div>\n" +
+    "<div class=\"destination-dir\">\n" +
     "<input class=\"form-control\" id=\"destinationDir\" name=\"destinationDir\" ng-model=\"pickedSecret.destinationDir\" type=\"text\" placeholder=\"/\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\">\n" +
     "</div>\n" +
-    "</div>\n" +
     "<div class=\"remove-secret\">\n" +
-    "<a ng-click=\"removeSecret($index)\" href=\"\" role=\"button\">\n" +
-    "<span class=\"pficon pficon-close remove-btn\" aria-hidden=\"true\"></span>\n" +
+    "<a ng-click=\"removeSecret($index)\" href=\"\" role=\"button\" class=\"remove-btn\">\n" +
+    "<span class=\"pficon pficon-close\" aria-hidden=\"true\"></span>\n" +
     "<span class=\"sr-only\">Remove build secret</span>\n" +
     "</a>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"row\" ng-if=\"$last\">\n" +
-    "<div class=\"col-lg-6\">\n" +
+    "<div class=\"help-blocks\">\n" +
     "<div class=\"help-block\">Source secret to copy into the builder pod at build time.</div>\n" +
-    "</div>\n" +
-    "<div class=\"col-lg-6\">\n" +
-    "<div class=\"directory\">\n" +
     "<div class=\"help-block\">Directory where the files will be available at build time.</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "</div>\n" +
-    "</div>\n" +
     "<div ng-if=\"strategyType === 'Custom'\">\n" +
-    "<div ng-repeat=\"pickedSecret in pickedSecrets\">\n" +
     "<div class=\"form-group\">\n" +
-    "<div class=\"row advanced-secrets\">\n" +
-    "<div class=\"col-lg-6\">\n" +
-    "<label class=\"picker-label\" ng-if=\"$first\">Build Secret</label>\n" +
+    "<div class=\"advanced-secrets\">\n" +
+    "<div class=\"input-labels\">\n" +
+    "<label class=\"input-label\">\n" +
+    "Build Secret\n" +
+    "</label>\n" +
+    "<label class=\"input-label\">\n" +
+    "Mount path\n" +
+    "</label>\n" +
+    "</div>\n" +
+    "<div ng-repeat=\"pickedSecret in pickedSecrets\">\n" +
+    "<div class=\"secret-row\">\n" +
+    "<div class=\"secret-name\">\n" +
     "<ui-select ng-required=\"pickedSecret.mountPath\" ng-model=\"pickedSecret.secretSource.name\">\n" +
     "<ui-select-match placeholder=\"Secret name\">{{$select.selected}}</ui-select-match>\n" +
     "<ui-select-choices repeat=\"secret in (secretsByType[type] | filter : $select.search)\">\n" +
@@ -7116,30 +7113,20 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
     "</div>\n" +
-    "<div class=\"col-lg-6\">\n" +
-    "<div class=\"directory\">\n" +
-    "<label for=\"mountPath\" ng-if=\"$first\">\n" +
-    "Mount path\n" +
-    "</label>\n" +
-    "<div>\n" +
+    "<div class=\"destination-dir\">\n" +
     "<input class=\"form-control\" id=\"mountPath\" name=\"mountPath\" ng-model=\"pickedSecret.mountPath\" type=\"text\" placeholder=\"/\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\">\n" +
     "</div>\n" +
-    "</div>\n" +
     "<div class=\"remove-secret\">\n" +
-    "<label class=\"sr-only\">Remove Build Secret</label>\n" +
-    "<a class=\"pficon pficon-close remove-btn\" aria-label=\"Delete row\" role=\"button\" ng-click=\"removeSecret($index)\" href=\"\"></a>\n" +
+    "<a ng-click=\"removeSecret($index)\" href=\"\" role=\"button\" class=\"remove-btn\">\n" +
+    "<span class=\"pficon pficon-close\" aria-hidden=\"true\"></span>\n" +
+    "<span class=\"sr-only\">Remove build secret</span>\n" +
+    "</a>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"row\" ng-if=\"$last\">\n" +
-    "<div class=\"col-lg-6\">\n" +
+    "<div class=\"help-blocks\">\n" +
     "<div class=\"help-block\">Source secret to mount into the builder pod at build time.</div>\n" +
-    "</div>\n" +
-    "<div class=\"col-lg-6\">\n" +
-    "<div class=\"directory\">\n" +
     "<div class=\"help-block\">Path at which to mount the secret.</div>\n" +
-    "</div>\n" +
-    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3466,7 +3466,7 @@ to{transform:rotate(359deg)}
 .nav-pf-tertiary-nav .list-group-item .list-group-item-value{padding-left:5px}
 .collapsed .nav-pf-secondary-nav{left:75px}
 .collapsed .nav-pf-tertiary-nav{left:calc(275px)}
-.secondary-collapse-toggle-pf,.tertiary-collapse-toggle-pf{display:none;font-family:FontAwesome;font-size:inherit;opacity:0;pointer-events:none;-webkit-font-smoothing:antialiased}
+.secondary-collapse-toggle-pf,.tertiary-collapse-toggle-pf{display:none;font-family:FontAwesome;font-size:inherit;opacity:0;-webkit-font-smoothing:antialiased;pointer-events:none}
 .collapsed.collapsed-secondary-nav-pf,.collapsed.collapsed-tertiary-nav-pf{width:200px}
 .collapsed.collapsed-secondary-nav-pf .secondary-nav-item-pf:hover>a,.collapsed.collapsed-tertiary-nav-pf .secondary-nav-item-pf:hover>a{z-index:1030}
 .collapsed.collapsed-secondary-nav-pf .nav-pf-secondary-nav,.collapsed.collapsed-tertiary-nav-pf .nav-pf-secondary-nav{left:0}
@@ -3802,6 +3802,7 @@ body{padding-right:0px!important}
 }
 @media (min-width:1400px){.metrics-compact .metrics-sparkline{width:230px}
 }
+.about .about-icon img,.command-line .about-icon img,.osc-form .template-options .form-group{width:100%}
 .metrics-compact .metrics-usage{display:block;margin-left:10px}
 @media (min-width:1200px){.metrics-compact .metrics-usage{display:inline-block}
 }
@@ -3830,18 +3831,6 @@ label.checkbox{font-weight:400}
 @media (max-width:767px){.istag-separator{display:none!important}
 }
 .create-route-icon,.create-storage-icon{padding-top:0;text-align:right}
-.about .about-icon img,.command-line .about-icon img{width:100%}
-.osc-secrets-form .basic-secrets .remove-secret{display:inline-block;margin-left:7px;vertical-align:8px}
-.osc-secrets-form .basic-secrets .secret-name{width:95%;display:inline-block}
-.osc-secrets-form .advanced-secrets{margin-bottom:5px}
-.osc-secrets-form .advanced-secrets .remove-secret{display:inline-block;margin-left:7px;vertical-align:2px}
-.osc-secrets-form .advanced-secrets .directory{width:90%;display:inline-block}
-@media (max-width:767px){.osc-secrets-form .basic-secrets .secret-name{width:90%;display:inline-block}
-.osc-secrets-form .remove-secret{vertical-align:2px}
-}
-.osc-secrets-form .remove-btn{color:#333;opacity:.65;font-size:15px;vertical-align:middle}
-.osc-secrets-form .remove-btn:hover{opacity:1;text-decoration:none}
-.osc-secrets-form .remove-btn:focus{text-decoration:none}
 .lifecycle-hook{padding-bottom:20px}
 .lifecycle-hook:first-of-type{padding-top:20px}
 .lifecycle-hook .read-only-tag-image{padding-bottom:10px}
@@ -3859,7 +3848,6 @@ label.checkbox{font-weight:400}
 .osc-form .template-options{line-height:1.5}
 .osc-form .template-options .list-unstyled .options{margin-bottom:12px}
 .osc-form .template-options .list-unstyled .help-block{margin:0 0 5px 2px}
-.osc-form .template-options .form-group{width:100%}
 .osc-form .template-options .form-group .parameter-input-wrapper{position:relative}
 .osc-form .template-options .form-group .parameter-input-wrapper .resize-input{position:absolute;right:6px;top:5px}
 .osc-form .template-options .form-group .parameter-input-wrapper .resize-input .fa-compress,.osc-form .template-options .form-group .parameter-input-wrapper .resize-input .fa-expand{transform:rotate(90deg)}
@@ -3944,13 +3932,6 @@ a.disabled-link:active,a.disabled-link:focus,a.disabled-link:hover{color:#bbb;te
 .modal-resource-action h1{font-size:21px;font-weight:500;margin-bottom:20px;overflow-wrap:break-word;min-width:0}
 .modal-resource-action p{font-size:16px}
 .ace_editor.dockerfile-mode .ace_constant.ace_numeric,.editor.yaml-mode .ace_constant.ace_numeric{color:inherit}
-.create-secret-modal{background-color:#F5F5F5}
-.create-secret-modal .modal-footer{margin-top:0px}
-.create-secret-modal .modal-body{padding:0px 18px}
-.secret-data{max-width:450px;max-height:150px}
-@media (max-width:991px){.secret-data{max-width:100%}
-}
-.create-secret-editor{height:150px}
 .edit-yaml h1{line-height:1.3}
 .edit-yaml .editor{line-height:1.5;width:100%;min-height:140px;height:50vh}
 .edit-yaml .editor .ace_gutter{color:#8b8d8f}
@@ -4751,6 +4732,23 @@ td.visible-print,th.visible-print{display:table-cell!important}
 .ui-select-bootstrap .ui-select-match-text span span{display:inline}
 .ui-select-bootstrap .ui-select-toggle>.caret{font-size:12px;font-style:normal;right:6px;top:10px;pointer-events:none}
 .ui-select-bootstrap .ui-select-search{width:100%!important}
+.osc-secrets-form .advanced-secrets .help-blocks,.osc-secrets-form .advanced-secrets .input-labels,.osc-secrets-form .basic-secrets .help-blocks,.osc-secrets-form .basic-secrets .input-labels{display:table;padding-right:30px;position:relative;width:100%}
+.osc-secrets-form .advanced-secrets .help-blocks .help-block,.osc-secrets-form .advanced-secrets .help-blocks .input-label,.osc-secrets-form .advanced-secrets .input-labels .help-block,.osc-secrets-form .advanced-secrets .input-labels .input-label,.osc-secrets-form .basic-secrets .help-blocks .help-block,.osc-secrets-form .basic-secrets .help-blocks .input-label,.osc-secrets-form .basic-secrets .input-labels .help-block,.osc-secrets-form .basic-secrets .input-labels .input-label{width:100%;float:left;padding-right:5px}
+.osc-secrets-form .advanced-secrets .secret-row,.osc-secrets-form .basic-secrets .secret-row{display:table;padding-right:30px;position:relative;width:100%;padding-bottom:5px}
+.osc-secrets-form .advanced-secrets .secret-row .secret-name,.osc-secrets-form .basic-secrets .secret-row .secret-name{float:left;padding-right:5px;width:100%}
+.osc-secrets-form .advanced-secrets .secret-row .remove-secret,.osc-secrets-form .basic-secrets .secret-row .remove-secret{position:absolute;right:0;top:0;width:30px}
+.osc-secrets-form .advanced-secrets .help-blocks .help-block,.osc-secrets-form .advanced-secrets .help-blocks .input-label,.osc-secrets-form .advanced-secrets .input-labels .help-block,.osc-secrets-form .advanced-secrets .input-labels .input-label{width:50%}
+.osc-secrets-form .advanced-secrets .secret-row .destination-dir,.osc-secrets-form .advanced-secrets .secret-row .secret-name{width:50%;display:inline-block}
+.osc-secrets-form .remove-btn{color:#333;margin-left:5px;opacity:.65;font-size:15px;vertical-align:middle}
+.osc-secrets-form .remove-btn:hover{opacity:1;text-decoration:none}
+.osc-secrets-form .remove-btn:focus{text-decoration:none}
+.create-secret-modal{background-color:#F5F5F5}
+.create-secret-modal .modal-footer{margin-top:0px}
+.create-secret-modal .modal-body{padding:0px 18px}
+.secret-data{max-width:450px;max-height:150px}
+@media (max-width:991px){.secret-data{max-width:100%}
+}
+.create-secret-editor{height:150px}
 .nav-sidenav-secondary .dropdown-header{color:#b3b3b3;font-size:12px;padding-bottom:10px;padding-left:37px;padding-top:10px}
 .sidebar-left .navbar-sidebar{border-bottom:0;border-left:0;border-top:0;margin:0;min-height:46px}
 .sidebar-left .navbar-sidebar.visible-xs-block{border:0}


### PR DESCRIPTION
Fixing bug 1388446 by updating the `osc-secret.html` and `osc-source-secret.html` + styling. They have similar styling that we use in the key-value-editor now.
Wasn't sure if we want to create a common mixin function, since most of the attributes are the same, just width is changed based on the parent classes(`basic-secrets`, `advanced-secrets`).
@spadgett @rhamilto PTAL
