### PR TITLE
Add trigger, but set automatic to false

### DIFF
--- a/app/scripts/services/applicationGenerator.js
+++ b/app/scripts/services/applicationGenerator.js
@@ -220,23 +220,21 @@ angular.module("openshiftConsole")
           }
         }
       };
-      if(input.deploymentConfig.deployOnNewImage){
-        deploymentConfig.spec.triggers.push(
-          {
-            type: "ImageChange",
-            imageChangeParams: {
-              automatic: true,
-              containerNames: [
-                input.name
-              ],
-              from: {
-                kind: imageSpec.kind,
-                name: imageSpec.toString()
-              }
+      deploymentConfig.spec.triggers.push(
+        {
+          type: "ImageChange",
+          imageChangeParams: {
+            automatic: !!input.deploymentConfig.deployOnNewImage,
+            containerNames: [
+              input.name
+            ],
+            from: {
+              kind: imageSpec.kind,
+              name: imageSpec.toString()
             }
           }
-        );
-      }
+        }
+      );
       if (input.deploymentConfig.deployOnConfigChange) {
         deploymentConfig.spec.triggers.push({type: "ConfigChange"});
       }

--- a/app/views/_triggers.html
+++ b/app/views/_triggers.html
@@ -19,7 +19,7 @@
           </div>
           <div class="build-phase">
             <status-icon status="build.status.phase"></status-icon>
-            {{build.status.phase}}<span ng-if="build | isIncompleteBuild">. A new deployment will be created automatically once the build completes.</span>
+            {{build.status.phase}}<span ng-if="(build | isIncompleteBuild) && trigger.imageChangeParams.automatic">. A new deployment will be created automatically once the build completes.</span>
           </div>
           <relative-timestamp timestamp="build.metadata.creationTimestamp" class="build-timestamp"></relative-timestamp>
           <div ng-if="'builds/log' | canI : 'get'" class="build-links">

--- a/app/views/browse/deployment-config.html
+++ b/app/views/browse/deployment-config.html
@@ -210,7 +210,10 @@
                                 <span ng-switch-default>{{trigger.type}}</span>
                                 <span ng-switch-when="ImageChange" ng-if="trigger.imageChangeParams.from">
                                   <dt>New Image For:</dt>
-                                  <dd>{{trigger.imageChangeParams.from | imageObjectRef : deploymentConfig.metadata.namespace}}</dd>
+                                  <dd>
+                                    {{trigger.imageChangeParams.from | imageObjectRef : deploymentConfig.metadata.namespace}}
+                                    <small ng-if="!trigger.imageChangeParams.automatic" class="text-muted">(disabled)</small>
+                                  </dd>
                                 </span>
                                 <span ng-switch-when="ConfigChange">
                                   <dt>Change Of:</dt>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1765,10 +1765,10 @@ containers:[ g ]
 }
 }
 };
-return a.deploymentConfig.deployOnNewImage && h.spec.triggers.push({
+return h.spec.triggers.push({
 type:"ImageChange",
 imageChangeParams:{
-automatic:!0,
+automatic:!!a.deploymentConfig.deployOnNewImage,
 containerNames:[ a.name ],
 from:{
 kind:b.kind,

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -743,7 +743,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"build-phase\">\n" +
     "<status-icon status=\"build.status.phase\"></status-icon>\n" +
-    "{{build.status.phase}}<span ng-if=\"build | isIncompleteBuild\">. A new deployment will be created automatically once the build completes.</span>\n" +
+    "{{build.status.phase}}<span ng-if=\"(build | isIncompleteBuild) && trigger.imageChangeParams.automatic\">. A new deployment will be created automatically once the build completes.</span>\n" +
     "</div>\n" +
     "<relative-timestamp timestamp=\"build.metadata.creationTimestamp\" class=\"build-timestamp\"></relative-timestamp>\n" +
     "<div ng-if=\"'builds/log' | canI : 'get'\" class=\"build-links\">\n" +
@@ -2117,7 +2117,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-switch-default>{{trigger.type}}</span>\n" +
     "<span ng-switch-when=\"ImageChange\" ng-if=\"trigger.imageChangeParams.from\">\n" +
     "<dt>New Image For:</dt>\n" +
-    "<dd>{{trigger.imageChangeParams.from | imageObjectRef : deploymentConfig.metadata.namespace}}</dd>\n" +
+    "<dd>\n" +
+    "{{trigger.imageChangeParams.from | imageObjectRef : deploymentConfig.metadata.namespace}}\n" +
+    "<small ng-if=\"!trigger.imageChangeParams.automatic\" class=\"text-muted\">(disabled)</small>\n" +
+    "</dd>\n" +
     "</span>\n" +
     "<span ng-switch-when=\"ConfigChange\">\n" +
     "<dt>Change Of:</dt>\n" +


### PR DESCRIPTION
If a user unchecks deploy automatically on new images, still add the image change trigger, but set automatic to false. This avoids image pull errors.

Fixes #808 

@jwforres PTAL
@jhadvig I think we should update the DC editor to handle this flag.
@kargakis CC