### PR TITLE
Fix inline learn more link in heading

### DIFF
--- a/app/styles/_membership.less
+++ b/app/styles/_membership.less
@@ -1,4 +1,13 @@
 .membership {
+  // TODO: make generic?
+  h1 {
+    .learn-more-inline {
+      white-space: nowrap;
+      margin-right: 10px;
+      margin-left: 0px;
+      display: inline-block;
+    }
+  }
   .content-pane {
     max-width: 1024px;
     margin-top: 50px;

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5153,13 +5153,14 @@ kubernetes-topology-graph{height:700px}
 @media (max-width:479px){.projects-bar .projects-sort .dropdown-menu{left:auto;right:0}
 }
 .projects-bar .vertical-divider{border-left:1px solid #bbb;display:inline-block;height:27px;margin:0 7px;vertical-align:middle;width:1px}
-.membership .content-pane .col-heading .col-add-role h3,.membership .content-pane .form-new-role .col-roles{display:none}
 .projects-header{margin-top:21px}
 .projects-instructions-link{white-space:pre}
 .projects-list{border-top:0;box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09);margin-bottom:20px}
 .projects-list .project-info:hover{background-color:#def3ff}
 .terminal-font,kubernetes-container-terminal .terminal{font-family:"Monospace Regular","DejaVu Sans Mono",Menlo,Monaco,Consolas,monospace;line-height:1em;font-size:12px}
 .key-value-editor .key-value-editor-header{margin-bottom:5px}
+.membership h1 .learn-more-inline{white-space:nowrap;margin-right:10px;margin-left:0px;display:inline-block}
+.membership .content-pane .col-heading .col-add-role h3,.membership .content-pane .form-new-role .col-roles{display:none}
 .membership .content-pane{max-width:1024px;margin-top:50px}
 .membership .content-pane .col-add-role{padding:10px 0;min-width:150px}
 .membership .content-pane .add-role-to{margin-left:-1px}


### PR DESCRIPTION
Problem:
![screen shot 2016-11-03 at 3 06 45 pm](https://cloud.githubusercontent.com/assets/280512/19981237/823d98c8-a1d7-11e6-9b9c-d2303681ed51.png)

Resolution:
![screen shot 2016-11-03 at 3 07 04 pm](https://cloud.githubusercontent.com/assets/280512/19981238/8244be0a-a1d7-11e6-875a-0e9f5230ed11.png)

The question is, will we use this in the future & should it be made generic?
@rhamilto @sg00dwin may be interested in commenting on that.

@jwforres @spadgett 
