### PR TITLE
Bug fix 1389734- Double links due to logic check error

### DIFF
--- a/app/views/browse/deployment-config.html
+++ b/app/views/browse/deployment-config.html
@@ -158,7 +158,7 @@
                             <span ng-if="!('deploymentconfigs' | canI : 'update')">none</span>
                           </p>
                           <volumes volumes="deploymentConfig.spec.template.spec.volumes" namespace="project.metadata.name"></volumes>
-                          <p ng-if="deploymentConfig.spec.template.spec.volumes.length && 'deploymentconfigs' | canI : 'update' ">
+                          <p ng-if="deploymentConfig.spec.template.spec.volumes.length && ('deploymentconfigs' | canI : 'update') ">
                             <a ng-href="project/{{project.metadata.name}}/attach-pvc?kind=DeploymentConfig&name={{deploymentConfig.metadata.name}}">Attach storage</a>
                           </p>
                         </div>

--- a/app/views/browse/deployment.html
+++ b/app/views/browse/deployment.html
@@ -173,7 +173,7 @@
                           <span ng-if="!('deploymentconfigs' | canI : 'update')">none</span>
                         </p>
                         <volumes volumes="deployment.spec.template.spec.volumes" namespace="project.metadata.name"></volumes>
-                        <p ng-if="deployment.spec.template.spec.volumes.length && 'deploymentconfigs' | canI : 'update'">
+                        <p ng-if="deployment.spec.template.spec.volumes.length && ('deploymentconfigs' | canI : 'update')">
                           <a ng-href="project/{{project.metadata.name}}/attach-pvc?kind=Deployment&name={{deployment.metadata.name}}&group=extensions">Attach storage</a>
                         </p>
                       </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2080,7 +2080,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"!('deploymentconfigs' | canI : 'update')\">none</span>\n" +
     "</p>\n" +
     "<volumes volumes=\"deploymentConfig.spec.template.spec.volumes\" namespace=\"project.metadata.name\"></volumes>\n" +
-    "<p ng-if=\"deploymentConfig.spec.template.spec.volumes.length && 'deploymentconfigs' | canI : 'update' \">\n" +
+    "<p ng-if=\"deploymentConfig.spec.template.spec.volumes.length && ('deploymentconfigs' | canI : 'update') \">\n" +
     "<a ng-href=\"project/{{project.metadata.name}}/attach-pvc?kind=DeploymentConfig&name={{deploymentConfig.metadata.name}}\">Attach storage</a>\n" +
     "</p>\n" +
     "</div>\n" +
@@ -2369,7 +2369,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"!('deploymentconfigs' | canI : 'update')\">none</span>\n" +
     "</p>\n" +
     "<volumes volumes=\"deployment.spec.template.spec.volumes\" namespace=\"project.metadata.name\"></volumes>\n" +
-    "<p ng-if=\"deployment.spec.template.spec.volumes.length && 'deploymentconfigs' | canI : 'update'\">\n" +
+    "<p ng-if=\"deployment.spec.template.spec.volumes.length && ('deploymentconfigs' | canI : 'update')\">\n" +
     "<a ng-href=\"project/{{project.metadata.name}}/attach-pvc?kind=Deployment&name={{deployment.metadata.name}}&group=extensions\">Attach storage</a>\n" +
     "</p>\n" +
     "</div>\n" +


### PR DESCRIPTION
Double links on the deployment pages due to a logic error (forgot parens)