### PR TITLE
Add view events link to failed deployment alert

### DIFF
--- a/app/scripts/directives/serviceGroupNotifications.js
+++ b/app/scripts/directives/serviceGroupNotifications.js
@@ -101,11 +101,12 @@ angular.module('openshiftConsole')
               message: 'Deployment ' + displayName + ' failed.',
               reason: annotation(mostRecentRC, 'openshift.io/deployment.status-reason'),
               links: [{
-                href: rcLink,
-                label: 'View Deployment'
-              }, {
                 href: logLink,
                 label: 'View Log'
+              }, {
+                // Show all events since the event might not be on the replication controller itself.
+                href: 'project/' + mostRecentRC.metadata.namespace + '/browse/events',
+                label: 'View Events'
               }]
             };
             break;

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -11751,11 +11751,11 @@ type:"error",
 message:"Deployment " + k + " failed.",
 reason:i(c, "openshift.io/deployment.status-reason"),
 links:[ {
-href:m,
-label:"View Deployment"
-}, {
 href:f,
 label:"View Log"
+}, {
+href:"project/" + c.metadata.namespace + "/browse/events",
+label:"View Events"
 } ]
 };
 }


### PR DESCRIPTION
Frequently the cause of the failure is in the events, not the deployment logs. Add a link so that users are more likely to check there.

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/20225677/a9cefbe8-a812-11e6-85ec-b8a00027e7ef.png)

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1365525