### PR TITLE
prevent secret modal from closing on outside click

### DIFF
--- a/app/scripts/directives/oscSecrets.js
+++ b/app/scripts/directives/oscSecrets.js
@@ -52,6 +52,7 @@ angular.module("openshiftConsole")
           $scope.newSecret = {};
           var modalInstance = $uibModal.open({
             animation: true,
+            backdrop: 'static',
             templateUrl: 'views/modals/create-secret.html',
             controller: 'CreateSecretModalController',
             scope: $scope

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -9223,6 +9223,7 @@ name:""
 b.newSecret = {};
 var e = a.open({
 animation:!0,
+backdrop:"static",
 templateUrl:"views/modals/create-secret.html",
 controller:"CreateSecretModalController",
 scope:b


### PR DESCRIPTION
Related Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1390490

This patch makes the "backdrop" for the "create new secret" modal
static, so that the modal is not accidentally closed if a click is made
outside of it. This enforces the use of the "cancel" button on the modal
in order to close it.

Path to modal: https://localhost:9000/project/lo/edit/builds/`name of your bc` > click on `advanced options` > click on `create new secret`

@jwforres