### PR TITLE
Search image stream tag names and description in catalog

### DIFF
--- a/app/scripts/directives/catalog/catalogImage.js
+++ b/app/scripts/directives/catalog/catalogImage.js
@@ -37,14 +37,19 @@ angular.module('openshiftConsole')
           return _.includes(tags, 'builder');
         };
 
-        var tags = _.get($scope, 'imageStream.status.tags', []);
-        $scope.tags = _.filter(tags, function(tag) {
-          return isBuilder(tag.tag) && !referenceTags[tag.tag];
-        });
+        // Watch status tags. Some tags might be removed from the list if they
+        // don't match the current filter.
+        $scope.$watch('imageStream.status.tags', function(tags) {
+          $scope.tags = _.filter(tags, function(tag) {
+            return isBuilder(tag.tag) && !referenceTags[tag.tag];
+          });
 
-        // Preselect the first tag value.
-        var firstTag = _.head($scope.tags);
-        _.set($scope, 'is.tag', firstTag);
+          var selected = _.get($scope, 'is.tag.tag');
+          if (!selected || !_.some($scope.tags, { tag: selected })) {
+            // Preselect the first tag value.
+            _.set($scope, 'is.tag', _.head($scope.tags));
+          }
+        });
       }
     };
   });

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3794,8 +3794,26 @@ _.each(e, function(d) {
 h(d, c) && (b[d.id] = b[d.id] || [], b[d.id].push(a), f = !0);
 }), f || (b[""] = b[""] || [], b[""].push(a));
 }), b;
-}, k = [ "metadata.name", 'metadata.annotations["openshift.io/display-name"]' ], l = function(a, b) {
-return c.filterForKeywords(a, k, b);
+}, k = a("displayName"), l = function(a, b) {
+if (!b.length) return a;
+var c = [];
+return _.each(a, function(a) {
+var d = _.get(a, "metadata.name", ""), e = k(a, !0), f = _.indexBy(a.spec.tags, "name");
+_.each(b, function(b) {
+b.test(d) || e && b.test(e) || _.each(a.spec.tags, function(a) {
+var c = _.get(a, "annotations.tags", "");
+if (!/\bbuilder\b/.test(c)) return void delete f[a.name];
+if (!b.test(a.name)) {
+var d = _.get(a, "annotations.description");
+d && b.test(d) || delete f[a.name];
+}
+});
+});
+var g;
+_.isEmpty(f) || (g = angular.copy(a), g.status.tags = _.filter(g.status.tags, function(a) {
+return f[a.tag];
+}), c.push(g));
+}), c;
 }, m = [ "metadata.name", 'metadata.annotations["openshift.io/display-name"]', "metadata.annotations.description" ], n = function(a, b) {
 return c.filterForKeywords(a, m, b);
 };
@@ -10118,12 +10136,16 @@ f[a.name] = c(b.imageStream, a.name), a.from && "ImageStreamTag" === a.from.kind
 var g = function(a) {
 var b = _.get(f, [ a ], []);
 return _.includes(b, "builder");
-}, h = _.get(b, "imageStream.status.tags", []);
-b.tags = _.filter(h, function(a) {
+};
+b.$watch("imageStream.status.tags", function(a) {
+b.tags = _.filter(a, function(a) {
 return g(a.tag) && !d[a.tag];
 });
-var i = _.head(b.tags);
-_.set(b, "is.tag", i);
+var c = _.get(b, "is.tag.tag");
+c && _.some(b.tags, {
+tag:c
+}) || _.set(b, "is.tag", _.head(b.tags));
+});
 }
 };
 } ]), angular.module("openshiftConsole").directive("catalogTemplate", function() {


### PR DESCRIPTION
Filter on specific image stream tag descriptions when searching the catalog. Limit the version dropdown to those tags that match the filter.

Fixes #705

@jwforres PTAL
@rhamilto CC