### PR TITLE
Allow project names to wrap and break as needed

### DIFF
--- a/app/styles/_projects.less
+++ b/app/styles/_projects.less
@@ -23,20 +23,29 @@
 
 .project-additional-info.list-view-pf-additional-info {
   @media (min-width: @screen-md-min) {
-    width: 60%;
+    width: 55%;
   }
 }
 
-.project-info.list-group-item {
-  border-bottom: 0;
-  border-color: #e0e0e0;
-  padding: 10px 20px;
+.project-info {
+  &.list-group-item {
+    border-bottom: 0;
+    border-color: #e0e0e0;
+    padding: 10px 20px;
+  }
+  .list-view-pf-description {
+    width: 100%;
+  }
+  .list-view-pf-main-info {
+    display: block;
+  }
+
 }
 
 .project-name-item.list-group-item-heading {
   @media (min-width: @screen-md-min) {
     white-space: normal;
-    width: 40%;
+    width: 45%;
   }
   .h1 {
     margin-bottom: 0;
@@ -46,7 +55,10 @@
       margin-left: 5px;
     }
     a {
+      display: block;
+      overflow: hidden;
       line-height: initial;
+      text-overflow: ellipsis;
     }
   }
   p {

--- a/app/views/projects.html
+++ b/app/views/projects.html
@@ -98,7 +98,7 @@
                           <div class="list-view-pf-description project-names">
                             <div class="list-group-item-heading project-name-item">
                               <h2 class="h1">
-                                <a class="tile-target" ng-href="project/{{project.metadata.name}}">{{project | displayName}}</a>
+                                <a class="tile-target" ng-href="project/{{project.metadata.name}}" title="{{project | displayName}}">{{project | displayName}}</a>
                                 <span ng-if="project.status.phase != 'Active'"
                                   data-toggle="tooltip"
                                   title="This project has been marked for deletion."

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -10278,7 +10278,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"list-view-pf-description project-names\">\n" +
     "<div class=\"list-group-item-heading project-name-item\">\n" +
     "<h2 class=\"h1\">\n" +
-    "<a class=\"tile-target\" ng-href=\"project/{{project.metadata.name}}\">{{project | displayName}}</a>\n" +
+    "<a class=\"tile-target\" ng-href=\"project/{{project.metadata.name}}\" title=\"{{project | displayName}}\">{{project | displayName}}</a>\n" +
     "<span ng-if=\"project.status.phase != 'Active'\" data-toggle=\"tooltip\" title=\"This project has been marked for deletion.\" class=\"pficon pficon-warning-triangle-o\"></span>\n" +
     "</h2>\n" +
     "<small>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4715,7 +4715,7 @@ td.visible-print,th.visible-print{display:table-cell!important}
 }
 ::-webkit-scrollbar-corner{background:0 0}
 ::-webkit-scrollbar{height:10px;overflow:visible;width:14px}
-.events-sidebar .right-content .event .event-details,.events-sidebar .right-content .event .event-details .event-message,.events-sidebar .right-content .event .event-details .event-object,.events-sidebar .right-content .event .event-details .event-reason{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.events-sidebar .right-content .event .event-details,.events-sidebar .right-content .event .event-details .event-message,.events-sidebar .right-content .event .event-details .event-object,.events-sidebar .right-content .event .event-details .event-reason{overflow:hidden;white-space:nowrap;text-overflow:ellipsis}
 ::-webkit-scrollbar-thumb{background-color:rgba(0,0,0,.08);background-clip:padding-box;border:solid transparent;border-width:1px;min-height:28px;max-height:60px;padding:100px 0 0;-webkit-box-shadow:inset 1px 1px 0 rgba(0,0,0,.1),inset 0 -1px 0 rgba(0,0,0,.07);box-shadow:inset 1px 1px 0 rgba(0,0,0,.1),inset 0 -1px 0 rgba(0,0,0,.07)}
 ::-webkit-scrollbar-thumb:active,::-webkit-scrollbar-thumb:hover{background-color:rgba(0,0,0,.18)}
 ::-webkit-scrollbar-track{background-clip:padding-box;background-color:rgba(0,0,0,.03)}
@@ -5131,14 +5131,17 @@ kubernetes-topology-graph{height:700px}
 .project-actions .project-action-item{margin-left:12px}
 @media (min-width:768px){.project-actions .project-action-item{margin-left:17px}
 }
-.project-info.list-group-item{border-bottom:0;border-color:#e0e0e0;padding:10px 20px}
 @media (min-width:992px){.project-actions{margin-top:0}
-.project-additional-info.list-view-pf-additional-info{width:60%}
-.project-name-item.list-group-item-heading{white-space:normal;width:40%}
+.project-additional-info.list-view-pf-additional-info{width:55%}
+}
+.project-info.list-group-item{border-bottom:0;border-color:#e0e0e0;padding:10px 20px}
+.project-info .list-view-pf-description{width:100%}
+.project-info .list-view-pf-main-info{display:block}
+@media (min-width:992px){.project-name-item.list-group-item-heading{white-space:normal;width:45%}
 }
 .project-name-item.list-group-item-heading .h1{margin-bottom:0;margin-top:0}
 .project-name-item.list-group-item-heading .h1 [data-toggle=tooltip]{cursor:help;margin-left:5px}
-.project-name-item.list-group-item-heading .h1 a{line-height:initial}
+.project-name-item.list-group-item-heading .h1 a{display:block;overflow:hidden;line-height:initial;text-overflow:ellipsis}
 .project-name-item.list-group-item-heading p{margin-bottom:0;margin-top:5px}
 .projects-bar{display:flex;flex-direction:column}
 @media (min-width:650px){.projects-bar{flex-direction:row;justify-content:space-between}


### PR DESCRIPTION
Fixes #831 

Rather than ellips-ing the project name at desktop resolutions and allowing it to wrap at mobile, how about we always allow it to wrap (wherever necessary)?  Breaking wherever necessary is the only way to resolve the bug.

![screen shot 2016-11-07 at 10 17 37 am](https://cloud.githubusercontent.com/assets/895728/20063216/5c207f16-a4d4-11e6-9e11-358b68cc79d0.PNG)
![screen shot 2016-11-07 at 10 17 51 am](https://cloud.githubusercontent.com/assets/895728/20063219/5c2120e2-a4d4-11e6-9fb8-2e340ca939e1.PNG)
![screen shot 2016-11-07 at 10 18 00 am](https://cloud.githubusercontent.com/assets/895728/20063220/5c23e78c-a4d4-11e6-9d45-f24ad37dea3c.PNG)
![screen shot 2016-11-07 at 10 18 20 am](https://cloud.githubusercontent.com/assets/895728/20063217/5c20681e-a4d4-11e6-95b9-30b19b4bf460.PNG)

@spadgett, PTAL

p.s., pfListView is a bag of hurt.  We should avoid using it for anything other than [the very specific context for which it was created](http://angular-patternfly.rhcloud.com/#/api/patternfly.views.directive:pfListView) because we're having to override a bunch of problems it introduces; we'd be better off just rolling our own solution.

