### PR TITLE
Membership: swap <a> for <button> 

### DIFF
--- a/app/views/membership.html
+++ b/app/views/membership.html
@@ -148,13 +148,12 @@
                             </div>
                           </ui-select-choices>
                         </ui-select>
-                        <a
-                          href=""
+                        <button
                           ng-disabled="disableAddForm || (!subject.newRole)"
                           ng-click="addRoleTo(subject.name, subjectKind.name, subject.newRole)"
                           class="btn btn-default add-role-to">
                           Add
-                        </a>
+                        </button>
                       </div>
                     </div>
                   </div>
@@ -248,13 +247,12 @@
                               </div>
                             </ui-select-choices>
                           </ui-select>
-                          <a
-                            href=""
+                          <button
                             ng-disabled="disableAddForm || (!newBinding.name) || (!newBinding.newRole)"
                             ng-click="addRoleTo(newBinding.name, newBinding.kind, newBinding.newRole, newBinding.namespace)"
                             class="btn btn-default add-role-to">
                             Add
-                          </a>
+                          </button>
                         </div>
                       </div>
                     </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8576,9 +8576,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
-    "<a href=\"\" ng-disabled=\"disableAddForm || (!subject.newRole)\" ng-click=\"addRoleTo(subject.name, subjectKind.name, subject.newRole)\" class=\"btn btn-default add-role-to\">\n" +
+    "<button ng-disabled=\"disableAddForm || (!subject.newRole)\" ng-click=\"addRoleTo(subject.name, subjectKind.name, subject.newRole)\" class=\"btn btn-default add-role-to\">\n" +
     "Add\n" +
-    "</a>\n" +
+    "</button>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -8627,9 +8627,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
-    "<a href=\"\" ng-disabled=\"disableAddForm || (!newBinding.name) || (!newBinding.newRole)\" ng-click=\"addRoleTo(newBinding.name, newBinding.kind, newBinding.newRole, newBinding.namespace)\" class=\"btn btn-default add-role-to\">\n" +
+    "<button ng-disabled=\"disableAddForm || (!newBinding.name) || (!newBinding.newRole)\" ng-click=\"addRoleTo(newBinding.name, newBinding.kind, newBinding.newRole, newBinding.namespace)\" class=\"btn btn-default add-role-to\">\n" +
     "Add\n" +
-    "</a>\n" +
+    "</button>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
Fix bug #1388391
Allows a true disabled button by using a `<button>` instead of a `<a>` styled to look like a button.

@jwforres @spadgett 