### PR TITLE
Update required field handling for source secrets

### DIFF
--- a/app/scripts/directives/createSecret.js
+++ b/app/scripts/directives/createSecret.js
@@ -72,8 +72,11 @@ angular.module("openshiftConsole")
             pickedServiceAccountToLink: "",
           };
         }
-        $scope.addGitconfig = false;
-        $scope.addCaCert = false;
+
+        $scope.add = {
+          gitconfig: false,
+          cacert: false
+        };
 
         // List SA only if $scope.serviceAccountToLink is not defined so user has to pick one.
         if (!$scope.serviceAccountToLink && AuthorizationService.canI('serviceaccounts', 'list') && AuthorizationService.canI('serviceaccounts', 'update')) {

--- a/app/views/directives/create-secret.html
+++ b/app/views/directives/create-secret.html
@@ -73,7 +73,7 @@
       </div>
 
       <div class="form-group">
-        <label for="passwordToken">Password or Token</label>
+        <label ng-class="{ required: !add.cacert && !add.gitconfig }" for="passwordToken">Password or Token</label>
         <div>
           <input class="form-control"
             id="passwordToken"
@@ -84,10 +84,10 @@
             spellcheck="false"
             aria-describedby="password-token-help"
             type="password"
-            ng-required="!newSecret.data.cacert && !newSecret.data.gitconfig">
+            ng-required="!add.cacert && !add.gitconfig">
         </div>
         <div class="help-block" id="password-token-help">
-          Password or token for Git authentication.
+          Password or token for Git authentication. Required if a ca.crt or .gitconfig file is not specified.
         </div>
       </div>
 
@@ -95,21 +95,21 @@
       <div class="form-group">
         <div class="checkbox">
           <label>
-            <input type="checkbox" ng-model="addCaCert">
+            <input type="checkbox" ng-model="add.cacert">
             Use a custom ca.crt file
           </label>
         </div>
       </div>
-      <div class="form-group" ng-if="addCaCert" id="cacert">
+      <div class="form-group" ng-if="add.cacert" id="cacert">
         <label class="required" for="cacert">CA Certificate File</label>
         <osc-file-input
           id="cacert-file-input"
           model="newSecret.data.cacert"
           drop-zone-id="cacert"
           dragging="false"
-          help-text="Upload your ca.cert file."
+          help-text="Upload your ca.crt file."
           show-values="false"
-          ng-required="!newSecret.data.gitconfig || !newSecret.data.passwordToken"></osc-file-input>
+          required="true"></osc-file-input>
         <div ui-ace="{
           mode: 'txt',
           theme: 'eclipse',
@@ -127,7 +127,7 @@
     <div ng-if="newSecret.authType === 'kubernetes.io/ssh-auth'">
       <div class="form-group" id="private-key">
         <label for="privateKey" class="required">SSH Private Key</label>
-        <osc-file-input 
+        <osc-file-input
           id="private-key-file-input"
           model="newSecret.data.privateKey"
           drop-zone-id="private-key"
@@ -139,7 +139,7 @@
           onLoad: aceLoaded,
           rendererOptions: {
             fadeFoldWidgets: true,
-            showPrintMargin: false 
+            showPrintMargin: false
           }
         }" ng-model="newSecret.data.privateKey" class="create-secret-editor ace-bordered" id="private-key-editor" required></div>
         <div class="help-block">
@@ -147,34 +147,34 @@
         </div>
       </div>
     </div>
-    
+
     <div ng-if="newSecret.type === 'source'">
       <div class="form-group">
         <div class="checkbox">
           <label>
-            <input type="checkbox" ng-model="addGitconfig">
+            <input type="checkbox" ng-model="add.gitconfig">
             Use a custom .gitconfig file
           </label>
         </div>
       </div>
 
-      <div class="form-group" ng-if="addGitconfig" id="gitconfig" ng-show="addGitconfig">
+      <div class="form-group" ng-if="add.gitconfig" id="gitconfig">
         <label class="required" for="gitconfig">Git Configuration File</label>
-        <osc-file-input 
+        <osc-file-input
           id="gitconfig-file-input"
           model="newSecret.data.gitconfig"
           drop-zone-id="gitconfig"
           dragging="false"
           help-text="Upload your .gitconfig or  file."
           show-values="false"
-          ng-required="!newSecret.data.cacert || !newSecret.data.passwordToken"></osc-file-input>
+          required="true"></osc-file-input>
         <div ui-ace="{
           mode: 'ini',
           theme: 'eclipse',
           onLoad: aceLoaded,
           rendererOptions: {
             fadeFoldWidgets: true,
-            showPrintMargin: false 
+            showPrintMargin: false
           }
         }" ng-model="newSecret.data.gitconfig" class="create-secret-editor ace-bordered" id="gitconfig-editor"></div>
       </div>
@@ -259,7 +259,7 @@
           onLoad: aceLoaded,
           rendererOptions: {
             fadeFoldWidgets: true,
-            showPrintMargin: false 
+            showPrintMargin: false
           }
         }" ng-model="newSecret.data.dockerConfig" class="create-secret-editor ace-bordered" id="dockerconfig-editor" required></div>
         <div class="help-block">
@@ -303,4 +303,4 @@
             ng-click="cancel()">Cancel</button>
   </div>
 </ng-form>
-  
+

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8033,7 +8033,10 @@ authType:"kubernetes.io/basic-auth",
 data:{},
 linkSecret:!1,
 pickedServiceAccountToLink:""
-}, c.addGitconfig = !1, c.addCaCert = !1, !c.serviceAccountToLink && b.canI("serviceaccounts", "list") && b.canI("serviceaccounts", "update") && a.list("serviceaccounts", c, function(a) {
+}, c.add = {
+gitconfig:!1,
+cacert:!1
+}, !c.serviceAccountToLink && b.canI("serviceaccounts", "list") && b.canI("serviceaccounts", "update") && a.list("serviceaccounts", c, function(a) {
 c.serviceAccounts = a.by("metadata.name"), c.serviceAccountsNames = _.keys(c.serviceAccounts);
 });
 var e = function(a, b) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5285,25 +5285,25 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "<div class=\"form-group\">\n" +
-    "<label for=\"passwordToken\">Password or Token</label>\n" +
+    "<label ng-class=\"{ required: !add.cacert && !add.gitconfig }\" for=\"passwordToken\">Password or Token</label>\n" +
     "<div>\n" +
-    "<input class=\"form-control\" id=\"passwordToken\" name=\"passwordToken\" ng-model=\"newSecret.data.passwordToken\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck aria-describedby=\"password-token-help\" type=\"password\" ng-required=\"!newSecret.data.cacert && !newSecret.data.gitconfig\">\n" +
+    "<input class=\"form-control\" id=\"passwordToken\" name=\"passwordToken\" ng-model=\"newSecret.data.passwordToken\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck aria-describedby=\"password-token-help\" type=\"password\" ng-required=\"!add.cacert && !add.gitconfig\">\n" +
     "</div>\n" +
     "<div class=\"help-block\" id=\"password-token-help\">\n" +
-    "Password or token for Git authentication.\n" +
+    "Password or token for Git authentication. Required if a ca.crt or .gitconfig file is not specified.\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"form-group\">\n" +
     "<div class=\"checkbox\">\n" +
     "<label>\n" +
-    "<input type=\"checkbox\" ng-model=\"addCaCert\">\n" +
+    "<input type=\"checkbox\" ng-model=\"add.cacert\">\n" +
     "Use a custom ca.crt file\n" +
     "</label>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"form-group\" ng-if=\"addCaCert\" id=\"cacert\">\n" +
+    "<div class=\"form-group\" ng-if=\"add.cacert\" id=\"cacert\">\n" +
     "<label class=\"required\" for=\"cacert\">CA Certificate File</label>\n" +
-    "<osc-file-input id=\"cacert-file-input\" model=\"newSecret.data.cacert\" drop-zone-id=\"cacert\" dragging=\"false\" help-text=\"Upload your ca.cert file.\" show-values=\"false\" ng-required=\"!newSecret.data.gitconfig || !newSecret.data.passwordToken\"></osc-file-input>\n" +
+    "<osc-file-input id=\"cacert-file-input\" model=\"newSecret.data.cacert\" drop-zone-id=\"cacert\" dragging=\"false\" help-text=\"Upload your ca.crt file.\" show-values=\"false\" required></osc-file-input>\n" +
     "<div ui-ace=\"{\n" +
     "          mode: 'txt',\n" +
     "          theme: 'eclipse',\n" +
@@ -5324,7 +5324,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "          onLoad: aceLoaded,\n" +
     "          rendererOptions: {\n" +
     "            fadeFoldWidgets: true,\n" +
-    "            showPrintMargin: false \n" +
+    "            showPrintMargin: false\n" +
     "          }\n" +
     "        }\" ng-model=\"newSecret.data.privateKey\" class=\"create-secret-editor ace-bordered\" id=\"private-key-editor\" required></div>\n" +
     "<div class=\"help-block\">\n" +
@@ -5336,21 +5336,21 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"form-group\">\n" +
     "<div class=\"checkbox\">\n" +
     "<label>\n" +
-    "<input type=\"checkbox\" ng-model=\"addGitconfig\">\n" +
+    "<input type=\"checkbox\" ng-model=\"add.gitconfig\">\n" +
     "Use a custom .gitconfig file\n" +
     "</label>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"form-group\" ng-if=\"addGitconfig\" id=\"gitconfig\" ng-show=\"addGitconfig\">\n" +
+    "<div class=\"form-group\" ng-if=\"add.gitconfig\" id=\"gitconfig\">\n" +
     "<label class=\"required\" for=\"gitconfig\">Git Configuration File</label>\n" +
-    "<osc-file-input id=\"gitconfig-file-input\" model=\"newSecret.data.gitconfig\" drop-zone-id=\"gitconfig\" dragging=\"false\" help-text=\"Upload your .gitconfig or  file.\" show-values=\"false\" ng-required=\"!newSecret.data.cacert || !newSecret.data.passwordToken\"></osc-file-input>\n" +
+    "<osc-file-input id=\"gitconfig-file-input\" model=\"newSecret.data.gitconfig\" drop-zone-id=\"gitconfig\" dragging=\"false\" help-text=\"Upload your .gitconfig or  file.\" show-values=\"false\" required></osc-file-input>\n" +
     "<div ui-ace=\"{\n" +
     "          mode: 'ini',\n" +
     "          theme: 'eclipse',\n" +
     "          onLoad: aceLoaded,\n" +
     "          rendererOptions: {\n" +
     "            fadeFoldWidgets: true,\n" +
-    "            showPrintMargin: false \n" +
+    "            showPrintMargin: false\n" +
     "          }\n" +
     "        }\" ng-model=\"newSecret.data.gitconfig\" class=\"create-secret-editor ace-bordered\" id=\"gitconfig-editor\"></div>\n" +
     "</div>\n" +
@@ -5391,7 +5391,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "          onLoad: aceLoaded,\n" +
     "          rendererOptions: {\n" +
     "            fadeFoldWidgets: true,\n" +
-    "            showPrintMargin: false \n" +
+    "            showPrintMargin: false\n" +
     "          }\n" +
     "        }\" ng-model=\"newSecret.data.dockerConfig\" class=\"create-secret-editor ace-bordered\" id=\"dockerconfig-editor\" required></div>\n" +
     "<div class=\"help-block\">\n" +


### PR DESCRIPTION
* Show a required `*` on the password label when required
* Require ca.cert or .gitconfig content when the checkbox for those options is checked
* Change scope var names to add.gitconfig and add.cacert so the updated values can be read outside of the `ng-if` where they're set.
* Use `required` attribute on osc-file-input. `ng-required` doesn't work.

Fixes #734
@jhadvig PTAL