### PR TITLE
Add support for wildcard subdomains

### DIFF
--- a/app/scripts/constants.js
+++ b/app/scripts/constants.js
@@ -52,6 +52,10 @@ window.OPENSHIFT_CONSTANTS = {
   // true indicates that deployment metrics should be disabled on the web console overview
   DISABLE_OVERVIEW_METRICS: false,
 
+  // true indicates that none of the routers support wildcard subdomains and
+  // removes the option from the route creation form.
+  DISABLE_WILDCARD_ROUTES: true,
+
   // This blacklist hides certain kinds from the "Other Resources" page because they are unpersisted, disallowed for most end users, or not supported by openshift but exist in kubernetes
   AVAILABLE_KINDS_BLACKLIST: [
       // These are k8s kinds that are not supported in the current release of OpenShift

--- a/app/scripts/controllers/edit/route.js
+++ b/app/scripts/controllers/edit/route.js
@@ -15,7 +15,8 @@ angular.module('openshiftConsole')
                                                AlertMessageService,
                                                DataService,
                                                Navigate,
-                                               ProjectsService) {
+                                               ProjectsService,
+                                               RoutesService) {
     $scope.alerts = {};
     $scope.renderOptions = {
       hideFilterWidget: true
@@ -51,9 +52,16 @@ angular.module('openshiftConsole')
         DataService.get("routes", $scope.routeName, context).then(
           function(original) {
             route = angular.copy(original);
+            var host = _.get(route, 'spec.host');
+            var isWildcard = _.get(route, 'spec.wildcardPolicy') === 'Subdomain';
+            if (isWildcard) {
+              // Display the route as a wildcard.
+              host = '*.' + RoutesService.getSubdomain(route);
+            }
             $scope.routing = {
               service: _.get(route, 'spec.to.name'),
-              host: _.get(route, 'spec.host'),
+              host: host,
+              wildcardPolicy: _.get(route, 'spec.wildcardPolicy'),
               path: _.get(route, 'spec.path'),
               targetPort: _.get(route, 'spec.port.targetPort'),
               tls: angular.copy(_.get(route, 'spec.tls'))

--- a/app/scripts/directives/oscRouting.js
+++ b/app/scripts/directives/oscRouting.js
@@ -29,7 +29,7 @@ angular.module("openshiftConsole")
    * routingDisabled:
    *   An expression that will disable the form (default: false)
    */
-  .directive("oscRouting", function() {
+  .directive("oscRouting", function(Constants) {
     return {
       require: '^form',
       restrict: 'E',
@@ -49,6 +49,17 @@ angular.module("openshiftConsole")
       },
       link: function(scope, element, attrs, formCtl) {
         scope.form = formCtl;
+
+        scope.disableWildcards = Constants.DISABLE_WILDCARD_ROUTES;
+
+        // Use different patterns for validating hostnames if wildcard subdomains are supported.
+        if (scope.disableWildcards) {
+          // See k8s.io/kubernetes/pkg/util/validation/validation.go
+          scope.hostnamePattern = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+        } else {
+          // Allow values like "*.example.com" in addition to the normal hostname regex.
+          scope.hostnamePattern = /^(\*(\.[a-z0-9]([-a-z0-9]*[a-z0-9]))+|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$/;
+        }
 
         var updatePortOptions = function(service) {
           if (!service) {

--- a/app/scripts/services/applicationGenerator.js
+++ b/app/scripts/services/applicationGenerator.js
@@ -126,12 +126,19 @@ angular.module("openshiftConsole")
           to: {
             kind: "Service",
             name: serviceName
-          }
+          },
+          wildcardPolicy: 'None'
         }
       };
 
-      if (input.routing.host) {
-        route.spec.host = input.routing.host;
+      var host = input.routing.host;
+      if (host) {
+        if (host.startsWith('*.')) {
+          route.spec.wildcardPolicy = 'Subdomain';
+          route.spec.host = 'wildcard' + host.substring(1);
+        } else {
+          route.spec.host = host;
+        }
       }
 
       if (input.routing.path) {

--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -449,12 +449,6 @@ label.checkbox {
   right: -3px;
 }
 
-.create-route-icon,
-.create-storage-icon {
-  padding-top: 0;
-  text-align: right;
-}
-
 .about,
 .command-line {
   .about-icon {

--- a/app/styles/_forms.less
+++ b/app/styles/_forms.less
@@ -2,3 +2,7 @@
   background-color: white;
   color: @text-color;
 }
+
+.input-group-addon.wildcard-prefix {
+  padding-left: 10px;
+}

--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -246,12 +246,19 @@
         margin-left: 2px;
         margin-right: 6px;
       }
+      .non-web-route {
+        // Add extra margin to account for the missing external link icon.
+        margin-left: 25px;
+      }
       @media (min-width: @screen-sm-min) {
         // At wider screen widths, always 0 margin.
         margin: 0;
         .fa-external-link {
           margin-left: 0;
           margin-right: 5px;
+        }
+        .non-web-route {
+          margin-left: 0;
         }
       }
     }

--- a/app/views/browse/route.html
+++ b/app/views/browse/route.html
@@ -43,7 +43,7 @@
                 </ul>
               </div>
             </h1>
-            <labels labels="route.metadata.labels" clickable="true" kind="routes" project-name="{{route.metadata.namespace}}" limit="3"></labels> 
+            <labels labels="route.metadata.labels" clickable="true" kind="routes" project-name="{{route.metadata.namespace}}" limit="3"></labels>
           </div>
         </div>
       </div><!-- /middle-header-->
@@ -59,16 +59,16 @@
                       {{route | routeLabel}}
                       <span data-toggle="popover" data-trigger="hover" data-content="The route is not accepting traffic yet because it has not been admitted by a router." style="cursor: help; padding-left: 5px;">
                         <status-icon status="'Pending'" disable-animation></status-icon>
-                        <span class="sr-only">Pending</span>                        
+                        <span class="sr-only">Pending</span>
                       </span>
-                    </span>  
+                    </span>
                     <div ng-repeat="ingress in route.status.ingress">
                       <span ng-if="(route | isWebRoute)">
                         <a href="{{route | routeWebURL : ingress.host}}" target="_blank">{{route | routeLabel : ingress.host}}</a>
                       </span>
                       <span ng-if="!(route | isWebRoute)">
                         {{route | routeLabel : ingress.host}}
-                      </span>                    
+                      </span>
                       &ndash;
                       <span ng-init="admittedCondition = (ingress | routeIngressCondition : 'Admitted')">
                         <span ng-if="!admittedCondition">admission status unknown for router '{{ingress.routerName}}'</span>
@@ -77,16 +77,18 @@
                         </span>
                         <span ng-if="admittedCondition.status === 'False'">
                           rejected by router '{{ingress.routerName}}' <relative-timestamp timestamp="admittedCondition.lastTransitionTime"></relative-timestamp>
-                        </span>                        
+                        </span>
                       </span>
                     </div>
                   </dd>
+                  <dt ng-if-start="route.spec.wildcardPolicy && route.spec.wildcardPolicy !== 'None' && route.spec.wildcardPolicy !== 'Subdomain'">Wildcard Policy:</dt>
+                  <dd ng-if-end>{{route.spec.wildcardPolicy}}</dd>
                   <dt>Path:</dt>
                   <dd>
                     <span ng-if="route.spec.path">{{route.spec.path}}</span>
                     <span ng-if="!route.spec.path"><em>none</em></span>
                   </dd>
-                  <dt>{{route.spec.to.kind || "Routes to"}}:</dt>
+                  <dt>{{route.spec.to.kind || "Routes To"}}:</dt>
                   <dd>
                     <a ng-href="{{route.spec.to.name | navigateResourceURL : route.spec.to.kind : route.metadata.namespace}}">{{route.spec.to.name}}</a>
                   </dd>
@@ -143,7 +145,7 @@
                 <div style="margin-bottom: 10px;">
                   <h4>TLS Settings</h4>
                   <dl class="dl-horizontal left" ng-if="route.spec.tls">
-                    <dt>Termination type:</dt>
+                    <dt>Termination Type:</dt>
                     <dd>{{route.spec.tls.termination}}</dd>
                     <dt ng-if-start="route.spec.tls.termination === 'edge'">Insecure Traffic:</dt>
                     <dd ng-if-end>{{route.spec.tls.insecureEdgeTerminationPolicy || 'None'}}</dd>

--- a/app/views/directives/osc-routing.html
+++ b/app/views/directives/osc-routing.html
@@ -42,7 +42,7 @@
           type="text"
           name="host"
           ng-model="route.host"
-          ng-pattern="/^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/"
+          ng-pattern="hostnamePattern"
           ng-maxlength="253"
           ng-readonly="hostReadOnly"
           placeholder="www.example.com"
@@ -52,15 +52,23 @@
           aria-describedby="route-host-help">
       <div>
         <span id="route-host-help" class="help-block">
-          Public hostname for the route.
-          <span ng-if="!hostReadOnly">If not specified, a hostname is generated.</span>
-          The hostname can't be changed after the route is created.
+          <p>
+            Public hostname for the route.
+            <span ng-if="!hostReadOnly">
+              If not specified, a hostname is generated.
+            </span>
+            <span ng-if="!disableWildcards">
+              You can use <var>*.example.com</var> with routers that support wildcard subdomains.
+            </span>
+          </p>
+          <p>The hostname can't be changed after the route is created.</p>
         </span>
       </div>
       <div class="has-error" ng-show="routeForm.host.$error.pattern && routeForm.host.$touched && !routingDisabled">
         <span class="help-block">
           Hostname must consist of lower-case letters, numbers, periods, and
           hyphens. It must start and end with a letter or number.
+          <span ng-if="!disableWildcards">Wildcard subdomains may start with <var>*.</var></span>
         </span>
       </div>
     </div>
@@ -152,9 +160,10 @@
 
     <div class="checkbox">
       <label>
-        <input type="checkbox" ng-model="secureRoute" id="secure-route">Secure route
+        <input type="checkbox" ng-model="secureRoute" aria-describedby="secure-route-help">
+        Secure route
       </label>
-      <div class="help-block">
+      <div class="help-block" id="secure-route-help">
         Routes can be secured using several TLS termination types for serving certificates.
       </div>
     </div>

--- a/app/views/edit/route.html
+++ b/app/views/edit/route.html
@@ -9,35 +9,31 @@
       <div class="middle-container">
         <div class="middle-content">
           <div class="container surface-shaded">
-            <div class="col-md-12">
+            <div class="col-md-10 col-md-offset-1">
               <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
               <alerts alerts="alerts"></alerts>
-              <div class="row">
-                <div class="col-md-10 col-md-offset-1 gutter-top">
-                  <h1>Edit Route {{routeName}}</h1>
-                  <div ng-if="loading">
-                    Loading...
-                  </div>
-                  <form name="form">
-                    <fieldset ng-disabled="disableInputs" ng-if="!loading">
-                      <osc-routing
-                          model="routing"
-                          services="services"
-                          show-name-input="false"
-                          host-read-only="true">
-                      </osc-routing>
-                      <div class="button-group gutter-top gutter-bottom">
-                        <button type="submit"
-                            class="btn btn-primary btn-lg"
-                            ng-click="updateRoute()"
-                            ng-disabled="form.$invalid || disableInputs"
-                            value="">Save</button>
-                        <a class="btn btn-default btn-lg" ng-href="{{routeURL}}">Cancel</a>
-                      </div>
-                    </fieldset>
-                  </form>
-                </div>
+              <h1>Edit Route {{routeName}}</h1>
+              <div ng-if="loading">
+                Loading...
               </div>
+              <form name="form">
+                <fieldset ng-disabled="disableInputs" ng-if="!loading">
+                  <osc-routing
+                      model="routing"
+                      services="services"
+                      show-name-input="false"
+                      host-read-only="true">
+                  </osc-routing>
+                  <div class="button-group gutter-top gutter-bottom">
+                    <button type="submit"
+                        class="btn btn-primary btn-lg"
+                        ng-click="updateRoute()"
+                        ng-disabled="form.$invalid || disableInputs"
+                        value="">Save</button>
+                    <a class="btn btn-default btn-lg" ng-href="{{routeURL}}">Cancel</a>
+                  </div>
+                </fieldset>
+              </form>
             </div>
           </div>
         </div><!-- /middle-content -->

--- a/app/views/overview/_service-group.html
+++ b/app/views/overview/_service-group.html
@@ -21,7 +21,7 @@
       </span>
       <a ng-if="displayRoute | isWebRoute" target="_blank"
          ng-href="{{displayRoute | routeWebURL}}">{{displayRoute | routeLabel}}</a>
-      <span ng-if="displayRoute && !(displayRoute | isWebRoute)">{{displayRoute | routeLabel}}</span>
+      <span ng-if="displayRoute && !(displayRoute | isWebRoute)" class="non-web-route">{{displayRoute | routeLabel}}</span>
       <span ng-if="routeWarningsByService[service.metadata.name] && routesByService[service.metadata.name].length === 1">
         <route-warnings warnings="routeWarningsByService[service.metadata.name]"></route-warnings>
       </span>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3050,12 +3050,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</div>\n" +
     "</dd>\n" +
+    "<dt ng-if-start=\"route.spec.wildcardPolicy && route.spec.wildcardPolicy !== 'None' && route.spec.wildcardPolicy !== 'Subdomain'\">Wildcard Policy:</dt>\n" +
+    "<dd ng-if-end>{{route.spec.wildcardPolicy}}</dd>\n" +
     "<dt>Path:</dt>\n" +
     "<dd>\n" +
     "<span ng-if=\"route.spec.path\">{{route.spec.path}}</span>\n" +
     "<span ng-if=\"!route.spec.path\"><em>none</em></span>\n" +
     "</dd>\n" +
-    "<dt>{{route.spec.to.kind || \"Routes to\"}}:</dt>\n" +
+    "<dt>{{route.spec.to.kind || \"Routes To\"}}:</dt>\n" +
     "<dd>\n" +
     "<a ng-href=\"{{route.spec.to.name | navigateResourceURL : route.spec.to.kind : route.metadata.namespace}}\">{{route.spec.to.name}}</a>\n" +
     "</dd>\n" +
@@ -3112,7 +3114,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div style=\"margin-bottom: 10px\">\n" +
     "<h4>TLS Settings</h4>\n" +
     "<dl class=\"dl-horizontal left\" ng-if=\"route.spec.tls\">\n" +
-    "<dt>Termination type:</dt>\n" +
+    "<dt>Termination Type:</dt>\n" +
     "<dd>{{route.spec.tls.termination}}</dd>\n" +
     "<dt ng-if-start=\"route.spec.tls.termination === 'edge'\">Insecure Traffic:</dt>\n" +
     "<dd ng-if-end>{{route.spec.tls.insecureEdgeTerminationPolicy || 'None'}}</dd>\n" +
@@ -6820,17 +6822,25 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"form-group\">\n" +
     "<label for=\"host\">Hostname</label>\n" +
     "\n" +
-    "<input id=\"host\" class=\"form-control\" type=\"text\" name=\"host\" ng-model=\"route.host\" ng-pattern=\"/^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/\" ng-maxlength=\"253\" ng-readonly=\"hostReadOnly\" placeholder=\"www.example.com\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"route-host-help\">\n" +
+    "<input id=\"host\" class=\"form-control\" type=\"text\" name=\"host\" ng-model=\"route.host\" ng-pattern=\"hostnamePattern\" ng-maxlength=\"253\" ng-readonly=\"hostReadOnly\" placeholder=\"www.example.com\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"route-host-help\">\n" +
     "<div>\n" +
     "<span id=\"route-host-help\" class=\"help-block\">\n" +
+    "<p>\n" +
     "Public hostname for the route.\n" +
-    "<span ng-if=\"!hostReadOnly\">If not specified, a hostname is generated.</span>\n" +
-    "The hostname can't be changed after the route is created.\n" +
+    "<span ng-if=\"!hostReadOnly\">\n" +
+    "If not specified, a hostname is generated.\n" +
+    "</span>\n" +
+    "<span ng-if=\"!disableWildcards\">\n" +
+    "You can use <var>*.example.com</var> with routers that support wildcard subdomains.\n" +
+    "</span>\n" +
+    "</p>\n" +
+    "<p>The hostname can't be changed after the route is created.</p>\n" +
     "</span>\n" +
     "</div>\n" +
     "<div class=\"has-error\" ng-show=\"routeForm.host.$error.pattern && routeForm.host.$touched && !routingDisabled\">\n" +
     "<span class=\"help-block\">\n" +
     "Hostname must consist of lower-case letters, numbers, periods, and hyphens. It must start and end with a letter or number.\n" +
+    "<span ng-if=\"!disableWildcards\">Wildcard subdomains may start with <var>*.</var></span>\n" +
     "</span>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -6893,9 +6903,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"checkbox\">\n" +
     "<label>\n" +
-    "<input type=\"checkbox\" ng-model=\"secureRoute\" id=\"secure-route\">Secure route\n" +
+    "<input type=\"checkbox\" ng-model=\"secureRoute\" aria-describedby=\"secure-route-help\">\n" +
+    "Secure route\n" +
     "</label>\n" +
-    "<div class=\"help-block\">\n" +
+    "<div class=\"help-block\" id=\"secure-route-help\">\n" +
     "Routes can be secured using several TLS termination types for serving certificates.\n" +
     "</div>\n" +
     "</div>\n" +
@@ -8179,11 +8190,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-container\">\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container surface-shaded\">\n" +
-    "<div class=\"col-md-12\">\n" +
+    "<div class=\"col-md-10 col-md-offset-1\">\n" +
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
-    "<div class=\"row\">\n" +
-    "<div class=\"col-md-10 col-md-offset-1 gutter-top\">\n" +
     "<h1>Edit Route {{routeName}}</h1>\n" +
     "<div ng-if=\"loading\">\n" +
     "Loading...\n" +
@@ -8198,8 +8207,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</fieldset>\n" +
     "</form>\n" +
-    "</div>\n" +
-    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -9653,7 +9660,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<i class=\"fa fa-angle-right fa-fw\" aria-hidden=\"true\" ng-if=\"collapse\"></i>\n" +
     "</span>\n" +
     "<a ng-if=\"displayRoute | isWebRoute\" target=\"_blank\" ng-href=\"{{displayRoute | routeWebURL}}\">{{displayRoute | routeLabel}}</a>\n" +
-    "<span ng-if=\"displayRoute && !(displayRoute | isWebRoute)\">{{displayRoute | routeLabel}}</span>\n" +
+    "<span ng-if=\"displayRoute && !(displayRoute | isWebRoute)\" class=\"non-web-route\">{{displayRoute | routeLabel}}</span>\n" +
     "<span ng-if=\"routeWarningsByService[service.metadata.name] && routesByService[service.metadata.name].length === 1\">\n" +
     "<route-warnings warnings=\"routeWarningsByService[service.metadata.name]\"></route-warnings>\n" +
     "</span>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3582,6 +3582,7 @@ to{transform:rotate(359deg)}
 .btn-flat-default{border:1px solid transparent}
 .btn-flat-default:focus,.btn-flat-default:hover{background-color:#f7f7f7;border-color:#e7e7e7}
 .copy-to-clipboard input.form-control:read-only{background-color:#fff;color:#363636}
+.input-group-addon.wildcard-prefix{padding-left:10px}
 .card-pf .image-icon,.card-pf .template-icon{font-size:28px;line-height:1;margin-right:15px;opacity:.38}
 .card-pf-badge{color:#999;font-size:11px;text-transform:uppercase}
 .card-pf-title-with-icon{align-items:center;display:flex;margin-bottom:15px}
@@ -3831,7 +3832,6 @@ label.checkbox{font-weight:400}
 @media (max-width:767px){.istag-separator{display:none!important}
 .osc-form .flow>.flow-block.right .action-inline{margin-left:0}
 }
-.create-route-icon,.create-storage-icon{padding-top:0;text-align:right}
 .lifecycle-hook{padding-bottom:20px}
 .lifecycle-hook:first-of-type{padding-top:20px}
 .lifecycle-hook .read-only-tag-image{padding-bottom:10px}
@@ -4378,8 +4378,10 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview .service-group-header .route-title{font-weight:300;line-height:1.4;margin:0 0 0 6px}
 .overview .service-group-header .route-title:only-child{margin:0}
 .overview .service-group-header .route-title .fa-external-link{margin-left:2px;margin-right:6px}
+.overview .service-group-header .route-title .non-web-route{margin-left:25px}
 @media (min-width:768px){.overview .service-group-header .route-title{margin:0}
 .overview .service-group-header .route-title .fa-external-link{margin-left:0;margin-right:5px}
+.overview .service-group-header .route-title .non-web-route{margin-left:0}
 }
 .overview .service-group-header .app-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:300;margin:0;text-transform:uppercase;min-width:130px}
 .overview .service-group-header .other-routes-msg{display:block;line-height:1.1;margin:3px 25px}

--- a/test/spec/services/applicationGeneratorSpec.js
+++ b/test/spec/services/applicationGeneratorSpec.js
@@ -186,6 +186,52 @@ describe("ApplicationGenerator", function(){
             name: "theServiceName"
           },
           host: "www.example.com",
+          wildcardPolicy: "None",
+          path: "/test",
+          port: {
+            targetPort: 'tcp-80'
+          },
+          tls: {
+            termination: "edge",
+            insecureEdgeTerminationPolicy: "Redirect",
+            certificate: "dummy-cert",
+            key: "dummy-key",
+            caCertificate: "dummy-ca-cert"
+          }
+        }
+      });
+    });
+
+    it("should generate a wildcard route when wildcard subdomains are set", function(){
+      // Add the same labels, annotations, and targetPort as application generator `generate()`
+      var routeInput = angular.copy(inputTemplate);
+      routeInput.labels.app = routeInput.name;
+      routeInput.annotations["openshift.io/generated-by"] = "OpenShiftWebConsole";
+      routeInput.routing.targetPort = 'tcp-80';
+      routeInput.routing.host = '*.example.com';
+
+      var route = ApplicationGenerator._generateRoute(routeInput, routeInput.name, "theServiceName");
+      expect(route).toEqual({
+        kind: "Route",
+        apiVersion: 'v1',
+        metadata: {
+          name: "ruby-hello-world",
+          labels : {
+            "foo" : "bar",
+            "abc" : "xyz",
+            "app": "ruby-hello-world"
+          },
+          annotations: {
+            "openshift.io/generated-by": "OpenShiftWebConsole"
+          }
+        },
+        spec: {
+          to: {
+            kind: "Service",
+            name: "theServiceName"
+          },
+          host: "wildcard.example.com",
+          wildcardPolicy: "Subdomain",
           path: "/test",
           port: {
             targetPort: 'tcp-80'


### PR DESCRIPTION
Add web console support for creating wildcard routes. Show wildcard routes as `*.my.subdomain` on the overview and routes pages. Warn when the router has not admitted the wildcard policy.

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/20152983/a4f76234-a68e-11e6-818c-7f27122adebf.png)

![screen shot 2016-11-09 at 3 11 06 pm](https://cloud.githubusercontent.com/assets/1167259/20153018/cecf99c8-a68e-11e6-8a1b-e125c4e41f88.png)

@jwforres @knobunc @rettori 