### PR TITLE
[WIP] Replacing layout.attrs with layout.flex

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,7 @@
     "registry-image-widgets": "0.0.2",
     "openshift-object-describer": "1.1.2",
     "layout.attrs": "2.1.1",
+    "layout.flex": "https://github.com/benjaminapetersen/layout.flex.git",
     "bootstrap-hover-dropdown": "2.1.3",
     "angular-ui-ace": "0.2.3",
     "ace-builds": "1.2.2",
@@ -88,6 +89,9 @@
       "main": [
         "dist/layout.attrs.css"
       ]
+    },
+    "layout.flex": {
+      "main": []
     },
     "term.js": {
       "main": [


### PR DESCRIPTION
Initial commit adding the replacement to the project.
TODO:
- [ ] import flex classes
- [ ] compile from `/src` files with a custom `$prefix` of `fx-` or something to ensure bootstrap's `row` doesn't conflict (`fx-row`)
- [ ] migrate existing `attrs` to `classes`

@sg00dwin @rhamilto getting this rolling to eliminate the flex attrs stuff.