### PR TITLE
Bug 1388448 - Show warning when docker config file is not in JSON format

### DIFF
--- a/app/scripts/directives/createSecret.js
+++ b/app/scripts/directives/createSecret.js
@@ -175,6 +175,19 @@ angular.module("openshiftConsole")
           });
         };
 
+        var updateEditorMode = _.debounce(function(){
+          try {
+            JSON.parse($scope.newSecret.data.dockerConfig);
+            $scope.invalidConfigFormat = false;
+          } catch (e) {
+            $scope.invalidConfigFormat = true;
+          }
+        }, 300, {
+          'leading': true
+        });
+
+        $scope.aceChanged = updateEditorMode;
+
         $scope.create = function() {
           $scope.alerts = {};
           var newSecret = constructSecretObject($scope.newSecret.data, $scope.newSecret.authType);

--- a/app/views/directives/create-secret.html
+++ b/app/views/directives/create-secret.html
@@ -113,7 +113,6 @@
         <div ui-ace="{
           mode: 'txt',
           theme: 'eclipse',
-          onLoad: aceLoaded,
           rendererOptions: {
             fadeFoldWidgets: true,
             showPrintMargin: false
@@ -136,7 +135,6 @@
           show-values="false"></osc-file-input>
         <div ui-ace="{
           theme: 'eclipse',
-          onLoad: aceLoaded,
           rendererOptions: {
             fadeFoldWidgets: true,
             showPrintMargin: false 
@@ -171,7 +169,6 @@
         <div ui-ace="{
           mode: 'ini',
           theme: 'eclipse',
-          onLoad: aceLoaded,
           rendererOptions: {
             fadeFoldWidgets: true,
             showPrintMargin: false 
@@ -256,7 +253,7 @@
         <div ui-ace="{
           mode: 'json',
           theme: 'eclipse',
-          onLoad: aceLoaded,
+          onChange: aceChanged,
           rendererOptions: {
             fadeFoldWidgets: true,
             showPrintMargin: false 
@@ -264,6 +261,11 @@
         }" ng-model="newSecret.data.dockerConfig" class="create-secret-editor ace-bordered" id="dockerconfig-editor" required></div>
         <div class="help-block">
           File with credentials and other configuration for connecting to a secured image registry.
+        </div>
+        <div class="has-warning" ng-show="invalidConfigFormat">
+          <span class="help-block">
+            Configuration file should be in JSON format.
+          </span>
         </div>
       </div>
     </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8121,8 +8121,16 @@ details:d("getErrorDetails")(a)
 }
 };
 });
-};
-c.create = function() {
+}, g = _.debounce(function() {
+try {
+JSON.parse(c.newSecret.data.dockerConfig), c.invalidConfigFormat = !1;
+} catch (a) {
+c.invalidConfigFormat = !0;
+}
+}, 300, {
+leading:!0
+});
+c.aceChanged = g, c.create = function() {
 c.alerts = {};
 var g = e(c.newSecret.data, c.newSecret.authType);
 a.create("secrets", null, g, c).then(function(a) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5305,7 +5305,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ui-ace=\"{\n" +
     "          mode: 'txt',\n" +
     "          theme: 'eclipse',\n" +
-    "          onLoad: aceLoaded,\n" +
     "          rendererOptions: {\n" +
     "            fadeFoldWidgets: true,\n" +
     "            showPrintMargin: false\n" +
@@ -5319,7 +5318,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<osc-file-input id=\"private-key-file-input\" model=\"newSecret.data.privateKey\" drop-zone-id=\"private-key\" dragging=\"false\" help-text=\"Upload your private SSH key file.\" show-values=\"false\"></osc-file-input>\n" +
     "<div ui-ace=\"{\n" +
     "          theme: 'eclipse',\n" +
-    "          onLoad: aceLoaded,\n" +
     "          rendererOptions: {\n" +
     "            fadeFoldWidgets: true,\n" +
     "            showPrintMargin: false \n" +
@@ -5345,7 +5343,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ui-ace=\"{\n" +
     "          mode: 'ini',\n" +
     "          theme: 'eclipse',\n" +
-    "          onLoad: aceLoaded,\n" +
     "          rendererOptions: {\n" +
     "            fadeFoldWidgets: true,\n" +
     "            showPrintMargin: false \n" +
@@ -5386,7 +5383,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ui-ace=\"{\n" +
     "          mode: 'json',\n" +
     "          theme: 'eclipse',\n" +
-    "          onLoad: aceLoaded,\n" +
+    "          onChange: aceChanged,\n" +
     "          rendererOptions: {\n" +
     "            fadeFoldWidgets: true,\n" +
     "            showPrintMargin: false \n" +
@@ -5394,6 +5391,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "        }\" ng-model=\"newSecret.data.dockerConfig\" class=\"create-secret-editor ace-bordered\" id=\"dockerconfig-editor\" required></div>\n" +
     "<div class=\"help-block\">\n" +
     "File with credentials and other configuration for connecting to a secured image registry.\n" +
+    "</div>\n" +
+    "<div class=\"has-warning\" ng-show=\"invalidConfigFormat\">\n" +
+    "<span class=\"help-block\">\n" +
+    "Configuration file should be in JSON format.\n" +
+    "</span>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
Adding a warning that the input should be in a JSON format.
Screen:
![screenshot-52](https://cloud.githubusercontent.com/assets/1668218/19774915/f9b038fc-9c6e-11e6-853b-59f3a699186d.png)

The blocking of the creation will be fixed as part of https://github.com/openshift/origin-web-console/pull/723

@spadgett PTAL