### PR TITLE
Remove path from hostname in route view

### DIFF
--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -338,19 +338,19 @@ angular.module('openshiftConsole')
     };
   })
   .filter('routeWebURL', function(routeHostFilter){
-    return function(route, host){
+    return function(route, host, omitPath){
         var scheme = (route.spec.tls && route.spec.tls.tlsTerminationType !== "") ? "https" : "http";
         var url = scheme + "://" + (host || routeHostFilter(route));
-        if (route.spec.path) {
+        if (route.spec.path && !omitPath) {
             url += route.spec.path;
         }
         return url;
     };
   })
   .filter('routeLabel', function(RoutesService, routeHostFilter, routeWebURLFilter, isWebRouteFilter) {
-    return function(route, host) {
+    return function(route, host, omitPath) {
       if (isWebRouteFilter(route)) {
-        return routeWebURLFilter(route, host);
+        return routeWebURLFilter(route, host, omitPath);
       }
 
       var label = (host || routeHostFilter(route));
@@ -362,6 +362,10 @@ angular.module('openshiftConsole')
         label = '*.' + RoutesService.getSubdomain(route);
       }
 
+      if(omitPath) {
+        return label;
+      }
+      
       if (route.spec.path) {
         label += route.spec.path;
       }

--- a/app/views/browse/route.html
+++ b/app/views/browse/route.html
@@ -56,7 +56,7 @@
                   <dt>Hostname<span ng-if="route.status.ingress.length > 1">s</span>:</dt>
                   <dd>
                     <span ng-if="!route.status.ingress">
-                      {{route | routeLabel}}
+                      {{route | routeLabel : null : true}}
                       <span data-toggle="popover" data-trigger="hover" data-content="The route is not accepting traffic yet because it has not been admitted by a router." style="cursor: help; padding-left: 5px;">
                         <status-icon status="'Pending'" disable-animation></status-icon>
                         <span class="sr-only">Pending</span>
@@ -64,7 +64,7 @@
                     </span>
                     <div ng-repeat="ingress in route.status.ingress">
                       <span ng-if="(route | isWebRoute)">
-                        <a href="{{route | routeWebURL : ingress.host}}" target="_blank">{{route | routeLabel : ingress.host}}</a>
+                        <a ng-href="{{route | routeWebURL : ingress.host}}" target="_blank">{{route | routeLabel : ingress.host : true}}</a>
                       </span>
                       <span ng-if="!(route | isWebRoute)">
                         {{route | routeLabel : ingress.host}}

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12767,15 +12767,15 @@ return function(b) {
 return !!a(b) && "Subdomain" !== _.get(b, "spec.wildcardPolicy");
 };
 } ]).filter("routeWebURL", [ "routeHostFilter", function(a) {
-return function(b, c) {
-var d = b.spec.tls && "" !== b.spec.tls.tlsTerminationType ? "https" :"http", e = d + "://" + (c || a(b));
-return b.spec.path && (e += b.spec.path), e;
+return function(b, c, d) {
+var e = b.spec.tls && "" !== b.spec.tls.tlsTerminationType ? "https" :"http", f = e + "://" + (c || a(b));
+return b.spec.path && !d && (f += b.spec.path), f;
 };
 } ]).filter("routeLabel", [ "RoutesService", "routeHostFilter", "routeWebURLFilter", "isWebRouteFilter", function(a, b, c, d) {
-return function(e, f) {
-if (d(e)) return c(e, f);
-var g = f || b(e);
-return g ? ("Subdomain" === _.get(e, "spec.wildcardPolicy") && (g = "*." + a.getSubdomain(e)), e.spec.path && (g += e.spec.path), g) :"<unknown host>";
+return function(e, f, g) {
+if (d(e)) return c(e, f, g);
+var h = f || b(e);
+return h ? ("Subdomain" === _.get(e, "spec.wildcardPolicy") && (h = "*." + a.getSubdomain(e)), g ? h :(e.spec.path && (h += e.spec.path), h)) :"<unknown host>";
 };
 } ]).filter("parameterPlaceholder", function() {
 return function(a) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3171,7 +3171,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt>Hostname<span ng-if=\"route.status.ingress.length > 1\">s</span>:</dt>\n" +
     "<dd>\n" +
     "<span ng-if=\"!route.status.ingress\">\n" +
-    "{{route | routeLabel}}\n" +
+    "{{route | routeLabel : null : true}}\n" +
     "<span data-toggle=\"popover\" data-trigger=\"hover\" data-content=\"The route is not accepting traffic yet because it has not been admitted by a router.\" style=\"cursor: help; padding-left: 5px\">\n" +
     "<status-icon status=\"'Pending'\" disable-animation></status-icon>\n" +
     "<span class=\"sr-only\">Pending</span>\n" +
@@ -3179,7 +3179,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "<div ng-repeat=\"ingress in route.status.ingress\">\n" +
     "<span ng-if=\"(route | isWebRoute)\">\n" +
-    "<a href=\"{{route | routeWebURL : ingress.host}}\" target=\"_blank\">{{route | routeLabel : ingress.host}}</a>\n" +
+    "<a ng-href=\"{{route | routeWebURL : ingress.host}}\" target=\"_blank\">{{route | routeLabel : ingress.host : true}}</a>\n" +
     "</span>\n" +
     "<span ng-if=\"!(route | isWebRoute)\">\n" +
     "{{route | routeLabel : ingress.host}}\n" +


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/5994

This patch removes a route's path from its routeLabel, but leaves the
original path (hostname + path) in the route's link (if any).

![route-page-with-hostname-and-path](https://cloud.githubusercontent.com/assets/3902875/20316432/ca10a7ec-ab2f-11e6-9261-69a9683157fe.png)


@jwforres @spadgett 