### PR TITLE
Update refresh delay in istag-select

### DIFF
--- a/app/views/directives/istag-select.html
+++ b/app/views/directives/istag-select.html
@@ -27,7 +27,7 @@
         <label class="sr-only">Tag</label>
         <ui-select required ng-model="istag.tagObject" ng-disabled="!istag.imageStream || selectDisabled">
           <ui-select-match placeholder="Tag">{{$select.selected.tag}}</ui-select-match>
-          <ui-select-choices group-by="groupTags" repeat="statusTag in (isByNamespace[istag.namespace][istag.imageStream].status.tags | filter : { tag: $select.search })" refresh="getTags($select.search)" refresh-delay="0">
+          <ui-select-choices group-by="groupTags" repeat="statusTag in (isByNamespace[istag.namespace][istag.imageStream].status.tags | filter : { tag: $select.search })" refresh="getTags($select.search)" refresh-delay="200">
             <div ng-bind-html="statusTag.tag | highlight : $select.search"></div>
           </ui-select-choices>
         </ui-select>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6093,7 +6093,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<label class=\"sr-only\">Tag</label>\n" +
     "<ui-select required ng-model=\"istag.tagObject\" ng-disabled=\"!istag.imageStream || selectDisabled\">\n" +
     "<ui-select-match placeholder=\"Tag\">{{$select.selected.tag}}</ui-select-match>\n" +
-    "<ui-select-choices group-by=\"groupTags\" repeat=\"statusTag in (isByNamespace[istag.namespace][istag.imageStream].status.tags | filter : { tag: $select.search })\" refresh=\"getTags($select.search)\" refresh-delay=\"0\">\n" +
+    "<ui-select-choices group-by=\"groupTags\" repeat=\"statusTag in (isByNamespace[istag.namespace][istag.imageStream].status.tags | filter : { tag: $select.search })\" refresh=\"getTags($select.search)\" refresh-delay=\"200\">\n" +
     "<div ng-bind-html=\"statusTag.tag | highlight : $select.search\"></div>\n" +
     "</ui-select-choices>\n" +
     "</ui-select>\n" +


### PR DESCRIPTION
- Update the value to match setting on [membership page](https://github.com/openshift/origin-web-console/pull/797).

Eliminates the constant flicker, though there is a still re-render of the drop down menu.  

@jwforres @spadgett 
