### PR TITLE
Consistently use headline case for labels on resource pages

### DIFF
--- a/app/views/_volumes.html
+++ b/app/views/_volumes.html
@@ -12,7 +12,7 @@
         secret
         <span class="small text-muted">(populated by a Secret when the pod is created)</span>
       </dd>
-      <dt>Secret name:</dt>
+      <dt>Secret Name:</dt>
       <dd>{{volume.secret.secretName}}</dd>
     </div>
     <div ng-if="volume.persistentVolumeClaim">
@@ -68,7 +68,7 @@
         <span class="small text-muted">(populated with information about the pod)</span>
        </dd>
       <div ng-repeat="item in volume.downwardAPI.items">
-        <dt>Volume file:</dt>
+        <dt>Volume File:</dt>
         <dd>{{item.fieldRef.fieldPath}}&#8201;&#8594;&#8201;{{item.path}}</dd>
       </div>
     </div>
@@ -81,7 +81,7 @@
       <dt>Name:</dt>
       <dd>{{volume.configMap.name}}</dd>
       <div ng-repeat="item in volume.configMap.items">
-        <dt>Key to file:</dt>
+        <dt>Key to File:</dt>
         <dd>{{item.key}}&#8201;&#8594;&#8201;{{item.path}}</dd>
       </div>
     </div>

--- a/app/views/browse/_build-details.html
+++ b/app/views/browse/_build-details.html
@@ -35,7 +35,7 @@
           </span>
         </dd>
         <div ng-if='build.spec.triggeredBy.length'>
-          <dt>Triggered by:</dt>
+          <dt>Triggered By:</dt>
           <dd>
             <div ng-repeat="trigger in build.spec.triggeredBy">
               <div ng-switch="trigger.message">
@@ -57,24 +57,24 @@
       </dl>
       <h3>Configuration <span class="small" ng-if="buildConfigName">created from <a href="{{build | configURLForResource}}">{{buildConfigName}}</a></span></h3>
       <dl class="dl-horizontal left">
-        <dt>Build strategy:</dt>
+        <dt>Build Strategy:</dt>
         <dd>{{build.spec.strategy.type | startCase}}</dd>
-        <dt ng-if-start="(build | buildStrategy).from">Builder image:</dt>
+        <dt ng-if-start="(build | buildStrategy).from">Builder Image:</dt>
         <dd ng-if-end class="truncate">{{(build | buildStrategy).from | imageObjectRef : build.metadata.namespace}}<span ng-if="!(build | buildStrategy).from"><em>none</em></span></dd>
-        <dt>Source type:</dt>
+        <dt>Source Type:</dt>
         <dd>{{build.spec.source.type}}</dd>
-        <dt ng-if-start="build.spec.source.git.uri">Source repo:</dt>
+        <dt ng-if-start="build.spec.source.git.uri">Source Repo:</dt>
         <dd ng-if-end><span class="word-break"><osc-git-link
                     uri="build.spec.source.git.uri"
                     ref="build.spec.source.git.ref"
                     context-dir="build.spec.source.contextDir">{{build.spec.source.git.uri}}</osc-git-link></span></dd>
-        <dt ng-if-start="build.spec.source.git.ref">Source ref:</dt>
+        <dt ng-if-start="build.spec.source.git.ref">Source Ref:</dt>
         <dd ng-if-end>{{build.spec.source.git.ref}}</dd>
-        <dt ng-if-start="build.spec.source.contextDir">Source context dir:</dt>
+        <dt ng-if-start="build.spec.source.contextDir">Source Context Dir:</dt>
         <dd ng-if-end>{{build.spec.source.contextDir}}</dd>
-        <dt ng-if-start="build.spec.output.to">Output image:</dt>
+        <dt ng-if-start="build.spec.output.to">Output Image:</dt>
         <dd ng-if-end>{{build.spec.output.to | imageObjectRef : build.metadata.namespace}}</dd>
-        <dt ng-if-start="build.spec.output.pushSecret.name">Push secret:</dt>
+        <dt ng-if-start="build.spec.output.pushSecret.name">Push Secret:</dt>
         <dd ng-if-end>{{build.spec.output.pushSecret.name}}</dd>
         <dt ng-if-start="build.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath">
           Jenkinsfile Path:

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -196,19 +196,19 @@
                             <h3>Configuration</h3>
                             <dl class="dl-horizontal left">
                               <div>
-                                <dt>Build strategy:</dt>
+                                <dt>Build Strategy:</dt>
                                 <dd>{{buildConfig.spec.strategy.type | startCase}}</dd>
                               </div>
                               <div ng-switch="buildConfig.spec.strategy.type">
                                 <div ng-switch-when="Source">
                                   <div ng-if="buildConfig.spec.strategy.sourceStrategy.from">
-                                    <dt>Builder image:</dt>
+                                    <dt>Builder Image:</dt>
                                     <dd>{{buildConfig.spec.strategy.sourceStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}</dd>
                                   </div>
                                 </div>
                                 <div ng-switch-when="Docker">
                                   <div ng-if="buildConfig.spec.strategy.dockerStrategy.from">
-                                    <dt>Builder image stream:</dt>
+                                    <dt>Builder Image Stream:</dt>
                                     <dd>{{buildConfig.spec.strategy.dockerStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}</dd>
                                   </div>
                                   <div ng-if="buildConfig.spec.source.dockerfile">
@@ -232,7 +232,7 @@
                                 </div>
                                 <div ng-switch-when="Custom">
                                   <div ng-if="buildConfig.spec.strategy.customStrategy.from">
-                                    <dt>Builder image stream:</dt>
+                                    <dt>Builder Image Stream:</dt>
                                     <dd>{{buildConfig.spec.strategy.customStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
                                     </dd>
                                   </div>
@@ -240,14 +240,14 @@
                               </div>
                               <div ng-if="buildConfig.spec.source">
                                 <div ng-if="buildConfig.spec.source.type == 'Git'">
-                                  <dt>Source repo:</dt>
+                                  <dt>Source Repo:</dt>
                                   <dd><span class="word-break"><osc-git-link
                                             uri="buildConfig.spec.source.git.uri"
                                             ref="buildConfig.spec.source.git.ref"
                                             context-dir="buildConfig.spec.source.contextDir">{{buildConfig.spec.source.git.uri}}</osc-git-link></span></dd>
-                                  <dt ng-if="buildConfig.spec.source.git.ref">Source ref:</dt>
+                                  <dt ng-if="buildConfig.spec.source.git.ref">Source Ref:</dt>
                                   <dd ng-if="buildConfig.spec.source.git.ref">{{buildConfig.spec.source.git.ref}}</dd>
-                                  <dt ng-if="buildConfig.spec.source.contextDir">Source context dir:</dt>
+                                  <dt ng-if="buildConfig.spec.source.contextDir">Source Context Dir:</dt>
                                   <dd ng-if="buildConfig.spec.source.contextDir">{{buildConfig.spec.source.contextDir}}</dd>
                                 </div>
                                 <div ng-if="buildConfig | isJenkinsPipelineStrategy">
@@ -290,7 +290,7 @@
                                   </dd>
                                 </div>
                                 <div ng-if="buildConfig.spec.source.images" class="image-sources">
-                                  <dt>Image sources:</dt>
+                                  <dt>Image Sources:</dt>
                                   <dd></dd>
                                   <div ng-repeat="imageSource in imageSources" class="image-source-item">
                                     <h4>{{imageSource.from | imageObjectRef : buildConfig.metadata.namespace}}</h4>
@@ -306,7 +306,7 @@
                                 </div>
                               </div>
                               <div ng-if="buildConfig.spec.output.to">
-                                <dt>Output to:</dt>
+                                <dt>Output To:</dt>
                                 <dd>{{buildConfig.spec.output.to | imageObjectRef : buildConfig.metadata.namespace}}</dd>
                               </div>
                               <div class="run-policy">
@@ -331,7 +331,7 @@
                             <div ng-repeat="trigger in buildConfig.spec.triggers">
                               <div ng-switch="trigger.type">
                                 <div ng-switch-when="GitHub">
-                                    <dt>GitHub webhook URL:
+                                    <dt>GitHub Webhook URL:
                                       <a href="{{'webhooks' | helpLink}}" target="_blank"><span class="learn-more-block">Learn more
                                       <i class="fa fa-external-link"></i></span></a>
                                     </dt>
@@ -340,7 +340,7 @@
                                     </dd>
                                 </div>
                                 <div ng-switch-when="Generic">
-                                    <dt>Generic webhook URL:
+                                    <dt>Generic Webhook URL:
                                       <a href="{{'webhooks' | helpLink}}" target="_blank"><span class="learn-more-block">Learn more <i class="fa fa-external-link"></i></span></a>
                                     </dt>
                                     <dd>
@@ -349,18 +349,18 @@
                                 </div>
                                 <div ng-switch-when="ImageChange">
                                   <dt>
-                                    New image for:
+                                    New Image For:
                                   </dt>
                                   <dd>
                                     {{(trigger.imageChange.from || (buildConfig | buildStrategy).from) | imageObjectRef : buildConfig.metadata.namespace}}
                                   </dd>
                                 </div>
                                 <div ng-switch-when="ConfigChange">
-                                  <dt>Config change for:</dt>
+                                  <dt>Config Change For:</dt>
                                   <dd>Build config {{buildConfig.metadata.name}}</dd>
                                 </div>
                                 <div ng-switch-default>
-                                  <dt>Other trigger:</dt>
+                                  <dt>Other Trigger:</dt>
                                   <dd>{{trigger.type}}</dd>
                                 </div>
                               </div>

--- a/app/views/browse/deployment-config.html
+++ b/app/views/browse/deployment-config.html
@@ -209,11 +209,11 @@
                               <span ng-switch="trigger.type">
                                 <span ng-switch-default>{{trigger.type}}</span>
                                 <span ng-switch-when="ImageChange" ng-if="trigger.imageChangeParams.from">
-                                  <dt>New image for:</dt>
+                                  <dt>New Image For:</dt>
                                   <dd>{{trigger.imageChangeParams.from | imageObjectRef : deploymentConfig.metadata.namespace}}</dd>
                                 </span>
                                 <span ng-switch-when="ConfigChange">
-                                  <dt>Change of:</dt>
+                                  <dt>Change Of:</dt>
                                   <dd>Config</dd>
                                 </span>
                               </span>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -768,7 +768,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "secret\n" +
     "<span class=\"small text-muted\">(populated by a Secret when the pod is created)</span>\n" +
     "</dd>\n" +
-    "<dt>Secret name:</dt>\n" +
+    "<dt>Secret Name:</dt>\n" +
     "<dd>{{volume.secret.secretName}}</dd>\n" +
     "</div>\n" +
     "<div ng-if=\"volume.persistentVolumeClaim\">\n" +
@@ -824,7 +824,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"small text-muted\">(populated with information about the pod)</span>\n" +
     "</dd>\n" +
     "<div ng-repeat=\"item in volume.downwardAPI.items\">\n" +
-    "<dt>Volume file:</dt>\n" +
+    "<dt>Volume File:</dt>\n" +
     "<dd>{{item.fieldRef.fieldPath}}&#8201;&#8594;&#8201;{{item.path}}</dd>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -837,7 +837,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt>Name:</dt>\n" +
     "<dd>{{volume.configMap.name}}</dd>\n" +
     "<div ng-repeat=\"item in volume.configMap.items\">\n" +
-    "<dt>Key to file:</dt>\n" +
+    "<dt>Key to File:</dt>\n" +
     "<dd>{{item.key}}&#8201;&#8594;&#8201;{{item.path}}</dd>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -1086,7 +1086,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</dd>\n" +
     "<div ng-if=\"build.spec.triggeredBy.length\">\n" +
-    "<dt>Triggered by:</dt>\n" +
+    "<dt>Triggered By:</dt>\n" +
     "<dd>\n" +
     "<div ng-repeat=\"trigger in build.spec.triggeredBy\">\n" +
     "<div ng-switch=\"trigger.message\">\n" +
@@ -1108,21 +1108,21 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</dl>\n" +
     "<h3>Configuration <span class=\"small\" ng-if=\"buildConfigName\">created from <a href=\"{{build | configURLForResource}}\">{{buildConfigName}}</a></span></h3>\n" +
     "<dl class=\"dl-horizontal left\">\n" +
-    "<dt>Build strategy:</dt>\n" +
+    "<dt>Build Strategy:</dt>\n" +
     "<dd>{{build.spec.strategy.type | startCase}}</dd>\n" +
-    "<dt ng-if-start=\"(build | buildStrategy).from\">Builder image:</dt>\n" +
+    "<dt ng-if-start=\"(build | buildStrategy).from\">Builder Image:</dt>\n" +
     "<dd ng-if-end class=\"truncate\">{{(build | buildStrategy).from | imageObjectRef : build.metadata.namespace}}<span ng-if=\"!(build | buildStrategy).from\"><em>none</em></span></dd>\n" +
-    "<dt>Source type:</dt>\n" +
+    "<dt>Source Type:</dt>\n" +
     "<dd>{{build.spec.source.type}}</dd>\n" +
-    "<dt ng-if-start=\"build.spec.source.git.uri\">Source repo:</dt>\n" +
+    "<dt ng-if-start=\"build.spec.source.git.uri\">Source Repo:</dt>\n" +
     "<dd ng-if-end><span class=\"word-break\"><osc-git-link uri=\"build.spec.source.git.uri\" ref=\"build.spec.source.git.ref\" context-dir=\"build.spec.source.contextDir\">{{build.spec.source.git.uri}}</osc-git-link></span></dd>\n" +
-    "<dt ng-if-start=\"build.spec.source.git.ref\">Source ref:</dt>\n" +
+    "<dt ng-if-start=\"build.spec.source.git.ref\">Source Ref:</dt>\n" +
     "<dd ng-if-end>{{build.spec.source.git.ref}}</dd>\n" +
-    "<dt ng-if-start=\"build.spec.source.contextDir\">Source context dir:</dt>\n" +
+    "<dt ng-if-start=\"build.spec.source.contextDir\">Source Context Dir:</dt>\n" +
     "<dd ng-if-end>{{build.spec.source.contextDir}}</dd>\n" +
-    "<dt ng-if-start=\"build.spec.output.to\">Output image:</dt>\n" +
+    "<dt ng-if-start=\"build.spec.output.to\">Output Image:</dt>\n" +
     "<dd ng-if-end>{{build.spec.output.to | imageObjectRef : build.metadata.namespace}}</dd>\n" +
-    "<dt ng-if-start=\"build.spec.output.pushSecret.name\">Push secret:</dt>\n" +
+    "<dt ng-if-start=\"build.spec.output.pushSecret.name\">Push Secret:</dt>\n" +
     "<dd ng-if-end>{{build.spec.output.pushSecret.name}}</dd>\n" +
     "<dt ng-if-start=\"build.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath\">\n" +
     "Jenkinsfile Path:\n" +
@@ -1643,19 +1643,19 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<h3>Configuration</h3>\n" +
     "<dl class=\"dl-horizontal left\">\n" +
     "<div>\n" +
-    "<dt>Build strategy:</dt>\n" +
+    "<dt>Build Strategy:</dt>\n" +
     "<dd>{{buildConfig.spec.strategy.type | startCase}}</dd>\n" +
     "</div>\n" +
     "<div ng-switch=\"buildConfig.spec.strategy.type\">\n" +
     "<div ng-switch-when=\"Source\">\n" +
     "<div ng-if=\"buildConfig.spec.strategy.sourceStrategy.from\">\n" +
-    "<dt>Builder image:</dt>\n" +
+    "<dt>Builder Image:</dt>\n" +
     "<dd>{{buildConfig.spec.strategy.sourceStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}</dd>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div ng-switch-when=\"Docker\">\n" +
     "<div ng-if=\"buildConfig.spec.strategy.dockerStrategy.from\">\n" +
-    "<dt>Builder image stream:</dt>\n" +
+    "<dt>Builder Image Stream:</dt>\n" +
     "<dd>{{buildConfig.spec.strategy.dockerStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}</dd>\n" +
     "</div>\n" +
     "<div ng-if=\"buildConfig.spec.source.dockerfile\">\n" +
@@ -1679,7 +1679,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div ng-switch-when=\"Custom\">\n" +
     "<div ng-if=\"buildConfig.spec.strategy.customStrategy.from\">\n" +
-    "<dt>Builder image stream:</dt>\n" +
+    "<dt>Builder Image Stream:</dt>\n" +
     "<dd>{{buildConfig.spec.strategy.customStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}\n" +
     "</dd>\n" +
     "</div>\n" +
@@ -1687,11 +1687,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div ng-if=\"buildConfig.spec.source\">\n" +
     "<div ng-if=\"buildConfig.spec.source.type == 'Git'\">\n" +
-    "<dt>Source repo:</dt>\n" +
+    "<dt>Source Repo:</dt>\n" +
     "<dd><span class=\"word-break\"><osc-git-link uri=\"buildConfig.spec.source.git.uri\" ref=\"buildConfig.spec.source.git.ref\" context-dir=\"buildConfig.spec.source.contextDir\">{{buildConfig.spec.source.git.uri}}</osc-git-link></span></dd>\n" +
-    "<dt ng-if=\"buildConfig.spec.source.git.ref\">Source ref:</dt>\n" +
+    "<dt ng-if=\"buildConfig.spec.source.git.ref\">Source Ref:</dt>\n" +
     "<dd ng-if=\"buildConfig.spec.source.git.ref\">{{buildConfig.spec.source.git.ref}}</dd>\n" +
-    "<dt ng-if=\"buildConfig.spec.source.contextDir\">Source context dir:</dt>\n" +
+    "<dt ng-if=\"buildConfig.spec.source.contextDir\">Source Context Dir:</dt>\n" +
     "<dd ng-if=\"buildConfig.spec.source.contextDir\">{{buildConfig.spec.source.contextDir}}</dd>\n" +
     "</div>\n" +
     "<div ng-if=\"buildConfig | isJenkinsPipelineStrategy\">\n" +
@@ -1734,7 +1734,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</dd>\n" +
     "</div>\n" +
     "<div ng-if=\"buildConfig.spec.source.images\" class=\"image-sources\">\n" +
-    "<dt>Image sources:</dt>\n" +
+    "<dt>Image Sources:</dt>\n" +
     "<dd></dd>\n" +
     "<div ng-repeat=\"imageSource in imageSources\" class=\"image-source-item\">\n" +
     "<h4>{{imageSource.from | imageObjectRef : buildConfig.metadata.namespace}}</h4>\n" +
@@ -1750,7 +1750,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"buildConfig.spec.output.to\">\n" +
-    "<dt>Output to:</dt>\n" +
+    "<dt>Output To:</dt>\n" +
     "<dd>{{buildConfig.spec.output.to | imageObjectRef : buildConfig.metadata.namespace}}</dd>\n" +
     "</div>\n" +
     "<div class=\"run-policy\">\n" +
@@ -1775,7 +1775,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-repeat=\"trigger in buildConfig.spec.triggers\">\n" +
     "<div ng-switch=\"trigger.type\">\n" +
     "<div ng-switch-when=\"GitHub\">\n" +
-    "<dt>GitHub webhook URL:\n" +
+    "<dt>GitHub Webhook URL:\n" +
     "<a href=\"{{'webhooks' | helpLink}}\" target=\"_blank\"><span class=\"learn-more-block\">Learn more\n" +
     "<i class=\"fa fa-external-link\"></i></span></a>\n" +
     "</dt>\n" +
@@ -1784,7 +1784,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</dd>\n" +
     "</div>\n" +
     "<div ng-switch-when=\"Generic\">\n" +
-    "<dt>Generic webhook URL:\n" +
+    "<dt>Generic Webhook URL:\n" +
     "<a href=\"{{'webhooks' | helpLink}}\" target=\"_blank\"><span class=\"learn-more-block\">Learn more <i class=\"fa fa-external-link\"></i></span></a>\n" +
     "</dt>\n" +
     "<dd>\n" +
@@ -1793,18 +1793,18 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div ng-switch-when=\"ImageChange\">\n" +
     "<dt>\n" +
-    "New image for:\n" +
+    "New Image For:\n" +
     "</dt>\n" +
     "<dd>\n" +
     "{{(trigger.imageChange.from || (buildConfig | buildStrategy).from) | imageObjectRef : buildConfig.metadata.namespace}}\n" +
     "</dd>\n" +
     "</div>\n" +
     "<div ng-switch-when=\"ConfigChange\">\n" +
-    "<dt>Config change for:</dt>\n" +
+    "<dt>Config Change For:</dt>\n" +
     "<dd>Build config {{buildConfig.metadata.name}}</dd>\n" +
     "</div>\n" +
     "<div ng-switch-default>\n" +
-    "<dt>Other trigger:</dt>\n" +
+    "<dt>Other Trigger:</dt>\n" +
     "<dd>{{trigger.type}}</dd>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -2116,11 +2116,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-switch=\"trigger.type\">\n" +
     "<span ng-switch-default>{{trigger.type}}</span>\n" +
     "<span ng-switch-when=\"ImageChange\" ng-if=\"trigger.imageChangeParams.from\">\n" +
-    "<dt>New image for:</dt>\n" +
+    "<dt>New Image For:</dt>\n" +
     "<dd>{{trigger.imageChangeParams.from | imageObjectRef : deploymentConfig.metadata.namespace}}</dd>\n" +
     "</span>\n" +
     "<span ng-switch-when=\"ConfigChange\">\n" +
-    "<dt>Change of:</dt>\n" +
+    "<dt>Change Of:</dt>\n" +
     "<dd>Config</dd>\n" +
     "</span>\n" +
     "</span>\n" +


### PR DESCRIPTION
We sometimes use headline case and sometimes sentence case. We're even inconsistent on the same page at times. Use headline case for the labels always.

Patternfly guidelines:

http://www.patternfly.org/styles/terminology-and-wording/

The guidelines don't seem to deal with this case specifically, although for other labels like input labels they say to use headline. Whatever we pick, I'd like to be consistent :)

@jwforres PTAL
@rhamilto CC