### PR TITLE
Remove incorrect minlength="2" restrictions on some resource names

### DIFF
--- a/app/views/create-project.html
+++ b/app/views/create-project.html
@@ -39,13 +39,20 @@
                       <span class="help-block">A unique name for the project.</span>
                     </div>
                     <div class="has-error">
-                      <span id="nameHelp" class="help-block" ng-if="createProjectForm.name.$error.pattern && createProjectForm.name.$touched">
-                        Project names may only contain lower-case letters, numbers, and dashes.
-                        They may not start or end with a dash.</span>
+                      <span id="nameHelp" class="help-block" ng-if="createProjectForm.name.$error.minlength && createProjectForm.name.$touched">
+                        Name must have at least two characters.
+                      </span>
                     </div>
                     <div class="has-error">
-                      <span class="help-block" ng-if="nameTaken">This name is already
-                          in use. Please choose a different name.</span>
+                      <span id="nameHelp" class="help-block" ng-if="createProjectForm.name.$error.pattern && createProjectForm.name.$touched">
+                        Project names may only contain lower-case letters, numbers, and dashes.
+                        They may not start or end with a dash.
+                      </span>
+                    </div>
+                    <div class="has-error">
+                      <span class="help-block" ng-if="nameTaken">
+                        This name is already in use. Please choose a different name.
+                      </span>
                     </div>
                   </div>
 

--- a/app/views/directives/edit-config-map.html
+++ b/app/views/directives/edit-config-map.html
@@ -14,7 +14,6 @@
             ng-required="showNameInput"
             ng-pattern="/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/"
             ng-maxlength="63"
-            ng-minlength="2"
             placeholder="my-config-map"
             select-on-focus
             autocorrect="off"

--- a/app/views/directives/osc-autoscaling.html
+++ b/app/views/directives/osc-autoscaling.html
@@ -13,7 +13,6 @@
           ng-readonly="nameReadOnly"
           ng-pattern="/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/"
           ng-maxlength="63"
-          ng-minlength="2"
           placeholder="my-hpa"
           select-on-focus
           autocorrect="off"

--- a/app/views/directives/osc-persistent-volume-claim.html
+++ b/app/views/directives/osc-persistent-volume-claim.html
@@ -47,7 +47,6 @@
         ng-required="true"
         ng-pattern="/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/"
         ng-maxlength="253"
-        ng-minlength="2"
         placeholder="my-storage-claim"
         select-on-focus
         autocorrect="off"

--- a/app/views/directives/osc-routing.html
+++ b/app/views/directives/osc-routing.html
@@ -14,7 +14,6 @@
           ng-required="showNameInput"
           ng-pattern="/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/"
           ng-maxlength="63"
-          ng-minlength="2"
           placeholder="my-route"
           select-on-focus
           autocorrect="off"

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4169,11 +4169,19 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"help-block\">A unique name for the project.</span>\n" +
     "</div>\n" +
     "<div class=\"has-error\">\n" +
-    "<span id=\"nameHelp\" class=\"help-block\" ng-if=\"createProjectForm.name.$error.pattern && createProjectForm.name.$touched\">\n" +
-    "Project names may only contain lower-case letters, numbers, and dashes. They may not start or end with a dash.</span>\n" +
+    "<span id=\"nameHelp\" class=\"help-block\" ng-if=\"createProjectForm.name.$error.minlength && createProjectForm.name.$touched\">\n" +
+    "Name must have at least two characters.\n" +
+    "</span>\n" +
     "</div>\n" +
     "<div class=\"has-error\">\n" +
-    "<span class=\"help-block\" ng-if=\"nameTaken\">This name is already in use. Please choose a different name.</span>\n" +
+    "<span id=\"nameHelp\" class=\"help-block\" ng-if=\"createProjectForm.name.$error.pattern && createProjectForm.name.$touched\">\n" +
+    "Project names may only contain lower-case letters, numbers, and dashes. They may not start or end with a dash.\n" +
+    "</span>\n" +
+    "</div>\n" +
+    "<div class=\"has-error\">\n" +
+    "<span class=\"help-block\" ng-if=\"nameTaken\">\n" +
+    "This name is already in use. Please choose a different name.\n" +
+    "</span>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"form-group\">\n" +
@@ -5865,7 +5873,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<label for=\"config-map-name\" class=\"required\">Name</label>\n" +
     "\n" +
     "<div ng-class=\"{ 'has-error': configMapForm.name.$invalid && configMapForm.name.$touched }\">\n" +
-    "<input id=\"config-map-name\" class=\"form-control\" type=\"text\" name=\"name\" ng-model=\"configMap.metadata.name\" ng-required=\"showNameInput\" ng-pattern=\"/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/\" ng-maxlength=\"63\" ng-minlength=\"2\" placeholder=\"my-config-map\" select-on-focus autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"config-map-name-help\">\n" +
+    "<input id=\"config-map-name\" class=\"form-control\" type=\"text\" name=\"name\" ng-model=\"configMap.metadata.name\" ng-required=\"showNameInput\" ng-pattern=\"/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/\" ng-maxlength=\"63\" placeholder=\"my-config-map\" select-on-focus autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"config-map-name-help\">\n" +
     "</div>\n" +
     "<div>\n" +
     "<span id=\"config-map-name-help\" class=\"help-block\">A unique name for the config map within the project.</span>\n" +
@@ -6653,7 +6661,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-show=\"showNameInput\" class=\"form-group\">\n" +
     "<label for=\"hpa-name\" class=\"required\">Autoscaler Name</label>\n" +
     "<span ng-class=\"{ 'has-error': form.name.$touched && form.name.$invalid }\">\n" +
-    "<input id=\"hpa-name\" class=\"form-control\" type=\"text\" name=\"name\" ng-model=\"autoscaling.name\" ng-required=\"showNameInput\" ng-readonly=\"nameReadOnly\" ng-pattern=\"/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/\" ng-maxlength=\"63\" ng-minlength=\"2\" placeholder=\"my-hpa\" select-on-focus autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"hpa-name-help\">\n" +
+    "<input id=\"hpa-name\" class=\"form-control\" type=\"text\" name=\"name\" ng-model=\"autoscaling.name\" ng-required=\"showNameInput\" ng-readonly=\"nameReadOnly\" ng-pattern=\"/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/\" ng-maxlength=\"63\" placeholder=\"my-hpa\" select-on-focus autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"hpa-name-help\">\n" +
     "</span>\n" +
     "<div>\n" +
     "<span id=\"hpa-name-help\" class=\"help-block\">\n" +
@@ -6971,7 +6979,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"claim-name\" class=\"required\">Name</label>\n" +
-    "<input id=\"claim-name\" class=\"form-control\" type=\"text\" name=\"name\" ng-model=\"claim.name\" ng-required=\"true\" ng-pattern=\"/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/\" ng-maxlength=\"253\" ng-minlength=\"2\" placeholder=\"my-storage-claim\" select-on-focus autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"claim-name-help\">\n" +
+    "<input id=\"claim-name\" class=\"form-control\" type=\"text\" name=\"name\" ng-model=\"claim.name\" ng-required=\"true\" ng-pattern=\"/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/\" ng-maxlength=\"253\" placeholder=\"my-storage-claim\" select-on-focus autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"claim-name-help\">\n" +
     "<div>\n" +
     "<span id=\"claim-name-help\" class=\"help-block\">A unique name for the storage claim within the project.</span>\n" +
     "</div>\n" +
@@ -7099,7 +7107,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-show=\"showNameInput\" class=\"form-group\">\n" +
     "<label for=\"route-name\" class=\"required\">Name</label>\n" +
     "\n" +
-    "<input id=\"route-name\" class=\"form-control\" type=\"text\" name=\"name\" ng-model=\"route.name\" ng-required=\"showNameInput\" ng-pattern=\"/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/\" ng-maxlength=\"63\" ng-minlength=\"2\" placeholder=\"my-route\" select-on-focus autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"route-name-help\">\n" +
+    "<input id=\"route-name\" class=\"form-control\" type=\"text\" name=\"name\" ng-model=\"route.name\" ng-required=\"showNameInput\" ng-pattern=\"/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/\" ng-maxlength=\"63\" placeholder=\"my-route\" select-on-focus autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"route-name-help\">\n" +
     "<div>\n" +
     "<span id=\"route-name-help\" class=\"help-block\">A unique name for the route within the project.</span>\n" +
     "</div>\n" +


### PR DESCRIPTION
Removed the minlength from the name field on the following create forms:

* Config maps
* HPAs
* PVCs
* Routes

These field names must be DNS 1123 subdomains, which do allow single character values.

Improved the minlength error message for project names, where it is required.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1396906

@rhamilto @benjaminapetersen FYI, I'm changing create-project.html
@jwforres PTAL