### PR TITLE
Update karma to run both firefox & chrome tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -576,7 +576,15 @@ module.exports = function (grunt) {
     karma: {
       unit: {
         configFile: 'test/karma.conf.js',
-        singleRun: true
+        singleRun: true,
+        // default in karma.conf.js is Firefox, however, Chrome has much better
+        // error messages when writing tests.  Call like this:
+        // grunt test
+        // grunt test --browsers=Chrome
+        // grunt test --browsers=Chrome,Firefox,Safari (be sure karma-<browser_name>-launcher is installed)
+        browsers: grunt.option('browsers') ?
+                    grunt.option('browsers').split(',') :
+                    ['Firefox']
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jasmine-spec-reporter": "1.1.2",
     "jshint-stylish": "0.2.0",
     "karma": "0.12.23",
+    "karma-chrome-launcher": "^2.0.0",
     "karma-coverage": "0.2.6",
     "karma-firefox-launcher": "^1.0.0",
     "karma-jasmine": "0.1.5",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -79,10 +79,9 @@ module.exports = function(config) {
     // - Safari (only Mac)
     // - PhantomJS
     // - IE (only Windows)
-    browsers: ['Firefox'],
-    // Which plugins to enable
     plugins: [
       'karma-firefox-launcher',
+      'karma-chrome-launcher',
       'karma-ng-html2js-preprocessor',
       'karma-jasmine',
       'karma-coverage'


### PR DESCRIPTION
Updating Karma to run both tests in both Firefox & Chrome concurrently:
- Firefox is much more valuable since we all tend to use Chrome
- Chrome, however, has much better error messages that make you less likely to throw yourself out the window while writing tests.

![screen shot 2016-11-18 at 12 54 38 pm](https://cloud.githubusercontent.com/assets/280512/20440460/2fd9611c-ad8e-11e6-971d-d9d7128baeea.png)

@jwforres @spadgett 