### PR TITLE
Allow filtering on project requester

### DIFF
--- a/app/scripts/controllers/projects.js
+++ b/app/scripts/controllers/projects.js
@@ -33,7 +33,8 @@ angular.module('openshiftConsole')
     var filterFields = [
       'metadata.name',
       'metadata.annotations["openshift.io/display-name"]',
-      'metadata.annotations["openshift.io/description"]'
+      'metadata.annotations["openshift.io/description"]',
+      'metadata.annotations["openshift.io/requester"]'
     ];
 
     var filterProjects = function() {
@@ -41,8 +42,15 @@ angular.module('openshiftConsole')
         KeywordService.filterForKeywords(sortedProjects, filterFields, filterKeywords);
     };
 
+    var previousSortID;
     var sortProjects = function() {
       var sortID = _.get($scope, 'sortConfig.currentField.id');
+
+      if (previousSortID !== sortID) {
+        // Default to desc for creation timestamp. Otherwise default to asc.
+        $scope.sortConfig.isAscending = sortID !== 'metadata.creationTimestamp';
+      }
+
       var sortValue = function(project) {
         var value = _.get(project, sortID) || _.get(project, 'metadata.name', '');
 
@@ -53,6 +61,9 @@ angular.module('openshiftConsole')
       sortedProjects = _.sortByOrder(projects,
                                      [ sortValue ],
                                      [ $scope.sortConfig.isAscending ? 'asc' : 'desc' ]);
+
+      // Remember the previous sort ID.
+      previousSortID = sortID;
     };
 
     var update = function() {
@@ -69,6 +80,14 @@ angular.module('openshiftConsole')
       }, {
         id: 'metadata.name',
         title: 'Name',
+        sortType: 'alpha'
+      }, {
+        id: 'metadata.annotations["openshift.io/requester"]',
+        title: 'Creator',
+        sortType: 'alpha'
+      }, {
+        id: 'metadata.creationTimestamp',
+        title: 'Creation Date',
         sortType: 'alpha'
       }],
       isAscending: true,

--- a/app/styles/_projects.less
+++ b/app/styles/_projects.less
@@ -91,6 +91,11 @@
       }
     }
   }
+  .projects-sort-label {
+    .hidden-xs();
+    margin-right: 6px;
+    padding-top: 3px;
+  }
   .projects-sort {
     flex: 1 0 auto;
     .form-group {

--- a/app/views/projects.html
+++ b/app/views/projects.html
@@ -52,6 +52,7 @@
                               </div>
                             </form>
                             <span class="vertical-divider"></span>
+                            <span class="projects-sort-label">Sort by</span>
                             <div class="projects-sort">
                               <div pf-sort config="sortConfig" class="sort-controls"></div>
                             </div>
@@ -96,7 +97,12 @@
                                   title="This project has been marked for deletion."
                                   class="pficon pficon-warning-triangle-o"></span>
                               </h2>
-                              <p class="hidden-xs project-name-item" ng-if="project | displayName : true">{{project.metadata.name}}</p>
+                              <small>
+                                <span ng-if="project | displayName : true">{{project.metadata.name}} &ndash;</span>
+                                created
+                                <span ng-if="project | annotation : 'openshift.io/requester'">by {{project | annotation : 'openshift.io/requester'}}</span>
+                                <relative-timestamp timestamp="project.metadata.creationTimestamp"></relative-timestamp>
+                              </small>
                             </div>
                             <div class="list-view-pf-additional-info project-additional-info">
                               <span class="list-group-item-text project-description">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3805,16 +3805,18 @@ var k, l, m = [], n = [];
 a.alerts = a.alerts || {}, a.loading = !0, a.showGetStarted = !1, a.canCreate = void 0, a.search = {
 text:""
 };
-var o = [ "metadata.name", 'metadata.annotations["openshift.io/display-name"]', 'metadata.annotations["openshift.io/description"]' ], p = function() {
-a.projects = i.filterForKeywords(l, o, n);
-}, q = function() {
-var b = _.get(a, "sortConfig.currentField.id"), c = function(a) {
+var o, p = [ "metadata.name", 'metadata.annotations["openshift.io/display-name"]', 'metadata.annotations["openshift.io/description"]', 'metadata.annotations["openshift.io/requester"]' ], q = function() {
+a.projects = i.filterForKeywords(l, p, n);
+}, r = function() {
+var b = _.get(a, "sortConfig.currentField.id");
+o !== b && (a.sortConfig.isAscending = "metadata.creationTimestamp" !== b);
+var c = function(a) {
 var c = _.get(a, b) || _.get(a, "metadata.name", "");
 return c.toLowerCase();
 };
-l = _.sortByOrder(k, [ c ], [ a.sortConfig.isAscending ? "asc" :"desc" ]);
-}, r = function() {
-q(), p();
+l = _.sortByOrder(k, [ c ], [ a.sortConfig.isAscending ? "asc" :"desc" ]), o = b;
+}, s = function() {
+r(), q();
 };
 a.sortConfig = {
 fields:[ {
@@ -3825,18 +3827,26 @@ sortType:"alpha"
 id:"metadata.name",
 title:"Name",
 sortType:"alpha"
+}, {
+id:'metadata.annotations["openshift.io/requester"]',
+title:"Creator",
+sortType:"alpha"
+}, {
+id:"metadata.creationTimestamp",
+title:"Creation Date",
+sortType:"alpha"
 } ],
 isAscending:!0,
-onSortChange:r
+onSortChange:s
 }, f.getAlerts().forEach(function(b) {
 a.alerts[b.name] = b.data;
 }), f.clearAlerts(), a.$watch("search.text", _.debounce(function(b) {
-n = i.generateKeywords(b), a.$apply(p);
+n = i.generateKeywords(b), a.$apply(q);
 }, 50, {
 maxWait:250
 })), g.withUser().then(function() {
 m.push(h.watch("projects", a, function(b) {
-k = _.toArray(b.by("metadata.name")), a.loading = !1, a.showGetStarted = _.isEmpty(k), r();
+k = _.toArray(b.by("metadata.name")), a.loading = !1, a.showGetStarted = _.isEmpty(k), s();
 }));
 }), h.get("projectrequests", null, a, {
 errorNotification:!1

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -10269,6 +10269,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</form>\n" +
     "<span class=\"vertical-divider\"></span>\n" +
+    "<span class=\"projects-sort-label\">Sort by</span>\n" +
     "<div class=\"projects-sort\">\n" +
     "<div pf-sort config=\"sortConfig\" class=\"sort-controls\"></div>\n" +
     "</div>\n" +
@@ -10301,7 +10302,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a class=\"tile-target\" ng-href=\"project/{{project.metadata.name}}\">{{project | displayName}}</a>\n" +
     "<span ng-if=\"project.status.phase != 'Active'\" data-toggle=\"tooltip\" title=\"This project has been marked for deletion.\" class=\"pficon pficon-warning-triangle-o\"></span>\n" +
     "</h2>\n" +
-    "<p class=\"hidden-xs project-name-item\" ng-if=\"project | displayName : true\">{{project.metadata.name}}</p>\n" +
+    "<small>\n" +
+    "<span ng-if=\"project | displayName : true\">{{project.metadata.name}} &ndash;</span>\n" +
+    "created\n" +
+    "<span ng-if=\"project | annotation : 'openshift.io/requester'\">by {{project | annotation : 'openshift.io/requester'}}</span>\n" +
+    "<relative-timestamp timestamp=\"project.metadata.creationTimestamp\"></relative-timestamp>\n" +
+    "</small>\n" +
     "</div>\n" +
     "<div class=\"list-view-pf-additional-info project-additional-info\">\n" +
     "<span class=\"list-group-item-text project-description\">\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4878,6 +4878,9 @@ kubernetes-topology-graph{height:700px}
 .projects-bar .projects-search{display:flex;margin-bottom:20px}
 .projects-bar .projects-search .search-pf{display:block;flex:0 1 auto}
 .projects-bar .projects-search .search-pf.has-button .form-group{display:block}
+.projects-bar .projects-sort-label{margin-right:6px;padding-top:3px}
+@media (max-width:767px){.projects-bar .projects-sort-label{display:none!important}
+}
 .projects-bar .projects-sort{flex:1 0 auto}
 .projects-bar .projects-sort .form-group{margin:0}
 .projects-bar .vertical-divider{border-left:1px solid #bbb;display:inline-block;height:27px;margin:0 7px;vertical-align:middle;width:1px}


### PR DESCRIPTION
Show the project requester with the creation date in small text below
the project display name. Let users filter on the requester so they can
list the projects they created. Allow sorting by creator or creation date.

Fixes #764

![screen shot 2016-10-31 at 9 45 42 am](https://cloud.githubusercontent.com/assets/1167259/19856502/1b0ff422-9f50-11e6-98f4-d0ccce8bf4b7.png)

@jwforres PTAL
@sspeiche CC