### PR TITLE
Improve Membership columns with long words or text

### DIFF
--- a/app/styles/_membership.less
+++ b/app/styles/_membership.less
@@ -9,7 +9,7 @@
     }
   }
   .content-pane {
-    max-width: 1024px;
+    width: 100%;
     margin-top: 50px;
     .col-add-role {
       padding: 10px 0;
@@ -38,9 +38,13 @@
       }
     }
     .col-name {
-      min-width: 165px;
-      padding: 0 5px 0 0;
-      word-wrap: break-word;
+      &.half-width {
+        min-width: 50%;
+      }
+      .word-break-all;
+      min-width: 225px;
+      max-width: 30%;
+      padding: 0 5px 10px 0;
       input {
         max-width: 150px;
       }
@@ -81,8 +85,7 @@
   }
 }
 
-
-@media(min-width: @screen-sm-min) {
+@media(min-width: @screen-xs-min) {
   .membership {
     .content-pane {
       .col-add-role {
@@ -109,7 +112,7 @@
         }
       }
       .col-name {
-        min-width: 180px;
+        width: 30%;
         input {
           max-width: 175px;
         }
@@ -128,11 +131,12 @@
 // fix for collapse of flex items in IE
 // https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored
 [flex-collapse-fix],
+[flex], // fixes ie flex-direction: column collapse issue
 .item-row,
 .col-heading,
 .col-name,
 .col-roles,
 .col-add-role {
-  //flex-shrink: 0;
+  flex-shrink: 0;
   flex-basis: auto;
 }

--- a/app/views/membership.html
+++ b/app/views/membership.html
@@ -64,18 +64,15 @@
 
                 <div
                   class="col-heading item-row"
-                  row mobile="column" tablet="column" flex-collapse-fix>
-                  <div row flex flex-collapse-fix>
-                    <div class="col-name" conceal="mobile">
-                      <h3>Name</h3>
-                    </div>
-                    <div class="col-roles" flex conceal="mobile">
-                      <h3>Roles</h3>
-                    </div>
+                  row mobile="column" flex-collapse-fix>
+                  <div class="col-name" flex conceal="mobile" ng-class="{ 'half-width': !mode.edit }">
+                    <h3>Name</h3>
                   </div>
-                  <div class="col-add-role" flex-collapse-fix>
-                    <h3
-                      ng-show="mode.edit">
+                  <div class="col-roles" flex conceal="mobile">
+                    <h3>Roles</h3>
+                  </div>
+                  <div ng-if="mode.edit" class="col-add-role" conceal="tablet" flex-collapse-fix>
+                    <h3>
                       Add another role
                     </h3>
                   </div>
@@ -90,7 +87,7 @@
                   ng-repeat="subject in subjectKind.subjects"
                   class="item-row highlight-hover"
                   row mobile="column">
-                  <div class="col-name" row cross-axis="center">
+                  <div class="col-name" row flex cross-axis="center" ng-class="{ 'half-width': !mode.edit }">
                     <a
                       ng-if="subject.namespace"
                       target="_blank"
@@ -128,8 +125,9 @@
                         action-title="remove role {{role}} from {{subject.name}}"></action-chip>
                     </div>
                     <div
+                      ng-if="mode.edit"
                       class="col-add-role">
-                      <div ng-show="mode.edit" row>
+                      <div row>
                         <ui-select
                           ng-if="filteredRoles.length"
                           ng-model="subject.newRole"

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8503,17 +8503,15 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "</div>\n" +
     "<div column class=\"content-pane\" ng-class=\"'content-' + subjectKind.name.toLowerCase()\">\n" +
-    "<div class=\"col-heading item-row\" row mobile=\"column\" tablet=\"column\" flex-collapse-fix>\n" +
-    "<div row flex flex-collapse-fix>\n" +
-    "<div class=\"col-name\" conceal=\"mobile\">\n" +
+    "<div class=\"col-heading item-row\" row mobile=\"column\" flex-collapse-fix>\n" +
+    "<div class=\"col-name\" flex conceal=\"mobile\" ng-class=\"{ 'half-width': !mode.edit }\">\n" +
     "<h3>Name</h3>\n" +
     "</div>\n" +
     "<div class=\"col-roles\" flex conceal=\"mobile\">\n" +
     "<h3>Roles</h3>\n" +
     "</div>\n" +
-    "</div>\n" +
-    "<div class=\"col-add-role\" flex-collapse-fix>\n" +
-    "<h3 ng-show=\"mode.edit\">\n" +
+    "<div ng-if=\"mode.edit\" class=\"col-add-role\" conceal=\"tablet\" flex-collapse-fix>\n" +
+    "<h3>\n" +
     "Add another role\n" +
     "</h3>\n" +
     "</div>\n" +
@@ -8524,7 +8522,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "</div>\n" +
     "<div ng-repeat=\"subject in subjectKind.subjects\" class=\"item-row highlight-hover\" row mobile=\"column\">\n" +
-    "<div class=\"col-name\" row cross-axis=\"center\">\n" +
+    "<div class=\"col-name\" row flex cross-axis=\"center\" ng-class=\"{ 'half-width': !mode.edit }\">\n" +
     "<a ng-if=\"subject.namespace\" target=\"_blank\" ng-href=\"project/{{project.metadata.name}}/browse/other?kind=ServiceAccount\">\n" +
     "<span>\n" +
     "{{subject.namespace}} /\n" +
@@ -8546,8 +8544,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"col-roles\" row tablet=\"column\" flex wrap axis=\"start\">\n" +
     "<action-chip ng-repeat=\"role in subject.roles\" key=\"role.metadata.name\" key-help=\"roleHelp(role)\" show-action=\"mode.edit\" action=\"confirmRemove(subject.name, subjectKind.name, role.metadata.name)\" action-title=\"remove role {{role}} from {{subject.name}}\"></action-chip>\n" +
     "</div>\n" +
-    "<div class=\"col-add-role\">\n" +
-    "<div ng-show=\"mode.edit\" row>\n" +
+    "<div ng-if=\"mode.edit\" class=\"col-add-role\">\n" +
+    "<div row>\n" +
     "<ui-select ng-if=\"filteredRoles.length\" ng-model=\"subject.newRole\" theme=\"bootstrap\" search-enabled=\"true\" title=\"Select a new role for {{subjectKind.name}}\" class=\"select-role\" flex>\n" +
     "<ui-select-match placeholder=\"Select a role\">\n" +
     "<span ng-bind=\"subject.newRole.metadata.name\"></span>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4831,7 +4831,7 @@ td.visible-print,th.visible-print{display:table-cell!important}
 .events-sidebar .right-content .event .event-details .event-reason{order:2}
 .events-sidebar .right-content .event .event-details .event-timestamp{text-align:right;margin-left:5px;min-width:100px}
 }
-.events-table td,.log-line-text{word-break:break-word;min-width:0;word-wrap:break-word}
+.events-table td,.log-line-text{word-wrap:break-word;word-break:break-word;min-width:0}
 .events-sidebar .right-content .event.highlight+.event{border-top:1px solid #d1d1d1}
 .events-badge{font-size:14px}
 .events-badge:hover{text-decoration:none}
@@ -5158,17 +5158,20 @@ kubernetes-topology-graph{height:700px}
 .projects-list{border-top:0;box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09);margin-bottom:20px}
 .projects-list .project-info:hover{background-color:#def3ff}
 .terminal-font,kubernetes-container-terminal .terminal{font-family:"Monospace Regular","DejaVu Sans Mono",Menlo,Monaco,Consolas,monospace;line-height:1em;font-size:12px}
+@media (min-width:768px){.container-terminal-wrapper{background-color:#000}
+}
 .key-value-editor .key-value-editor-header{margin-bottom:5px}
 .membership h1 .learn-more-inline{white-space:nowrap;margin-right:10px;margin-left:0px;display:inline-block}
 .membership .content-pane .col-heading .col-add-role h3,.membership .content-pane .form-new-role .col-roles{display:none}
-.membership .content-pane{max-width:1024px;margin-top:50px}
+.membership .content-pane{width:100%;margin-top:50px}
 .membership .content-pane .col-add-role{padding:10px 0;min-width:150px}
 .membership .content-pane .add-role-to{margin-left:-1px}
 .membership .content-pane .col-heading,.membership .content-pane .item-row{border-bottom:1px solid #ededed}
 .membership .content-pane .col-heading h3,.membership .content-pane .item-row h3{margin:0}
 .membership .content-pane .item-row{padding:5px 10px 5px 5px;margin-bottom:20px}
 .membership .content-pane .col-heading{margin-bottom:20px}
-.membership .content-pane .col-name{min-width:165px;padding:0 5px 0 0;word-wrap:break-word}
+.membership .content-pane .col-name{word-break:break-all;word-break:break-word;overflow-wrap:break-word;min-width:225px;max-width:30%;padding:0 5px 10px 0}
+.membership .content-pane .col-name.half-width{min-width:50%}
 .membership .content-pane .col-name input{max-width:150px}
 .membership .content-pane .col-name .new-project{margin-top:2px}
 .membership .content-pane .content-serviceaccount .form-new-role .col-roles{display:block}
@@ -5176,16 +5179,15 @@ kubernetes-topology-graph{height:700px}
 .membership .content-pane .select-project,.membership .content-pane .select-role{width:150px}
 .membership .content-pane .select-role small{color:#999}
 .membership .content-pane .select-role .active small{color:#c0e0f0}
-@media (min-width:768px){.container-terminal-wrapper{background-color:#000}
-.membership .content-pane .col-heading .col-add-role h3,.membership .content-pane .form-new-role .col-roles{display:block}
+@media (min-width:480px){.membership .content-pane .col-heading .col-add-role h3,.membership .content-pane .form-new-role .col-roles{display:block}
 .membership .content-pane .col-add-role{padding:0;min-width:245px}
 .membership .content-pane .col-heading,.membership .content-pane .item-row{border-bottom:none;margin-bottom:none}
 .membership .content-pane .item-row.highlight-hover:hover{background-color:#fafafa}
 .membership .content-pane .col-heading .col-add-role a{display:block;padding-left:10px}
-.membership .content-pane .col-name{min-width:180px}
+.membership .content-pane .col-name{width:30%}
 .membership .content-pane .col-name input{max-width:175px}
 }
-.col-add-role,.col-heading,.col-name,.col-roles,.item-row,[flex-collapse-fix]{flex-basis:auto}
+.col-add-role,.col-heading,.col-name,.col-roles,.item-row,[flex-collapse-fix],[flex]{flex-shrink:0;flex-basis:auto}
 .action-chip{margin:0 5px 2px 0;font-size:12px;display:flex;flex-direction:row}
 .action-chip .item{padding:.2em .6em .3em}
 .action-chip .item:first-child{border-top-left-radius:2px;border-bottom-left-radius:2px}


### PR DESCRIPTION
Fix bug #1388340 
Improves word wrapping within container columns with or w/o hyphenation or natural breaks.

long user names:
![screen shot 2016-11-01 at 12 08 27 pm 1](https://cloud.githubusercontent.com/assets/280512/19897014/bec98a7e-a02c-11e6-9916-2f149ceae5ad.png)

long service account names (namespace / name): 
![screen shot 2016-11-01 at 12 15 55 pm](https://cloud.githubusercontent.com/assets/280512/19897062/00dc63dc-a02d-11e6-826d-7c1a231ed04f.png)


@jwforres @spadgett 
