### PR TITLE
Fix minification issue with overview metrics

### DIFF
--- a/app/views/overview/_dc.html
+++ b/app/views/overview/_dc.html
@@ -131,7 +131,7 @@
         ng-if="showMetrics && !collapse"
         pods="podsByOwnerUID[activeReplicationController.metadata.uid]"
         containers="activeReplicationController.spec.template.spec.containers"
-        compact="true"
+        profile="compact"
         class="overview-metrics">
       </deployment-metrics>
       <pod-template ng-if="!showMetrics" pod-template="activeReplicationController.spec.template"></pod-template>

--- a/app/views/overview/_deployment.html
+++ b/app/views/overview/_deployment.html
@@ -68,7 +68,7 @@
         ng-if="showMetrics && !collapse"
         pods="podsByOwnerUID[latestReplicaSet.metadata.uid]"
         containers="latestReplicaSet.spec.template.spec.containers"
-        compact="true"
+        profile="compact"
         class="overview-metrics">
       </deployment-metrics>
       <pod-template ng-if="!showMetrics" pod-template="latestReplicaSet.spec.template"></pod-template>

--- a/app/views/overview/_pod.html
+++ b/app/views/overview/_pod.html
@@ -33,7 +33,7 @@
         ng-if="showMetrics && !collapse"
         pods="[pod]"
         containers="pod.spec.containers"
-        compact="true"
+        profile="compact"
         class="overview-metrics">
       </deployment-metrics>
       <pod-template ng-if="!showMetrics" pod-template="pod"></pod-template>

--- a/app/views/overview/_set.html
+++ b/app/views/overview/_set.html
@@ -40,7 +40,7 @@
         ng-if="showMetrics && !collapse"
         pods="podsByOwnerUID[set.metadata.uid]"
         containers="set.spec.template.spec.containers"
-        compact="true"
+        profile="compact"
         class="overview-metrics">
       </deployment-metrics>
       <pod-template ng-if="!showMetrics" pod-template="set.spec.template"></pod-template>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10488,34 +10488,34 @@ restrict:"E",
 scope:{
 pods:"=",
 containers:"=",
-compact:"="
+profile:"@"
 },
 templateUrl:function(a, b) {
-return b.compact ? "views/directives/metrics-compact.html" :"views/directives/deployment-metrics.html";
+return "compact" === b.profile ? "views/directives/metrics-compact.html" :"views/directives/deployment-metrics.html";
 },
 link:function(b) {
 function d(a) {
 return null === a.value || void 0 === a.value;
 }
 function f(a) {
-var c;
-c = b.compact ? a.compactDatasetLabel || a.label :"Average Usage";
-var e = {}, f = [ "Date" ], g = [ c ], h = [ f, g ], i = function(a) {
+var b;
+b = w ? a.compactDatasetLabel || a.label :"Average Usage";
+var c = {}, e = [ "Date" ], f = [ b ], g = [ e, f ], h = function(a) {
 var b = "" + a.start;
-return e[b] || (e[b] = {
+return c[b] || (c[b] = {
 total:0,
 count:0
-}), e[b];
+}), c[b];
 };
-return _.each(z[a.descriptor], function(a) {
+return _.each(A[a.descriptor], function(a) {
 _.each(a, function(a) {
-var b = i(a);
-(!x || x < a.end) && (x = a.end), d(a) || (b.total += a.value, b.count = b.count + 1);
+var b = h(a);
+(!y || y < a.end) && (y = a.end), d(a) || (b.total += a.value, b.count = b.count + 1);
 });
-}), _.each(e, function(b, c) {
+}), _.each(c, function(b, c) {
 var d;
-d = b.count ? b.total / b.count :null, f.push(Number(c)), g.push(a.convert ? a.convert(d) :d);
-}), g.length > 1 && (a.lastValue = _.last(g) || 0), h;
+d = b.count ? b.total / b.count :null, e.push(Number(c)), f.push(a.convert ? a.convert(d) :d);
+}), f.length > 1 && (a.lastValue = _.last(f) || 0), g;
 }
 function i(a, c) {
 var e = [], g = {
@@ -10523,13 +10523,13 @@ type:"spline"
 };
 return b.showAverage ? (_.each(a[c.descriptor], function(a, b) {
 p(c.descriptor, b, a);
-}), g.type = "area-spline", b.compact && c.compactType && (g.type = c.compactType), g.x = "Date", g.columns = f(c), g) :(_.each(a[c.descriptor], function(a, b) {
+}), g.type = "area-spline", w && c.compactType && (g.type = c.compactType), g.x = "Date", g.columns = f(c), g) :(_.each(a[c.descriptor], function(a, b) {
 p(c.descriptor, b, a);
 var f = b + "-dates";
 _.set(g, [ "xs", b ], f);
 var h = [ f ], i = [ b ];
-e.push(h), e.push(i), _.each(z[c.descriptor][b], function(a) {
-if (h.push(a.start), (!x || x < a.end) && (x = a.end), d(a)) i.push(a.value); else {
+e.push(h), e.push(i), _.each(A[c.descriptor][b], function(a) {
+if (h.push(a.start), (!y || y < a.end) && (y = a.end), d(a)) i.push(a.value); else {
 var b = c.convert ? c.convert(a.value) :a.value;
 i.push(b);
 }
@@ -10539,19 +10539,19 @@ return a[0];
 }), g);
 }
 function j(a) {
-w || (b.loaded = !0, b.showAverage = _.size(b.pods) > 5 || b.compact, _.each(b.metrics, function(c) {
+x || (b.loaded = !0, b.showAverage = _.size(b.pods) > 5 || w, _.each(b.metrics, function(c) {
 var d, e = i(a, c), f = c.descriptor;
-b.compact && c.compactCombineWith && (f = c.compactCombineWith, c.lastValue && (B[f].lastValue = (B[f].lastValue || 0) + c.lastValue)), t[f] ? (t[f].load(e), b.showAverage ? t[f].legend.hide() :t[f].legend.show()) :(d = C(c), d.data = e, t[f] = c3.generate(d));
+w && c.compactCombineWith && (f = c.compactCombineWith, c.lastValue && (C[f].lastValue = (C[f].lastValue || 0) + c.lastValue)), t[f] ? (t[f].load(e), b.showAverage ? t[f].legend.hide() :t[f].legend.show()) :(d = D(c), d.data = e, t[f] = c3.generate(d));
 }));
 }
 function k() {
-return b.compact ? "-15mn" :"-" + b.options.timeRange.value + "mn";
+return w ? "-15mn" :"-" + b.options.timeRange.value + "mn";
 }
 function l() {
 return 60 * b.options.timeRange.value * 1e3;
 }
 function m() {
-return b.compact ? "1mn" :Math.floor(l() / v) + "ms";
+return w ? "1mn" :Math.floor(l() / v) + "ms";
 }
 function n() {
 var a = _.find(b.pods, "metadata.namespace");
@@ -10562,7 +10562,7 @@ containerName:b.options.selectedContainer.name,
 namespace:a.metadata.namespace,
 bucketDuration:m()
 };
-return x ? c.start = x :c.start = k(), c;
+return y ? c.start = y :c.start = k(), c;
 }
 }
 function o() {
@@ -10571,10 +10571,10 @@ return a ? (b.loaded = !0, !1) :!b.metricsError;
 }
 function p(a, c, d) {
 b.noData = !1;
-var e = _.initial(d), f = _.get(z, [ a, c ]);
-if (!f) return void _.set(z, [ a, c ], e);
+var e = _.initial(d), f = _.get(A, [ a, c ]);
+if (!f) return void _.set(A, [ a, c ], e);
 var g = _.takeRight(f.concat(e), v);
-_.set(z, [ a, c ], g);
+_.set(A, [ a, c ], g);
 }
 function q(a) {
 b.loaded = !0, b.metricsError = {
@@ -10583,15 +10583,15 @@ details:_.get(a, "data.errorMsg") || _.get(a, "statusText") || "Status code " + 
 };
 }
 function r() {
-if (!A && o()) {
-y = Date.now();
+if (!B && o()) {
+z = Date.now();
 var a = n();
 h.getPodMetrics(a).then(j, q);
 }
 }
-var s, t = {}, u = 6e4, v = 30, w = !1;
+var s, t = {}, u = 6e4, v = 30, w = "compact" === b.profile, x = !1;
 b.uniqueID = _.uniqueId("metrics-");
-var x, y, z = {}, A = b.compact;
+var y, z, A = {}, B = w;
 b.metrics = [ {
 label:"Memory",
 units:"MiB",
@@ -10626,7 +10626,7 @@ compactDatasetLabel:"Received",
 compactType:"spline",
 chartID:"network-rx-" + b.uniqueID
 } ];
-var B = _.indexBy(b.metrics, "descriptor");
+var C = _.indexBy(b.metrics, "descriptor");
 b.loaded = !1, b.noData = !0, h.getMetricsURL().then(function(a) {
 b.metricsURL = a;
 }), b.options = {
@@ -10647,12 +10647,12 @@ label:"Last week",
 value:10080
 } ]
 }, b.options.timeRange = _.head(b.options.rangeOptions), b.options.selectedContainer = _.head(b.containers);
-var C = function(a) {
+var D = function(a) {
 return {
 bindto:"#" + a.chartID,
 axis:{
 x:{
-show:!b.compact,
+show:!w,
 type:"timeseries",
 padding:{
 left:0,
@@ -10664,7 +10664,7 @@ format:"%a %H:%M"
 }
 },
 y:{
-show:!b.compact,
+show:!w,
 label:a.units,
 min:0,
 padding:{
@@ -10680,13 +10680,13 @@ return d3.round(a, 3);
 }
 },
 legend:{
-show:!b.compact && !b.showAverage
+show:!w && !b.showAverage
 },
 point:{
 show:!1
 },
 size:{
-height:b.compact ? 35 :175
+height:w ? 35 :175
 },
 tooltip:{
 format:{
@@ -10700,9 +10700,9 @@ return d3.round(b, 2) + " " + a.units;
 b.formatUsage = function(a) {
 return a < .01 ? "0" :a < 1 ? d3.format(".1r")(a) :d3.format(".2r")(a);
 }, b.$watch("options", function() {
-z = {}, x = null, delete b.metricsError, r();
+A = {}, y = null, delete b.metricsError, r();
 }, !0), s = a(r, u, !1), b.updateInView = function(a) {
-A = !a, a && (!y || Date.now() > y + u) && r();
+B = !a, a && (!z || Date.now() > z + u) && r();
 }, e.$on("metrics.charts.resize", function() {
 c(function() {
 _.each(t, function(a) {
@@ -10712,7 +10712,7 @@ a.flush();
 }), b.$on("$destroy", function() {
 s && (a.cancel(s), s = null), angular.forEach(t, function(a) {
 a.destroy();
-}), t = null, w = !0;
+}), t = null, x = !0;
 });
 }
 };

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -9556,7 +9556,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div column class=\"overview-tile-details\" ng-if=\"activeReplicationController && !inProgressDeployment\">\n" +
     "\n" +
     "\n" +
-    "<deployment-metrics ng-if=\"showMetrics && !collapse\" pods=\"podsByOwnerUID[activeReplicationController.metadata.uid]\" containers=\"activeReplicationController.spec.template.spec.containers\" compact class=\"overview-metrics\">\n" +
+    "<deployment-metrics ng-if=\"showMetrics && !collapse\" pods=\"podsByOwnerUID[activeReplicationController.metadata.uid]\" containers=\"activeReplicationController.spec.template.spec.containers\" profile=\"compact\" class=\"overview-metrics\">\n" +
     "</deployment-metrics>\n" +
     "<pod-template ng-if=\"!showMetrics\" pod-template=\"activeReplicationController.spec.template\"></pod-template>\n" +
     "\n" +
@@ -9618,7 +9618,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div column class=\"overview-tile-details\" ng-if=\"latestReplicaSet && !inProgressDeployment\">\n" +
     "\n" +
     "\n" +
-    "<deployment-metrics ng-if=\"showMetrics && !collapse\" pods=\"podsByOwnerUID[latestReplicaSet.metadata.uid]\" containers=\"latestReplicaSet.spec.template.spec.containers\" compact class=\"overview-metrics\">\n" +
+    "<deployment-metrics ng-if=\"showMetrics && !collapse\" pods=\"podsByOwnerUID[latestReplicaSet.metadata.uid]\" containers=\"latestReplicaSet.spec.template.spec.containers\" profile=\"compact\" class=\"overview-metrics\">\n" +
     "</deployment-metrics>\n" +
     "<pod-template ng-if=\"!showMetrics\" pod-template=\"latestReplicaSet.spec.template\"></pod-template>\n" +
     "\n" +
@@ -9664,7 +9664,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</a>\n" +
     "</div>\n" +
     "<div column class=\"overview-tile-details\">\n" +
-    "<deployment-metrics ng-if=\"showMetrics && !collapse\" pods=\"[pod]\" containers=\"pod.spec.containers\" compact class=\"overview-metrics\">\n" +
+    "<deployment-metrics ng-if=\"showMetrics && !collapse\" pods=\"[pod]\" containers=\"pod.spec.containers\" profile=\"compact\" class=\"overview-metrics\">\n" +
     "</deployment-metrics>\n" +
     "<pod-template ng-if=\"!showMetrics\" pod-template=\"pod\"></pod-template>\n" +
     "</div>\n" +
@@ -9855,7 +9855,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "\n" +
     "<div column class=\"overview-tile-details\">\n" +
-    "<deployment-metrics ng-if=\"showMetrics && !collapse\" pods=\"podsByOwnerUID[set.metadata.uid]\" containers=\"set.spec.template.spec.containers\" compact class=\"overview-metrics\">\n" +
+    "<deployment-metrics ng-if=\"showMetrics && !collapse\" pods=\"podsByOwnerUID[set.metadata.uid]\" containers=\"set.spec.template.spec.containers\" profile=\"compact\" class=\"overview-metrics\">\n" +
     "</deployment-metrics>\n" +
     "<pod-template ng-if=\"!showMetrics\" pod-template=\"set.spec.template\"></pod-template>\n" +
     "</div>\n" +


### PR DESCRIPTION
The HTML minifier was changing attribute `compact="true"` to just `compact`, which caused the full metrics to be shown in the overview in the built binary.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1390499

@jwforres PTAL