### PR TITLE
Build config source fixes

### DIFF
--- a/app/scripts/controllers/edit/buildConfig.js
+++ b/app/scripts/controllers/edit/buildConfig.js
@@ -79,7 +79,7 @@ angular.module('openshiftConsole')
       from: {},
       to: {},
       fromSource: {}
-    }
+    };
 
     $scope.sources = {
       "binary": false,
@@ -197,9 +197,6 @@ angular.module('openshiftConsole')
             }
 
             $scope.options.forcePull = !!$scope.buildStrategy.forcePull;
-            if ($scope.sources.binary) {
-              $scope.options.binaryAsFile = ($scope.buildConfig.spec.source.binary.asFile) ? $scope.buildConfig.spec.source.binary.asFile : "";
-            }
             if ($scope.strategyType === "Docker") {
               $scope.options.noCache = !!$scope.buildConfig.spec.strategy.dockerStrategy.noCache;
               // Only DockerStrategy can have empty Strategy object and therefore it's from object
@@ -300,17 +297,6 @@ angular.module('openshiftConsole')
                   destinationDir: path.value
                 };
               });
-    };
-
-    var updateBinarySource = function() {
-      // If binarySource check if the AsFile string is set and construct the object accordingly.
-      if ($scope.sources.binary) {
-        if ($scope.options.binaryAsFile !== "") {
-          $scope.updatedBuildConfig.spec.source.binary.asFile = $scope.options.binaryAsFile;
-        } else {
-          $scope.updatedBuildConfig.spec.source.binary = {};
-        }
-      }
     };
 
     var constructImageObject = function(optionsModel) {
@@ -424,8 +410,6 @@ angular.module('openshiftConsole')
         }
         break;
       }
-
-      updateBinarySource();
 
       // If imageSources are present update each ones From and Paths.
       if ($scope.sources.images && !_.isEmpty($scope.sourceImages)) {

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -199,45 +199,6 @@
                                 <dt>Build Strategy:</dt>
                                 <dd>{{buildConfig.spec.strategy.type | startCase}}</dd>
                               </div>
-                              <div ng-switch="buildConfig.spec.strategy.type">
-                                <div ng-switch-when="Source">
-                                  <div ng-if="buildConfig.spec.strategy.sourceStrategy.from">
-                                    <dt>Builder Image:</dt>
-                                    <dd>{{buildConfig.spec.strategy.sourceStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}</dd>
-                                  </div>
-                                </div>
-                                <div ng-switch-when="Docker">
-                                  <div ng-if="buildConfig.spec.strategy.dockerStrategy.from">
-                                    <dt>Builder Image Stream:</dt>
-                                    <dd>{{buildConfig.spec.strategy.dockerStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}</dd>
-                                  </div>
-                                  <div ng-if="buildConfig.spec.source.dockerfile">
-                                    <dt>Dockerfile:</dt><dd></dd>
-                                    <div ui-ace="{
-                                      mode: 'dockerfile',
-                                      theme: 'dreamweaver',
-                                      onLoad: aceLoaded,
-                                      highlightActiveLine: false,
-                                      showGutter: false,
-                                      rendererOptions: {
-                                        fadeFoldWidgets: true,
-                                        highlightActiveLine: false,
-                                        showPrintMargin: false
-                                      },
-                                      advanced: {
-                                        highlightActiveLine: false
-                                      }
-                                    }" readonly ng-model="buildConfig.spec.source.dockerfile" class="ace-bordered ace-read-only ace-inline dockerfile-mode mar-top-md"></div>
-                                  </div>
-                                </div>
-                                <div ng-switch-when="Custom">
-                                  <div ng-if="buildConfig.spec.strategy.customStrategy.from">
-                                    <dt>Builder Image Stream:</dt>
-                                    <dd>{{buildConfig.spec.strategy.customStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
-                                    </dd>
-                                  </div>
-                                </div>
-                              </div>
                               <div ng-if="buildConfig.spec.source">
                                 <div ng-if="buildConfig.spec.source.type == 'Git'">
                                   <dt>Source Repo:</dt>
@@ -277,6 +238,8 @@
                                     }" readonly ng-model="buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile" class="ace-bordered ace-inline ace-read-only mar-top-md"></div>
                                   </div>
                                 </div>
+                                <dt ng-if-start="buildConfig.spec.source.binary.asFile">Binary Input as File:</dt>
+                                <dd ng-if-end>{{buildConfig.spec.source.binary.asFile}}</dd>
                                 <div ng-if="buildConfig.spec.source.type == 'None'">
                                   <dt>Source:</dt>
                                   <dd>
@@ -305,6 +268,8 @@
                                   </div>
                                 </div>
                               </div>
+                              <dt ng-if-start="(buildConfig | buildStrategy).from">Builder Image:</dt>
+                              <dd ng-if-end>{{(buildConfig | buildStrategy).from | imageObjectRef : buildConfig.metadata.namespace}}</dd>
                               <div ng-if="buildConfig.spec.output.to">
                                 <dt>Output To:</dt>
                                 <dd>{{buildConfig.spec.output.to | imageObjectRef : buildConfig.metadata.namespace}}</dd>
@@ -322,6 +287,24 @@
                                     </a>
                                   </span>
                                 </dd>
+                              </div>
+                              <div ng-if="buildConfig.spec.source.dockerfile">
+                                <dt>Dockerfile:</dt><dd></dd>
+                                <div ui-ace="{
+                                  mode: 'dockerfile',
+                                  theme: 'dreamweaver',
+                                  onLoad: aceLoaded,
+                                  highlightActiveLine: false,
+                                  showGutter: false,
+                                  rendererOptions: {
+                                    fadeFoldWidgets: true,
+                                    highlightActiveLine: false,
+                                    showPrintMargin: false
+                                  },
+                                  advanced: {
+                                    highlightActiveLine: false
+                                  }
+                                }" readonly ng-model="buildConfig.spec.source.dockerfile" class="ace-bordered ace-read-only ace-inline dockerfile-mode mar-top-md"></div>
                               </div>
                             </dl>
                           </div>

--- a/app/views/edit/build-config.html
+++ b/app/views/edit/build-config.html
@@ -145,29 +145,6 @@
                               </span>
                             </label>
                           </div>
-
-                          <div ng-if="sources.binary && updatedBuildConfig.spec.source">
-                            <div class="form-group">
-                              <label for="binaryAsBuild">
-                                Binary Input As File
-                                <span class="help action-inline">
-                                  <a href="">
-                                    <i class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Indicates that the provided binary input should be considered a single file within the build input. For example, specifying 'webapp.war' would place the provided binary as '/webapp.war' for the builder. If left empty, the Docker and Source build strategies assume this file is a zip, tar, or tar.gz file and extract it as the source. The custom strategy receives this binary as standard input. This filename may not contain slashes or be '..' or '.'."></i>
-                                  </a>
-                                </span>
-                              </label>
-                              <div>
-                                <input class="form-control"
-                                  id="binaryAsBuild"
-                                  name="binaryAsBuild"
-                                  type="text"
-                                  ng-model="options.binaryAsFile"
-                                  autocorrect="off"
-                                  autocapitalize="off"
-                                  spellcheck="false">
-                              </div>
-                            </div>
-                          </div>
                         </div>
 
                         <div class="form-groups" ng-show="sources.images">
@@ -249,6 +226,9 @@
                           </div>
                         </div>
                       </dl>
+                      <div ng-if="!sources.git && !sources.dockerfile && !sources.images">
+                        There are no editable source types for this build config.
+                      </div>
                     </div>
 
                     <div ng-if="updatedBuildConfig | isJenkinsPipelineStrategy" class="section">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -6359,13 +6359,13 @@ e.get(b.project).then(_.spread(function(e, g) {
 a.project = e, a.context = g, a.breadcrumbs[0].title = f("displayName")(e), c.get("buildconfigs", b.buildconfig, g).then(function(e) {
 a.buildConfig = e, a.updatedBuildConfig = angular.copy(a.buildConfig), a.buildStrategy = n(a.updatedBuildConfig), a.strategyType = a.buildConfig.spec.strategy.type, a.envVars = a.buildStrategy.env || [], _.each(a.envVars, function(a) {
 f("altTextForValueFrom")(a);
-}), a.triggers = o(a.triggers, a.buildConfig.spec.triggers), a.sources = w(a.sources, a.buildConfig.spec.source), _.has(e, "spec.strategy.jenkinsPipelineStrategy.jenkinsfile") && (a.jenkinsfileOptions.type = "inline"), c.list("secrets", g, function(b) {
+}), a.triggers = o(a.triggers, a.buildConfig.spec.triggers), a.sources = v(a.sources, a.buildConfig.spec.source), _.has(e, "spec.strategy.jenkinsPipelineStrategy.jenkinsfile") && (a.jenkinsfileOptions.type = "inline"), c.list("secrets", g, function(b) {
 var c = d.groupSecretsByType(b), e = _.mapValues(c, function(a) {
 return _.map(a, "metadata.name");
 });
 a.secrets.secretsByType = _.each(e, function(a) {
 a.unshift("");
-}), t();
+}), s();
 });
 var h = function(a, b) {
 a.type = b && b.kind ? b.kind :"None";
@@ -6391,7 +6391,7 @@ value:a.destinationDir
 };
 })) :(a.imageSourceFromObjects = [], a.sourceImages.forEach(function(b) {
 a.imageSourceFromObjects.push(b.from);
-}))), a.options.forcePull = !!a.buildStrategy.forcePull, a.sources.binary && (a.options.binaryAsFile = a.buildConfig.spec.source.binary.asFile ? a.buildConfig.spec.source.binary.asFile :""), "Docker" === a.strategyType && (a.options.noCache = !!a.buildConfig.spec.strategy.dockerStrategy.noCache, a.buildFromTypes.push("None")), m.push(c.watchObject("buildconfigs", b.buildconfig, g, function(b, c) {
+}))), a.options.forcePull = !!a.buildStrategy.forcePull, "Docker" === a.strategyType && (a.options.noCache = !!a.buildConfig.spec.strategy.dockerStrategy.noCache, a.buildFromTypes.push("None")), m.push(c.watchObject("buildconfigs", b.buildconfig, g, function(b, c) {
 "MODIFIED" === c && (a.alerts["updated/deleted"] = {
 type:"warning",
 message:"This build configuration has changed since you started editing it. You'll need to copy any changes you've made and edit again."
@@ -6470,9 +6470,7 @@ sourcePath:a.name,
 destinationDir:a.value
 };
 });
-}, q = function() {
-a.sources.binary && ("" !== a.options.binaryAsFile ? a.updatedBuildConfig.spec.source.binary.asFile = a.options.binaryAsFile :a.updatedBuildConfig.spec.source.binary = {});
-}, r = function(b) {
+}, q = function(b) {
 var c = {};
 switch (b.type) {
 case "ImageStreamTag":
@@ -6497,12 +6495,12 @@ name:_.last(d)
 }, c.namespace = 1 !== d.length ? d[0] :a.buildConfig.metadata.namespace;
 }
 return c;
-}, s = function() {
+}, r = function() {
 var b = [].concat(a.triggers.githubWebhooks, a.triggers.genericWebhooks, a.triggers.imageChangeTriggers, a.triggers.builderImageChangeTrigger, a.triggers.configChangeTrigger);
 return b = _.filter(b, function(a) {
 return _.has(a, "disabled") && !a.disabled || a.present;
 }), b = _.map(b, "data");
-}, t = function() {
+}, s = function() {
 switch (a.secrets.picked = {
 gitSecret:a.buildConfig.spec.source.sourceSecret ? [ a.buildConfig.spec.source.sourceSecret ] :[ {
 name:""
@@ -6532,14 +6530,14 @@ name:""
 mountPath:""
 } ];
 }
-}, u = function(a, b, c) {
+}, t = function(a, b, c) {
 b.name ? a[c] = b :delete a[c];
-}, v = function(b, c) {
+}, u = function(b, c) {
 var d = "Custom" === a.strategyType ? "secretSource" :"secret", e = _.filter(c, function(a) {
 return a[d].name;
 });
 _.isEmpty(e) ? delete b.secrets :b.secrets = e;
-}, w = function(a, b) {
+}, v = function(a, b) {
 return "None" === b.type ? a :(a.none = !1, angular.forEach(b, function(b, c) {
 a[c] = !0;
 }), a);
@@ -6553,16 +6551,16 @@ break;
 case "JenkinsPipeline":
 "path" === a.jenkinsfileOptions.type ? delete a.updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile :delete a.updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath;
 }
-switch (q(), a.sources.images && !_.isEmpty(a.sourceImages) && (a.updatedBuildConfig.spec.source.images[0].paths = p(a.imageSourcePaths), a.updatedBuildConfig.spec.source.images[0].from = r(a.imageOptions.fromSource)), "None" === a.imageOptions.from.type ? delete n(a.updatedBuildConfig).from :n(a.updatedBuildConfig).from = r(a.imageOptions.from), "None" === a.imageOptions.to.type ? delete a.updatedBuildConfig.spec.output.to :a.updatedBuildConfig.spec.output.to = r(a.imageOptions.to), n(a.updatedBuildConfig).env = l.compactEntries(a.envVars), u(a.updatedBuildConfig.spec.source, _.head(a.secrets.picked.gitSecret), "sourceSecret"), u(n(a.updatedBuildConfig), _.head(a.secrets.picked.pullSecret), "pullSecret"), u(a.updatedBuildConfig.spec.output, _.head(a.secrets.picked.pushSecret), "pushSecret"), a.strategyType) {
+switch (a.sources.images && !_.isEmpty(a.sourceImages) && (a.updatedBuildConfig.spec.source.images[0].paths = p(a.imageSourcePaths), a.updatedBuildConfig.spec.source.images[0].from = q(a.imageOptions.fromSource)), "None" === a.imageOptions.from.type ? delete n(a.updatedBuildConfig).from :n(a.updatedBuildConfig).from = q(a.imageOptions.from), "None" === a.imageOptions.to.type ? delete a.updatedBuildConfig.spec.output.to :a.updatedBuildConfig.spec.output.to = q(a.imageOptions.to), n(a.updatedBuildConfig).env = l.compactEntries(a.envVars), t(a.updatedBuildConfig.spec.source, _.head(a.secrets.picked.gitSecret), "sourceSecret"), t(n(a.updatedBuildConfig), _.head(a.secrets.picked.pullSecret), "pullSecret"), t(a.updatedBuildConfig.spec.output, _.head(a.secrets.picked.pushSecret), "pushSecret"), a.strategyType) {
 case "Source":
 case "Docker":
-v(a.updatedBuildConfig.spec.source, a.secrets.picked.sourceSecrets);
+u(a.updatedBuildConfig.spec.source, a.secrets.picked.sourceSecrets);
 break;
 
 case "Custom":
-v(n(a.updatedBuildConfig), a.secrets.picked.sourceSecrets);
+u(n(a.updatedBuildConfig), a.secrets.picked.sourceSecrets);
 }
-a.updatedBuildConfig.spec.triggers = s(), c.update("buildconfigs", a.updatedBuildConfig.metadata.name, a.updatedBuildConfig, a.context).then(function() {
+a.updatedBuildConfig.spec.triggers = r(), c.update("buildconfigs", a.updatedBuildConfig.metadata.name, a.updatedBuildConfig, a.context).then(function() {
 j.addAlert({
 name:a.updatedBuildConfig.metadata.name,
 data:{

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1652,45 +1652,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt>Build Strategy:</dt>\n" +
     "<dd>{{buildConfig.spec.strategy.type | startCase}}</dd>\n" +
     "</div>\n" +
-    "<div ng-switch=\"buildConfig.spec.strategy.type\">\n" +
-    "<div ng-switch-when=\"Source\">\n" +
-    "<div ng-if=\"buildConfig.spec.strategy.sourceStrategy.from\">\n" +
-    "<dt>Builder Image:</dt>\n" +
-    "<dd>{{buildConfig.spec.strategy.sourceStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}</dd>\n" +
-    "</div>\n" +
-    "</div>\n" +
-    "<div ng-switch-when=\"Docker\">\n" +
-    "<div ng-if=\"buildConfig.spec.strategy.dockerStrategy.from\">\n" +
-    "<dt>Builder Image Stream:</dt>\n" +
-    "<dd>{{buildConfig.spec.strategy.dockerStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}</dd>\n" +
-    "</div>\n" +
-    "<div ng-if=\"buildConfig.spec.source.dockerfile\">\n" +
-    "<dt>Dockerfile:</dt><dd></dd>\n" +
-    "<div ui-ace=\"{\n" +
-    "                                      mode: 'dockerfile',\n" +
-    "                                      theme: 'dreamweaver',\n" +
-    "                                      onLoad: aceLoaded,\n" +
-    "                                      highlightActiveLine: false,\n" +
-    "                                      showGutter: false,\n" +
-    "                                      rendererOptions: {\n" +
-    "                                        fadeFoldWidgets: true,\n" +
-    "                                        highlightActiveLine: false,\n" +
-    "                                        showPrintMargin: false\n" +
-    "                                      },\n" +
-    "                                      advanced: {\n" +
-    "                                        highlightActiveLine: false\n" +
-    "                                      }\n" +
-    "                                    }\" readonly=\"readonly\" ng-model=\"buildConfig.spec.source.dockerfile\" class=\"ace-bordered ace-read-only ace-inline dockerfile-mode mar-top-md\"></div>\n" +
-    "</div>\n" +
-    "</div>\n" +
-    "<div ng-switch-when=\"Custom\">\n" +
-    "<div ng-if=\"buildConfig.spec.strategy.customStrategy.from\">\n" +
-    "<dt>Builder Image Stream:</dt>\n" +
-    "<dd>{{buildConfig.spec.strategy.customStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}\n" +
-    "</dd>\n" +
-    "</div>\n" +
-    "</div>\n" +
-    "</div>\n" +
     "<div ng-if=\"buildConfig.spec.source\">\n" +
     "<div ng-if=\"buildConfig.spec.source.type == 'Git'\">\n" +
     "<dt>Source Repo:</dt>\n" +
@@ -1727,6 +1688,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "                                    }\" readonly=\"readonly\" ng-model=\"buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile\" class=\"ace-bordered ace-inline ace-read-only mar-top-md\"></div>\n" +
     "</div>\n" +
     "</div>\n" +
+    "<dt ng-if-start=\"buildConfig.spec.source.binary.asFile\">Binary Input as File:</dt>\n" +
+    "<dd ng-if-end>{{buildConfig.spec.source.binary.asFile}}</dd>\n" +
     "<div ng-if=\"buildConfig.spec.source.type == 'None'\">\n" +
     "<dt>Source:</dt>\n" +
     "<dd>\n" +
@@ -1755,6 +1718,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
+    "<dt ng-if-start=\"(buildConfig | buildStrategy).from\">Builder Image:</dt>\n" +
+    "<dd ng-if-end>{{(buildConfig | buildStrategy).from | imageObjectRef : buildConfig.metadata.namespace}}</dd>\n" +
     "<div ng-if=\"buildConfig.spec.output.to\">\n" +
     "<dt>Output To:</dt>\n" +
     "<dd>{{buildConfig.spec.output.to | imageObjectRef : buildConfig.metadata.namespace}}</dd>\n" +
@@ -1772,6 +1737,24 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</a>\n" +
     "</span>\n" +
     "</dd>\n" +
+    "</div>\n" +
+    "<div ng-if=\"buildConfig.spec.source.dockerfile\">\n" +
+    "<dt>Dockerfile:</dt><dd></dd>\n" +
+    "<div ui-ace=\"{\n" +
+    "                                  mode: 'dockerfile',\n" +
+    "                                  theme: 'dreamweaver',\n" +
+    "                                  onLoad: aceLoaded,\n" +
+    "                                  highlightActiveLine: false,\n" +
+    "                                  showGutter: false,\n" +
+    "                                  rendererOptions: {\n" +
+    "                                    fadeFoldWidgets: true,\n" +
+    "                                    highlightActiveLine: false,\n" +
+    "                                    showPrintMargin: false\n" +
+    "                                  },\n" +
+    "                                  advanced: {\n" +
+    "                                    highlightActiveLine: false\n" +
+    "                                  }\n" +
+    "                                }\" readonly=\"readonly\" ng-model=\"buildConfig.spec.source.dockerfile\" class=\"ace-bordered ace-read-only ace-inline dockerfile-mode mar-top-md\"></div>\n" +
     "</div>\n" +
     "</dl>\n" +
     "</div>\n" +
@@ -7547,21 +7530,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</label>\n" +
     "</div>\n" +
-    "<div ng-if=\"sources.binary && updatedBuildConfig.spec.source\">\n" +
-    "<div class=\"form-group\">\n" +
-    "<label for=\"binaryAsBuild\">\n" +
-    "Binary Input As File\n" +
-    "<span class=\"help action-inline\">\n" +
-    "<a href=\"\">\n" +
-    "<i class=\"pficon pficon-help\" data-toggle=\"tooltip\" aria-hidden=\"true\" data-original-title=\"Indicates that the provided binary input should be considered a single file within the build input. For example, specifying 'webapp.war' would place the provided binary as '/webapp.war' for the builder. If left empty, the Docker and Source build strategies assume this file is a zip, tar, or tar.gz file and extract it as the source. The custom strategy receives this binary as standard input. This filename may not contain slashes or be '..' or '.'.\"></i>\n" +
-    "</a>\n" +
-    "</span>\n" +
-    "</label>\n" +
-    "<div>\n" +
-    "<input class=\"form-control\" id=\"binaryAsBuild\" name=\"binaryAsBuild\" type=\"text\" ng-model=\"options.binaryAsFile\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\">\n" +
-    "</div>\n" +
-    "</div>\n" +
-    "</div>\n" +
     "</div>\n" +
     "<div class=\"form-groups\" ng-show=\"sources.images\">\n" +
     "<div class=\"single-image-source\" ng-if=\"sourceImages.length === 1\">\n" +
@@ -7611,6 +7579,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</dl>\n" +
+    "<div ng-if=\"!sources.git && !sources.dockerfile && !sources.images\">\n" +
+    "There are no editable source types for this build config.\n" +
+    "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"updatedBuildConfig | isJenkinsPipelineStrategy\" class=\"section\">\n" +
     "<h3 class=\"with-divider\">Jenkins Pipeline Configuration</h3>\n" +


### PR DESCRIPTION
* Show message when there are no editable source types in the editor
* Show the binary input as file in the browse page configuration tab
* Show the Dockerfile on the browse page if it exists, even when
  `spec.strategy.type` isn't `Docker`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1393803


@jwforres PTAL