### PR TITLE
Tighten up spacing on edit dc and edit bc forms

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -1003,6 +1003,7 @@ a.disabled-link {
     border-top: 1px solid rgba(0, 0, 0, 0.15);
     padding-top: 21px;
     padding-bottom: 10px;
+    margin-top: 10px;
   }
   .labels {
     .form-group {

--- a/app/views/edit/build-config.html
+++ b/app/views/edit/build-config.html
@@ -91,7 +91,7 @@
                               <div class="help-block" id="context-dir-help">Optional subdirectory for the application source code, used as the context directory for the build.</div>
                             </div>
                             <div class="form-group">
-                              <osc-secrets model="secrets.picked.gitSecret" 
+                              <osc-secrets model="secrets.picked.gitSecret"
                                           namespace="projectName"
                                           display-type="source"
                                           type="source"
@@ -500,7 +500,7 @@
                         <a href="{{'source_secrets' | helpLink}}" aria-hidden="true" target="_blank"><span class="learn-more-inline">Learn more&nbsp;<i class="fa fa-external-link"></i></span></a>
                       </h3>
                       <div class="form-group">
-                        <osc-source-secrets model="secrets.picked.sourceSecrets" 
+                        <osc-source-secrets model="secrets.picked.sourceSecrets"
                                     namespace="projectName"
                                     secrets-by-type="secrets.secretsByType"
                                     strategy-type="strategyType"
@@ -512,7 +512,7 @@
                       </div>
 
                     </div>
-                    <div class="section" ng-if="view.advancedOptions">
+                    <div class="section mar-bottom-lg" ng-if="view.advancedOptions">
                       <h3 class="with-divider">Run Policy
                         <span class="help action-inline">
                           <a href="">
@@ -537,8 +537,8 @@
                         <div class="help-block" ng-switch-default>Builds triggered from this Build Configuration will run using the {{updatedBuildConfig.spec.runPolicy | sentenceCase}} policy.</div>
                       </div>
                     </div>
-                  
-                    <div class="gutter-top">
+
+                    <div>
                       <a href="" ng-click="view.advancedOptions = !view.advancedOptions" role="button">{{view.advancedOptions ? 'Hide' : 'Show'}} advanced options</a>
                     </div>
                     <div class="buttons gutter-top-bottom">

--- a/app/views/edit/deployment-config.html
+++ b/app/views/edit/deployment-config.html
@@ -257,7 +257,7 @@
                               </div>
                             </div>
                           </div>
-                          <div class="gutter-top">
+                          <div class="mar-top-lg">
                             <div ng-if="!view.advancedStrategyOptions">To set additional parameters or edit lifecycle hooks, view <a href="" ng-click="view.advancedStrategyOptions = true">advanced strategy options.</a></div>
                             <a ng-if="view.advancedStrategyOptions" href="" ng-click="view.advancedStrategyOptions = false">Hide strategy advanced options</a>
                           </div>
@@ -269,35 +269,32 @@
                         <h3 class="with-divider">Images</h3>
                         <dl class="dl-horizontal left">
 
-                          <div ng-repeat="(containerName, containerConfig) in containerConfigByName" class="gutter-bottom">
+                          <div ng-repeat="(containerName, containerConfig) in containerConfigByName">
                             <div class="container-name">
                               <h4>Container {{containerName}}</h4>
                             </div>
                             <div class="checkbox form-group">
                               <label>
                                 <input type="checkbox" ng-model="containerConfig.hasDeploymentTrigger">
-                                Automatically start new deployments when the image stream tag is updated.
+                                Automatically start new deployments when an image stream tag is updated.
                               </label>
                             </div>
-                            <div class="form-group" ng-if="containerConfig.hasDeploymentTrigger">
+                            <div ng-if="containerConfig.hasDeploymentTrigger">
                               <label class="required">Image Change Trigger</label>
                               <istag-select model="containerConfig.triggerData.istag" select-disabled="disableInputs" include-shared-namespace="true"></istag-select>
-                              <span class="help-block">New deployments will automatically start when the image stream tag is updated.</span>
                             </div>
 
-                            <div ng-if="!containerConfig.hasDeploymentTrigger">
+                            <div ng-if="!containerConfig.hasDeploymentTrigger" class="form-group">
                               <label for="imageName" class="required">Image Name</label>
-                              <div>
-                                <input class="form-control"
-                                  id="imageName"
-                                  name="imageName"
-                                  ng-model="containerConfig.image"
-                                  type="text"
-                                  autocorrect="off"
-                                  autocapitalize="off"
-                                  spellcheck="false"
-                                  required>
-                              </div>
+                              <input class="form-control"
+                                id="imageName"
+                                name="imageName"
+                                ng-model="containerConfig.image"
+                                type="text"
+                                autocorrect="off"
+                                autocapitalize="off"
+                                spellcheck="false"
+                                required>
                             </div>
                           </div>
 
@@ -309,7 +306,7 @@
                           </div>
 
                           <div ng-if="view.advancedImageOptions">
-                            <div class="gutter-top">
+                            <div class="mar-top-lg">
                               <osc-secrets model="secrets.pullSecrets"
                                           namespace="projectName"
                                           display-type="pull"
@@ -322,7 +319,7 @@
                             </div>
                           </div>
 
-                          <div class="gutter-top">
+                          <div class="mar-top-lg">
                             <div ng-if="!view.advancedImageOptions">To set secrets for pulling your images from private image registries, view <a href="" ng-click="view.advancedImageOptions = true">advanced image options.</a></div>
                             <a ng-if="view.advancedImageOptions" href="" ng-click="view.advancedImageOptions = false">Hide advanced image options</a>
                           </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7759,7 +7759,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</osc-source-secrets>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"section\" ng-if=\"view.advancedOptions\">\n" +
+    "<div class=\"section mar-bottom-lg\" ng-if=\"view.advancedOptions\">\n" +
     "<h3 class=\"with-divider\">Run Policy\n" +
     "<span class=\"help action-inline\">\n" +
     "<a href=\"\">\n" +
@@ -7783,7 +7783,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"help-block\" ng-switch-default>Builds triggered from this Build Configuration will run using the {{updatedBuildConfig.spec.runPolicy | sentenceCase}} policy.</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"gutter-top\">\n" +
+    "<div>\n" +
     "<a href=\"\" ng-click=\"view.advancedOptions = !view.advancedOptions\" role=\"button\">{{view.advancedOptions ? 'Hide' : 'Show'}} advanced options</a>\n" +
     "</div>\n" +
     "<div class=\"buttons gutter-top-bottom\">\n" +
@@ -7986,7 +7986,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"gutter-top\">\n" +
+    "<div class=\"mar-top-lg\">\n" +
     "<div ng-if=\"!view.advancedStrategyOptions\">To set additional parameters or edit lifecycle hooks, view <a href=\"\" ng-click=\"view.advancedStrategyOptions = true\">advanced strategy options.</a></div>\n" +
     "<a ng-if=\"view.advancedStrategyOptions\" href=\"\" ng-click=\"view.advancedStrategyOptions = false\">Hide strategy advanced options</a>\n" +
     "</div>\n" +
@@ -7995,26 +7995,23 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"section\">\n" +
     "<h3 class=\"with-divider\">Images</h3>\n" +
     "<dl class=\"dl-horizontal left\">\n" +
-    "<div ng-repeat=\"(containerName, containerConfig) in containerConfigByName\" class=\"gutter-bottom\">\n" +
+    "<div ng-repeat=\"(containerName, containerConfig) in containerConfigByName\">\n" +
     "<div class=\"container-name\">\n" +
     "<h4>Container {{containerName}}</h4>\n" +
     "</div>\n" +
     "<div class=\"checkbox form-group\">\n" +
     "<label>\n" +
     "<input type=\"checkbox\" ng-model=\"containerConfig.hasDeploymentTrigger\">\n" +
-    "Automatically start new deployments when the image stream tag is updated.\n" +
+    "Automatically start new deployments when an image stream tag is updated.\n" +
     "</label>\n" +
     "</div>\n" +
-    "<div class=\"form-group\" ng-if=\"containerConfig.hasDeploymentTrigger\">\n" +
+    "<div ng-if=\"containerConfig.hasDeploymentTrigger\">\n" +
     "<label class=\"required\">Image Change Trigger</label>\n" +
     "<istag-select model=\"containerConfig.triggerData.istag\" select-disabled=\"disableInputs\" include-shared-namespace=\"true\"></istag-select>\n" +
-    "<span class=\"help-block\">New deployments will automatically start when the image stream tag is updated.</span>\n" +
     "</div>\n" +
-    "<div ng-if=\"!containerConfig.hasDeploymentTrigger\">\n" +
+    "<div ng-if=\"!containerConfig.hasDeploymentTrigger\" class=\"form-group\">\n" +
     "<label for=\"imageName\" class=\"required\">Image Name</label>\n" +
-    "<div>\n" +
     "<input class=\"form-control\" id=\"imageName\" name=\"imageName\" ng-model=\"containerConfig.image\" type=\"text\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" required>\n" +
-    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"checkbox form-group\">\n" +
@@ -8024,12 +8021,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</label>\n" +
     "</div>\n" +
     "<div ng-if=\"view.advancedImageOptions\">\n" +
-    "<div class=\"gutter-top\">\n" +
+    "<div class=\"mar-top-lg\">\n" +
     "<osc-secrets model=\"secrets.pullSecrets\" namespace=\"projectName\" display-type=\"pull\" type=\"image\" secrets-by-type=\"secretsByType\" service-account-to-link=\"default\" alerts=\"alerts\" allow-multiple-secrets=\"true\">\n" +
     "</osc-secrets>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"gutter-top\">\n" +
+    "<div class=\"mar-top-lg\">\n" +
     "<div ng-if=\"!view.advancedImageOptions\">To set secrets for pulling your images from private image registries, view <a href=\"\" ng-click=\"view.advancedImageOptions = true\">advanced image options.</a></div>\n" +
     "<a ng-if=\"view.advancedImageOptions\" href=\"\" ng-click=\"view.advancedImageOptions = false\">Hide advanced image options</a>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3949,7 +3949,7 @@ a.disabled-link:active,a.disabled-link:focus,a.disabled-link:hover{color:#bbb;te
 .modal-debug-terminal .modal-footer{padding-top:0}
 .ace-inline{height:300px}
 #from-file .editor{height:350px}
-.edit-form .with-divider{border-top:1px solid rgba(0,0,0,.15);padding-top:21px;padding-bottom:10px}
+.edit-form .with-divider{border-top:1px solid rgba(0,0,0,.15);padding-top:21px;padding-bottom:10px;margin-top:10px}
 .edit-form .labels .form-group{width:44%}
 .edit-form .labels .form-group .form-control{width:100%}
 .edit-form .checkbox{margin:10px 0}


### PR DESCRIPTION
@jwforres PTAL. Small change, but some of the spacing seemed off. I also removed some help text that repeated the checkbox label said.

Before:

![screen shot 2016-11-02 at 3 27 30 pm](https://cloud.githubusercontent.com/assets/1167259/19944169/0c1c1582-a111-11e6-8b4e-4929c31f87a1.png)

After:

![screen shot 2016-11-02 at 3 27 10 pm](https://cloud.githubusercontent.com/assets/1167259/19944175/12b321c4-a111-11e6-9089-ddebc59a27e7.png)
