### PR TITLE
Attach storage form updates

### DIFF
--- a/app/scripts/controllers/createPersistentVolumeClaim.js
+++ b/app/scripts/controllers/createPersistentVolumeClaim.js
@@ -24,7 +24,7 @@ angular.module('openshiftConsole')
         link: "project/" + $scope.projectName + "/browse/storage"
       },
       {
-        title: "Request Storage"
+        title: "Create Storage"
       }
     ];
 

--- a/app/views/attach-pvc.html
+++ b/app/views/attach-pvc.html
@@ -26,7 +26,7 @@
 
                   <div ng-if="project && ('persistentvolumeclaims' | canI : 'create')" class="text-center">
                     <a ng-href="project/{{project.metadata.name}}/create-pvc"
-                       class="btn btn-primary">Request Storage</a>
+                       class="btn btn-primary">Create Storage</a>
                   </div>
 
                   <p ng-if="project && !('persistentvolumeclaims' | canI : 'create')">
@@ -71,18 +71,19 @@
                         </table>
                       </div>
                       <div ng-if="!(project && ('persistentvolumeclaims' | canI : 'create'))" class="help-block">
-                        Select a storage request to use.
+                        Select storage to use.
                       </div>
                       <div ng-if="project && ('persistentvolumeclaims' | canI : 'create')" class="help-block">
-                        Select a storage request or <a ng-href="project/{{project.metadata.name}}/create-pvc" >request more storage</a>.
+                        Select storage to use or <a ng-href="project/{{project.metadata.name}}/create-pvc" >create storage</a>.
                       </div>
+
                       <h3>Volume</h3>
                       <div class="help-block">
                         Specify details about how volumes are going to be mounted inside containers.
                       </div>
 
                       <div class="form-group mar-top-xl">
-                        <label for="route-name">Mount path</label>
+                        <label for="route-name">Mount Path</label>
                         <input
                             id="mount-path"
                             class="form-control"
@@ -111,7 +112,7 @@
                       </div>
 
                       <div class="form-group">
-                        <label for="volume-name">Volume name</label>
+                        <label for="volume-name">Volume Name</label>
                         <input
                             id="volume-path"
                             class="form-control"

--- a/app/views/attach-pvc.html
+++ b/app/views/attach-pvc.html
@@ -10,9 +10,9 @@
       <div class="middle-container">
         <div class="middle-content">
           <div class="container surface-shaded">
-            <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
             <div class="row">
-              <div class="col-md-12">
+              <div class="col-md-10 col-md-offset-1">
+                <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
                 <alerts alerts="alerts"></alerts>
                 <div ng-show="!pvcs || !attach.resource">Loading...</div>
 
@@ -36,143 +36,137 @@
                   <p ng-if="attach.resource"><a ng-href="{{attach.resource | navigateResourceURL}}">Back to {{kind | humanizeKind}} {{name}}</a></p>
                 </div>
 
-                <div class="row" ng-show="pvcs && pvcs.length && attach.resource">
-                  <div class="col-md-10 col-md-offset-1 gutter-top">
-                    <h1>Add Storage</h1>
-                    <div>
-                      <span class="help-block">
-                        Add an existing persistent volume claim to the template of {{kind | humanizeKind}} <b>{{name}}</b>.
-                      </span>
-                    </div>
-                    <form name="attachPVCForm">
-                      <fieldset ng-disabled="disableInputs">
-                        <div class="form-group">
-                          <label for="persistentVolumeClaim" class="required">Storage</label>
-                          <div>
-                            <span id="persistent-volume-claim-help" class="help-block">Select storage to attach to</span>
-                          </div>
-                          <table style="margin-bottom:0;background-color:transparent;" class="table table-condensed table-borderless">
-                            <tbody>
-                              <tr ng-repeat="pvc in pvcs track by (pvc | uid)">
-                                <td style="padding-left:0;">
-                                  <input
-                                    type="radio"
-                                    name="persistentVolumeClaim"
-                                    ng-model="attach.persistentVolumeClaim"
-                                    ng-value="pvc"
-                                    aria-describedby="pvc-help">
-                                </td>
-                                <td><a ng-href="{{pvc | navigateResourceURL}}">{{pvc.metadata.name}}</a></td>
-                                <td ng-if="pvc.spec.volumeName">{{pvc.status.capacity['storage'] | usageWithUnits: 'storage'}}</td>
-                                <td ng-if="!pvc.spec.volumeName">{{pvc.spec.resources.requests['storage'] | usageWithUnits: 'storage'}}</td>
-                                <td>({{pvc.spec.accessModes | accessModes | join}})</td>
-                                <td>
-                                  {{pvc.status.phase}}
-                                  <span ng-if="pvc.spec.volumeName">
-                                    to volume <strong>{{pvc.spec.volumeName}}</strong>
-                                  </span>
-                                </td>
-                              </tr>
-                            </tbody>
-                          </table>
+                <div ng-show="pvcs && pvcs.length && attach.resource" class="mar-top-xl">
+                  <h1>Add Storage</h1>
+                  <div class="help-block">
+                    Add an existing persistent volume claim to the template of {{kind | humanizeKind}} {{name}}.
+                  </div>
+                  <form name="attachPVCForm" class="mar-top-lg">
+                    <fieldset ng-disabled="disableInputs">
+                      <div class="form-group">
+                        <label for="persistentVolumeClaim" class="required">Storage</label>
+                        <table style="margin-bottom:0;background-color:transparent;" class="table table-condensed table-borderless">
+                          <tbody>
+                            <tr ng-repeat="pvc in pvcs track by (pvc | uid)">
+                              <td style="padding-left:0;">
+                                <input
+                                  type="radio"
+                                  name="persistentVolumeClaim"
+                                  ng-model="attach.persistentVolumeClaim"
+                                  ng-value="pvc"
+                                  aria-describedby="pvc-help">
+                              </td>
+                              <td><a ng-href="{{pvc | navigateResourceURL}}">{{pvc.metadata.name}}</a></td>
+                              <td ng-if="pvc.spec.volumeName">{{pvc.status.capacity['storage'] | usageWithUnits: 'storage'}}</td>
+                              <td ng-if="!pvc.spec.volumeName">{{pvc.spec.resources.requests['storage'] | usageWithUnits: 'storage'}}</td>
+                              <td>({{pvc.spec.accessModes | accessModes | join}})</td>
+                              <td>
+                                {{pvc.status.phase}}
+                                <span ng-if="pvc.spec.volumeName">
+                                  to volume <strong>{{pvc.spec.volumeName}}</strong>
+                                </span>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                      <div ng-if="!(project && ('persistentvolumeclaims' | canI : 'create'))" class="help-block">
+                        Select a storage request to use.
+                      </div>
+                      <div ng-if="project && ('persistentvolumeclaims' | canI : 'create')" class="help-block">
+                        Select a storage request or <a ng-href="project/{{project.metadata.name}}/create-pvc" >request more storage</a>.
+                      </div>
+                      <h3>Volume</h3>
+                      <div class="help-block">
+                        Specify details about how volumes are going to be mounted inside containers.
+                      </div>
+
+                      <div class="form-group mar-top-xl">
+                        <label for="route-name">Mount path</label>
+                        <input
+                            id="mount-path"
+                            class="form-control"
+                            type="text"
+                            name="mountPath"
+                            ng-model="attach.mountPath"
+                            ng-pattern="/^\/.*$/"
+                            placeholder="example: /data"
+                            autocorrect="off"
+                            autocapitalize="off"
+                            spellcheck="false"
+                            aria-describedby="mount-path-help">
+                        <div>
+                          <span id="mount-path-help" class="help-block">Mount path for the volume inside the container. If not specified, the volume will not be mounted automatically.</span>
                         </div>
-                        <div  ng-if="project && ('persistentvolumeclaims' | canI : 'create')">
-                          Or&nbsp;<a ng-href="project/{{project.metadata.name}}/create-pvc" >create storage.</a>
+                        <div class="has-error" ng-show="attachPVCForm.mountPath.$error.pattern && attachPVCForm.mountPath.$touched">
+                          <span class="help-block">
+                            Mount path must be a valid path to a directory starting with <code>/</code>.
+                          </span>
                         </div>
-                        <h3>Volume</h3>
+                        <div class="has-error" ng-show="isVolumeMountPathUsed">
+                          <span class="help-block">
+                            Volume mount in that path already exists. Please choose another mount path.
+                          </span>
+                        </div>
+                      </div>
+
+                      <div class="form-group">
+                        <label for="volume-name">Volume name</label>
+                        <input
+                            id="volume-path"
+                            class="form-control"
+                            type="text"
+                            name="volumeName"
+                            ng-model="attach.volumeName"
+                            placeholder="(generated if empty)"
+                            autocorrect="off"
+                            autocapitalize="off"
+                            spellcheck="false"
+                            aria-describedby="volume-name-help">
+                        <div>
+                          <span id="volume-name-help" class="help-block">Unique name used to identify this volume. If not specified, a volume name is generated.</span>
+                        </div>
+                      </div>
+                      <div class="has-error" ng-show="isVolumeNameUsed">
+                        <span class="help-block">
+                          Volume name already exists. Please choose another name.
+                        </span>
+                      </div>
+
+                      <div ng-show="attach.containers.all">
+                        The volume will be mounted into all containers. You can <a href=""
+                          ng-click="attach.containers.all = false">select specific containers</a> instead.
+                      </div>
+
+                      <div ng-show="!attach.containers.all" class="form-group">
+                        <h3>Containers</h3>
                         <div>
                           <span class="help-block">
-                            Specify details about how volumes are going to be mounted inside containers.
+                            Add the volume to the following containers:
                           </span>
                         </div>
-
-                        <div class="form-group">
-                          <label for="route-name">Mount path</label>
-                          <input
-                              id="mount-path"
-                              class="form-control"
-                              type="text"
-                              name="mountPath"
-                              ng-model="attach.mountPath"
-                              ng-pattern="/^\/.*$/"
-                              placeholder="example: /data"
-                              autocorrect="off"
-                              autocapitalize="off"
-                              spellcheck="false"
-                              aria-describedby="mount-path-help">
-                          <div>
-                            <span id="mount-path-help" class="help-block">Mount path for the volume inside the container. If not specified, the volume will not be mounted automatically.</span>
-                          </div>
-                          <div class="has-error" ng-show="attachPVCForm.mountPath.$error.pattern && attachPVCForm.mountPath.$touched">
-                            <span class="help-block">
-                              Mount path must be a valid path to a directory starting with <code>/</code>.
-                            </span>
-                          </div>
-                          <div class="has-error" ng-show="isVolumeMountPathUsed">
-                            <span class="help-block">
-                              Volume mount in that path already exists. Please choose another mount path.
-                            </span>
-                          </div>
+                        <div class="checkbox" ng-repeat="container in attach.resource.spec.template.spec.containers">
+                          <label>
+                            <input type="checkbox" ng-model="attach.containers.individual[container.name]">
+                            <b>{{container.name}}</b> from image <i>{{container.image}}</i>
+                          </label>
                         </div>
-
-                        <div class="form-group">
-                          <label for="volume-name">Volume name</label>
-                          <input
-                              id="volume-path"
-                              class="form-control"
-                              type="text"
-                              name="volumeName"
-                              ng-model="attach.volumeName"
-                              placeholder="(generated if empty)"
-                              autocorrect="off"
-                              autocapitalize="off"
-                              spellcheck="false"
-                              aria-describedby="volume-name-help">
-                          <div>
-                            <span id="volume-name-help" class="help-block">Unique name used to identify this volume. If not specified, a volume name is generated.</span>
-                          </div>
-                        </div>
-                        <div class="has-error" ng-show="isVolumeNameUsed">
+                        <div class="has-error" ng-show="!containerToAttachProvided()">
                           <span class="help-block">
-                            Volume name already exists. Please choose another name.
+                            You must select at least one container.
                           </span>
                         </div>
+                      </div>
 
-                        <div ng-show="attach.containers.all">
-                          The volume will be mounted into all containers. You can <a href=""
-                            ng-click="attach.containers.all = false">select specific containers</a> instead.
-                        </div>
-
-                        <div ng-show="!attach.containers.all" class="form-group">
-                          <h3>Containers</h3>
-                          <div>
-                            <span class="help-block">
-                              Add the volume to the following containers:
-                            </span>
-                          </div>
-                          <div class="checkbox" ng-repeat="container in attach.resource.spec.template.spec.containers">
-                            <label>
-                              <input type="checkbox" ng-model="attach.containers.individual[container.name]">
-                              <b>{{container.name}}</b> from image <i>{{container.image}}</i>
-                            </label>
-                          </div>
-                          <div class="has-error" ng-show="!containerToAttachProvided()">
-                            <span class="help-block">
-                              You must select at least one container.
-                            </span>
-                          </div>
-                        </div>
-
-                        <div class="button-group gutter-top gutter-bottom">
-                          <button type="submit"
-                              class="btn btn-primary btn-lg"
-                              ng-click="attachPVC()"
-                              ng-disabled="attachPVCForm.$invalid || disableInputs || !attachPVC || !containerToAttachProvided()">Add</button>
-                          <a class="btn btn-default btn-lg" role="button" href="#" back>Cancel</a>
-                        </div>
-                      </fieldset>
-                    </form>
-                  </div>
+                      <div class="button-group gutter-top gutter-bottom">
+                        <button type="submit"
+                            class="btn btn-primary btn-lg"
+                            ng-click="attachPVC()"
+                            ng-disabled="attachPVCForm.$invalid || disableInputs || !attachPVC || !containerToAttachProvided()">Add</button>
+                        <a class="btn btn-default btn-lg" role="button" href="#" back>Cancel</a>
+                      </div>
+                    </fieldset>
+                  </form>
                 </div>
               </div><!-- /col-md-* -->
             </div>

--- a/app/views/create-persistent-volume-claim.html
+++ b/app/views/create-persistent-volume-claim.html
@@ -14,9 +14,9 @@
                 <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
                 <alerts alerts="alerts"></alerts>
                 <div class="mar-top-xl">
-                  <h1>Request Storage</h1>
+                  <h1>Create Storage</h1>
                   <div class="help-block">
-                    Create a request for an administrator defined storage asset by requesting size and access mode attributes for a best fit.
+                    Create a request for an administrator-defined storage asset by specifying size and permissions for a best fit.
                   </div>
                   <form name="createPersistentVolumeClaimForm" class="mar-top-lg">
                     <fieldset ng-disabled="disableInputs">

--- a/app/views/directives/osc-persistent-volume-claim.html
+++ b/app/views/directives/osc-persistent-volume-claim.html
@@ -47,7 +47,7 @@
         ng-pattern="/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/"
         ng-maxlength="253"
         ng-minlength="2"
-        placeholder="my-storage-request"
+        placeholder="my-storage-claim"
         select-on-focus
         autocorrect="off"
         autocapitalize="off"
@@ -92,7 +92,7 @@
     <!-- capacity -->
     <div class="form-group">
       <fieldset class="form-inline compute-resource">
-      <label class="required">Capacity</label>
+      <label class="required">Size</label>
       <div ng-class="{ 'has-error': form.$invalid }">
         <label class="sr-only">Amount</label>
         <input type="number"
@@ -111,11 +111,9 @@
                 ng-attr-id="claim-capacity-unit"
                 class="form-control inline-select">
         </select>
-        </div>
-      <div>
-         <span id="claim-capacity-help" class="help-block">
-           Size of the storage request.
-        </span>
+       </div>
+       <div id="claim-capacity-help" class="help-block">
+         Desired storage capacity.
       </div>
       <div class="has-error" ng-show="persistentVolumeClaimForm.capacity.$error.pattern && persistentVolumeClaimForm.capacity.$touched && !claimDisabled">
         <span class="help-block">
@@ -127,17 +125,17 @@
     <!--advanced options-->
     <div ng-show="!showAdvancedOptions" class="mar-bottom-xl">
       <a href=""
-         ng-click="showAdvancedOptions = true">Use label selectors in the storage request</a>
+         ng-click="showAdvancedOptions = true">Use label selectors to request storage</a>
     </div>
 
     <div ng-show="showAdvancedOptions" class="form-group">
       <fieldset class="compute-resource">
         <label>Label Selector</label>
         <div class="help-block mar-bottom-lg">
-          Enter a label and value to use with your requested storage.
-           <div class="learn-more-block">
-             <a ng-href="{{'selector_label' | helpLink}}" target="_blank">Learn more <i class="fa fa-external-link" aria-hidden="true"> </i></a>
-           </div>
+          Enter a label and value to use for your storage.
+          <div class="learn-more-block">
+            <a ng-href="{{'selector_label' | helpLink}}" target="_blank">Learn more <i class="fa fa-external-link" aria-hidden="true"> </i></a>
+          </div>
         </div>
         <key-value-editor
           entries="claim.selectedLabels"

--- a/app/views/storage.html
+++ b/app/views/storage.html
@@ -23,11 +23,11 @@
             <div class="col-md-12">
               <div class="section-header page-header-bleed-right page-header-bleed-left">
                 <div class="hidden-xs pull-right" ng-if="project && ('persistentvolumeclaims' | canI : 'create')">
-                  <a ng-href="project/{{project.metadata.name}}/create-pvc" class="btn btn-default">Request Storage</a>
+                  <a ng-href="project/{{project.metadata.name}}/create-pvc" class="btn btn-default">Create Storage</a>
                 </div>
                 <h2>Persistent Volume Claims</h2>
                 <div class="visible-xs-block mar-bottom-sm" ng-if="project && ('persistentvolumeclaims' | canI : 'create')">
-                  <a ng-href="project/{{project.metadata.name}}/create-pvc" class="btn btn-default">Request Storage</a>
+                  <a ng-href="project/{{project.metadata.name}}/create-pvc" class="btn btn-default">Create Storage</a>
                 </div>
               </div>
               <table class="table table-bordered table-hover table-mobile" ng-class="{ 'table-empty': (pvcs | hashSize) === 0 }">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7940,7 +7940,7 @@ link:"project/" + c.projectName
 title:"Storage",
 link:"project/" + c.projectName + "/browse/storage"
 }, {
-title:"Request Storage"
+title:"Create Storage"
 } ], h.get(b.project).then(_.spread(function(b, e) {
 function g() {
 var a = {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -933,7 +933,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "A <b>persistent volume claim</b> is required to attach to this {{kind | humanizeKind}}, but none are loaded on this project.\n" +
     "</p>\n" +
     "<div ng-if=\"project && ('persistentvolumeclaims' | canI : 'create')\" class=\"text-center\">\n" +
-    "<a ng-href=\"project/{{project.metadata.name}}/create-pvc\" class=\"btn btn-primary\">Request Storage</a>\n" +
+    "<a ng-href=\"project/{{project.metadata.name}}/create-pvc\" class=\"btn btn-primary\">Create Storage</a>\n" +
     "</div>\n" +
     "<p ng-if=\"project && !('persistentvolumeclaims' | canI : 'create')\">\n" +
     "To claim storage from a persistent volume, refer to the documentation on <a target=\"_blank\" ng-href=\"{{'persistent_volumes' | helpLink}}\">using persistent volumes</a>.\n" +
@@ -970,17 +970,17 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</table>\n" +
     "</div>\n" +
     "<div ng-if=\"!(project && ('persistentvolumeclaims' | canI : 'create'))\" class=\"help-block\">\n" +
-    "Select a storage request to use.\n" +
+    "Select storage to use.\n" +
     "</div>\n" +
     "<div ng-if=\"project && ('persistentvolumeclaims' | canI : 'create')\" class=\"help-block\">\n" +
-    "Select a storage request or <a ng-href=\"project/{{project.metadata.name}}/create-pvc\">request more storage</a>.\n" +
+    "Select storage to use or <a ng-href=\"project/{{project.metadata.name}}/create-pvc\">create storage</a>.\n" +
     "</div>\n" +
     "<h3>Volume</h3>\n" +
     "<div class=\"help-block\">\n" +
     "Specify details about how volumes are going to be mounted inside containers.\n" +
     "</div>\n" +
     "<div class=\"form-group mar-top-xl\">\n" +
-    "<label for=\"route-name\">Mount path</label>\n" +
+    "<label for=\"route-name\">Mount Path</label>\n" +
     "<input id=\"mount-path\" class=\"form-control\" type=\"text\" name=\"mountPath\" ng-model=\"attach.mountPath\" ng-pattern=\"/^\\/.*$/\" placeholder=\"example: /data\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"mount-path-help\">\n" +
     "<div>\n" +
     "<span id=\"mount-path-help\" class=\"help-block\">Mount path for the volume inside the container. If not specified, the volume will not be mounted automatically.</span>\n" +
@@ -997,7 +997,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "<div class=\"form-group\">\n" +
-    "<label for=\"volume-name\">Volume name</label>\n" +
+    "<label for=\"volume-name\">Volume Name</label>\n" +
     "<input id=\"volume-path\" class=\"form-control\" type=\"text\" name=\"volumeName\" ng-model=\"attach.volumeName\" placeholder=\"(generated if empty)\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"volume-name-help\">\n" +
     "<div>\n" +
     "<span id=\"volume-name-help\" class=\"help-block\">Unique name used to identify this volume. If not specified, a volume name is generated.</span>\n" +
@@ -3929,9 +3929,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"mar-top-xl\">\n" +
-    "<h1>Request Storage</h1>\n" +
+    "<h1>Create Storage</h1>\n" +
     "<div class=\"help-block\">\n" +
-    "Create a request for an administrator defined storage asset by requesting size and access mode attributes for a best fit.\n" +
+    "Create a request for an administrator-defined storage asset by specifying size and permissions for a best fit.\n" +
     "</div>\n" +
     "<form name=\"createPersistentVolumeClaimForm\" class=\"mar-top-lg\">\n" +
     "<fieldset ng-disabled=\"disableInputs\">\n" +
@@ -6686,7 +6686,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"claim-name\" class=\"required\">Name</label>\n" +
-    "<input id=\"claim-name\" class=\"form-control\" type=\"text\" name=\"name\" ng-model=\"claim.name\" ng-required=\"true\" ng-pattern=\"/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/\" ng-maxlength=\"253\" ng-minlength=\"2\" placeholder=\"my-storage-request\" select-on-focus autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"claim-name-help\">\n" +
+    "<input id=\"claim-name\" class=\"form-control\" type=\"text\" name=\"name\" ng-model=\"claim.name\" ng-required=\"true\" ng-pattern=\"/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/\" ng-maxlength=\"253\" ng-minlength=\"2\" placeholder=\"my-storage-claim\" select-on-focus autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"claim-name-help\">\n" +
     "<div>\n" +
     "<span id=\"claim-name-help\" class=\"help-block\">A unique name for the storage claim within the project.</span>\n" +
     "</div>\n" +
@@ -6719,7 +6719,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<div class=\"form-group\">\n" +
     "<fieldset class=\"form-inline compute-resource\">\n" +
-    "<label class=\"required\">Capacity</label>\n" +
+    "<label class=\"required\">Size</label>\n" +
     "<div ng-class=\"{ 'has-error': form.$invalid }\">\n" +
     "<label class=\"sr-only\">Amount</label>\n" +
     "<input type=\"number\" name=\"amount\" ng-attr-id=\"claim-amount\" ng-model=\"claim.amount\" ng-required=\"true\" min=\"0\" ng-attr-placeholder=\"10\" class=\"form-control\" ng-attr-aria-describedby=\"claim-capacity-help\">\n" +
@@ -6727,10 +6727,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<select ng-model=\"claim.unit\" name=\"unit\" ng-options=\"option.value as option.label for option in units\" ng-attr-id=\"claim-capacity-unit\" class=\"form-control inline-select\">\n" +
     "</select>\n" +
     "</div>\n" +
-    "<div>\n" +
-    "<span id=\"claim-capacity-help\" class=\"help-block\">\n" +
-    "Size of the storage request.\n" +
-    "</span>\n" +
+    "<div id=\"claim-capacity-help\" class=\"help-block\">\n" +
+    "Desired storage capacity.\n" +
     "</div>\n" +
     "<div class=\"has-error\" ng-show=\"persistentVolumeClaimForm.capacity.$error.pattern && persistentVolumeClaimForm.capacity.$touched && !claimDisabled\">\n" +
     "<span class=\"help-block\">\n" +
@@ -6741,13 +6739,13 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "\n" +
     "<div ng-show=\"!showAdvancedOptions\" class=\"mar-bottom-xl\">\n" +
-    "<a href=\"\" ng-click=\"showAdvancedOptions = true\">Use label selectors in the storage request</a>\n" +
+    "<a href=\"\" ng-click=\"showAdvancedOptions = true\">Use label selectors to request storage</a>\n" +
     "</div>\n" +
     "<div ng-show=\"showAdvancedOptions\" class=\"form-group\">\n" +
     "<fieldset class=\"compute-resource\">\n" +
     "<label>Label Selector</label>\n" +
     "<div class=\"help-block mar-bottom-lg\">\n" +
-    "Enter a label and value to use with your requested storage.\n" +
+    "Enter a label and value to use for your storage.\n" +
     "<div class=\"learn-more-block\">\n" +
     "<a ng-href=\"{{'selector_label' | helpLink}}\" target=\"_blank\">Learn more <i class=\"fa fa-external-link\" aria-hidden=\"true\"> </i></a>\n" +
     "</div>\n" +
@@ -11098,11 +11096,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"col-md-12\">\n" +
     "<div class=\"section-header page-header-bleed-right page-header-bleed-left\">\n" +
     "<div class=\"hidden-xs pull-right\" ng-if=\"project && ('persistentvolumeclaims' | canI : 'create')\">\n" +
-    "<a ng-href=\"project/{{project.metadata.name}}/create-pvc\" class=\"btn btn-default\">Request Storage</a>\n" +
+    "<a ng-href=\"project/{{project.metadata.name}}/create-pvc\" class=\"btn btn-default\">Create Storage</a>\n" +
     "</div>\n" +
     "<h2>Persistent Volume Claims</h2>\n" +
     "<div class=\"visible-xs-block mar-bottom-sm\" ng-if=\"project && ('persistentvolumeclaims' | canI : 'create')\">\n" +
-    "<a ng-href=\"project/{{project.metadata.name}}/create-pvc\" class=\"btn btn-default\">Request Storage</a>\n" +
+    "<a ng-href=\"project/{{project.metadata.name}}/create-pvc\" class=\"btn btn-default\">Create Storage</a>\n" +
     "</div>\n" +
     "</div>\n" +
     "<table class=\"table table-bordered table-hover table-mobile\" ng-class=\"{ 'table-empty': (pvcs | hashSize) === 0 }\">\n" +

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -922,9 +922,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-container\">\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container surface-shaded\">\n" +
-    "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<div class=\"row\">\n" +
-    "<div class=\"col-md-12\">\n" +
+    "<div class=\"col-md-10 col-md-offset-1\">\n" +
+    "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-show=\"!pvcs || !attach.resource\">Loading...</div>\n" +
     "<div ng-show=\"pvcs && !pvcs.length && attach.resource\" class=\"empty-state-message empty-state-full-page\">\n" +
@@ -940,21 +940,15 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "<p ng-if=\"attach.resource\"><a ng-href=\"{{attach.resource | navigateResourceURL}}\">Back to {{kind | humanizeKind}} {{name}}</a></p>\n" +
     "</div>\n" +
-    "<div class=\"row\" ng-show=\"pvcs && pvcs.length && attach.resource\">\n" +
-    "<div class=\"col-md-10 col-md-offset-1 gutter-top\">\n" +
+    "<div ng-show=\"pvcs && pvcs.length && attach.resource\" class=\"mar-top-xl\">\n" +
     "<h1>Add Storage</h1>\n" +
-    "<div>\n" +
-    "<span class=\"help-block\">\n" +
-    "Add an existing persistent volume claim to the template of {{kind | humanizeKind}} <b>{{name}}</b>.\n" +
-    "</span>\n" +
+    "<div class=\"help-block\">\n" +
+    "Add an existing persistent volume claim to the template of {{kind | humanizeKind}} {{name}}.\n" +
     "</div>\n" +
-    "<form name=\"attachPVCForm\">\n" +
+    "<form name=\"attachPVCForm\" class=\"mar-top-lg\">\n" +
     "<fieldset ng-disabled=\"disableInputs\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"persistentVolumeClaim\" class=\"required\">Storage</label>\n" +
-    "<div>\n" +
-    "<span id=\"persistent-volume-claim-help\" class=\"help-block\">Select storage to attach to</span>\n" +
-    "</div>\n" +
     "<table style=\"margin-bottom:0;background-color:transparent\" class=\"table table-condensed table-borderless\">\n" +
     "<tbody>\n" +
     "<tr ng-repeat=\"pvc in pvcs track by (pvc | uid)\">\n" +
@@ -975,16 +969,17 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</tbody>\n" +
     "</table>\n" +
     "</div>\n" +
-    "<div ng-if=\"project && ('persistentvolumeclaims' | canI : 'create')\">\n" +
-    "Or&nbsp;<a ng-href=\"project/{{project.metadata.name}}/create-pvc\">create storage.</a>\n" +
+    "<div ng-if=\"!(project && ('persistentvolumeclaims' | canI : 'create'))\" class=\"help-block\">\n" +
+    "Select a storage request to use.\n" +
+    "</div>\n" +
+    "<div ng-if=\"project && ('persistentvolumeclaims' | canI : 'create')\" class=\"help-block\">\n" +
+    "Select a storage request or <a ng-href=\"project/{{project.metadata.name}}/create-pvc\">request more storage</a>.\n" +
     "</div>\n" +
     "<h3>Volume</h3>\n" +
-    "<div>\n" +
-    "<span class=\"help-block\">\n" +
+    "<div class=\"help-block\">\n" +
     "Specify details about how volumes are going to be mounted inside containers.\n" +
-    "</span>\n" +
     "</div>\n" +
-    "<div class=\"form-group\">\n" +
+    "<div class=\"form-group mar-top-xl\">\n" +
     "<label for=\"route-name\">Mount path</label>\n" +
     "<input id=\"mount-path\" class=\"form-control\" type=\"text\" name=\"mountPath\" ng-model=\"attach.mountPath\" ng-pattern=\"/^\\/.*$/\" placeholder=\"example: /data\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"mount-path-help\">\n" +
     "<div>\n" +
@@ -1041,7 +1036,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</fieldset>\n" +
     "</form>\n" +
-    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
* Align breadcrumbs with content
* Clean up margins around help text
* Change "create storage" to "request storage" for consistency with the action name on other pages

Before:

![screen shot 2016-11-02 at 8 02 17 am](https://cloud.githubusercontent.com/assets/1167259/19929445/cc8ae01a-a0d9-11e6-9a6b-8c563ca77be2.png)

After (updated text called out):

![screen shot 2016-11-02 at 8 12 45 am](https://cloud.githubusercontent.com/assets/1167259/19929449/d092cf56-a0d9-11e6-9e75-3bc3585ef07e.png)

@jwforres PTAL. The large diff is mostly from whitespace changes.

@erinboyd @zherman0 CC