### PR TITLE
Membership: temporarily eliminate default description tooltip for roles

### DIFF
--- a/app/scripts/controllers/membership.js
+++ b/app/scripts/controllers/membership.js
@@ -166,7 +166,10 @@ angular
           if(!role) {
             return;
           }
-          var noInfoMessage = 'There is no additional information about this role.';
+          // NOTE: hiding tooltip entirely for now, until descriptions merge:
+          // https://github.com/openshift/origin/pull/11328
+          // the tooltip will still work if roles are manually annotated
+          var noInfoMessage = ''; // prev: 'There is no additional information about this role.';
           var namespace = _.get(role, 'metadata.namespace');
           var name = _.get(role, 'metadata.name');
           var prefix = namespace ? (namespace + ' / ' + name + ': ') : '';

--- a/app/scripts/directives/actionChip.js
+++ b/app/scripts/directives/actionChip.js
@@ -25,8 +25,8 @@ angular
       scope: {
         key: '=?',
         value: '=?',
-        keyHelp: '=?',
-        valueHelp: '=?',
+        keyHelp: '=?',    // optional, or empty string for false
+        valueHelp: '=',   // optional, or empty string for false
         action: '&?',     // callback fn,
         actionIcon: '=?', // default is pficon pficon-close
         showAction: '=?'  // bool to show-hide the action button

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4894,7 +4894,7 @@ name:b.metadata.name
 },
 roleHelp:function(a) {
 if (a) {
-var b = "There is no additional information about this role.", c = _.get(a, "metadata.namespace"), d = _.get(a, "metadata.name"), e = c ? c + " / " + d + ": " :"";
+var b = "", c = _.get(a, "metadata.namespace"), d = _.get(a, "metadata.name"), e = c ? c + " / " + d + ": " :"";
 return a ? e + (q(a, "description") || b) :b;
 }
 }
@@ -9938,7 +9938,7 @@ scope:{
 key:"=?",
 value:"=?",
 keyHelp:"=?",
-valueHelp:"=?",
+valueHelp:"=",
 action:"&?",
 actionIcon:"=?",
 showAction:"=?"


### PR DESCRIPTION
Until descriptions merge: https://github.com/openshift/origin/pull/11328
The tooltip will still function if a cluster admin manually annotates roles.

@jwforres @spadgett 