### PR TITLE
[WIP] Reduce overall size and tightening of .toast-pf alerts on overview

### DIFF
--- a/app/styles/_pipeline.less
+++ b/app/styles/_pipeline.less
@@ -541,7 +541,7 @@
     font-size: 16px;
     opacity: .85;
     position: absolute;
-    right: 14px;
+    right: 10px;
     top: 7px;
     &:hover {
       opacity: 1;

--- a/app/styles/_toast.less
+++ b/app/styles/_toast.less
@@ -1,0 +1,16 @@
+//
+// Toast alerts
+// -------------------------------------------------
+
+.overview .alert.toast-pf {
+  padding: 6px 10px 6px 44px;
+  .close {
+    font-size: 16px;
+    margin-top: 2px;
+  }
+  > .pficon {
+    font-size: 16px;
+    padding-top: 10px;
+    width: 35px;
+  }
+}

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -37,6 +37,7 @@
 @import "_substructure.less";
 @import "_tables.less";
 @import "_tile.less";
+@import "_toast.less";
 @import "_topology.less";
 @import "_typography.less";
 @import "_spacers.less";

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4616,7 +4616,7 @@ to{background-color:transparent}
 .build-pipeline-collapsed .build-summary,.triggers .build .build-summary{border-bottom:0;border-right:0;-webkit-flex-direction:row;-moz-flex-direction:row;-ms-flex-direction:row;flex-direction:row;-webkit-justify-content:flex-start;-moz-justify-content:flex-start;justify-content:flex-start;position:relative;text-align:left}
 .build-pipeline-collapsed .build-summary.dismissible,.triggers .build .build-summary.dismissible{padding-right:30px}
 .build-pipeline-collapsed .build-timestamp,.triggers .build .build-timestamp{float:right!important;float:right}
-.build-pipeline-collapsed .close,.triggers .build .close{color:#8b8d8f;font-size:16px;opacity:.85;position:absolute;right:14px;top:7px}
+.build-pipeline-collapsed .close,.triggers .build .close{color:#8b8d8f;font-size:16px;opacity:.85;position:absolute;right:10px;top:7px}
 .build-pipeline-collapsed .close:hover,.triggers .build .close:hover{opacity:1}
 .navbar-project-menu{width:100%}
 .navbar-project-menu .navbar-project-search{display:inline-block}
@@ -4953,6 +4953,9 @@ body,html{margin:0;padding:0}
 .tile-row .tile-item-count{background-color:#ccc;font-weight:600;padding:4px 6px;position:absolute;right:10px;top:10px}
 .tile-row .tile-title{text-align:center}
 .tile-row .tile-title h3{margin:0 20px}
+.overview .alert.toast-pf{padding:6px 10px 6px 44px}
+.overview .alert.toast-pf .close{font-size:16px;margin-top:2px}
+.overview .alert.toast-pf>.pficon{font-size:16px;padding-top:10px;width:35px}
 kubernetes-topology-graph{height:700px}
 .kube-topology{margin-bottom:-5px}
 .kube-topology g.DeploymentConfig text{font-family:FontAwesome;font-size:20px;fill:#9467bd}


### PR DESCRIPTION
**Height 36px (updated pr)**
<img width="444" alt="screen shot 2016-11-15 at 11 37 42 am" src="https://cloud.githubusercontent.com/assets/1874151/20314356/fd107666-ab27-11e6-96a7-bd12fb91fbd1.png">


**Height 31px (initial pr)**
<img width="447" alt="screen shot 2016-11-15 at 11 43 44 am" src="https://cloud.githubusercontent.com/assets/1874151/20314623/d045cf72-ab28-11e6-82e1-dba435e23b94.png">


**Height 45px (current)**
<img width="502" alt="screen shot 2016-11-15 at 11 32 24 am" src="https://cloud.githubusercontent.com/assets/1874151/20314169/40db6924-ab27-11e6-9882-bd6ceadd38e3.png">

Fixes #238
