### PR TITLE
Updates to make spacing beneath middle header and ui-tabs consistent. And ...

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -119,10 +119,17 @@
   }
 }
 
-.nav-tabs, .tab-content {
+.nav-tabs {
   margin-bottom: @grid-gutter-width / 2;
-  margin-top: @grid-gutter-width / 2;
 }
+
+.resource-details {
+  h3 {
+    border-bottom: 1px solid #eee;
+    padding-bottom: 10px;
+  }
+}
+
 
 .hide-tabs .nav-tabs {
   display: none;
@@ -210,6 +217,10 @@ mark {
   .latest-build-timestamp {
     margin-left: 25px;
   }
+}
+
+.registry-image-pull {
+  margin-bottom: @grid-gutter-width / 2;
 }
 
 .image-sources {
@@ -1142,11 +1153,6 @@ labels + .resource-details {
 [flex].page-header {
   // reduced for consistency if used with flex
   margin-top: 21px;
-}
-
-.resource-details h3 {
-  padding-bottom: 10px;
-  border-bottom: 1px solid #eee;
 }
 
 h1 small.meta, .build-config-summary .meta {

--- a/app/styles/_log.less
+++ b/app/styles/_log.less
@@ -3,6 +3,7 @@
 }
 .log-header {
   margin-bottom: 3px;
+  margin-top: @grid-gutter-width / 2;
   label {
     margin-bottom: 0;
   }

--- a/app/styles/_membership.less
+++ b/app/styles/_membership.less
@@ -10,7 +10,6 @@
   }
   .content-pane {
     width: 100%;
-    margin-top: 50px;
     .col-add-role {
       padding: 10px 0;
       min-width: 150px;

--- a/app/styles/_substructure.less
+++ b/app/styles/_substructure.less
@@ -70,6 +70,7 @@ html,body {
         height: 100%;
         .middle-header {
           .flex(@columns: 0 0 auto);
+          margin-bottom: @grid-gutter-width / 2;
         }
         .middle-content {
           .flex(@columns: 1 1 auto);

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -193,7 +193,6 @@
                       <div class="resource-details">
                         <div class="row">
                           <div class="col-lg-6">
-                            <h3>Configuration</h3>
                             <dl class="dl-horizontal left">
                               <div>
                                 <dt>Build Strategy:</dt>

--- a/app/views/browse/config-map.html
+++ b/app/views/browse/config-map.html
@@ -46,7 +46,7 @@
           </div>
         </div>
       </div><!-- /middle-header-->
-      <div class="middle-content gutter-top">
+      <div class="middle-content">
         <div class="container-fluid">
           <div ng-if="configMap" class="row">
             <div class="col-sm-12">

--- a/app/views/browse/config-maps.html
+++ b/app/views/browse/config-maps.html
@@ -23,7 +23,7 @@
       <div class="middle-content">
         <div class="container-fluid">
           <div class="row">
-            <div class="col-md-12 gutter-top">
+            <div class="col-md-12">
               <div ng-if="!loaded">Loading...</div>
               <div ng-if="loaded">
                 <table class="table table-bordered table-hover table-mobile">

--- a/app/views/browse/deployment-config.html
+++ b/app/views/browse/deployment-config.html
@@ -96,19 +96,19 @@
             <div ng-if="!loaded">Loading...</div>
             <div class="row" ng-if="loaded">
               <div class="col-md-12" ng-class="{ 'hide-tabs' : !deploymentConfig }">
+                <div ng-if="deploymentConfig.spec.paused" class="alert alert-info animate-if">
+                  <span class="pficon pficon-info" aria-hidden="true"></span>
+                  <strong>{{deploymentConfig.metadata.name}} is paused.</strong>
+                  This will stop any new deployments and deployment triggers from running
+                  until resumed.
+                  <span ng-if="!updatingPausedState && ('deploymentconfigs' | canI : 'update')">
+                    <a href="" ng-click="setPaused(false)" role="button">Resume deployment</a>
+                  </span>
+                </div>
                 <uib-tabset>
                   <uib-tab active="selectedTab.details">
                     <uib-tab-heading>Details</uib-tab-heading>
                     <div class="resource-details" ng-if="deploymentConfig">
-                      <div ng-if="deploymentConfig.spec.paused" class="alert alert-info animate-if">
-                        <span class="pficon pficon-info" aria-hidden="true"></span>
-                        <strong>{{deploymentConfig.metadata.name}} is paused.</strong>
-                        This will stop any new deployments and deployment triggers from running
-                        until resumed.
-                        <span ng-if="!updatingPausedState && ('deploymentconfigs' | canI : 'update')">
-                          <a href="" ng-click="setPaused(false)" role="button">Resume deployment</a>
-                        </span>
-                      </div>
                       <div class="row">
                         <div class="col-lg-6">
                           <h3>Configuration</h3>

--- a/app/views/browse/image.html
+++ b/app/views/browse/image.html
@@ -16,7 +16,7 @@
           </div>
         </div>
       </div><!-- /middle-header-->
-      <div class="middle-content gutter-top" persist-tab-state>
+      <div class="middle-content" persist-tab-state>
         <div class="container-fluid">
           <div ng-if="imageStream && !image">Loading...</div>
           <div class="row" ng-if="image">
@@ -32,7 +32,7 @@
                   </registry-image-meta>
                 </uib-tab>
                 <uib-tab heading="Config" active="selectedTab.config">
-                  <uib-tab-heading>Config</uib-tab-heading>
+                  <uib-tab-heading>Configuration</uib-tab-heading>
                   <registry-image-config image="image">
                   </registry-image-config>
                 </uib-tab>

--- a/app/views/browse/imagestream.html
+++ b/app/views/browse/imagestream.html
@@ -40,7 +40,7 @@
           </div>
         </div>
       </div><!-- /middle-header-->
-      <div class="middle-content gutter-top">
+      <div class="middle-content">
         <div class="container-fluid">
           <div class="row" ng-if="imageStream">
             <div class="col-md-12">

--- a/app/views/browse/persistent-volume-claim.html
+++ b/app/views/browse/persistent-volume-claim.html
@@ -50,7 +50,7 @@
       <div class="middle-content">
         <div class="container-fluid">
           <div class="row" ng-if="pvc" >
-            <div class="col-md-12 gutter-top">
+            <div class="col-md-12">
               <div class="resource-details">
                 <dl class="dl-horizontal left">
                   <dt>Status:</dt>
@@ -84,4 +84,3 @@
     </div><!-- /middle-container -->
   </div><!-- /middle-section -->
   </project-page>
-

--- a/app/views/browse/pod.html
+++ b/app/views/browse/pod.html
@@ -133,7 +133,7 @@
                       </div>
 
                       <div ng-if="!noContainersYet">
-                        <div class="mar-bottom-md">
+                        <div class="mar-bottom-md mar-top-xl">
                           <span class="pficon pficon-info" aria-hidden="true"></span>
                           When you navigate away from this pod, any open terminal connections will be closed.
                           This will kill any foreground processes you started from the terminal.

--- a/app/views/browse/route.html
+++ b/app/views/browse/route.html
@@ -47,7 +47,7 @@
           </div>
         </div>
       </div><!-- /middle-header-->
-      <div class="middle-content gutter-top">
+      <div class="middle-content">
         <div class="container-fluid">
           <div class="row" ng-if="route">
             <div class="col-sm-12">

--- a/app/views/browse/routes.html
+++ b/app/views/browse/routes.html
@@ -23,7 +23,7 @@
       <div class="middle-content">
         <div class="container-fluid">
           <div class="row">
-            <div class="col-md-12 gutter-top">
+            <div class="col-md-12">
               <table class="table table-bordered table-hover table-mobile">
                 <thead>
                   <tr>

--- a/app/views/browse/secret.html
+++ b/app/views/browse/secret.html
@@ -38,7 +38,7 @@
           </div>
         </div>
       </div><!-- /middle-header-->
-      <div class="middle-content gutter-top">
+      <div class="middle-content">
         <div class="container-fluid">
           <div ng-if="secret" class="row">
             <div class="col-sm-12">

--- a/app/views/builds.html
+++ b/app/views/builds.html
@@ -20,7 +20,7 @@
       <div class="middle-content">
         <div class="container-fluid">
           <div class="row">
-            <div class="col-md-12 gutter-top">
+            <div class="col-md-12">
               <table class="table table-bordered table-hover table-mobile">
                 <thead>
                   <tr>

--- a/app/views/deployments.html
+++ b/app/views/deployments.html
@@ -20,8 +20,7 @@
       <div class="middle-content">
         <div class="container-fluid">
           <div class="row">
-            <div class="col-md-12"
-                 ng-class="{ 'gutter-top': !(deployments | hashSize) && !(replicaSets | hashSize) }">
+            <div class="col-md-12">
               <h3 ng-if="(deployments | hashSize) || (replicaSets | hashSize)">Deployment Configurations</h3>
               <table class="table table-bordered table-hover table-mobile">
                 <thead>

--- a/app/views/directives/annotations.html
+++ b/app/views/directives/annotations.html
@@ -1,4 +1,4 @@
-<div class="gutter-top-bottom">
+<div class="gutter-bottom">
   <p>
     <a href="" ng-click="toggleAnnotations()" ng-if="!expandAnnotations">Show annotations</a>
     <a href="" ng-click="toggleAnnotations()" ng-if="expandAnnotations">Hide annotations</a>

--- a/app/views/directives/pod-metrics.html
+++ b/app/views/directives/pod-metrics.html
@@ -1,4 +1,4 @@
-<div class="metrics" ng-if="pod || deployment">
+<div class="metrics mar-top-xl" ng-if="pod || deployment">
   <div ng-show="!metricsError" class="metrics-options">
     <!-- Let the user select the container if we're showing pod metrics. -->
     <div ng-if="pod.spec.containers.length" class="form-group">

--- a/app/views/events.html
+++ b/app/views/events.html
@@ -15,7 +15,7 @@
       <div class="middle-content">
         <div class="container-fluid">
           <div class="row">
-            <div class="col-md-12 gutter-top" ng-if="projectContext">
+            <div class="col-md-12" ng-if="projectContext">
               <events project-context="projectContext" ng-if="projectContext"></events>
             </div>
           </div>

--- a/app/views/images.html
+++ b/app/views/images.html
@@ -20,7 +20,7 @@
       <div class="middle-content">
         <div class="container-fluid">
           <div class="row">
-            <div class="col-md-12 gutter-top">
+            <div class="col-md-12">
               <table class="table table-bordered table-hover table-mobile">
                 <thead>
                   <tr>

--- a/app/views/other-resources.html
+++ b/app/views/other-resources.html
@@ -27,7 +27,7 @@
       <div class="middle-content">
         <div class="container-fluid">
           <div class="row">
-            <div class="col-md-12 gutter-top">
+            <div class="col-md-12">
               <table class="table table-bordered table-mobile" ng-class="{ 'table-empty': (resources | hashSize) === 0 }">
                 <thead>
                   <tr>

--- a/app/views/pipelines.html
+++ b/app/views/pipelines.html
@@ -4,14 +4,20 @@
 <!-- Middle section -->
 <div class="middle-section">
   <div class="middle-container">
+    <div class="middle-header">
+      <div class="container-fluid">
+        <div class="page-header page-header-bleed-right page-header-bleed-left">
+          <h1>
+            Pipelines
+          </h1>
+          <alerts alerts="alerts"></alerts>
+        </div>
+      </div>
+    </div>
     <div class="middle-content pipelines-page">
       <div class="container-fluid">
         <div class="row">
           <div class="col-md-12">
-            <div class="page-header page-header-bleed-right page-header-bleed-left">
-              <h1 class="mar-top-none">Pipelines</h1>
-            </div>
-            <alerts alerts="alerts"></alerts>
             <div ng-if="!(buildConfigs | hashSize)" class="mar-top-lg">
               <div ng-if="!buildConfigsLoaded">
                 Loading...
@@ -45,7 +51,7 @@
                     Start Pipeline
                   </button>
                 </div>
-                <h2>
+                <h2 class="mar-top-none">
                   <a ng-href="{{buildConfig | navigateResourceURL}}">{{buildConfigName}}</a>
                   <small>created <relative-timestamp timestamp="buildConfig.metadata.creationTimestamp"></relative-timestamp></small>
                 </h2>

--- a/app/views/pods.html
+++ b/app/views/pods.html
@@ -20,7 +20,7 @@
       <div class="middle-content">
         <div class="container-fluid">
           <div class="row">
-            <div class="col-md-12 gutter-top">
+            <div class="col-md-12">
               <pods-table pods="pods" empty-message="emptyMessage"></pods-table>
             </div><!-- /col-* -->
           </div>

--- a/app/views/project.html
+++ b/app/views/project.html
@@ -35,7 +35,7 @@
       <div class="middle-content surface-shaded">
         <div class="container-fluid surface-shaded">
           <div class="row">
-            <div class="col-md-12 gutter-top">
+            <div class="col-md-12">
 
               <!-- Empty states -->
               <div ng-if="(services | hashSize) === 0 && (monopodsByService[''] | hashSize) === 0 && (deploymentsByServiceByDeploymentConfig[''] | hashSize) === 0">
@@ -122,7 +122,7 @@
                               <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
                               This service has <a href="project/{{projectName}}/browse/routes">routes</a> with warnings.
                             </small>
-                          </div>                          
+                          </div>
                         </h2>
 
                         <!-- If no route is present, show the service name large -->

--- a/app/views/secrets.html
+++ b/app/views/secrets.html
@@ -20,7 +20,7 @@
           <div ng-if="!loaded" class="mar-top-xl">Loading...</div>
           <div ng-if="loaded" class="row">
             <div class="col-md-12">
-              <h3>Source Secrets</h3>
+              <h2>Source Secrets</h2>
               <table class="table table-bordered table-hover table-mobile secrets-table">
                 <thead>
                   <tr>
@@ -49,7 +49,7 @@
                 </tbody>
               </table>
               <div ng-if="secretsByType.images.length !== 0">
-                <h3>Image Secrets</h3>
+                <h2>Image Secrets</h2>
                 <table class="table table-bordered table-hover table-mobile secrets-table">
                   <thead>
                     <tr>
@@ -74,7 +74,7 @@
                 </table>
               </div>
               <div ng-if="secretsByType.other.length !== 0">
-                <h3>Other Secrets</h3>
+                <h2>Other Secrets</h2>
                 <table class="table table-bordered table-hover table-mobile secrets-table">
                   <thead>
                     <tr>

--- a/app/views/services.html
+++ b/app/views/services.html
@@ -20,7 +20,7 @@
       <div class="middle-content">
         <div class="container-fluid">
           <div class="row">
-            <div class="col-md-12 gutter-top">
+            <div class="col-md-12">
               <table class="table table-bordered table-hover table-mobile">
                 <thead>
                   <tr>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1653,7 +1653,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"resource-details\">\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-lg-6\">\n" +
-    "<h3>Configuration</h3>\n" +
     "<dl class=\"dl-horizontal left\">\n" +
     "<div>\n" +
     "<dt>Build Strategy:</dt>\n" +
@@ -1988,7 +1987,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"middle-content gutter-top\">\n" +
+    "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div ng-if=\"configMap\" class=\"row\">\n" +
     "<div class=\"col-sm-12\">\n" +
@@ -2044,7 +2043,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\">\n" +
-    "<div class=\"col-md-12 gutter-top\">\n" +
+    "<div class=\"col-md-12\">\n" +
     "<div ng-if=\"!loaded\">Loading...</div>\n" +
     "<div ng-if=\"loaded\">\n" +
     "<table class=\"table table-bordered table-hover table-mobile\">\n" +
@@ -2161,10 +2160,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"!loaded\">Loading...</div>\n" +
     "<div class=\"row\" ng-if=\"loaded\">\n" +
     "<div class=\"col-md-12\" ng-class=\"{ 'hide-tabs' : !deploymentConfig }\">\n" +
-    "<uib-tabset>\n" +
-    "<uib-tab active=\"selectedTab.details\">\n" +
-    "<uib-tab-heading>Details</uib-tab-heading>\n" +
-    "<div class=\"resource-details\" ng-if=\"deploymentConfig\">\n" +
     "<div ng-if=\"deploymentConfig.spec.paused\" class=\"alert alert-info animate-if\">\n" +
     "<span class=\"pficon pficon-info\" aria-hidden=\"true\"></span>\n" +
     "<strong>{{deploymentConfig.metadata.name}} is paused.</strong>\n" +
@@ -2173,6 +2168,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a href=\"\" ng-click=\"setPaused(false)\" role=\"button\">Resume deployment</a>\n" +
     "</span>\n" +
     "</div>\n" +
+    "<uib-tabset>\n" +
+    "<uib-tab active=\"selectedTab.details\">\n" +
+    "<uib-tab-heading>Details</uib-tab-heading>\n" +
+    "<div class=\"resource-details\" ng-if=\"deploymentConfig\">\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-lg-6\">\n" +
     "<h3>Configuration</h3>\n" +
@@ -2609,7 +2608,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"middle-content gutter-top\" persist-tab-state>\n" +
+    "<div class=\"middle-content\" persist-tab-state>\n" +
     "<div class=\"container-fluid\">\n" +
     "<div ng-if=\"imageStream && !image\">Loading...</div>\n" +
     "<div class=\"row\" ng-if=\"image\">\n" +
@@ -2625,7 +2624,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</registry-image-meta>\n" +
     "</uib-tab>\n" +
     "<uib-tab heading=\"Config\" active=\"selectedTab.config\">\n" +
-    "<uib-tab-heading>Config</uib-tab-heading>\n" +
+    "<uib-tab-heading>Configuration</uib-tab-heading>\n" +
     "<registry-image-config image=\"image\">\n" +
     "</registry-image-config>\n" +
     "</uib-tab>\n" +
@@ -2682,7 +2681,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"middle-content gutter-top\">\n" +
+    "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\" ng-if=\"imageStream\">\n" +
     "<div class=\"col-md-12\">\n" +
@@ -2835,7 +2834,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\" ng-if=\"pvc\">\n" +
-    "<div class=\"col-md-12 gutter-top\">\n" +
+    "<div class=\"col-md-12\">\n" +
     "<div class=\"resource-details\">\n" +
     "<dl class=\"dl-horizontal left\">\n" +
     "<dt>Status:</dt>\n" +
@@ -2963,7 +2962,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</h2>\n" +
     "</div>\n" +
     "<div ng-if=\"!noContainersYet\">\n" +
-    "<div class=\"mar-bottom-md\">\n" +
+    "<div class=\"mar-bottom-md mar-top-xl\">\n" +
     "<span class=\"pficon pficon-info\" aria-hidden=\"true\"></span>\n" +
     "When you navigate away from this pod, any open terminal connections will be closed. This will kill any foreground processes you started from the terminal.\n" +
     "</div>\n" +
@@ -3166,7 +3165,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"middle-content gutter-top\">\n" +
+    "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\" ng-if=\"route\">\n" +
     "<div class=\"col-sm-12\">\n" +
@@ -3348,7 +3347,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\">\n" +
-    "<div class=\"col-md-12 gutter-top\">\n" +
+    "<div class=\"col-md-12\">\n" +
     "<table class=\"table table-bordered table-hover table-mobile\">\n" +
     "<thead>\n" +
     "<tr>\n" +
@@ -3449,7 +3448,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"middle-content gutter-top\">\n" +
+    "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div ng-if=\"secret\" class=\"row\">\n" +
     "<div class=\"col-sm-12\">\n" +
@@ -3696,7 +3695,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\">\n" +
-    "<div class=\"col-md-12 gutter-top\">\n" +
+    "<div class=\"col-md-12\">\n" +
     "<table class=\"table table-bordered table-hover table-mobile\">\n" +
     "<thead>\n" +
     "<tr>\n" +
@@ -4767,7 +4766,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\">\n" +
-    "<div class=\"col-md-12\" ng-class=\"{ 'gutter-top': !(deployments | hashSize) && !(replicaSets | hashSize) }\">\n" +
+    "<div class=\"col-md-12\">\n" +
     "<h3 ng-if=\"(deployments | hashSize) || (replicaSets | hashSize)\">Deployment Configurations</h3>\n" +
     "<table class=\"table table-bordered table-hover table-mobile\">\n" +
     "<thead>\n" +
@@ -5327,7 +5326,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/directives/annotations.html',
-    "<div class=\"gutter-top-bottom\">\n" +
+    "<div class=\"gutter-bottom\">\n" +
     "<p>\n" +
     "<a href=\"\" ng-click=\"toggleAnnotations()\" ng-if=\"!expandAnnotations\">Show annotations</a>\n" +
     "<a href=\"\" ng-click=\"toggleAnnotations()\" ng-if=\"expandAnnotations\">Hide annotations</a>\n" +
@@ -7462,7 +7461,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/directives/pod-metrics.html',
-    "<div class=\"metrics\" ng-if=\"pod || deployment\">\n" +
+    "<div class=\"metrics mar-top-xl\" ng-if=\"pod || deployment\">\n" +
     "<div ng-show=\"!metricsError\" class=\"metrics-options\">\n" +
     "\n" +
     "<div ng-if=\"pod.spec.containers.length\" class=\"form-group\">\n" +
@@ -8645,7 +8644,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\">\n" +
-    "<div class=\"col-md-12 gutter-top\" ng-if=\"projectContext\">\n" +
+    "<div class=\"col-md-12\" ng-if=\"projectContext\">\n" +
     "<events project-context=\"projectContext\" ng-if=\"projectContext\"></events>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -8679,7 +8678,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\">\n" +
-    "<div class=\"col-md-12 gutter-top\">\n" +
+    "<div class=\"col-md-12\">\n" +
     "<table class=\"table table-bordered table-hover table-mobile\">\n" +
     "<thead>\n" +
     "<tr>\n" +
@@ -9643,7 +9642,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\">\n" +
-    "<div class=\"col-md-12 gutter-top\">\n" +
+    "<div class=\"col-md-12\">\n" +
     "<table class=\"table table-bordered table-mobile\" ng-class=\"{ 'table-empty': (resources | hashSize) === 0 }\">\n" +
     "<thead>\n" +
     "<tr>\n" +
@@ -10229,14 +10228,20 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<div class=\"middle-section\">\n" +
     "<div class=\"middle-container\">\n" +
+    "<div class=\"middle-header\">\n" +
+    "<div class=\"container-fluid\">\n" +
+    "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
+    "<h1>\n" +
+    "Pipelines\n" +
+    "</h1>\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
     "<div class=\"middle-content pipelines-page\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
-    "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
-    "<h1 class=\"mar-top-none\">Pipelines</h1>\n" +
-    "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!(buildConfigs | hashSize)\" class=\"mar-top-lg\">\n" +
     "<div ng-if=\"!buildConfigsLoaded\">\n" +
     "Loading...\n" +
@@ -10265,7 +10270,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Start Pipeline\n" +
     "</button>\n" +
     "</div>\n" +
-    "<h2>\n" +
+    "<h2 class=\"mar-top-none\">\n" +
     "<a ng-href=\"{{buildConfig | navigateResourceURL}}\">{{buildConfigName}}</a>\n" +
     "<small>created <relative-timestamp timestamp=\"buildConfig.metadata.creationTimestamp\"></relative-timestamp></small>\n" +
     "</h2>\n" +
@@ -10341,7 +10346,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\">\n" +
-    "<div class=\"col-md-12 gutter-top\">\n" +
+    "<div class=\"col-md-12\">\n" +
     "<pods-table pods=\"pods\" empty-message=\"emptyMessage\"></pods-table>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -10389,7 +10394,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-content surface-shaded\">\n" +
     "<div class=\"container-fluid surface-shaded\">\n" +
     "<div class=\"row\">\n" +
-    "<div class=\"col-md-12 gutter-top\">\n" +
+    "<div class=\"col-md-12\">\n" +
     "\n" +
     "<div ng-if=\"(services | hashSize) === 0 && (monopodsByService[''] | hashSize) === 0 && (deploymentsByServiceByDeploymentConfig[''] | hashSize) === 0\">\n" +
     "\n" +
@@ -10959,7 +10964,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"!loaded\" class=\"mar-top-xl\">Loading...</div>\n" +
     "<div ng-if=\"loaded\" class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
-    "<h3>Source Secrets</h3>\n" +
+    "<h2>Source Secrets</h2>\n" +
     "<table class=\"table table-bordered table-hover table-mobile secrets-table\">\n" +
     "<thead>\n" +
     "<tr>\n" +
@@ -10988,7 +10993,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</tbody>\n" +
     "</table>\n" +
     "<div ng-if=\"secretsByType.images.length !== 0\">\n" +
-    "<h3>Image Secrets</h3>\n" +
+    "<h2>Image Secrets</h2>\n" +
     "<table class=\"table table-bordered table-hover table-mobile secrets-table\">\n" +
     "<thead>\n" +
     "<tr>\n" +
@@ -11013,7 +11018,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</table>\n" +
     "</div>\n" +
     "<div ng-if=\"secretsByType.other.length !== 0\">\n" +
-    "<h3>Other Secrets</h3>\n" +
+    "<h2>Other Secrets</h2>\n" +
     "<table class=\"table table-bordered table-hover table-mobile secrets-table\">\n" +
     "<thead>\n" +
     "<tr>\n" +
@@ -11069,7 +11074,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\">\n" +
-    "<div class=\"col-md-12 gutter-top\">\n" +
+    "<div class=\"col-md-12\">\n" +
     "<table class=\"table table-bordered table-hover table-mobile\">\n" +
     "<thead>\n" +
     "<tr>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3749,7 +3749,8 @@ body{padding-right:0px!important}
 .nav-tabs>li>.dropdown-menu.pull-right{left:auto;right:15px}
 .nav-tabs .open>a,.nav-tabs .open>a:focus,.nav-tabs .open>a:hover{background-color:transparent}
 .nav-tabs>li>a:before{left:0!important}
-.nav-tabs,.tab-content{margin-bottom:20px;margin-top:20px}
+.nav-tabs{margin-bottom:20px}
+.resource-details h3{border-bottom:1px solid #eee;padding-bottom:10px}
 .empty-project{margin:10px auto;max-width:500px;padding:30px}
 .empty-project .fa{width:16px}
 .empty-project dd{margin-left:20px;margin-bottom:10px}
@@ -3771,6 +3772,7 @@ mark{padding:0;background-color:rgba(252,248,160,.5)}
 .build-config-summary .latest-build-status{margin-right:5px}
 .build-config-summary .latest-build-status .status-icon{width:20px}
 .build-config-summary .latest-build-timestamp{margin-left:25px}
+.registry-image-pull{margin-bottom:20px}
 .image-sources .destination-dir:before,.image-sources .source-path:after{content:"\00a0 "}
 @media (max-width:767px){.pipelines-page h2 small{display:block;margin-top:3px}
 .pipelines-page .source-repo{display:block}
@@ -3978,7 +3980,6 @@ pre.clipped.scroll{max-height:150px;overflow:auto;width:100%}
 }
 labels+.resource-details{margin-top:10px}
 [flex].page-header{margin-top:21px}
-.resource-details h3{padding-bottom:10px;border-bottom:1px solid #eee}
 .build-config-summary .meta,h1 small.meta{font-size:12px}
 .data-toolbar .data-toolbar-filter .filter .navbar-filter-widget .label-filter .selectize-control .selectize-input,.data-toolbar .data-toolbar-filter .filter .navbar-filter-widget .label-filter .selectize-control .selectize-input input,.selectize-dropdown{font-size:13px}
 @media (max-width:480px){.build-config-summary .meta,h1 small.meta{display:block;margin-top:5px}
@@ -4858,7 +4859,7 @@ body,html{margin:0;padding:0}
 .console-os .middle{height:100%}
 .console-os .middle .middle-section{position:absolute;top:0;left:0;height:100%;width:100%}
 .console-os .middle .middle-section .middle-container{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;height:100%}
-.console-os .middle .middle-section .middle-container .middle-header{-webkit-flex:0 0 auto;-moz-flex:0 0 auto;-ms-flex:0 0 auto;flex:0 0 auto}
+.console-os .middle .middle-section .middle-container .middle-header{-webkit-flex:0 0 auto;-moz-flex:0 0 auto;-ms-flex:0 0 auto;flex:0 0 auto;margin-bottom:20px}
 .console-os .middle .middle-section .middle-container .middle-content{-webkit-flex:1 1 auto;-moz-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;position:relative;width:100%}
 .header-toolbar{background-color:#fff;border-bottom:1px solid #e4e4e4}
 .surface-shaded{background-color:#f2f2f2}
@@ -5059,7 +5060,7 @@ kubernetes-topology-graph{height:700px}
 .log-header .log-actions .btn-link,.log-view{padding:0}
 .mar-left-xxl{margin-left:30px}
 .log-title{margin-top:0}
-.log-header{margin-bottom:3px}
+.log-header{margin-bottom:3px;margin-top:20px}
 .log-header label{margin-bottom:0}
 .log-header .dash{color:#9c9c9c;margin:0 2px}
 .log-header .log-actions form{display:inline-block}
@@ -5172,7 +5173,7 @@ kubernetes-topology-graph{height:700px}
 .key-value-editor .key-value-editor-header{margin-bottom:5px}
 .membership h1 .learn-more-inline{white-space:nowrap;margin-right:10px;margin-left:0px;display:inline-block}
 .membership .content-pane .col-heading .col-add-role h3,.membership .content-pane .form-new-role .col-roles{display:none}
-.membership .content-pane{width:100%;margin-top:50px}
+.membership .content-pane{width:100%}
 .membership .content-pane .col-add-role{padding:10px 0;min-width:150px}
 .membership .content-pane .add-role-to{margin-left:-1px}
 .membership .content-pane .col-heading,.membership .content-pane .item-row{border-bottom:1px solid #ededed}


### PR DESCRIPTION
... several misc changes for consistency.

Applied `margin-bottom: 20px` to `.middle-header` and `nav-tabs` so consistent spacing is present. Removed margin-top from `nav-tabs` and `.gutter-top` class to prevent double spacing. Then addressed special cases as needed... log-header, registry-image-pull, pod-metrics

Misc changes for uniformity
- Moved pipelines heading markup into `.middle-header`
- Changed "Config" tab heading to "Configuration" on /browse/images/
- Moved deploy-config paused alert to be above tabs so that it's visible from any tab state on that section.
- Changed secondary headings on /browse/secrets/ to `h2` for consistency with /browse/storage/

Fixes https://github.com/openshift/origin-web-console/issues/878

<img width="868" alt="screen shot 2016-11-21 at 12 56 45 pm" src="https://cloud.githubusercontent.com/assets/1874151/20496287/9244fd1e-aff2-11e6-9655-b37c2ab01ccb.png">