### PR TITLE
Add project membership link to projects list

### DIFF
--- a/app/styles/_projects.less
+++ b/app/styles/_projects.less
@@ -15,6 +15,9 @@
   }
   .project-action-item {
     margin-left: 12px;
+    @media (min-width: @screen-sm-min) {
+      margin-left: 17px;
+    }
   }
 }
 

--- a/app/views/projects.html
+++ b/app/views/projects.html
@@ -67,14 +67,20 @@
                     <div class="list-group list-view-pf projects-list">
                       <div ng-repeat="project in projects" class="list-group-item project-info tile-click">
                         <div row class="list-view-pf-actions project-actions" ng-if="project.status.phase == 'Active'">
-                          <span class="fa-lg project-action-item">
+                          <span class="fa-lg project-action-item" title="View and Edit Membership">
+                            <a ng-href="project/{{project.metadata.name}}/membership" class="action-button">
+                              <i class="pficon pficon-users" aria-hidden="true"></i>
+                              <span class="sr-only">View and Edit Membership</span>
+                            </a>
+                          </span>
+                          <span class="fa-lg project-action-item" title="Edit Display Name and Description">
                             <!-- Return to the web console root URL (this page) after editing. -->
                             <a ng-href="project/{{project.metadata.name}}/edit?then=./" class="action-button">
                               <i class="fa fa-pencil" aria-hidden="true"></i>
-                              <span class="sr-only">Edit Project</span>
+                              <span class="sr-only">Edit Display Name and Description</span>
                             </a>
                           </span>
-                          <span>
+                          <span title="Delete Project">
                             <delete-link
                               class="fa-lg project-action-item"
                               kind="Project"
@@ -118,10 +124,6 @@
                       <span ng-if="!newProjectMessage">A cluster admin can create a project for you by running the command
                         <code>oadm new-project &lt;projectname&gt; --admin={{user.metadata.name || '&lt;YourUsername&gt;'}}</code></span>
                       <span ng-if="newProjectMessage" ng-bind-html="newProjectMessage | linky : '_blank'" class="projects-instructions-link"></span>
-                    </p>
-                    <p class="projects-instructions">
-                      A project admin can add you to a role on a project by running the command
-                      <code>oc policy add-role-to-user &lt;role&gt; {{user.metadata.name || '&lt;YourUsername&gt;'}} -n &lt;projectname&gt;</code>
                     </p>
                   </div>
                 </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -10256,14 +10256,20 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"list-group list-view-pf projects-list\">\n" +
     "<div ng-repeat=\"project in projects\" class=\"list-group-item project-info tile-click\">\n" +
     "<div row class=\"list-view-pf-actions project-actions\" ng-if=\"project.status.phase == 'Active'\">\n" +
-    "<span class=\"fa-lg project-action-item\">\n" +
+    "<span class=\"fa-lg project-action-item\" title=\"View and Edit Membership\">\n" +
+    "<a ng-href=\"project/{{project.metadata.name}}/membership\" class=\"action-button\">\n" +
+    "<i class=\"pficon pficon-users\" aria-hidden=\"true\"></i>\n" +
+    "<span class=\"sr-only\">View and Edit Membership</span>\n" +
+    "</a>\n" +
+    "</span>\n" +
+    "<span class=\"fa-lg project-action-item\" title=\"Edit Display Name and Description\">\n" +
     "\n" +
     "<a ng-href=\"project/{{project.metadata.name}}/edit?then=./\" class=\"action-button\">\n" +
     "<i class=\"fa fa-pencil\" aria-hidden=\"true\"></i>\n" +
-    "<span class=\"sr-only\">Edit Project</span>\n" +
+    "<span class=\"sr-only\">Edit Display Name and Description</span>\n" +
     "</a>\n" +
     "</span>\n" +
-    "<span>\n" +
+    "<span title=\"Delete Project\">\n" +
     "<delete-link class=\"fa-lg project-action-item\" kind=\"Project\" resource-name=\"{{project.metadata.name}}\" project-name=\"{{project.metadata.name}}\" display-name=\"{{(project | displayName)}}\" type-name-to-confirm=\"true\" stay-on-current-page=\"true\" alerts=\"alerts\" button-only>\n" +
     "</delete-link>\n" +
     "</span>\n" +
@@ -10295,10 +10301,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"!newProjectMessage\">A cluster admin can create a project for you by running the command\n" +
     "<code>oadm new-project &lt;projectname&gt; --admin={{user.metadata.name || '&lt;YourUsername&gt;'}}</code></span>\n" +
     "<span ng-if=\"newProjectMessage\" ng-bind-html=\"newProjectMessage | linky : '_blank'\" class=\"projects-instructions-link\"></span>\n" +
-    "</p>\n" +
-    "<p class=\"projects-instructions\">\n" +
-    "A project admin can add you to a role on a project by running the command\n" +
-    "<code>oc policy add-role-to-user &lt;role&gt; {{user.metadata.name || '&lt;YourUsername&gt;'}} -n &lt;projectname&gt;</code>\n" +
     "</p>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5129,6 +5129,8 @@ kubernetes-topology-graph{height:700px}
 .col-md-12>.alerts:first-child{margin-top:20px}
 .project-actions{margin:20px 0 0}
 .project-actions .project-action-item{margin-left:12px}
+@media (min-width:768px){.project-actions .project-action-item{margin-left:17px}
+}
 .project-info.list-group-item{border-bottom:0;border-color:#e0e0e0;padding:10px 20px}
 @media (min-width:992px){.project-actions{margin-top:0}
 .project-additional-info.list-view-pf-additional-info{width:60%}


### PR DESCRIPTION
Rather than showing the CLI command to add users to the project, add an action directly on the projects list for viewing and editing membership now that it can be changed in the web console.

![screen shot 2016-11-07 at 8 38 00 am](https://cloud.githubusercontent.com/assets/1167259/20059826/13f0742a-a4c6-11e6-9772-681b91abdb16.png)

/cc @jwforres @benjaminapetersen @sspeiche 