### PR TITLE
Introduce block class wrapper to control spacing consistency for form h2 headings

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -499,6 +499,11 @@ label.checkbox {
       &.right {
         font-size: @font-size-small;
         font-weight: normal;
+        .action-inline {
+          @media (max-width: @screen-xs-max) {
+            margin-left: 0;
+          }
+        }
       }
       .action {
           font-size: @font-size-small;
@@ -509,6 +514,7 @@ label.checkbox {
         margin-bottom: 0;
         > li {
           font-size: @font-size-small;
+          padding-right: 0;
           text-align: left;
         }
       }
@@ -1217,5 +1223,14 @@ copy-to-clipboard .input-group {
 @media (max-width: @screen-xxs-max) {
   .col-xxs-12 {
     width: 100%;
+  }
+}
+
+// Use to control spacing on the parent div to prevent spacing discrepancy at mobile
+.h2-help-block {
+  margin-bottom: (@line-height-computed / 2);
+  h2 {
+    margin-bottom: 0;
+    margin-right: 5px;
   }
 }

--- a/app/styles/_utils.less
+++ b/app/styles/_utils.less
@@ -16,3 +16,9 @@
 .hide-if-empty:empty {
   display: none !important;
 }
+
+// keep icon from wrapping early
+.appended-icon {
+  display:inline-block;
+  .nowrap;
+}

--- a/app/views/create/fromimage.html
+++ b/app/views/create/fromimage.html
@@ -209,12 +209,12 @@
                                   Launch the first build when the build configuration is created
                                 </label>
                               </div>
-                              <h3>Environment Variables (Build and Runtime) <span class="help action-inline">
+                              <h3>Environment Variables <span class="appended-icon">(Build and Runtime) <span class="help action-inline">
                                 <a href data-toggle="tooltip"
                                    data-original-title="Environment variables are used to configure and pass information to running containers.  These environment variables will be available during your build and at runtime.">
                                   <i class="pficon pficon-help"></i>
                                 </a>
-                              </span></h3>
+                              </span></span></h3>
                               <key-value-editor
                                 entries="buildConfigEnvVars"
                                 key-placeholder="name"
@@ -248,12 +248,12 @@
                                 </label>
                                 </div>
                                 <div>
-                                  <h3>Environment Variables (Runtime only) <span class="help action-inline">
+                                  <h3>Environment Variables <span class="appended-icon">(Runtime only) <span class="help action-inline">
                                     <a href="" data-toggle="tooltip"
                                        data-original-title="Environment variables are used to configure and pass information to running containers.  These environment variables will only be available at runtime.">
                                       <i class="pficon pficon-help"></i>
                                     </a>
-                                  </span></h3>
+                                  </span></span></h3>
                                   <p ng-show="DCEnvVarsFromImage.length">
                                     <a
                                       href=""

--- a/app/views/directives/create-secret.html
+++ b/app/views/directives/create-secret.html
@@ -1,7 +1,7 @@
 <alerts alerts="alerts"></alerts>
 
 <ng-form name="secretForm">
-  <div for="secretType" ng-if="!type" class="form-group">
+  <div for="secretType" ng-if="!type" class="form-group mar-top-lg">
     <label>Secret Type</label>
     <ui-select required ng-model="newSecret.type" search-enabled="false" ng-change="newSecret.authType = secretAuthTypeMap[newSecret.type].authTypes[0].id">
       <ui-select-match>{{$select.selected | upperFirst}} Secret</ui-select-match>
@@ -303,4 +303,3 @@
             ng-click="cancel()">Cancel</button>
   </div>
 </ng-form>
-

--- a/app/views/directives/osc-form-section.html
+++ b/app/views/directives/osc-form-section.html
@@ -1,4 +1,4 @@
-<div class="flow">
+<div class="flow h2-help-block">
   <div class="flow-block">
     <h2>{{header}}</h2>
   </div>

--- a/app/views/newfromtemplate.html
+++ b/app/views/newfromtemplate.html
@@ -17,7 +17,7 @@
                     <div class="col-md-2 template-name gutter-top hidden-sm hidden-xs">
                       <span class="fa fa-cubes"></span>
                     </div>
-                    <div class="col-md-9">
+                    <div class="col-md-8">
                       <fieldset ng-disabled="disableInputs">
                         <osc-image-summary resource="template"></osc-image-summary>
                         <div ng-if="templateImages.length" class="images">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4311,11 +4311,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Launch the first build when the build configuration is created\n" +
     "</label>\n" +
     "</div>\n" +
-    "<h3>Environment Variables (Build and Runtime) <span class=\"help action-inline\">\n" +
+    "<h3>Environment Variables <span class=\"appended-icon\">(Build and Runtime) <span class=\"help action-inline\">\n" +
     "<a href data-toggle=\"tooltip\" data-original-title=\"Environment variables are used to configure and pass information to running containers.  These environment variables will be available during your build and at runtime.\">\n" +
     "<i class=\"pficon pficon-help\"></i>\n" +
     "</a>\n" +
-    "</span></h3>\n" +
+    "</span></span></h3>\n" +
     "<key-value-editor entries=\"buildConfigEnvVars\" key-placeholder=\"name\" value-placeholder=\"value\" key-validator=\"[a-zA-Z][a-zA-Z0-9_]*\" key-validator-error-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" add-row-link=\"Add environment variable\"></key-value-editor>\n" +
     "</osc-form-section>\n" +
     "\n" +
@@ -4336,11 +4336,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</label>\n" +
     "</div>\n" +
     "<div>\n" +
-    "<h3>Environment Variables (Runtime only) <span class=\"help action-inline\">\n" +
+    "<h3>Environment Variables <span class=\"appended-icon\">(Runtime only) <span class=\"help action-inline\">\n" +
     "<a href=\"\" data-toggle=\"tooltip\" data-original-title=\"Environment variables are used to configure and pass information to running containers.  These environment variables will only be available at runtime.\">\n" +
     "<i class=\"pficon pficon-help\"></i>\n" +
     "</a>\n" +
-    "</span></h3>\n" +
+    "</span></span></h3>\n" +
     "<p ng-show=\"DCEnvVarsFromImage.length\">\n" +
     "<a href=\"\" ng-click=\"showDCEnvs = (!showDCEnvs)\">\n" +
     "{{showDCEnvs ? 'Hide' : 'Show'}} image environment variables\n" +
@@ -5203,7 +5203,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   $templateCache.put('views/directives/create-secret.html',
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<ng-form name=\"secretForm\">\n" +
-    "<div for=\"secretType\" ng-if=\"!type\" class=\"form-group\">\n" +
+    "<div for=\"secretType\" ng-if=\"!type\" class=\"form-group mar-top-lg\">\n" +
     "<label>Secret Type</label>\n" +
     "<ui-select required ng-model=\"newSecret.type\" search-enabled=\"false\" ng-change=\"newSecret.authType = secretAuthTypeMap[newSecret.type].authTypes[0].id\">\n" +
     "<ui-select-match>{{$select.selected | upperFirst}} Secret</ui-select-match>\n" +
@@ -6498,7 +6498,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/directives/osc-form-section.html',
-    "<div class=\"flow\">\n" +
+    "<div class=\"flow h2-help-block\">\n" +
     "<div class=\"flow-block\">\n" +
     "<h2>{{header}}</h2>\n" +
     "</div>\n" +
@@ -9215,7 +9215,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"col-md-2 template-name gutter-top hidden-sm hidden-xs\">\n" +
     "<span class=\"fa fa-cubes\"></span>\n" +
     "</div>\n" +
-    "<div class=\"col-md-9\">\n" +
+    "<div class=\"col-md-8\">\n" +
     "<fieldset ng-disabled=\"disableInputs\">\n" +
     "<osc-image-summary resource=\"template\"></osc-image-summary>\n" +
     "<div ng-if=\"templateImages.length\" class=\"images\">\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3829,6 +3829,7 @@ label.checkbox{font-weight:400}
 .icon-xl{font-size:128px}
 .istag-separator{color:#9c9c9c;position:absolute;top:2px;right:-3px}
 @media (max-width:767px){.istag-separator{display:none!important}
+.osc-form .flow>.flow-block.right .action-inline{margin-left:0}
 }
 .create-route-icon,.create-storage-icon{padding-top:0;text-align:right}
 .lifecycle-hook{padding-bottom:20px}
@@ -3841,9 +3842,10 @@ label.checkbox{font-weight:400}
 .osc-form span.fa.visible-xs-inline{margin-right:10px}
 .osc-form .flow{border-top:1px solid rgba(0,0,0,.15);display:table;margin-top:40px;width:100%}
 .osc-form .flow>.flow-block{display:inline-block}
-.osc-form .flow>.flow-block .action,.osc-form .flow>.flow-block.right{font-size:11px;font-weight:400}
+.osc-form .flow>.flow-block.right{font-size:11px;font-weight:400}
+.osc-form .flow>.flow-block .action{font-size:11px;font-weight:400}
 .osc-form .flow>.flow-block>ul.list-inline{margin-bottom:0}
-.osc-form .flow>.flow-block>ul.list-inline>li{font-size:11px;text-align:left}
+.osc-form .flow>.flow-block>ul.list-inline>li{font-size:11px;padding-right:0;text-align:left}
 .osc-form .first-section .flow{margin-top:20px;border-top:0}
 .osc-form .template-options{line-height:1.5}
 .osc-form .template-options .list-unstyled .options{margin-bottom:12px}
@@ -3998,6 +4000,8 @@ copy-to-clipboard .input-group{max-width:300px}
 .tech-preview-header{justify-content:space-between}
 @media (max-width:479px){.col-xxs-12{width:100%}
 }
+.h2-help-block{margin-bottom:10.5px}
+.h2-help-block h2{margin-bottom:0;margin-right:5px}
 .data-toolbar{padding:5px 0}
 .data-toolbar.other-resources-toolbar .data-toolbar-dropdown{min-width:210px}
 .data-toolbar .checkbox{margin-bottom:0;margin-top:10px}
@@ -5120,6 +5124,7 @@ kubernetes-topology-graph{height:700px}
 }
 .settings-item{margin:4px 8px 4px 0}
 .hide-if-empty:empty{display:none!important}
+.appended-icon{display:inline-block;white-space:nowrap}
 .donut-title-med-pf{font-size:22.5px;font-weight:300}
 .col-md-12>.alerts:first-child{margin-top:20px}
 .project-actions{margin:20px 0 0}


### PR DESCRIPTION
Add markup to keep help icon from wrapping awkwardly at mobile.
Misc: Add spacing class so create secret and create storage match
Misc: Change markup grid so that fromtemplate and [fromimage](https://github.com/openshift/origin-web-console/blob/master/app/views/create/fromimage.html#L20) forms are consistent widths

Fixes https://github.com/openshift/origin-web-console/issues/812


<img width="363" alt="screen shot 2016-11-03 at 4 40 05 pm" src="https://cloud.githubusercontent.com/assets/1874151/19984390/80663c28-a1e4-11e6-9fe2-266aedcf74e0.png">

<img width="342" alt="screen shot 2016-11-03 at 4 36 17 pm" src="https://cloud.githubusercontent.com/assets/1874151/19984348/57cbd71e-a1e4-11e6-97fe-38f01fbee931.png">

