### PR TITLE
Adding middle truncation to warning popovers

### DIFF
--- a/app/scripts/filters/util.js
+++ b/app/scripts/filters/util.js
@@ -500,6 +500,35 @@ angular.module('openshiftConsole')
       return truncated;
     };
   })
+  .filter('middleEllipses', function() {
+    /* Adapted from https://github.com/jviotti/angular-middle-ellipses
+     * Usage:  {{ 'MyVeryLongString' | middleEllipses:5:' ... ' }}
+     */
+    return function(input, limit, ellipses) {
+
+      // If the limit is less than 3, return the string
+      if (limit < 3) {
+        return input;
+      }
+
+      // Do nothing, the string doesn't need truncation.
+      if (input.length <= limit) {
+        return input;
+      }
+
+      // If no ellipses is specified, use a default
+      if (!ellipses) {
+        ellipses = '...';
+      }
+
+      var lengthOfTheSidesAfterTruncation = Math.floor((limit - 1) / 2);
+      var finalLeftPart = input.slice(0, lengthOfTheSidesAfterTruncation);
+      var finalRightPart = input.slice(input.length - lengthOfTheSidesAfterTruncation);
+
+      return finalLeftPart + ellipses + finalRightPart;
+    };
+
+  })
   // Checks if a value is null or undefined.
   .filter('isNil', function() {
     return function(value) {

--- a/app/views/directives/_warnings-popover.html
+++ b/app/views/directives/_warnings-popover.html
@@ -1,6 +1,6 @@
 <span ng-if="content">
   <span
-    dynamic-content="{{content}}"
+    dynamic-content="{{content | middleEllipses:350:'...<br>...'}}"
     data-toggle="popover"
     data-trigger="hover"
     data-html="true"

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -13441,6 +13441,14 @@ h !== -1 && (e = e.substring(0, h));
 }
 return e;
 };
+}).filter("middleEllipses", function() {
+return function(a, b, c) {
+if (b < 3) return a;
+if (a.length <= b) return a;
+c || (c = "...");
+var d = Math.floor((b - 1) / 2), e = a.slice(0, d), f = a.slice(a.length - d);
+return e + c + f;
+};
 }).filter("isNil", function() {
 return function(a) {
 return null === a || void 0 === a;

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5109,7 +5109,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/directives/_warnings-popover.html',
     "<span ng-if=\"content\">\n" +
-    "<span dynamic-content=\"{{content}}\" data-toggle=\"popover\" data-trigger=\"hover\" data-html=\"true\" class=\"pficon pficon-warning-triangle-o warnings-popover\" aria-hidden=\"true\">\n" +
+    "<span dynamic-content=\"{{content | middleEllipses:350:'...<br>...'}}\" data-toggle=\"popover\" data-trigger=\"hover\" data-html=\"true\" class=\"pficon pficon-warning-triangle-o warnings-popover\" aria-hidden=\"true\">\n" +
     "</span>\n" +
     "<span class=\"sr-only\">{{content}}</span>\n" +
     "</span>"


### PR DESCRIPTION
Additional fix for https://bugzilla.redhat.com/show_bug.cgi?id=1389658

Popover text exceeding 350 characters will get truncated in the middle.  I arbitrarily chose 350.  Should it be more/less?

![screen shot 2016-11-02 at 11 47 17 am](https://cloud.githubusercontent.com/assets/895728/19935909/20f0c242-a0f2-11e6-902a-876732e0bfd9.PNG)

@jwforres or @spadgett, PTAL