### PR TITLE
Improve URL linking in log viewer

### DIFF
--- a/app/scripts/directives/logViewer.js
+++ b/app/scripts/directives/logViewer.js
@@ -14,6 +14,18 @@ angular.module('openshiftConsole')
     function($sce, $timeout, $window, AuthService, APIDiscovery, DataService, logLinks, BREAKPOINTS) {
       // cache the jQuery win, but not clobber angular's $window
       var $win = $(window);
+
+      // Based on https://github.com/drudru/ansi_up/blob/v1.3.0/ansi_up.js#L93-L97
+      // and https://github.com/angular/angular.js/blob/v1.5.8/src/ngSanitize/filter/linky.js#L131-L132
+      // The AngularJS `linky` regex will avoid matching special characters like `"` at the end of the URL.
+      // Like `ansi_up.linkify`, assumes `text` is already HTML escaped.
+      // Opens the link in a new window.
+      var linkify = function(text) {
+        return text.replace(/https?:\/\/[A-Za-z0-9._%+-]+\S*[^\s.;,(){}<>"\u201d\u2019]/gm, function(str) {
+          return "<a href=\"" + str + "\" target=\"_blank\">" + str + "</a>";
+        });
+      };
+
       // Keep a reference the DOM node rather than the jQuery object for cloneNode.
       var logLineTemplate =
         $('<tr class="log-line">' +
@@ -31,7 +43,7 @@ angular.module('openshiftConsole')
         // Escape ANSI color codes
         var escaped = ansi_up.escape_for_html(text);
         var html = ansi_up.ansi_to_html(escaped);
-        var linkifiedHTML = ansi_up.linkify(html);
+        var linkifiedHTML = linkify(html);
         line.lastChild.innerHTML = linkifiedHTML;
 
         return line;

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10757,10 +10757,14 @@ a.destroy();
 }
 };
 } ]), angular.module("openshiftConsole").directive("logViewer", [ "$sce", "$timeout", "$window", "AuthService", "APIDiscovery", "DataService", "logLinks", "BREAKPOINTS", function(a, b, c, d, e, f, g, h) {
-var i = $(window), j = $('<tr class="log-line"><td class="log-line-number"></td><td class="log-line-text"></td></tr>').get(0), k = function(a, b) {
-var c = j.cloneNode(!0);
+var i = $(window), j = function(a) {
+return a.replace(/https?:\/\/[A-Za-z0-9._%+-]+\S*[^\s.;,(){}<>"\u201d\u2019]/gm, function(a) {
+return '<a href="' + a + '" target="_blank">' + a + "</a>";
+});
+}, k = $('<tr class="log-line"><td class="log-line-number"></td><td class="log-line-text"></td></tr>').get(0), l = function(a, b) {
+var c = k.cloneNode(!0);
 c.firstChild.setAttribute("data-line-number", a);
-var d = ansi_up.escape_for_html(b), e = ansi_up.ansi_to_html(d), f = ansi_up.linkify(e);
+var d = ansi_up.escape_for_html(b), e = ansi_up.ansi_to_html(d), f = j(e);
 return c.lastChild.innerHTML = f, c;
 };
 return {
@@ -10781,13 +10785,13 @@ empty:"=?",
 run:"=?"
 },
 controller:[ "$scope", function(j) {
-var l, m, n, o, p, q = document.documentElement;
+var k, m, n, o, p, q = document.documentElement;
 j.logViewerID = _.uniqueId("log-viewer"), j.empty = !0;
 var r = function() {
 o = window.innerWidth < h.screenSmMin && !j.fixedHeight ? null :m;
 }, s = function() {
 j.$apply(function() {
-var a = l.getBoundingClientRect();
+var a = k.getBoundingClientRect();
 j.fixedHeight ? j.showScrollLinks = a && a.height > j.fixedHeight :j.showScrollLinks = a && (a.top < 0 || a.bottom > q.clientHeight);
 });
 }, t = !1, u = function() {
@@ -10827,11 +10831,11 @@ t = !0, g.scrollBottom(o);
 }, B = function() {
 j.autoScrollActive = !j.autoScrollActive, j.autoScrollActive && A();
 }, C = document.createDocumentFragment(), D = _.debounce(function() {
-l.appendChild(C), C = document.createDocumentFragment(), j.autoScrollActive && A(), j.showScrollLinks || s();
+k.appendChild(C), C = document.createDocumentFragment(), j.autoScrollActive && A(), j.showScrollLinks || s();
 }, 100, {
 maxWait:300
 }), E = function(a) {
-z && (z.stop(), z = null), a || (D.cancel(), l && (l.innerHTML = ""), C = document.createDocumentFragment());
+z && (z.stop(), z = null), a || (D.cancel(), k && (k.innerHTML = ""), C = document.createDocumentFragment());
 }, F = function() {
 if (E(), j.name && j.run) {
 angular.extend(j, {
@@ -10847,7 +10851,7 @@ limitBytes:10485760
 }, j.options);
 z = f.createStream(j.resource, j.name, j.context, a);
 var c = 0, d = function(a) {
-c++, C.appendChild(k(c, a)), D();
+c++, C.appendChild(l(c, a)), D();
 };
 z.onMessage(function(b, e, f) {
 j.$evalAsync(function() {
@@ -10892,7 +10896,7 @@ backlink:URI.encode(c.location.href)
 }), this.cacheScrollableNode = function(a) {
 m = a, n = $(m);
 }, this.cacheLogNode = function(a) {
-l = a;
+k = a;
 }, this.cacheAffixable = function(a) {
 p = $(a);
 }, this.start = function() {


### PR DESCRIPTION
Avoid matching special characters like `"` and `.` at the end of the URL. Also open the links in a new window.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1392509

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/20068054/58c2e5aa-a4e5-11e6-84db-2487714c544f.png)

@jwforres 