### PR TITLE
[WIP] Convert some pod warnings to errors

### DIFF
--- a/app/scripts/directives/podDonut.js
+++ b/app/scripts/directives/podDonut.js
@@ -5,7 +5,7 @@ angular.module('openshiftConsole')
                                   hashSizeFilter,
                                   isPullingImageFilter,
                                   isTerminatingFilter,
-                                  isTroubledPodFilter,
+                                  podWarningsFilter,
                                   numContainersReadyFilter,
                                   Logger,
                                   ChartsService) {
@@ -153,7 +153,10 @@ angular.module('openshiftConsole')
             return 'Terminating';
           }
 
-          if (isTroubledPodFilter(pod)) {
+          var warnings = podWarningsFilter(pod);
+          if (_.some(warnings), { severity: 'error' }) {
+            return 'Failed';
+          } else if (warnings.length) {
             return 'Warning';
           }
 

--- a/app/scripts/directives/popups.js
+++ b/app/scripts/directives/popups.js
@@ -85,6 +85,9 @@ angular.module('openshiftConsole')
           if (content) {
             content += '<br>';
           }
+          if (warnings[i].severity === "error") {
+            $scope.hasError = true;
+          }
           content += warnings[i].message;
         }
         $scope.content = content;

--- a/app/scripts/directives/statusIcon.js
+++ b/app/scripts/directives/statusIcon.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('openshiftConsole')
-  .directive('statusIcon', [
+  .directive('statusIcon',
     function() {
       return {
         restrict: 'E',
@@ -16,4 +16,4 @@ angular.module('openshiftConsole')
         }
       };
     }
-  ]);
+  );

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -523,6 +523,7 @@ angular.module('openshiftConsole')
           if (isContainerFailedFilter(containerStatus)) {
             if (isTerminatingFilter(pod)) {
               warnings.push({
+                severity: "error",
                 reason: "NonZeroExitTerminatingPod",
                 pod: pod.metadata.name,
                 container: containerStatus.name,
@@ -530,6 +531,7 @@ angular.module('openshiftConsole')
               });
             } else {
               warnings.push({
+                severity: "warning",
                 reason: "NonZeroExit",
                 pod: pod.metadata.name,
                 container: containerStatus.name,
@@ -539,6 +541,7 @@ angular.module('openshiftConsole')
           }
           if (isContainerLoopingFilter(containerStatus)) {
             warnings.push({
+              severity: "error",
               reason: "Looping",
               pod: pod.metadata.name,
               container: containerStatus.name,
@@ -547,6 +550,7 @@ angular.module('openshiftConsole')
           }
           if (isContainerUnpreparedFilter(containerStatus)) {
             warnings.push({
+              severity: "warning",
               reason: "Unprepared",
               pod: pod.metadata.name,
               container: containerStatus.name,

--- a/app/views/directives/_warnings-popover.html
+++ b/app/views/directives/_warnings-popover.html
@@ -4,7 +4,8 @@
     data-toggle="popover"
     data-trigger="hover"
     data-html="true"
-    class="pficon pficon-warning-triangle-o warnings-popover"
+    class="pficon warnings-popover"
+    ng-class="{'pficon-warning-triangle-o': !hasError, 'pficon-error-circle-o': hasError}"
     aria-hidden="true">
   </span>
   <span class="sr-only">{{content}}</span>

--- a/app/views/directives/pods-table.html
+++ b/app/views/directives/pods-table.html
@@ -15,9 +15,6 @@
     <tr>
       <td data-title="Name">
         <a href="{{pod | navigateResourceURL}}">{{pod.metadata.name}}</a>
-        <span ng-if="pod | isTroubledPod">
-          <pod-warnings pod="pod"></pod-warnings>
-        </span>
         <span ng-if="pod | isDebugPod">
           <i class="fa fa-bug info-popover"
              aria-hidden="true"

--- a/app/views/monitoring.html
+++ b/app/views/monitoring.html
@@ -87,9 +87,6 @@
                           <div class="list-view-pf-description">
                             <div class="list-group-item-heading">
                               <a ng-href="{{pod | navigateResourceURL}}"><span ng-bind-html="pod.metadata.name | highlightKeywords : filterKeywords"></span></a>
-                              <span ng-if="pod | isTroubledPod">
-                                <pod-warnings pod="pod"></pod-warnings>
-                              </span>
                               <small>created <span am-time-ago="pod.metadata.creationTimestamp"></span></small>
                             </div>
                             <div class="list-group-item-text">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10170,7 +10170,7 @@ pod:"="
 },
 link:function(b) {
 var c, d = "", e = a(b.pod);
-for (c = 0; c < e.length; c++) d && (d += "<br>"), d += e[c].message;
+for (c = 0; c < e.length; c++) d && (d += "<br>"), "error" === e[c].severity && (b.hasError = !0), d += e[c].message;
 b.content = d;
 },
 templateUrl:"views/directives/_warnings-popover.html"
@@ -11483,7 +11483,7 @@ e.cacheScrollableNode(document.getElementById(a.fixedHeight ? a.logViewerID + "-
 }, 0);
 }
 };
-} ]), angular.module("openshiftConsole").directive("statusIcon", [ function() {
+} ]), angular.module("openshiftConsole").directive("statusIcon", function() {
 return {
 restrict:"E",
 templateUrl:"views/directives/_status-icon.html",
@@ -11496,7 +11496,7 @@ link:function(a, b, c) {
 a.spinning = !angular.isDefined(c.disableAnimation);
 }
 };
-} ]), angular.module("openshiftConsole").directive("ellipsisPulser", [ function() {
+}), angular.module("openshiftConsole").directive("ellipsisPulser", [ function() {
 return {
 restrict:"E",
 scope:{
@@ -11507,7 +11507,7 @@ msg:"@"
 },
 templateUrl:"views/directives/_ellipsis-pulser.html"
 };
-} ]), angular.module("openshiftConsole").directive("podDonut", [ "$timeout", "hashSizeFilter", "isPullingImageFilter", "isTerminatingFilter", "isTroubledPodFilter", "numContainersReadyFilter", "Logger", "ChartsService", function(a, b, c, d, e, f, g, h) {
+} ]), angular.module("openshiftConsole").directive("podDonut", [ "$timeout", "hashSizeFilter", "isPullingImageFilter", "isTerminatingFilter", "podWarningsFilter", "numContainersReadyFilter", "Logger", "ChartsService", function(a, b, c, d, e, f, g, h) {
 return {
 restrict:"E",
 scope:{
@@ -11534,7 +11534,11 @@ var b = f(a), c = a.spec.containers.length;
 return b === c;
 }
 function l(a) {
-return d(a) ? "Terminating" :e(a) ? "Warning" :c(a) ? "Pulling" :"Running" !== a.status.phase || k(a) ? _.get(a, "status.phase", "Unknown") :"Not Ready";
+if (d(a)) return "Terminating";
+var b = e(a);
+return _.some(b), {
+severity:"error"
+} ? "Failed" :b.length ? "Warning" :c(a) ? "Pulling" :"Running" !== a.status.phase || k(a) ? _.get(a, "status.phase", "Unknown") :"Not Ready";
 }
 function m() {
 var b = {};
@@ -13217,21 +13221,25 @@ pod:f.metadata.name,
 message:"The pod has been stuck in the pending state for more than five minutes."
 }), "Running" === f.status.phase && f.status.containerStatuses && _.each(f.status.containerStatuses, function(a) {
 return !!a.state && (c(a) && (e(f) ? g.push({
+severity:"error",
 reason:"NonZeroExitTerminatingPod",
 pod:f.metadata.name,
 container:a.name,
 message:"The container " + a.name + " did not stop cleanly when terminated (exit code " + a.state.terminated.exitCode + ")."
 }) :g.push({
+severity:"warning",
 reason:"NonZeroExit",
 pod:f.metadata.name,
 container:a.name,
 message:"The container " + a.name + " failed (exit code " + a.state.terminated.exitCode + ")."
 })), b(a) && g.push({
+severity:"error",
 reason:"Looping",
 pod:f.metadata.name,
 container:a.name,
 message:"The container " + a.name + " is crashing frequently. It must wait before it will be restarted again."
 }), void (d(a) && g.push({
+severity:"warning",
 reason:"Unprepared",
 pod:f.metadata.name,
 container:a.name,

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5595,7 +5595,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/directives/_warnings-popover.html',
     "<span ng-if=\"content\">\n" +
-    "<span dynamic-content=\"{{content | middleEllipses:350:'...<br>...'}}\" data-toggle=\"popover\" data-trigger=\"hover\" data-html=\"true\" class=\"pficon pficon-warning-triangle-o warnings-popover\" aria-hidden=\"true\">\n" +
+    "<span dynamic-content=\"{{content | middleEllipses:350:'...<br>...'}}\" data-toggle=\"popover\" data-trigger=\"hover\" data-html=\"true\" class=\"pficon warnings-popover\" ng-class=\"{'pficon-warning-triangle-o': !hasError, 'pficon-error-circle-o': hasError}\" aria-hidden=\"true\">\n" +
     "</span>\n" +
     "<span class=\"sr-only\">{{content}}</span>\n" +
     "</span>"
@@ -7859,9 +7859,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tr>\n" +
     "<td data-title=\"Name\">\n" +
     "<a href=\"{{pod | navigateResourceURL}}\">{{pod.metadata.name}}</a>\n" +
-    "<span ng-if=\"pod | isTroubledPod\">\n" +
-    "<pod-warnings pod=\"pod\"></pod-warnings>\n" +
-    "</span>\n" +
     "<span ng-if=\"pod | isDebugPod\">\n" +
     "<i class=\"fa fa-bug info-popover\" aria-hidden=\"true\" data-toggle=\"popover\" data-trigger=\"hover\" dynamic-content=\"Debugging pod {{pod | debugPodSourceName}}\"></i>\n" +
     "<span class=\"sr-only\">Debugging pod {{pod | debugPodSourceName}}</span>\n" +
@@ -9713,9 +9710,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"list-view-pf-description\">\n" +
     "<div class=\"list-group-item-heading\">\n" +
     "<a ng-href=\"{{pod | navigateResourceURL}}\"><span ng-bind-html=\"pod.metadata.name | highlightKeywords : filterKeywords\"></span></a>\n" +
-    "<span ng-if=\"pod | isTroubledPod\">\n" +
-    "<pod-warnings pod=\"pod\"></pod-warnings>\n" +
-    "</span>\n" +
     "<small>created <span am-time-ago=\"pod.metadata.creationTimestamp\"></span></small>\n" +
     "</div>\n" +
     "<div class=\"list-group-item-text\">\n" +


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/7733

This patch displays an "error" highlight on the pod donut if at least
a single container is crash-looping, or has failed.

![overview-pafge-with-failed-pod](https://cloud.githubusercontent.com/assets/3902875/20542746/f1c3be86-b0d0-11e6-93a7-4d29390a1caa.png)

![pods-table-with-failed-pod](https://cloud.githubusercontent.com/assets/3902875/20542792/2e2a85c6-b0d1-11e6-953f-5dc640b31d5a.png)


@jwforres @spadgett 