### PR TITLE
Bug 1389685 - Support empty input of destinationDir on BC editor page

### DIFF
--- a/app/scripts/controllers/edit/buildConfig.js
+++ b/app/scripts/controllers/edit/buildConfig.js
@@ -385,10 +385,12 @@ angular.module('openshiftConsole')
     };
 
     var updateSourceSecrets = function(object, pickedSecrets) {
-      var lastPickedSecret = _.head(pickedSecrets);
-      var property = $scope.strategyType === "Custom" ? "mountPath" : "destinationDir";
-      if (lastPickedSecret[property]) {
-        object.secrets = pickedSecrets;
+      var property = $scope.strategyType === "Custom" ? "secretSource" : "secret";
+      var nonEmptySecrets = _.filter(pickedSecrets, function(secret) {
+        return secret[property].name;
+      });
+      if (!_.isEmpty(nonEmptySecrets)) {
+        object.secrets = nonEmptySecrets;
       } else {
         delete object.secrets;
       }

--- a/app/scripts/directives/oscSourceSecrets.js
+++ b/app/scripts/directives/oscSourceSecrets.js
@@ -21,9 +21,9 @@ angular.module("openshiftConsole")
           var lastSecret = _.last($scope.pickedSecrets);
           switch ($scope.strategyType) {
           case 'Custom':
-            return lastSecret.secretSource.name && lastSecret.mountPath;
+            return lastSecret.secretSource.name;
           default:
-            return lastSecret.secret.name && lastSecret.destinationDir;
+            return lastSecret.secret.name;
           }
         };
 

--- a/app/views/directives/osc-source-secrets.html
+++ b/app/views/directives/osc-source-secrets.html
@@ -27,8 +27,7 @@
                   placeholder="/"
                   autocorrect="off"
                   autocapitalize="off"
-                  spellcheck="false"
-                  ng-required="pickedSecret.secret.name">
+                  spellcheck="false">
               </div>
             </div>
             <div class="remove-secret">
@@ -59,9 +58,9 @@
         <div class="row advanced-secrets">
           <div class="col-lg-6">
             <label class="picker-label" ng-if="$first">Build Secret</label>
-            <ui-select ng-required="pickedSecret.mountPath !== ''" ng-model="pickedSecret.secretSource.name">
+            <ui-select ng-required="pickedSecret.mountPath" ng-model="pickedSecret.secretSource.name">
               <ui-select-match placeholder="Secret name">{{$select.selected}}</ui-select-match>
-              <ui-select-choices repeat="secret in (secretsByType | filter : $select.search)">
+              <ui-select-choices repeat="secret in (secretsByType[type] | filter : $select.search)">
                 <div ng-bind-html="secret | highlight : $select.search"></div>
               </ui-select-choices>
             </ui-select>
@@ -81,8 +80,7 @@
                   placeholder="/"
                   autocorrect="off"
                   autocapitalize="off"
-                  spellcheck="false"
-                  ng-required="pickedSecret.sourceSecret.name">
+                  spellcheck="false">
               </div>
             </div>
             <div class="remove-secret">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -6475,8 +6475,10 @@ mountPath:""
 }, u = function(a, b, c) {
 b.name ? a[c] = b :delete a[c];
 }, v = function(b, c) {
-var d = _.head(c), e = "Custom" === a.strategyType ? "mountPath" :"destinationDir";
-d[e] ? b.secrets = c :delete b.secrets;
+var d = "Custom" === a.strategyType ? "secretSource" :"secret", e = _.filter(c, function(a) {
+return a[d].name;
+});
+_.isEmpty(e) ? delete b.secrets :b.secrets = e;
 }, w = function(a, b) {
 return "None" === b.type ? a :(a.none = !1, angular.forEach(b, function(b, c) {
 a[c] = !0;
@@ -9185,10 +9187,10 @@ b.canAddSourceSecret = function() {
 var a = _.last(b.pickedSecrets);
 switch (b.strategyType) {
 case "Custom":
-return a.secretSource.name && a.mountPath;
+return a.secretSource.name;
 
 default:
-return a.secret.name && a.destinationDir;
+return a.secret.name;
 }
 }, b.setLastSecretsName = function(a) {
 var c = _.last(b.pickedSecrets);

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7090,7 +7090,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Destination Directory\n" +
     "</label>\n" +
     "<div>\n" +
-    "<input class=\"form-control\" id=\"destinationDir\" name=\"destinationDir\" ng-model=\"pickedSecret.destinationDir\" type=\"text\" placeholder=\"/\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck ng-required=\"pickedSecret.secret.name\">\n" +
+    "<input class=\"form-control\" id=\"destinationDir\" name=\"destinationDir\" ng-model=\"pickedSecret.destinationDir\" type=\"text\" placeholder=\"/\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"remove-secret\">\n" +
@@ -7120,9 +7120,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"row advanced-secrets\">\n" +
     "<div class=\"col-lg-6\">\n" +
     "<label class=\"picker-label\" ng-if=\"$first\">Build Secret</label>\n" +
-    "<ui-select ng-required=\"pickedSecret.mountPath !== ''\" ng-model=\"pickedSecret.secretSource.name\">\n" +
+    "<ui-select ng-required=\"pickedSecret.mountPath\" ng-model=\"pickedSecret.secretSource.name\">\n" +
     "<ui-select-match placeholder=\"Secret name\">{{$select.selected}}</ui-select-match>\n" +
-    "<ui-select-choices repeat=\"secret in (secretsByType | filter : $select.search)\">\n" +
+    "<ui-select-choices repeat=\"secret in (secretsByType[type] | filter : $select.search)\">\n" +
     "<div ng-bind-html=\"secret | highlight : $select.search\"></div>\n" +
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
@@ -7133,7 +7133,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Mount path\n" +
     "</label>\n" +
     "<div>\n" +
-    "<input class=\"form-control\" id=\"mountPath\" name=\"mountPath\" ng-model=\"pickedSecret.mountPath\" type=\"text\" placeholder=\"/\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck ng-required=\"pickedSecret.sourceSecret.name\">\n" +
+    "<input class=\"form-control\" id=\"mountPath\" name=\"mountPath\" ng-model=\"pickedSecret.mountPath\" type=\"text\" placeholder=\"/\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"remove-secret\">\n" +


### PR DESCRIPTION
Fixes two bugzillas:
- https://bugzilla.redhat.com/show_bug.cgi?id=1388812
- https://bugzilla.redhat.com/show_bug.cgi?id=1389685

Since the `destinationDir` && `mountPoint` parameters are not mandatory had to remove the ng-required attribute + adjust the logic for saving and adding the secrets.

@spadgett PTAL