### PR TITLE
Add in-context Jenkinsfile help

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -270,6 +270,7 @@
         <script src="scripts/controllers/modals/confirmReplaceModal.js"></script>
         <script src="scripts/controllers/modals/processTemplateModal.js"></script>
         <script src="scripts/controllers/modals/linkService.js"></script>
+        <script src="scripts/controllers/modals/jenkinsfileExamplesModal.js"></script>
         <script src="scripts/controllers/about.js"></script>
         <script src="scripts/controllers/commandLine.js"></script>
         <script src="scripts/controllers/createPersistentVolumeClaim.js"></script>

--- a/app/scripts/constants.js
+++ b/app/scripts/constants.js
@@ -39,6 +39,8 @@ window.OPENSHIFT_CONSTANTS = {
     "roles":                   "architecture/additional_concepts/authorization.html#roles",
     "service_accounts":        "dev_guide/service_accounts.html",
     "users_and_groups":        "architecture/additional_concepts/authentication.html#users-and-groups",
+    "pipeline-builds":         "architecture/core_concepts/builds_and_image_streams.html#pipeline-build",
+    "pipeline-plugin":         "using_images/other_images/jenkins.html#openshift-origin-pipeline-plug-in",
     // default should remain last, add new links above
     "default":                 "welcome/index.html"
   },

--- a/app/scripts/controllers/build.js
+++ b/app/scripts/controllers/build.js
@@ -12,6 +12,7 @@ angular.module('openshiftConsole')
                                            $routeParams,
                                            BuildsService,
                                            DataService,
+                                           ModalsService,
                                            Navigate,
                                            ProjectsService) {
     $scope.projectName = $routeParams.project;
@@ -197,6 +198,10 @@ angular.module('openshiftConsole')
                 };
               });
           }
+        };
+
+        $scope.showJenkinsfileExamples = function() {
+          ModalsService.showJenkinsfileExamples();
         };
 
         $scope.$on('$destroy', function(){

--- a/app/scripts/controllers/buildConfig.js
+++ b/app/scripts/controllers/buildConfig.js
@@ -16,6 +16,7 @@ angular.module('openshiftConsole')
                                                  ImagesService,
                                                  DataService,
                                                  LabelFilter,
+                                                 ModalsService,
                                                  ProjectsService,
                                                  keyValueEditorUtils) {
     $scope.projectName = $routeParams.project;
@@ -264,6 +265,10 @@ angular.module('openshiftConsole')
                 details: $filter('getErrorDetails')(result)
               };
             });
+        };
+
+        $scope.showJenkinsfileExamples = function() {
+          ModalsService.showJenkinsfileExamples();
         };
 
         $scope.$on('$destroy', function(){

--- a/app/scripts/controllers/modals/jenkinsfileExamplesModal.js
+++ b/app/scripts/controllers/modals/jenkinsfileExamplesModal.js
@@ -1,0 +1,8 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .controller('JenkinsfileExamplesModalController', function($scope, $uibModalInstance) {
+    $scope.ok = function() {
+      $uibModalInstance.close('ok');
+    };
+  });

--- a/app/scripts/services/modals.js
+++ b/app/scripts/services/modals.js
@@ -16,6 +16,14 @@ angular.module("openshiftConsole")
         });
 
         return modalInstance.result;
+      },
+
+      showJenkinsfileExamples: function() {
+        $uibModal.open({
+          animation: true,
+          templateUrl: 'views/modals/jenkinsfile-examples-modal.html',
+          controller: 'JenkinsfileExamplesModalController'
+        });
       }
     };
   });

--- a/app/styles/_forms.less
+++ b/app/styles/_forms.less
@@ -6,3 +6,12 @@
 .input-group-addon.wildcard-prefix {
   padding-left: 10px;
 }
+
+.editor-examples {
+  padding: 19px;
+  margin-bottom: 20px;
+  border: 1px solid @color-pf-black-300;
+  .copy-to-clipboard {
+    margin-top: 3px;
+  }
+}

--- a/app/views/browse/_build-details.html
+++ b/app/views/browse/_build-details.html
@@ -87,7 +87,7 @@
         <dt ng-if-start="build.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath">
           Jenkinsfile Path:
         </dt>
-        <dd ng-if-end>
+        <dd>
           <span ng-if="build | jenkinsfileLink">
             <a ng-href="{{build | jenkinsfileLink}}">{{build.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}</a>
           </span>
@@ -95,10 +95,16 @@
             {{build.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}
           </span>
         </dd>
+        <div ng-if-end class="small">
+          <a href="" ng-click="showJenkinsfileExamples()">What's a Jenkinsfile?</a>
+        </div>
         <dt ng-if-start="build.spec.strategy.jenkinsPipelineStrategy.jenkinsfile">
           Jenkinsfile:
         </dt>
         <dd></dd>
+        <div class="small pull-right mar-top-sm">
+          <a href="" ng-click="showJenkinsfileExamples()">What's a Jenkinsfile?</a>
+        </div>
         <div ng-if-end ui-ace="{
           mode: 'groovy',
           theme: 'eclipse',

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -234,9 +234,17 @@
                                     <dd ng-if="!(buildConfig | jenkinsfileLink)">
                                       {{buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}
                                     </dd>
+                                    <div class="small">
+                                      <a href="" ng-click="showJenkinsfileExamples()">What's a Jenkinsfile?</a>
+                                    </div>
                                   </div>
                                   <div ng-if="buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile">
-                                    <dt>Jenkinsfile:</dt><dd></dd>
+                                    <div class="small pull-right mar-top-sm">
+                                      <a href="" ng-click="showJenkinsfileExamples()">What's a Jenkinsfile?</a>
+                                    </div>
+                                    <dt>
+                                      Jenkinsfile:
+                                    </dt><dd></dd>
                                     <div ui-ace="{
                                       mode: 'groovy',
                                       theme: 'eclipse',
@@ -249,7 +257,7 @@
                                       advanced: {
                                         highlightActiveLine: false
                                       }
-                                    }" readonly ng-model="buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile" class="ace-bordered ace-inline ace-read-only mar-top-md"></div>
+                                    }" readonly ng-model="buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile" class="ace-bordered ace-inline ace-read-only"></div>
                                   </div>
                                 </div>
                                 <dt ng-if-start="buildConfig.spec.source.binary.asFile">Binary Input as File:</dt>

--- a/app/views/edit/build-config.html
+++ b/app/views/edit/build-config.html
@@ -232,7 +232,7 @@
                     </div>
 
                     <div ng-if="updatedBuildConfig | isJenkinsPipelineStrategy" class="section">
-                      <h3 class="with-divider">Jenkins Pipeline Configuration</h3>
+                      <h3 ng-class="{ 'with-divider': !sources.none }">Jenkins Pipeline Configuration</h3>
                       <div class="form-group" ng-if="buildConfig.spec.source.type === 'Git'">
                         <label for="jenkinsfile-type">Jenkinsfile Type</label>
                         <select
@@ -267,15 +267,25 @@
 
                       <div ng-if="jenkinsfileOptions.type === 'inline'">
                         <label>Jenkinsfile</label>
-                          <div ui-ace="{
-                            mode: 'groovy',
-                            theme: 'eclipse',
-                            onLoad: aceLoaded,
-                            rendererOptions: {
-                              fadeFoldWidgets: true,
-                              showPrintMargin: false
-                            }
-                          }" ng-model="updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile" class="ace-bordered ace-inline"></div>
+                        <div ui-ace="{
+                          mode: 'groovy',
+                          theme: 'eclipse',
+                          onLoad: aceLoaded,
+                          rendererOptions: {
+                            fadeFoldWidgets: true,
+                            showPrintMargin: false
+                          }
+                        }" ng-model="updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile" class="ace-bordered ace-inline"></div>
+                      </div>
+                      <div class="mar-top-md mar-bottom-md">
+                        <a ng-if="!view.jenkinsfileExamples" href="" ng-click="view.jenkinsfileExamples = true">What's a Jenkinsfile?</a>
+                      </div>
+                      <div ng-if="view.jenkinsfileExamples" class="editor-examples">
+                        <div class="pull-right mar-top-md">
+                          <a href="" ng-click="view.jenkinsfileExamples = false">Hide examples</a>
+                        </div>
+                        <h4>Jenkinsfile Examples</h4>
+                        <ng-include src="'views/edit/jenkinsfile-examples.html'"></ng-include>
                       </div>
                     </div>
                     <div ng-if="sources.none && !(updatedBuildConfig | isJenkinsPipelineStrategy)">

--- a/app/views/edit/jenkinsfile-examples.html
+++ b/app/views/edit/jenkinsfile-examples.html
@@ -1,0 +1,48 @@
+<div>
+  <p>
+    A Jenkinsfile is a Groovy script that defines your pipeline. In the Jenkinsfile, you can declare
+    pipeline stages and run one or more steps within each stage. Here are some examples you can use
+    in your pipelines.
+  </p>
+  <p>
+    Declare a new pipeline stage called <var>Build:</var>
+    <copy-to-clipboard
+        display-wide="true"
+        clipboard-text="'stage \'Build\''">
+    </copy-to-clipboard>
+  </p>
+  <p>
+    Start a build for build config <var>my-build-config:</var>
+    <copy-to-clipboard
+        display-wide="true"
+        clipboard-text="'openshiftBuild(buildConfig: \'my-build-config\', showBuildLogs: \'true\')'">
+    </copy-to-clipboard>
+  </p>
+  <p>
+    Start a deployment for deployment config <var>my-deployment-config:</var>
+    <copy-to-clipboard
+        display-wide="true"
+        clipboard-text="'openshiftDeploy(deploymentConfig: \'my-deployment-config\')'">
+    </copy-to-clipboard>
+  </p>
+  <p>
+    Run the shell command <var>make test:</var>
+    <copy-to-clipboard
+        display-wide="true"
+        clipboard-text="'sh \'make test\''">
+    </copy-to-clipboard>
+  </p>
+  <p>
+    Prompt for manual input:
+    <copy-to-clipboard
+        display-wide="true"
+        clipboard-text="'input \'Promote to production?\''">
+    </copy-to-clipboard>
+  </p>
+  <p>
+    Learn more about
+    <a ng-href="{{ 'pipeline-builds' | helpLink}}" target="_blank">Pipeline Builds</a>
+    and the
+    <a ng-href="{{ 'pipeline-plugin' | helpLink}}" target="_blank">OpenShift Pipeline Plugin</a>.
+  </p>
+</div>

--- a/app/views/modals/jenkinsfile-examples-modal.html
+++ b/app/views/modals/jenkinsfile-examples-modal.html
@@ -1,0 +1,9 @@
+<div>
+  <div class="modal-body">
+    <h2>Jenkinsfile Examples</h2>
+    <ng-include src="'views/edit/jenkinsfile-examples.html'"></ng-include>
+  </div>
+  <div class="modal-footer">
+      <button class="btn btn-lg btn-default" type="button" ng-click="ok()">OK</button>
+  </div>
+</div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -36,6 +36,8 @@ authorization:"architecture/additional_concepts/authorization.html",
 roles:"architecture/additional_concepts/authorization.html#roles",
 service_accounts:"dev_guide/service_accounts.html",
 users_and_groups:"architecture/additional_concepts/authentication.html#users-and-groups",
+"pipeline-builds":"architecture/core_concepts/builds_and_image_streams.html#pipeline-build",
+"pipeline-plugin":"using_images/other_images/jenkins.html#openshift-origin-pipeline-plug-in",
 "default":"welcome/index.html"
 },
 CLI:{
@@ -3929,6 +3931,13 @@ modalConfig:b
 }
 });
 return c.result;
+},
+showJenkinsfileExamples:function() {
+a.open({
+animation:!0,
+templateUrl:"views/modals/jenkinsfile-examples-modal.html",
+controller:"JenkinsfileExamplesModalController"
+});
 }
 };
 } ]), angular.module("openshiftConsole").controller("ProjectsController", [ "$scope", "$filter", "$location", "$route", "$timeout", "AlertMessageService", "AuthService", "DataService", "KeywordService", "Logger", function(a, b, c, d, e, f, g, h, i, j) {
@@ -5220,7 +5229,7 @@ details:a("getErrorDetails")(b)
 f.unwatchAll(i);
 });
 }));
-} ]), angular.module("openshiftConsole").controller("BuildConfigController", [ "$scope", "$filter", "$routeParams", "AlertMessageService", "APIService", "BuildsService", "ImagesService", "DataService", "LabelFilter", "ProjectsService", "keyValueEditorUtils", function(a, b, c, d, e, f, g, h, i, j, k) {
+} ]), angular.module("openshiftConsole").controller("BuildConfigController", [ "$scope", "$filter", "$routeParams", "AlertMessageService", "APIService", "BuildsService", "ImagesService", "DataService", "LabelFilter", "ModalsService", "ProjectsService", "keyValueEditorUtils", function(a, b, c, d, e, f, g, h, i, j, k, l) {
 a.projectName = c.project, a.buildConfigName = c.buildconfig, a.buildConfig = null, a.labelSuggestions = {}, a.alerts = {}, a.breadcrumbs = [], a.forms = {}, a.expand = {
 imageEnv:!1
 }, c.isPipeline ? a.breadcrumbs.push({
@@ -5237,13 +5246,13 @@ a.alerts[b.name] = b.data;
 var b = a.getSession();
 b.setOption("tabSize", 2), b.setOption("useSoftTabs", !0), a.$blockScrolling = 1 / 0;
 };
-var l, m = b("orderObjectsByDate"), n = b("buildConfigForBuild"), o = b("buildStrategy"), p = [], q = function(c) {
-a.updatedBuildConfig = angular.copy(c), a.envVars = o(a.updatedBuildConfig).env || [], _.each(a.envVars, function(a) {
+var m, n = b("orderObjectsByDate"), o = b("buildConfigForBuild"), p = b("buildStrategy"), q = [], r = function(c) {
+a.updatedBuildConfig = angular.copy(c), a.envVars = p(a.updatedBuildConfig).env || [], _.each(a.envVars, function(a) {
 b("altTextForValueFrom")(a);
 });
 };
 a.saveEnvVars = function() {
-a.envVars = _.filter(a.envVars, "name"), o(a.updatedBuildConfig).env = k.compactEntries(angular.copy(a.envVars)), h.update("buildconfigs", c.buildconfig, a.updatedBuildConfig, l).then(function() {
+a.envVars = _.filter(a.envVars, "name"), p(a.updatedBuildConfig).env = l.compactEntries(angular.copy(a.envVars)), h.update("buildconfigs", c.buildconfig, a.updatedBuildConfig, m).then(function() {
 a.alerts.saveBCEnvVarsSuccess = {
 type:"success",
 message:a.buildConfigName + " was updated."
@@ -5256,14 +5265,14 @@ details:"Reason: " + b("getErrorDetails")(c)
 };
 });
 }, a.clearEnvVarUpdates = function() {
-q(a.buildConfig), a.forms.bcEnvVars.$setPristine();
+r(a.buildConfig), a.forms.bcEnvVars.$setPristine();
 };
-var r, s = function(c, d) {
+var s, t = function(c, d) {
 a.loaded = !0, a.buildConfig = c, a.buildConfigPaused = f.isPaused(a.buildConfig), a.buildConfig.spec.source.images && (a.imageSources = a.buildConfig.spec.source.images, a.imageSourcesPaths = [], a.imageSources.forEach(function(c) {
 a.imageSourcesPaths.push(b("destinationSourcePair")(c.paths));
 }));
-var i = _.get(o(c), "from", {}), j = i.kind + "/" + i.name + "/" + (i.namespace || a.projectName);
-r !== j && (_.includes([ "ImageStreamTag", "ImageStreamImage" ], i.kind) ? (r = j, h.get(e.kindToResource(i.kind), i.name, {
+var i = _.get(p(c), "from", {}), j = i.kind + "/" + i.name + "/" + (i.namespace || a.projectName);
+s !== j && (_.includes([ "ImageStreamTag", "ImageStreamImage" ], i.kind) ? (s = j, h.get(e.kindToResource(i.kind), i.name, {
 namespace:i.namespace || a.projectName
 }, {
 errorNotification:!1
@@ -5271,10 +5280,10 @@ errorNotification:!1
 a.BCEnvVarsFromImage = g.getEnvironment(b);
 }, function() {
 a.BCEnvVarsFromImage = [];
-})) :a.BCEnvVarsFromImage = []), q(c), "DELETED" === d && (a.alerts.deleted = {
+})) :a.BCEnvVarsFromImage = []), r(c), "DELETED" === d && (a.alerts.deleted = {
 type:"warning",
 message:"This build configuration has been deleted."
-}, a.buildConfigDeleted = !0), !a.forms.bcEnvVars || a.forms.bcEnvVars.$pristine ? q(c) :a.alerts.background_update = {
+}, a.buildConfigDeleted = !0), !a.forms.bcEnvVars || a.forms.bcEnvVars.$pristine ? r(c) :a.alerts.background_update = {
 type:"warning",
 message:"This build configuration has been updated in the background. Saving your changes may create a conflict or cause loss of data.",
 links:[ {
@@ -5285,24 +5294,24 @@ return a.clearEnvVarUpdates(), !0;
 } ]
 }, a.paused = f.isPaused(a.buildConfig);
 };
-j.get(c.project).then(_.spread(function(d, e) {
+k.get(c.project).then(_.spread(function(d, e) {
 function g() {
 i.getLabelSelector().isEmpty() || !$.isEmptyObject(a.builds) || $.isEmptyObject(a.unfilteredBuilds) ? delete a.alerts.builds :a.alerts.builds = {
 type:"warning",
 details:"The active filters are hiding all builds."
 };
 }
-a.project = d, l = e, h.get("buildconfigs", c.buildconfig, e).then(function(a) {
-s(a), p.push(h.watchObject("buildconfigs", c.buildconfig, e, s));
+a.project = d, m = e, h.get("buildconfigs", c.buildconfig, e).then(function(a) {
+t(a), q.push(h.watchObject("buildconfigs", c.buildconfig, e, t));
 }, function(c) {
 a.loaded = !0, a.alerts.load = {
 type:"error",
 message:404 === c.status ? "This build configuration can not be found, it may have been deleted." :"The build configuration details could not be loaded.",
 details:404 === c.status ? "Any remaining build history for this build will be shown." :"Reason: " + b("getErrorDetails")(c)
 };
-}), p.push(h.watch("builds", e, function(b, d, e) {
+}), q.push(h.watch("builds", e, function(b, d, e) {
 if (a.emptyMessage = "No builds to show", d) {
-var h = n(e);
+var h = o(e);
 if (h === c.buildconfig) {
 var j = e.metadata.name;
 switch (d) {
@@ -5316,7 +5325,7 @@ delete a.unfilteredBuilds[j];
 }
 }
 } else a.unfilteredBuilds = f.validatedBuildsForBuildConfig(c.buildconfig, b.by("metadata.name"));
-a.builds = i.getLabelSelector().select(a.unfilteredBuilds), g(), i.addLabelSuggestionsFromResources(a.unfilteredBuilds, a.labelSuggestions), i.setLabelSuggestions(a.labelSuggestions), a.orderedBuilds = m(a.builds, !0), a.latestBuild = a.orderedBuilds.length ? a.orderedBuilds[0] :null;
+a.builds = i.getLabelSelector().select(a.unfilteredBuilds), g(), i.addLabelSuggestionsFromResources(a.unfilteredBuilds, a.labelSuggestions), i.setLabelSuggestions(a.labelSuggestions), a.orderedBuilds = n(a.builds, !0), a.latestBuild = a.orderedBuilds.length ? a.orderedBuilds[0] :null;
 }, {
 http:{
 params:{
@@ -5328,7 +5337,7 @@ omission:""
 }
 })), i.onActiveFiltersChanged(function(b) {
 a.$apply(function() {
-a.builds = b.select(a.unfilteredBuilds), a.orderedBuilds = m(a.builds, !0), a.latestBuild = a.orderedBuilds.length ? a.orderedBuilds[0] :null, g();
+a.builds = b.select(a.unfilteredBuilds), a.orderedBuilds = n(a.builds, !0), a.latestBuild = a.orderedBuilds.length ? a.orderedBuilds[0] :null, g();
 });
 }), a.startBuild = function() {
 f.startBuild(a.buildConfig.metadata.name, e).then(function(b) {
@@ -5343,11 +5352,13 @@ message:"An error occurred while starting the build.",
 details:b("getErrorDetails")(c)
 };
 });
+}, a.showJenkinsfileExamples = function() {
+j.showJenkinsfileExamples();
 }, a.$on("$destroy", function() {
-h.unwatchAll(p);
+h.unwatchAll(q);
 });
 }));
-} ]), angular.module("openshiftConsole").controller("BuildController", [ "$scope", "$filter", "$routeParams", "BuildsService", "DataService", "Navigate", "ProjectsService", function(a, b, c, d, e, f, g) {
+} ]), angular.module("openshiftConsole").controller("BuildController", [ "$scope", "$filter", "$routeParams", "BuildsService", "DataService", "ModalsService", "Navigate", "ProjectsService", function(a, b, c, d, e, f, g, h) {
 a.projectName = c.project, a.build = null, a.buildConfig = null, a.buildConfigName = c.buildconfig, a.builds = {}, a.alerts = {}, a.showSecret = !1, a.renderOptions = {
 hideFilterWidget:!0
 }, a.breadcrumbs = [], c.isPipeline ? (a.breadcrumbs.push({
@@ -5365,36 +5376,36 @@ link:"project/" + c.project + "/browse/builds/" + c.buildconfig
 })), a.breadcrumbs.push({
 title:c.build
 });
-var h = [], i = function(b) {
+var i = [], j = function(b) {
 a.logCanRun = !_.includes([ "New", "Pending", "Error" ], b.status.phase);
-}, j = function() {
+}, k = function() {
 a.buildConfig ? a.canBuild = d.canBuild(a.buildConfig) :a.canBuild = !1;
-}, k = function(c, d) {
-a.loaded = !0, a.build = c, i(c);
+}, l = function(c, d) {
+a.loaded = !0, a.build = c, j(c);
 var e = b("annotation")(c, "buildNumber");
 e && (a.breadcrumbs[2].title = "#" + e), "DELETED" === d && (a.alerts.deleted = {
 type:"warning",
 message:"This build has been deleted."
 });
-}, l = function(c) {
+}, m = function(c) {
 a.loaded = !0, a.alerts.load = {
 type:"error",
 message:"The build details could not be loaded.",
 details:"Reason: " + b("getErrorDetails")(c)
 };
-}, m = function(b, c) {
+}, n = function(b, c) {
 "DELETED" === c && (a.alerts.deleted = {
 type:"warning",
 message:"Build configuration " + a.buildConfigName + " has been deleted."
-}, a.buildConfigDeleted = !0), a.buildConfig = b, a.buildConfigPaused = d.isPaused(a.buildConfig), j();
+}, a.buildConfigDeleted = !0), a.buildConfig = b, a.buildConfigPaused = d.isPaused(a.buildConfig), k();
 };
-g.get(c.project).then(_.spread(function(g, i) {
-a.project = g, a.projectContext = i, a.logOptions = {}, e.get("builds", c.build, i).then(function(a) {
-k(a), h.push(e.watchObject("builds", c.build, i, k)), h.push(e.watchObject("buildconfigs", c.buildconfig, i, m));
-}, l), a.toggleSecret = function() {
+h.get(c.project).then(_.spread(function(h, j) {
+a.project = h, a.projectContext = j, a.logOptions = {}, e.get("builds", c.build, j).then(function(a) {
+l(a), i.push(e.watchObject("builds", c.build, j, l)), i.push(e.watchObject("buildconfigs", c.buildconfig, j, n));
+}, m), a.toggleSecret = function() {
 a.showSecret = !0;
 }, a.cancelBuild = function() {
-d.cancelBuild(a.build, a.buildConfigName, i).then(function(b) {
+d.cancelBuild(a.build, a.buildConfigName, j).then(function(b) {
 a.alerts.cancel = {
 type:"success",
 message:"Cancelled build " + b.metadata.name + " of " + a.buildConfigName + "."
@@ -5407,9 +5418,9 @@ details:b("getErrorDetails")(c)
 };
 });
 };
-var j = function(c) {
+var k = function(c) {
 if (b("isJenkinsPipelineStrategy")(a.build) || !b("canI")("builds/log", "get")) return [ {
-href:f.resourceURL(c),
+href:g.resourceURL(c),
 label:"View Build"
 } ];
 var d = b("buildLogURL")(c);
@@ -5420,8 +5431,8 @@ label:"View Log"
 };
 a.cloneBuild = function() {
 var c = _.get(a, "build.metadata.name");
-c && a.canBuild && d.cloneBuild(c, i).then(function(b) {
-var d = j(b);
+c && a.canBuild && d.cloneBuild(c, j).then(function(b) {
+var d = k(b);
 a.alerts.rebuild = {
 type:"success",
 message:"Build " + c + " is being rebuilt as " + b.metadata.name + ".",
@@ -5434,8 +5445,10 @@ message:"An error occurred while rerunning the build.",
 details:b("getErrorDetails")(c)
 };
 });
+}, a.showJenkinsfileExamples = function() {
+f.showJenkinsfileExamples();
 }, a.$on("$destroy", function() {
-e.unwatchAll(h);
+e.unwatchAll(i);
 });
 }));
 } ]), angular.module("openshiftConsole").controller("ImageController", [ "$scope", "$routeParams", "DataService", "ProjectsService", "$filter", "ImageStreamsService", "imageLayers", function(a, b, c, d, e, f, g) {
@@ -8375,6 +8388,10 @@ return b !== a.service && !_.includes(d, b.metadata.name);
 b.close(_.get(a, "link.selectedService"));
 }, a.cancel = function() {
 b.dismiss();
+};
+} ]), angular.module("openshiftConsole").controller("JenkinsfileExamplesModalController", [ "$scope", "$uibModalInstance", function(a, b) {
+a.ok = function() {
+b.close("ok");
 };
 } ]), angular.module("openshiftConsole").controller("AboutController", [ "$scope", "AuthService", "Constants", function(a, b, c) {
 b.withUser(), a.version = {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1313,7 +1313,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt ng-if-start=\"build.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath\">\n" +
     "Jenkinsfile Path:\n" +
     "</dt>\n" +
-    "<dd ng-if-end>\n" +
+    "<dd>\n" +
     "<span ng-if=\"build | jenkinsfileLink\">\n" +
     "<a ng-href=\"{{build | jenkinsfileLink}}\">{{build.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}</a>\n" +
     "</span>\n" +
@@ -1321,10 +1321,16 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "{{build.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}\n" +
     "</span>\n" +
     "</dd>\n" +
+    "<div ng-if-end class=\"small\">\n" +
+    "<a href=\"\" ng-click=\"showJenkinsfileExamples()\">What's a Jenkinsfile?</a>\n" +
+    "</div>\n" +
     "<dt ng-if-start=\"build.spec.strategy.jenkinsPipelineStrategy.jenkinsfile\">\n" +
     "Jenkinsfile:\n" +
     "</dt>\n" +
     "<dd></dd>\n" +
+    "<div class=\"small pull-right mar-top-sm\">\n" +
+    "<a href=\"\" ng-click=\"showJenkinsfileExamples()\">What's a Jenkinsfile?</a>\n" +
+    "</div>\n" +
     "<div ng-if-end ui-ace=\"{\n" +
     "          mode: 'groovy',\n" +
     "          theme: 'eclipse',\n" +
@@ -1894,9 +1900,17 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dd ng-if=\"!(buildConfig | jenkinsfileLink)\">\n" +
     "{{buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}\n" +
     "</dd>\n" +
+    "<div class=\"small\">\n" +
+    "<a href=\"\" ng-click=\"showJenkinsfileExamples()\">What's a Jenkinsfile?</a>\n" +
+    "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile\">\n" +
-    "<dt>Jenkinsfile:</dt><dd></dd>\n" +
+    "<div class=\"small pull-right mar-top-sm\">\n" +
+    "<a href=\"\" ng-click=\"showJenkinsfileExamples()\">What's a Jenkinsfile?</a>\n" +
+    "</div>\n" +
+    "<dt>\n" +
+    "Jenkinsfile:\n" +
+    "</dt><dd></dd>\n" +
     "<div ui-ace=\"{\n" +
     "                                      mode: 'groovy',\n" +
     "                                      theme: 'eclipse',\n" +
@@ -1909,7 +1923,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "                                      advanced: {\n" +
     "                                        highlightActiveLine: false\n" +
     "                                      }\n" +
-    "                                    }\" readonly=\"readonly\" ng-model=\"buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile\" class=\"ace-bordered ace-inline ace-read-only mar-top-md\"></div>\n" +
+    "                                    }\" readonly=\"readonly\" ng-model=\"buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile\" class=\"ace-bordered ace-inline ace-read-only\"></div>\n" +
     "</div>\n" +
     "</div>\n" +
     "<dt ng-if-start=\"buildConfig.spec.source.binary.asFile\">Binary Input as File:</dt>\n" +
@@ -8180,7 +8194,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"updatedBuildConfig | isJenkinsPipelineStrategy\" class=\"section\">\n" +
-    "<h3 class=\"with-divider\">Jenkins Pipeline Configuration</h3>\n" +
+    "<h3 ng-class=\"{ 'with-divider': !sources.none }\">Jenkins Pipeline Configuration</h3>\n" +
     "<div class=\"form-group\" ng-if=\"buildConfig.spec.source.type === 'Git'\">\n" +
     "<label for=\"jenkinsfile-type\">Jenkinsfile Type</label>\n" +
     "<select id=\"jenkinsfile-type\" class=\"form-control\" ng-model=\"jenkinsfileOptions.type\" ng-options=\"type.id as type.title for type in jenkinsfileTypes\" aria-describedby=\"jenkinsfile-type-help\">\n" +
@@ -8199,14 +8213,24 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"jenkinsfileOptions.type === 'inline'\">\n" +
     "<label>Jenkinsfile</label>\n" +
     "<div ui-ace=\"{\n" +
-    "                            mode: 'groovy',\n" +
-    "                            theme: 'eclipse',\n" +
-    "                            onLoad: aceLoaded,\n" +
-    "                            rendererOptions: {\n" +
-    "                              fadeFoldWidgets: true,\n" +
-    "                              showPrintMargin: false\n" +
-    "                            }\n" +
-    "                          }\" ng-model=\"updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile\" class=\"ace-bordered ace-inline\"></div>\n" +
+    "                          mode: 'groovy',\n" +
+    "                          theme: 'eclipse',\n" +
+    "                          onLoad: aceLoaded,\n" +
+    "                          rendererOptions: {\n" +
+    "                            fadeFoldWidgets: true,\n" +
+    "                            showPrintMargin: false\n" +
+    "                          }\n" +
+    "                        }\" ng-model=\"updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile\" class=\"ace-bordered ace-inline\"></div>\n" +
+    "</div>\n" +
+    "<div class=\"mar-top-md mar-bottom-md\">\n" +
+    "<a ng-if=\"!view.jenkinsfileExamples\" href=\"\" ng-click=\"view.jenkinsfileExamples = true\">What's a Jenkinsfile?</a>\n" +
+    "</div>\n" +
+    "<div ng-if=\"view.jenkinsfileExamples\" class=\"editor-examples\">\n" +
+    "<div class=\"pull-right mar-top-md\">\n" +
+    "<a href=\"\" ng-click=\"view.jenkinsfileExamples = false\">Hide examples</a>\n" +
+    "</div>\n" +
+    "<h4>Jenkinsfile Examples</h4>\n" +
+    "<ng-include src=\"'views/edit/jenkinsfile-examples.html'\"></ng-include>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"sources.none && !(updatedBuildConfig | isJenkinsPipelineStrategy)\">\n" +
@@ -8776,6 +8800,46 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
+    "</div>"
+  );
+
+
+  $templateCache.put('views/edit/jenkinsfile-examples.html',
+    "<div>\n" +
+    "<p>\n" +
+    "A Jenkinsfile is a Groovy script that defines your pipeline. In the Jenkinsfile, you can declare pipeline stages and run one or more steps within each stage. Here are some examples you can use in your pipelines.\n" +
+    "</p>\n" +
+    "<p>\n" +
+    "Declare a new pipeline stage called <var>Build:</var>\n" +
+    "<copy-to-clipboard display-wide=\"true\" clipboard-text=\"'stage \\'Build\\''\">\n" +
+    "</copy-to-clipboard>\n" +
+    "</p>\n" +
+    "<p>\n" +
+    "Start a build for build config <var>my-build-config:</var>\n" +
+    "<copy-to-clipboard display-wide=\"true\" clipboard-text=\"'openshiftBuild(buildConfig: \\'my-build-config\\', showBuildLogs: \\'true\\')'\">\n" +
+    "</copy-to-clipboard>\n" +
+    "</p>\n" +
+    "<p>\n" +
+    "Start a deployment for deployment config <var>my-deployment-config:</var>\n" +
+    "<copy-to-clipboard display-wide=\"true\" clipboard-text=\"'openshiftDeploy(deploymentConfig: \\'my-deployment-config\\')'\">\n" +
+    "</copy-to-clipboard>\n" +
+    "</p>\n" +
+    "<p>\n" +
+    "Run the shell command <var>make test:</var>\n" +
+    "<copy-to-clipboard display-wide=\"true\" clipboard-text=\"'sh \\'make test\\''\">\n" +
+    "</copy-to-clipboard>\n" +
+    "</p>\n" +
+    "<p>\n" +
+    "Prompt for manual input:\n" +
+    "<copy-to-clipboard display-wide=\"true\" clipboard-text=\"'input \\'Promote to production?\\''\">\n" +
+    "</copy-to-clipboard>\n" +
+    "</p>\n" +
+    "<p>\n" +
+    "Learn more about\n" +
+    "<a ng-href=\"{{ 'pipeline-builds' | helpLink}}\" target=\"_blank\">Pipeline Builds</a>\n" +
+    "and the\n" +
+    "<a ng-href=\"{{ 'pipeline-plugin' | helpLink}}\" target=\"_blank\">OpenShift Pipeline Plugin</a>.\n" +
+    "</p>\n" +
     "</div>"
   );
 
@@ -9479,6 +9543,19 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<button class=\"btn btn-lg btn-default\" type=\"button\" ng-click=\"cancel();\">Cancel</button>\n" +
     "</div>\n" +
     "</form>\n" +
+    "</div>"
+  );
+
+
+  $templateCache.put('views/modals/jenkinsfile-examples-modal.html',
+    "<div>\n" +
+    "<div class=\"modal-body\">\n" +
+    "<h2>Jenkinsfile Examples</h2>\n" +
+    "<ng-include src=\"'views/edit/jenkinsfile-examples.html'\"></ng-include>\n" +
+    "</div>\n" +
+    "<div class=\"modal-footer\">\n" +
+    "<button class=\"btn btn-lg btn-default\" type=\"button\" ng-click=\"ok()\">OK</button>\n" +
+    "</div>\n" +
     "</div>"
   );
 

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3541,8 +3541,8 @@ to{transform:rotate(359deg)}
 .wizard-pf-review-content .wizard-pf-review-item.sub-item{margin-left:10px}
 .wizard-pf-review-content .wizard-pf-review-item .wizard-pf-review-item-label{font-weight:700;padding-right:10px}
 .wizard-pf-review-content .wizard-pf-review-item .wizard-pf-review-item-field{font-weight:700;margin:5px 0;padding-right:10px}
-.card-pf-body,.wizard-pf-review-content .wizard-pf-review-item .wizard-pf-review-item-field:last-of-type{margin-bottom:0}
 .wizard-pf-review-content .wizard-pf-review-item .wizard-pf-review-item-field:first-of-type{margin-top:0}
+.wizard-pf-review-content .wizard-pf-review-item .wizard-pf-review-item-field:last-of-type{margin-bottom:0}
 .wizard-pf-review-content .wizard-pf-review-item .wizard-pf-review-item-field.sub-field{margin-left:10px}
 .wizard-pf-success-icon{color:#3f9c35;font-size:72.8px;line-height:72.8px}
 .wizard-pf-footer{border-top:1px solid #d1d1d1;margin-top:0;padding-bottom:17px}
@@ -3581,9 +3581,12 @@ to{transform:rotate(359deg)}
 .btn-flat-default:focus,.btn-flat-default:hover{background-color:#f7f7f7;border-color:#e7e7e7}
 .copy-to-clipboard input.form-control:read-only{background-color:#fff;color:#363636}
 .input-group-addon.wildcard-prefix{padding-left:10px}
+.editor-examples{padding:19px;margin-bottom:20px;border:1px solid #d1d1d1}
+.editor-examples .copy-to-clipboard{margin-top:3px}
 .card-pf{box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09)}
 .card-pf .image-icon,.card-pf .template-icon{font-size:28px;line-height:1;margin-right:15px;opacity:.38}
 .card-pf-badge{color:#999;font-size:11px;text-transform:uppercase}
+.card-pf-body{margin-bottom:0}
 .card-pf-title-with-icon{align-items:center;display:flex;margin-bottom:15px}
 .row-cards-pf-flex{display:flex;flex-wrap:wrap}
 .row-cards-pf-flex:before{display:none}


### PR DESCRIPTION
Show information about the Jenkinsfile in a modal for pipeline build configs and builds. We give a help link builds that use Jenkinsfile path as well.

https://trello.com/c/nEjWsvyL

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/20716162/4dfd1a28-b61f-11e6-8162-7d9b4d231070.png)

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/20716176/566eb77a-b61f-11e6-9fb3-4d2a9c48bf1f.png)

Show the examples below the editor when editing a pipeline so that you can copy and paste.

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/20716192/66ddd136-b61f-11e6-8c86-25c3a9473988.png)

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/20716204/720c033e-b61f-11e6-822e-48860b297215.png)

@jwforres @bparees @gabemontero @danmcp @sspeiche 