### PR TITLE
Add build view option to edit build configuration

### DIFF
--- a/app/views/browse/build.html
+++ b/app/views/browse/build.html
@@ -39,6 +39,10 @@
                      class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
                      data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                   <ul class="dropdown-menu actions action-button">
+                    <li ng-if="'buildconfigs' | canI : 'update'">
+                      <a ng-href="{{buildConfig | editResourceURL}}" role="button">Edit Configuration</a>
+                    </li>
+                    <li class="divider" ng-if="'buildconfigs' | canI : 'update'"></li>
                     <li ng-if="!build.metadata.deletionTimestamp && (build | isIncompleteBuild) && ('builds' | canI : 'update')"
                         class="visible-xs-inline">
                       <a href=""

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1871,6 +1871,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</button>\n" +
     "<a href=\"\" class=\"dropdown-toggle actions-dropdown-kebab visible-xs-inline\" data-toggle=\"dropdown\"><i class=\"fa fa-ellipsis-v\"></i><span class=\"sr-only\">Actions</span></a>\n" +
     "<ul class=\"dropdown-menu actions action-button\">\n" +
+    "<li ng-if=\"'buildconfigs' | canI : 'update'\">\n" +
+    "<a ng-href=\"{{buildConfig | editResourceURL}}\" role=\"button\">Edit Configuration</a>\n" +
+    "</li>\n" +
+    "<li class=\"divider\" ng-if=\"'buildconfigs' | canI : 'update'\"></li>\n" +
     "<li ng-if=\"!build.metadata.deletionTimestamp && (build | isIncompleteBuild) && ('builds' | canI : 'update')\" class=\"visible-xs-inline\">\n" +
     "<a href=\"\" role=\"button\" ng-click=\"cancelBuild()\">Cancel Build</a>\n" +
     "</li>\n" +


### PR DESCRIPTION
Related Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1386603
Related discussion: https://github.com/openshift/origin/issues/10096

This patch adds an `Edit Configuration` option to a build page that
allows a user to edit the build's config.

![build-page-edit-config-option](https://cloud.githubusercontent.com/assets/3902875/20444020/61fc0384-ad9d-11e6-8493-ba62c4ad3c8b.png)

![build-config-edit-page-from-build-page](https://cloud.githubusercontent.com/assets/3902875/20444038/76bd8acc-ad9d-11e6-8e15-489104f72d6b.png)

cc @jwforres @bparees @spadgett 