### PR TITLE
Move flex attr rule under .membership parent

### DIFF
--- a/app/styles/_membership.less
+++ b/app/styles/_membership.less
@@ -82,6 +82,19 @@
         }
       }
     }
+    // FIXME (bpeterse): to update in layout.attrs & eliminate the workaround here
+    // fix for collapse of flex items in IE
+    // https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored
+    [flex-collapse-fix],
+    [flex], // fixes ie flex-direction: column collapse issue
+    .item-row,
+    .col-heading,
+    .col-name,
+    .col-roles,
+    .col-add-role {
+      flex-shrink: 0;
+      flex-basis: auto;
+    }
   }
 }
 
@@ -124,19 +137,4 @@
       }
     }
   }
-}
-
-
-// FIXME (bpeterse): to update in layout.attrs & eliminate the workaround here
-// fix for collapse of flex items in IE
-// https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored
-[flex-collapse-fix],
-[flex], // fixes ie flex-direction: column collapse issue
-.item-row,
-.col-heading,
-.col-name,
-.col-roles,
-.col-add-role {
-  flex-shrink: 0;
-  flex-basis: auto;
 }

--- a/app/views/directives/header/default-header.html
+++ b/app/views/directives/header/default-header.html
@@ -2,7 +2,7 @@
   <div row>
     <div class="navbar-header">
       <!-- mobile nav menu -->
-      <div row flex class="navbar-flex-btn toggle-menu">
+      <div row class="navbar-flex-btn toggle-menu">
         <button type="button" class="navbar-toggle project-action-btn ng-isolate-scope" data-toggle="collapse" data-target=".navbar-collapse-2">
           <span class="sr-only">Toggle navigation</span>
           <span class="icon-bar"></span>

--- a/app/views/directives/header/project-header.html
+++ b/app/views/directives/header/project-header.html
@@ -5,7 +5,7 @@
   <div class="nav navbar-project-menu">
     <div row>
       <!-- mobile nav menu -->
-      <div row flex class="navbar-flex-btn toggle-menu">
+      <div row class="navbar-flex-btn toggle-menu">
         <button type="button" class="navbar-toggle project-action-btn ng-isolate-scope" data-toggle="collapse" data-target=".navbar-collapse-1">
           <span class="sr-only">Toggle navigation</span>
           <span class="icon-bar"></span>
@@ -19,7 +19,7 @@
         <select class="selectpicker form-control" data-selected-text-format="count>3" id="boostrapSelect" title=""></select>
       </div>
       <!-- create buttons show at mobile -->
-      <div row flex class="navbar-flex-btn project-action" ng-if="project.metadata.name | canIAddToProject">
+      <div row class="navbar-flex-btn project-action" ng-if="project.metadata.name | canIAddToProject">
         <a row class="project-action-btn" href="project/{{project.metadata.name}}/create" ng-disabled="project.status.phase != 'Active'" title="Add to project">
           <i class="fa fa-plus visible-xs-inline-block"></i><span class="hidden-xs">Add to project</span>
         </a>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5979,7 +5979,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div row>\n" +
     "<div class=\"navbar-header\">\n" +
     "\n" +
-    "<div row flex class=\"navbar-flex-btn toggle-menu\">\n" +
+    "<div row class=\"navbar-flex-btn toggle-menu\">\n" +
     "<button type=\"button\" class=\"navbar-toggle project-action-btn ng-isolate-scope\" data-toggle=\"collapse\" data-target=\".navbar-collapse-2\">\n" +
     "<span class=\"sr-only\">Toggle navigation</span>\n" +
     "<span class=\"icon-bar\"></span>\n" +
@@ -6008,7 +6008,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"nav navbar-project-menu\">\n" +
     "<div row>\n" +
     "\n" +
-    "<div row flex class=\"navbar-flex-btn toggle-menu\">\n" +
+    "<div row class=\"navbar-flex-btn toggle-menu\">\n" +
     "<button type=\"button\" class=\"navbar-toggle project-action-btn ng-isolate-scope\" data-toggle=\"collapse\" data-target=\".navbar-collapse-1\">\n" +
     "<span class=\"sr-only\">Toggle navigation</span>\n" +
     "<span class=\"icon-bar\"></span>\n" +
@@ -6022,7 +6022,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<select class=\"selectpicker form-control\" data-selected-text-format=\"count>3\" id=\"boostrapSelect\" title=\"\"></select>\n" +
     "</div>\n" +
     "\n" +
-    "<div row flex class=\"navbar-flex-btn project-action\" ng-if=\"project.metadata.name | canIAddToProject\">\n" +
+    "<div row class=\"navbar-flex-btn project-action\" ng-if=\"project.metadata.name | canIAddToProject\">\n" +
     "<a row class=\"project-action-btn\" href=\"project/{{project.metadata.name}}/create\" ng-disabled=\"project.status.phase != 'Active'\" title=\"Add to project\">\n" +
     "<i class=\"fa fa-plus visible-xs-inline-block\"></i><span class=\"hidden-xs\">Add to project</span>\n" +
     "</a>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5190,6 +5190,7 @@ kubernetes-topology-graph{height:700px}
 .membership .content-pane .select-project,.membership .content-pane .select-role{width:150px}
 .membership .content-pane .select-role small{color:#999}
 .membership .content-pane .select-role .active small{color:#c0e0f0}
+.membership .content-pane .col-add-role,.membership .content-pane .col-heading,.membership .content-pane .col-name,.membership .content-pane .col-roles,.membership .content-pane .item-row,.membership .content-pane [flex-collapse-fix],.membership .content-pane [flex]{flex-shrink:0;flex-basis:auto}
 @media (min-width:480px){.membership .content-pane .col-heading .col-add-role h3,.membership .content-pane .form-new-role .col-roles{display:block}
 .membership .content-pane .col-add-role{padding:0;min-width:245px}
 .membership .content-pane .col-heading,.membership .content-pane .item-row{border-bottom:none;margin-bottom:none}
@@ -5198,7 +5199,6 @@ kubernetes-topology-graph{height:700px}
 .membership .content-pane .col-name{width:30%}
 .membership .content-pane .col-name input{max-width:175px}
 }
-.col-add-role,.col-heading,.col-name,.col-roles,.item-row,[flex-collapse-fix],[flex]{flex-shrink:0;flex-basis:auto}
 .action-chip{margin:0 5px 2px 0;font-size:12px;display:flex;flex-direction:row}
 .action-chip .item{padding:.2em .6em .3em}
 .action-chip .item:first-child{border-top-left-radius:2px;border-bottom-left-radius:2px}


### PR DESCRIPTION
Move offending [flex] attr rule into `.membership {}` block per [comment](https://github.com/openshift/origin-web-console/pull/841#issuecomment-258965367) by @benjaminapetersen 
and remove redundant 'flex' attributes from the hamburger menu and add to project link in the mobile headers since those divs have `.navbar-flex-btn` class which already has a [flex property](https://github.com/openshift/origin-web-console/blob/2b6d3f1daf4532b0cabbe55df61acb6b31ca27f5/app/styles/_navbar-alt.less#L266) 

fixes https://github.com/openshift/origin-web-console/issues/837
fixes https://github.com/openshift/origin-web-console/issues/833




<img width="674" alt="screen shot 2016-11-08 at 2 23 36 pm" src="https://cloud.githubusercontent.com/assets/1874151/20114215/64de4c3a-a5c1-11e6-82d9-4f2ed6074752.png">

<img width="604" alt="screen shot 2016-11-08 at 2 25 13 pm 2" src="https://cloud.githubusercontent.com/assets/1874151/20114199/567bf098-a5c1-11e6-8334-e5f12f45d34e.png">


