### PR TITLE
Show content directly if only one subcategory has items

### DIFF
--- a/app/scripts/directives/catalog.js
+++ b/app/scripts/directives/catalog.js
@@ -91,8 +91,10 @@ angular.module('openshiftConsole')
           updateState();
         }
 
+        var nonEmptyCategories;
         function updateCategoryCounts() {
           $scope.noFilterMatches = true;
+          nonEmptyCategories = [];
 
           var countByCategory = {};
           _.each($scope.filteredBuildersByCategory, function(builders, id) {
@@ -105,8 +107,12 @@ angular.module('openshiftConsole')
           // Check to see if entire categories have content.
           $scope.allContentHidden = true;
           _.each($scope.categories, function(category) {
-            var hasContent = _.some(category.items, function(item) {
-              return countByCategory[item.id];
+            var hasContent = false;
+            _.each(category.items, function(item) {
+              if (countByCategory[item.id]) {
+                nonEmptyCategories.push(item);
+                hasContent = true;
+              }
             });
             _.set($scope, ['hasContent', category.id], hasContent);
             if (hasContent) {
@@ -130,6 +136,11 @@ angular.module('openshiftConsole')
           updateCategoryCounts();
 
           if ($scope.loaded) {
+            if ($scope.parentCategory && nonEmptyCategories.length === 1) {
+              // If there is only one subcategory with items, just show the items.
+              $scope.singleCategory = _.head(nonEmptyCategories);
+            }
+
             Logger.log("templates by category", $scope.templatesByCategory);
             Logger.log("builder images", $scope.buildersByCategory);
           }

--- a/app/views/catalog/catalog.html
+++ b/app/views/catalog/catalog.html
@@ -1,6 +1,6 @@
-<p ng-if="emptyCatalog && !loaded">Loading...</p>
+<p ng-if="!loaded">Loading...</p>
 
-<div ng-if="emptyCatalog && loaded && !nonBuilderImages.length" class="empty-state-message empty-state-full-page">
+<div ng-if="emptyCatalog && loaded" class="empty-state-message empty-state-full-page">
   <h2 class="text-center">No images or templates.</h2>
 
   <p class="gutter-top">
@@ -18,11 +18,7 @@
   <p><a href="{{projectName | projectOverviewURL}}">Back to overview</a></p>
 </div>
 
-<!-- Show an abbreviated message if only non-builders exist in the project.
-     We show a link to view the non-builder images below. -->
-<p ng-if="emptyCatalog && loaded && nonBuilderImages.length">No builder images or templates.</p>
-
-<div ng-show="!emptyCatalog">
+<div ng-show="!emptyCatalog && loaded && !singleCategory">
   <p ng-if="!parentCategory">Choose from web frameworks, databases, and other components to
   add content to your project.</p>
 
@@ -111,3 +107,14 @@
   </div>
 </div>
 
+<!-- If there is only one subcategory with items, just show the items. -->
+<div ng-if="singleCategory">
+  <category-content
+      project-name="projectName"
+      project-image-streams="projectImageStreams"
+      openshift-image-streams="openshiftImageStreams"
+      project-templates="projectTemplates"
+      openshift-templates="openshiftTemplates"
+      category="singleCategory">
+  </category-content>
+</div>

--- a/app/views/catalog/category-content.html
+++ b/app/views/catalog/category-content.html
@@ -1,4 +1,4 @@
-<p ng-if="emptyCategory && !loaded">Loading...</p>
+<p ng-if="!loaded">Loading...</p>
 
 <div ng-if="emptyCategory && loaded" class="empty-state-message empty-state-full-page">
   <h2 class="text-center">No images or templates.</h2>
@@ -16,7 +16,7 @@
   <p><a ng-href="project/{{projectName}}/create">Back to catalog</a></p>
 </div>
 
-<div ng-if="!emptyCategory && !catalog.subcategories">
+<div ng-if="loaded && !emptyCategory && !catalog.subcategories">
   <form role="form" fit class="search-pf has-button mar-bottom-xl">
     <div class="form-group has-clear">
       <!-- Add a hidden label for screen readers. -->

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10001,21 +10001,21 @@ e.templatesByCategory = a.categorizeTemplates(b), e.emptyCatalog = e.emptyCatalo
 }
 }
 function i() {
-e.noFilterMatches = !0;
+e.noFilterMatches = !0, k = [];
 var a = {};
 _.each(e.filteredBuildersByCategory, function(b, c) {
 a[c] = _.size(b);
 }), _.each(e.filteredTemplatesByCategory, function(b, c) {
 a[c] = (a[c] || 0) + _.size(b);
 }), e.allContentHidden = !0, _.each(e.categories, function(b) {
-var c = _.some(b.items, function(b) {
-return a[b.id];
-});
-_.set(e, [ "hasContent", b.id ], c), c && (e.allContentHidden = !1);
+var c = !1;
+_.each(b.items, function(b) {
+a[b.id] && (k.push(b), c = !0);
+}), _.set(e, [ "hasContent", b.id ], c), c && (e.allContentHidden = !1);
 }), e.countByCategory = a;
 }
 function j() {
-e.loaded = e.projectTemplates && e.openshiftTemplates && e.projectImageStreams && e.openshiftImageStreams, f(), i(), e.loaded && (d.log("templates by category", e.templatesByCategory), d.log("builder images", e.buildersByCategory));
+e.loaded = e.projectTemplates && e.openshiftTemplates && e.projectImageStreams && e.openshiftImageStreams, f(), i(), e.loaded && (e.parentCategory && 1 === k.length && (e.singleCategory = _.head(k)), d.log("templates by category", e.templatesByCategory), d.log("builder images", e.buildersByCategory));
 }
 e.categories = _.get(e, "parentCategory.subcategories", b.CATALOG_CATEGORIES), e.loaded = !1, e.emptyCatalog = !0, e.filter = {
 keyword:""
@@ -10026,7 +10026,9 @@ f(), i();
 }, 200, {
 maxWait:1e3,
 trailing:!0
-})), e.$watchGroup([ "openshiftImageStreams", "projectImageStreams" ], g), e.$watchGroup([ "openshiftTemplates", "projectTemplates" ], h);
+}));
+var k;
+e.$watchGroup([ "openshiftImageStreams", "projectImageStreams" ], g), e.$watchGroup([ "openshiftTemplates", "projectTemplates" ], h);
 }
 };
 } ]), angular.module("openshiftConsole").directive("categoryContent", [ "CatalogService", "Constants", "KeywordService", "Logger", function(a, b, c, d) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3721,8 +3721,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/catalog/catalog.html',
-    "<p ng-if=\"emptyCatalog && !loaded\">Loading...</p>\n" +
-    "<div ng-if=\"emptyCatalog && loaded && !nonBuilderImages.length\" class=\"empty-state-message empty-state-full-page\">\n" +
+    "<p ng-if=\"!loaded\">Loading...</p>\n" +
+    "<div ng-if=\"emptyCatalog && loaded\" class=\"empty-state-message empty-state-full-page\">\n" +
     "<h2 class=\"text-center\">No images or templates.</h2>\n" +
     "<p class=\"gutter-top\">\n" +
     "No images or templates are loaded for this project or the shared\n" +
@@ -3735,9 +3735,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "<p><a href=\"{{projectName | projectOverviewURL}}\">Back to overview</a></p>\n" +
     "</div>\n" +
-    "\n" +
-    "<p ng-if=\"emptyCatalog && loaded && nonBuilderImages.length\">No builder images or templates.</p>\n" +
-    "<div ng-show=\"!emptyCatalog\">\n" +
+    "<div ng-show=\"!emptyCatalog && loaded && !singleCategory\">\n" +
     "<p ng-if=\"!parentCategory\">Choose from web frameworks, databases, and other components to add content to your project.</p>\n" +
     "<form role=\"form\" fit class=\"search-pf has-button\">\n" +
     "<div class=\"form-group has-clear\">\n" +
@@ -3799,12 +3797,17 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
+    "</div>\n" +
+    "\n" +
+    "<div ng-if=\"singleCategory\">\n" +
+    "<category-content project-name=\"projectName\" project-image-streams=\"projectImageStreams\" openshift-image-streams=\"openshiftImageStreams\" project-templates=\"projectTemplates\" openshift-templates=\"openshiftTemplates\" category=\"singleCategory\">\n" +
+    "</category-content>\n" +
     "</div>"
   );
 
 
   $templateCache.put('views/catalog/category-content.html',
-    "<p ng-if=\"emptyCategory && !loaded\">Loading...</p>\n" +
+    "<p ng-if=\"!loaded\">Loading...</p>\n" +
     "<div ng-if=\"emptyCategory && loaded\" class=\"empty-state-message empty-state-full-page\">\n" +
     "<h2 class=\"text-center\">No images or templates.</h2>\n" +
     "<p class=\"gutter-top\">\n" +
@@ -3817,7 +3820,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "<p><a ng-href=\"project/{{projectName}}/create\">Back to catalog</a></p>\n" +
     "</div>\n" +
-    "<div ng-if=\"!emptyCategory && !catalog.subcategories\">\n" +
+    "<div ng-if=\"loaded && !emptyCategory && !catalog.subcategories\">\n" +
     "<form role=\"form\" fit class=\"search-pf has-button mar-bottom-xl\">\n" +
     "<div class=\"form-group has-clear\">\n" +
     "\n" +


### PR DESCRIPTION
If only one add-to-project subcategory has items, show those items directly instead of making users click through to see them.

@jwforres PTAL