### PR TITLE
Show 3 catalog columns instead of 4

### DIFF
--- a/app/views/catalog/_image.html
+++ b/app/views/catalog/_image.html
@@ -1,4 +1,4 @@
-<div class="col-xxs-12 col-xs-6 col-sm-6 col-md-4 col-lg-3">
+<div class="col-xxs-12 col-xs-6 col-sm-6 col-md-4">
   <div class="card-pf">
     <div class="card-pf-body card-pf-body-with-version">
       <div class="card-pf-details">

--- a/app/views/catalog/_template.html
+++ b/app/views/catalog/_template.html
@@ -1,4 +1,4 @@
-<div class="col-xxs-12 col-xs-6 col-sm-6 col-md-4 col-lg-3">
+<div class="col-xxs-12 col-xs-6 col-sm-6 col-md-4">
   <div class="card-pf">
     <div class="card-pf-body">
       <div class="card-pf-title-with-icon">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3772,7 +3772,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/catalog/_image.html',
-    "<div class=\"col-xxs-12 col-xs-6 col-sm-6 col-md-4 col-lg-3\">\n" +
+    "<div class=\"col-xxs-12 col-xs-6 col-sm-6 col-md-4\">\n" +
     "<div class=\"card-pf\">\n" +
     "<div class=\"card-pf-body card-pf-body-with-version\">\n" +
     "<div class=\"card-pf-details\">\n" +
@@ -3825,7 +3825,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/catalog/_template.html',
-    "<div class=\"col-xxs-12 col-xs-6 col-sm-6 col-md-4 col-lg-3\">\n" +
+    "<div class=\"col-xxs-12 col-xs-6 col-sm-6 col-md-4\">\n" +
     "<div class=\"card-pf\">\n" +
     "<div class=\"card-pf-body\">\n" +
     "<div class=\"card-pf-title-with-icon\">\n" +


### PR DESCRIPTION
I think this improves the layout for large descriptions or categories with only a few items. We might even truncate the text sooner.

Before:

![screen shot 2016-11-18 at 2 45 26 pm](https://cloud.githubusercontent.com/assets/1167259/20444090/ac0c0820-ad9d-11e6-8798-ad54e73dff18.png)

After:

![screen shot 2016-11-18 at 2 44 15 pm](https://cloud.githubusercontent.com/assets/1167259/20444046/82305538-ad9d-11e6-9067-a9e5a8821777.png)

@rhamilto @jwforres opinions?