### PR TITLE
Don't request stacked metrics for container-level metrics

### DIFF
--- a/app/scripts/directives/podMetrics.js
+++ b/app/scripts/directives/podMetrics.js
@@ -375,8 +375,7 @@ angular.module('openshiftConsole')
             return _.assign(config, {
               namespace: scope.pod.metadata.namespace,
               pod: scope.pod,
-              containerName: metric.containerMetric ? scope.options.selectedContainer.name : "pod",
-              stacked: true
+              containerName: metric.containerMetric ? scope.options.selectedContainer.name : "pod"
             });
           }
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10299,8 +10299,7 @@ bucketDuration:o()
 return b.data && b.data.length ? (d = _.last(b.data), e.start = d.end) :e.start = c, j.pod ? _.assign(e, {
 namespace:j.pod.metadata.namespace,
 pod:j.pod,
-containerName:a.containerMetric ? j.options.selectedContainer.name :"pod",
-stacked:!0
+containerName:a.containerMetric ? j.options.selectedContainer.name :"pod"
 }) :null;
 }
 function q() {


### PR DESCRIPTION
We were incorrectly using the stacked URL template for requesting memory and CPU usage for a container on the pod metrics tab, which caused pod-level metrics to be displayed rather than container-level metrics.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1387274

With this change, we are correctly displaying different values for the different containers.

<img width="515" alt="screen shot 2016-11-02 at 9 46 33 am" src="https://cloud.githubusercontent.com/assets/1167259/19931101/b52ba3fc-a0e1-11e6-8fd6-6ea16ab198e0.png">

<img width="547" alt="screen shot 2016-11-02 at 9 46 27 am" src="https://cloud.githubusercontent.com/assets/1167259/19931107/b9a13e2e-a0e1-11e6-844c-83774274db5e.png">

@jwforres PTAL
@derekwaynecarr @sjenning CC