### PR TITLE
Allow all scripts in hack/ to use local grunt and bower binaries

### DIFF
--- a/hack/clean-deps.sh
+++ b/hack/clean-deps.sh
@@ -2,9 +2,11 @@
 
 set -e
 
-echo "Cleaning up bower_components and node_modules..."
-rm -rf bower_components/*
-rm -rf node_modules/*
+# We don't need bower to be installed globally for the system, so 
+# we can amend our path to look into the local node_modules for the
+# correct binaries.
+repo_root="$( dirname "${BASH_SOURCE}" )/.."
+export PATH="${PATH}:${repo_root}/node_modules/bower/bin"
 
 if which bower > /dev/null 2>&1 ; then
   # In case upstream components change things without incrementing versions
@@ -13,3 +15,6 @@ if which bower > /dev/null 2>&1 ; then
 else
   echo "Skipping bower cache clean, bower not installed."
 fi
+
+echo "Cleaning up bower_components and node_modules..."
+rm -rf bower_components/* node_modules/*

--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -5,8 +5,6 @@ set -e
 OPENSHIFT_JVM_VERSION=v1.0.50
 
 STARTTIME=$(date +%s)
-#OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-#source "${OS_ROOT}/hack/common.sh"
 
 TMPDIR="${TMPDIR:-"/tmp"}"
 LOG_DIR="${LOG_DIR:-$(mktemp -d ${TMPDIR}/openshift.assets.logs.XXXX)}"
@@ -30,7 +28,8 @@ function cmd() {
 # We don't need grunt and bower to be installed globally for the system,
 # so we can amend our path to look into the local node_modules for the
 # correct binaries.
-export PATH="${PATH}:$(pwd)/node_modules/bower/bin:$(pwd)/node_modules/grunt-cli/bin"
+repo_root="$( dirname "${BASH_SOURCE}" )/.."
+export PATH="${PATH}:${repo_root}/node_modules/bower/bin:${repo_root}/node_modules/grunt-cli/bin"
 
 # Install bower if needed
 if ! which bower > /dev/null 2>&1 ; then

--- a/hack/test-headless.sh
+++ b/hack/test-headless.sh
@@ -22,6 +22,12 @@ if ! which Xvfb >/dev/null 2>&1; then
 	exit 1
 fi
 
+# We don't need grunt to be installed globally for the system, so 
+# we can amend our path to look into the local node_modules for the
+# correct binaries.
+repo_root="$( dirname "${BASH_SOURCE}" )/.."
+export PATH="${PATH}:${repo_root}/node_modules/grunt-cli/bin"
+
 echo "[INFO] Starting virtual framebuffer for headless tests..."
 export DISPLAY=':10'
 export SCREEN='0'

--- a/hack/verify-dist.sh
+++ b/hack/verify-dist.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+# We don't need grunt to be installed globally for the system,  so 
+# we can amend our path to look into the local node_modules for the
+# correct binaries.
+repo_root="$( dirname "${BASH_SOURCE}" )/.."
+export PATH="${PATH}:${repo_root}/node_modules/grunt-cli/bin"
+
 grunt build
 
 echo "Verifying that checked in built files under dist match the source..."


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

There are some hidden issues with finding the repo root using `dirname` (as you can see we have a more sophisticated means by which we do it in Origin's `hack/lib/init.sh`) but I do not know how complicated we need to make this ... the `dirname` approach should work in most standard environments.