### PR TITLE
Add additional check to addRoleToUser() to further insulate from duplication

### DIFF
--- a/app/scripts/controllers/membership.js
+++ b/app/scripts/controllers/membership.js
@@ -44,8 +44,9 @@ angular
         },
         update: {
           subject: {
-            success: _.template('The role "<%= roleName %>" was given to "<%= subjectName %>".'),
-            error: _.template('The role "<%= roleName %>" was not given to "<%= subjectName %>".')
+            success: _.template('The role "<%= roleName %>" was granted to "<%= subjectName %>".'),
+            error: _.template('The role "<%= roleName %>" could not be granted to "<%= subjectName %>".'),
+            exists: _.template('The role "<%= roleName %>" has already been granted to "<%= subjectName %>".')
           }
         },
         errorReason: _.template('Reason: "<%= httpErr %>"')
@@ -279,11 +280,16 @@ angular
               // infer this, but isn't clear at the moment.  Will fast-follow PR if
               // a good solution is found.
               var rolebindingToUpdate = _.find($scope.roleBindings, {roleRef: {name: role.metadata.name}});
-
-              if(rolebindingToUpdate) {
-                return updateBinding(rolebindingToUpdate, subject, subjectNamespace);
+              if(rolebindingToUpdate && _.some(rolebindingToUpdate.subjects, {name: subjectName})) {
+                showAlert('rolebindingUpdate', 'info', messages.update.subject.exists({
+                  roleName: role.metadata.name,
+                  subjectName: subjectName
+                }));
+              } else if(rolebindingToUpdate) {
+                updateBinding(rolebindingToUpdate, subject, subjectNamespace);
+              } else {
+                createBinding(role, subject, subjectNamespace);
               }
-              return createBinding(role, subject, subjectNamespace);
             }
           });
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4797,8 +4797,9 @@ error:_.template('The role "<%= roleName %>" was not removed from "<%= subjectNa
 },
 update:{
 subject:{
-success:_.template('The role "<%= roleName %>" was given to "<%= subjectName %>".'),
-error:_.template('The role "<%= roleName %>" was not given to "<%= subjectName %>".')
+success:_.template('The role "<%= roleName %>" was granted to "<%= subjectName %>".'),
+error:_.template('The role "<%= roleName %>" could not be granted to "<%= subjectName %>".'),
+exists:_.template('The role "<%= roleName %>" has already been granted to "<%= subjectName %>".')
 }
 },
 errorReason:_.template('Reason: "<%= httpErr %>"')
@@ -4958,7 +4959,12 @@ roleRef:{
 name:c.metadata.name
 }
 });
-return g ? x(g, f, e) :w(c, f, e);
+g && _.some(g.subjects, {
+name:a
+}) ? t("rolebindingUpdate", "info", s.update.subject.exists({
+roleName:c.metadata.name,
+subjectName:a
+})) :g ? x(g, f, e) :w(c, f, e);
 }
 }), m.listAllRoles(n, {
 errorNotification:!1


### PR DESCRIPTION
Fixes bug #1388060 

The "select role" picker already filters out roles that a subject already owns.  This update is for the manual input box at the bottom of the list.  If a user enters an existing subject name & selects a role that that the subject already has an info alert will notify that the update is unnecessary.

![screen shot 2016-11-01 at 4 29 41 pm](https://cloud.githubusercontent.com/assets/280512/19906254/6c343bbe-a050-11e6-8906-8e93db4406d6.png)

@jwforres @spadgett 