### PR TITLE
Updating annotations directive to always display Show/Hide Annotation…

### DIFF
--- a/app/views/directives/annotations.html
+++ b/app/views/directives/annotations.html
@@ -1,21 +1,28 @@
-<div ng-if="annotations" class="gutter-top-bottom">
-  <a href="" ng-click="toggleAnnotations()" ng-if="annotations && !expandAnnotations">Show annotations</a>
-  <a href="" ng-click="toggleAnnotations()" ng-if="annotations && expandAnnotations">Hide annotations</a>
-  <div ng-if="expandAnnotations" class="table-responsive" style="margin-top: 5px;">
-    <table class="table table-bordered table-bordered-columns key-value-table">
-      <tbody>
-        <tr ng-repeat="(annotationKey, annotationValue) in annotations">
-          <td class="key">{{annotationKey}}</td>
-          <td class="value">
-            <truncate-long-text
-                content="annotationValue | prettifyJSON"
-                limit="500"
-                newlineLimit="20"
-                expandable="true">
-            </truncate-long-text>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+<div class="gutter-top-bottom">
+  <p>
+    <a href="" ng-click="toggleAnnotations()" ng-if="!expandAnnotations">Show annotations</a>
+    <a href="" ng-click="toggleAnnotations()" ng-if="expandAnnotations">Hide annotations</a>
+  </p>
+  <div ng-if="expandAnnotations">
+    <div ng-if="annotations" class="table-responsive">
+      <table class="table table-bordered table-bordered-columns key-value-table">
+        <tbody>
+          <tr ng-repeat="(annotationKey, annotationValue) in annotations">
+            <td class="key">{{annotationKey}}</td>
+            <td class="value">
+              <truncate-long-text
+                  content="annotationValue | prettifyJSON"
+                  limit="500"
+                  newlineLimit="20"
+                  expandable="true">
+              </truncate-long-text>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p ng-if="!annotations">
+      There are no annotations on this resource.
+    </p>
   </div>
 </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5321,10 +5321,13 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/directives/annotations.html',
-    "<div ng-if=\"annotations\" class=\"gutter-top-bottom\">\n" +
-    "<a href=\"\" ng-click=\"toggleAnnotations()\" ng-if=\"annotations && !expandAnnotations\">Show annotations</a>\n" +
-    "<a href=\"\" ng-click=\"toggleAnnotations()\" ng-if=\"annotations && expandAnnotations\">Hide annotations</a>\n" +
-    "<div ng-if=\"expandAnnotations\" class=\"table-responsive\" style=\"margin-top: 5px\">\n" +
+    "<div class=\"gutter-top-bottom\">\n" +
+    "<p>\n" +
+    "<a href=\"\" ng-click=\"toggleAnnotations()\" ng-if=\"!expandAnnotations\">Show annotations</a>\n" +
+    "<a href=\"\" ng-click=\"toggleAnnotations()\" ng-if=\"expandAnnotations\">Hide annotations</a>\n" +
+    "</p>\n" +
+    "<div ng-if=\"expandAnnotations\">\n" +
+    "<div ng-if=\"annotations\" class=\"table-responsive\">\n" +
     "<table class=\"table table-bordered table-bordered-columns key-value-table\">\n" +
     "<tbody>\n" +
     "<tr ng-repeat=\"(annotationKey, annotationValue) in annotations\">\n" +
@@ -5336,6 +5339,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</tr>\n" +
     "</tbody>\n" +
     "</table>\n" +
+    "</div>\n" +
+    "<p ng-if=\"!annotations\">\n" +
+    "There are no annotations on this resource.\n" +
+    "</p>\n" +
     "</div>\n" +
     "</div>"
   );


### PR DESCRIPTION
…s link

and adding message “There are no annotations on this resource.” if
there are no annotations.

Resolves https://github.com/openshift/origin/issues/7643

Always show link
![screen shot 2016-11-18 at 1 53 34 pm](https://cloud.githubusercontent.com/assets/895728/20442605/3c0bc156-ad97-11e6-871c-71fc56b0f79f.PNG)

If no annotations, display message
![screen shot 2016-11-18 at 1 53 39 pm](https://cloud.githubusercontent.com/assets/895728/20442606/3c124652-ad97-11e6-9fd3-2db8cad8fe44.PNG)

If annotations, show annotations
![screen shot 2016-11-18 at 1 53 44 pm](https://cloud.githubusercontent.com/assets/895728/20442607/3c13b410-ad97-11e6-8c5c-8dbac4330438.PNG)

@jwforres, PTAL
