### PR TITLE
Fix add storage links

### DIFF
--- a/app/scripts/controllers/attachPVC.js
+++ b/app/scripts/controllers/attachPVC.js
@@ -63,7 +63,7 @@ angular.module('openshiftConsole')
       name: $routeParams.name,
       kind: $routeParams.kind,
       namespace: $routeParams.project,
-      subpage: 'Attach Storage',
+      subpage: 'Add Storage',
       includeProject: true
     });
 
@@ -99,7 +99,7 @@ angular.module('openshiftConsole')
               $scope.breadcrumbs = BreadcrumbsService.getBreadcrumbs({
                 object: resource,
                 project: project,
-                subpage: 'Attach Storage',
+                subpage: 'Add Storage',
                 includeProject: true
               });
             },

--- a/app/views/browse/_replica-set-details.html
+++ b/app/views/browse/_replica-set-details.html
@@ -91,9 +91,16 @@
       <h4>Volumes</h4>
       <div ng-if="!replicaSet.spec.template.spec.volumes.length">
         <div ng-if="kind === 'ReplicaSet'">
-          <a ng-if="resource | canI : 'update'"
-             ng-href="project/{{project.metadata.name}}/attach-pvc?kind=ReplicaSet&name={{replicaSet.metadata.name}}&group=extensions">Add storage</a>
-          <span ng-if="!(resource | canI : 'update')">none</span>
+          <div ng-if="deployment">
+            <a ng-if="{ group: 'extensions', resource: 'deployments' } | canI : 'update'"
+              ng-href="project/{{project.metadata.name}}/attach-pvc?kind=Deployment&name={{deployment.metadata.name}}&group=extensions">Add storage</a>
+            <span ng-if="!({ group: 'extensions', resource: 'deployments' } | canI : 'update')">none</span>
+          </div>
+          <div ng-if="!deployment">
+            <a ng-if="resource | canI : 'update'"
+               ng-href="project/{{project.metadata.name}}/attach-pvc?kind=ReplicaSet&name={{replicaSet.metadata.name}}&group=extensions">Add storage</a>
+            <span ng-if="!(resource | canI : 'update')">none</span>
+          </div>
         </div>
         <div ng-if="kind === 'ReplicationController'">
           <div ng-if="deploymentConfigName">

--- a/app/views/browse/pod.html
+++ b/app/views/browse/pod.html
@@ -23,7 +23,7 @@
                      data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                   <ul class="dropdown-menu actions action-button">
                     <li ng-if="(pod | annotation:'deploymentConfig') && ('deploymentconfigs' | canI : 'update')">
-                      <a ng-href="project/{{project.metadata.name}}/attach-pvc?deploymentconfig={{pod | annotation:'deploymentConfig'}}"
+                      <a ng-href="project/{{project.metadata.name}}/attach-pvc?kind=DeploymentConfig&name={{pod | annotation:'deploymentConfig'}}"
                          role="button">Add Storage</a>
                     </li>
                     <li ng-if="'pods' | canI : 'update'">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7834,7 +7834,7 @@ individual:{}
 name:b.name,
 kind:b.kind,
 namespace:b.project,
-subpage:"Attach Storage",
+subpage:"Add Storage",
 includeProject:!0
 }), i.get(b.project).then(_.spread(function(e, h) {
 c.project = e, c.breadcrumbs[0].title = a("displayName")(e);
@@ -7851,7 +7851,7 @@ c.attach.containers.individual[a.name] = !0;
 }), c.attach.resource = a, c.breadcrumbs = f.getBreadcrumbs({
 object:a,
 project:e,
-subpage:"Attach Storage",
+subpage:"Add Storage",
 includeProject:!0
 });
 }, function(a) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1367,8 +1367,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<h4>Volumes</h4>\n" +
     "<div ng-if=\"!replicaSet.spec.template.spec.volumes.length\">\n" +
     "<div ng-if=\"kind === 'ReplicaSet'\">\n" +
+    "<div ng-if=\"deployment\">\n" +
+    "<a ng-if=\"{ group: 'extensions', resource: 'deployments' } | canI : 'update'\" ng-href=\"project/{{project.metadata.name}}/attach-pvc?kind=Deployment&name={{deployment.metadata.name}}&group=extensions\">Add storage</a>\n" +
+    "<span ng-if=\"!({ group: 'extensions', resource: 'deployments' } | canI : 'update')\">none</span>\n" +
+    "</div>\n" +
+    "<div ng-if=\"!deployment\">\n" +
     "<a ng-if=\"resource | canI : 'update'\" ng-href=\"project/{{project.metadata.name}}/attach-pvc?kind=ReplicaSet&name={{replicaSet.metadata.name}}&group=extensions\">Add storage</a>\n" +
     "<span ng-if=\"!(resource | canI : 'update')\">none</span>\n" +
+    "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"kind === 'ReplicationController'\">\n" +
     "<div ng-if=\"deploymentConfigName\">\n" +
@@ -2755,7 +2761,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a href=\"\" class=\"dropdown-toggle actions-dropdown-kebab visible-xs-inline\" data-toggle=\"dropdown\"><i class=\"fa fa-ellipsis-v\"></i><span class=\"sr-only\">Actions</span></a>\n" +
     "<ul class=\"dropdown-menu actions action-button\">\n" +
     "<li ng-if=\"(pod | annotation:'deploymentConfig') && ('deploymentconfigs' | canI : 'update')\">\n" +
-    "<a ng-href=\"project/{{project.metadata.name}}/attach-pvc?deploymentconfig={{pod | annotation:'deploymentConfig'}}\" role=\"button\">Add Storage</a>\n" +
+    "<a ng-href=\"project/{{project.metadata.name}}/attach-pvc?kind=DeploymentConfig&name={{pod | annotation:'deploymentConfig'}}\" role=\"button\">Add Storage</a>\n" +
     "</li>\n" +
     "<li ng-if=\"'pods' | canI : 'update'\">\n" +
     "<a ng-href=\"{{pod | editYamlURL}}\" role=\"button\">Edit YAML</a>\n" +


### PR DESCRIPTION
* Use correct link for pod owned by a deployment config
* Update deployment when a replica set is owned by a deployment
  (in page link, the actions menu was already doing this)
* Update breadcrumb on add storage page to match action label

@jwforres 