### PR TITLE
Adjust <alerts> on pages without breadcrumbs so there is a consistent …

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -737,7 +737,7 @@ a.subtle-link {
   .task-expanded-details {
     margin-top: 20px;
     .alert {
-      margin-bottom: 0;
+      margin-bottom: 7px;
     }
   }
 }

--- a/app/views/browse/config-maps.html
+++ b/app/views/browse/config-maps.html
@@ -12,7 +12,6 @@
             </div>
             <h1>Config Maps</h1>
           </div>
-          <alerts alerts="alerts"></alerts>
           <div ng-if="!renderOptions.showGetStarted" class="data-toolbar">
             <div class="data-toolbar-filter">
               <project-filter></project-filter>
@@ -22,6 +21,7 @@
       </div><!-- /middle-header-->
       <div class="middle-content">
         <div class="container-fluid">
+          <alerts alerts="alerts"></alerts>
           <div class="row">
             <div class="col-md-12">
               <div ng-if="!loaded">Loading...</div>

--- a/app/views/browse/routes.html
+++ b/app/views/browse/routes.html
@@ -12,7 +12,6 @@
             </div>
             <h1>Routes</h1>
           </div>
-          <alerts alerts="alerts"></alerts>
           <div ng-if="!renderOptions.showGetStarted" class="data-toolbar">
             <div class="data-toolbar-filter">
               <project-filter></project-filter>
@@ -22,6 +21,7 @@
       </div><!-- /middle-header-->
       <div class="middle-content">
         <div class="container-fluid">
+          <alerts alerts="alerts"></alerts>
           <div class="row">
             <div class="col-md-12">
               <table class="table table-bordered table-hover table-mobile">

--- a/app/views/builds.html
+++ b/app/views/builds.html
@@ -9,7 +9,6 @@
           <div class="page-header page-header-bleed-right page-header-bleed-left">
             <h1>Builds</h1>
           </div>
-          <alerts alerts="alerts"></alerts>
           <div ng-if="!renderOptions.showGetStarted" class="data-toolbar">
             <div class="data-toolbar-filter">
               <project-filter></project-filter>
@@ -19,6 +18,7 @@
       </div><!-- /middle-header-->
       <div class="middle-content">
         <div class="container-fluid">
+          <alerts alerts="alerts"></alerts>
           <div class="row">
             <div class="col-md-12">
               <table class="table table-bordered table-hover table-mobile">

--- a/app/views/deployments.html
+++ b/app/views/deployments.html
@@ -9,7 +9,6 @@
           <div class="page-header page-header-bleed-right page-header-bleed-left">
             <h1>Deployments</h1>
           </div>
-          <alerts alerts="alerts"></alerts>
           <div ng-if="!renderOptions.showGetStarted" class="data-toolbar">
             <div class="data-toolbar-filter">
               <project-filter></project-filter>
@@ -19,6 +18,7 @@
       </div><!-- /middle-header-->
       <div class="middle-content">
         <div class="container-fluid">
+          <alerts alerts="alerts"></alerts>
           <div class="row">
             <div class="col-md-12">
               <h3 ng-if="(deployments | hashSize) || (replicaSets | hashSize)">Deployment Configurations</h3>

--- a/app/views/events.html
+++ b/app/views/events.html
@@ -9,11 +9,11 @@
           <div class="page-header page-header-bleed-right page-header-bleed-left">
             <h1>Events</h1>
           </div>
-          <alerts alerts="alerts"></alerts>
         </div>
       </div><!-- /middle-header-->
       <div class="middle-content">
         <div class="container-fluid">
+          <alerts alerts="alerts"></alerts>
           <div class="row">
             <div class="col-md-12" ng-if="projectContext">
               <events project-context="projectContext" ng-if="projectContext"></events>

--- a/app/views/images.html
+++ b/app/views/images.html
@@ -9,7 +9,6 @@
           <div class="page-header page-header-bleed-right page-header-bleed-left">
             <h1>Image Streams</h1>
           </div>
-          <alerts alerts="alerts"></alerts>
           <div class="data-toolbar">
             <div class="data-toolbar-filter">
               <project-filter></project-filter>
@@ -19,6 +18,7 @@
       </div><!-- /middle-header-->
       <div class="middle-content">
         <div class="container-fluid">
+          <alerts alerts="alerts"></alerts>
           <div class="row">
             <div class="col-md-12">
               <table class="table table-bordered table-hover table-mobile">

--- a/app/views/membership.html
+++ b/app/views/membership.html
@@ -22,12 +22,12 @@
                  </a>
                </span>
             </h1>
-            <alerts alerts="alerts"></alerts>
           </div>
         </div>
       </div>
       <div class="middle-content" persist-tab-state>
         <div class="container-fluid">
+          <alerts alerts="alerts"></alerts>
           <div class="row">
             <div class="col-md-12">
 

--- a/app/views/monitoring.html
+++ b/app/views/monitoring.html
@@ -13,7 +13,6 @@
                 <events-badge project-context="projectContext" ng-if="projectContext" class="pull-right" sidebar-collapsed="renderOptions.collapseEventsSidebar"></events-badge>
               </h1>
             </div>
-            <alerts alerts="alerts"></alerts>
             <div class="data-toolbar">
               <ui-select class="data-toolbar-dropdown" ng-model="kindSelector.selected" theme="bootstrap" search-enabled="true" ng-disabled="kindSelector.disabled" title="Choose a resource">
                 <ui-select-match placeholder="Choose a resource">{{$select.selected.label ? $select.selected.label : ($select.selected.kind | humanizeKind : true)}}</ui-select-match>
@@ -54,6 +53,7 @@
         </div><!-- /middle-header-->
         <div class="middle-content">
           <div class="container-fluid">
+            <alerts alerts="alerts"></alerts>
             <div class="row">
               <div class="col-md-12">
                 <div ng-if="kindSelector.selected.kind === 'All' || kindSelector.selected.kind === 'Pods'">

--- a/app/views/other-resources.html
+++ b/app/views/other-resources.html
@@ -9,7 +9,6 @@
           <div class="page-header page-header-bleed-right page-header-bleed-left">
             <h1>Other Resources</h1>
           </div>
-          <alerts alerts="alerts"></alerts>
           <div class="data-toolbar other-resources-toolbar">
             <ui-select class="data-toolbar-dropdown" ng-model="kindSelector.selected" theme="bootstrap" search-enabled="true" ng-disabled="kindSelector.disabled" title="Choose a resource">
               <ui-select-match placeholder="Choose a resource to list...">{{$select.selected.kind | humanizeKind : true}}</ui-select-match>
@@ -26,6 +25,7 @@
       </div><!-- /middle-header-->
       <div class="middle-content">
         <div class="container-fluid">
+          <alerts alerts="alerts"></alerts>
           <div class="row">
             <div class="col-md-12">
               <table class="table table-bordered table-mobile" ng-class="{ 'table-empty': (resources | hashSize) === 0 }">

--- a/app/views/pipelines.html
+++ b/app/views/pipelines.html
@@ -10,12 +10,12 @@
           <h1>
             Pipelines
           </h1>
-          <alerts alerts="alerts"></alerts>
         </div>
       </div>
     </div>
     <div class="middle-content pipelines-page">
       <div class="container-fluid">
+        <alerts alerts="alerts"></alerts>
         <div class="row">
           <div class="col-md-12">
             <div ng-if="!(buildConfigs | hashSize)" class="mar-top-lg">

--- a/app/views/pods.html
+++ b/app/views/pods.html
@@ -9,7 +9,6 @@
           <div class="page-header page-header-bleed-right page-header-bleed-left">
             <h1>Pods</h1>
           </div>
-          <alerts alerts="alerts"></alerts>
           <div ng-if="!renderOptions.showGetStarted" class="data-toolbar">
             <div class="data-toolbar-filter">
               <project-filter></project-filter>
@@ -19,6 +18,7 @@
       </div><!-- /middle-header-->
       <div class="middle-content">
         <div class="container-fluid">
+          <alerts alerts="alerts"></alerts>
           <div class="row">
             <div class="col-md-12">
               <pods-table pods="pods" empty-message="emptyMessage"></pods-table>

--- a/app/views/quota.html
+++ b/app/views/quota.html
@@ -11,11 +11,11 @@
                 <span ng-if="clusterQuotas | hashSize">Cluster </span>Quota
               </h1>
             </div>
-            <alerts alerts="alerts"></alerts>
           </div>
         </div><!-- /middle-header-->
         <div class="middle-content">
           <div class="container-fluid">
+            <alerts alerts="alerts"></alerts>
             <div class="row">
               <div class="col-md-12">
                 <div ng-if="!(quotas | hashSize) && !(clusterQuotas | hashSize)" class="mar-top-xl">

--- a/app/views/secrets.html
+++ b/app/views/secrets.html
@@ -12,11 +12,11 @@
             </div>
             <h1>Secrets</h1>
           </div>
-          <alerts alerts="alerts"></alerts>
         </div>
       </div><!-- /middle-header-->
       <div class="middle-content">
         <div class="container-fluid">
+          <alerts alerts="alerts"></alerts>
           <div ng-if="!loaded" class="mar-top-xl">Loading...</div>
           <div ng-if="loaded" class="row">
             <div class="col-md-12">

--- a/app/views/services.html
+++ b/app/views/services.html
@@ -9,7 +9,6 @@
           <div class="page-header page-header-bleed-right page-header-bleed-left">
             <h1>Services</h1>
           </div>
-          <alerts alerts="alerts"></alerts>
           <div class="data-toolbar">
             <div class="data-toolbar-filter">
               <project-filter></project-filter>
@@ -19,6 +18,7 @@
       </div><!-- /middle-header-->
       <div class="middle-content">
         <div class="container-fluid">
+          <alerts alerts="alerts"></alerts>
           <div class="row">
             <div class="col-md-12">
               <table class="table table-bordered table-hover table-mobile">

--- a/app/views/storage.html
+++ b/app/views/storage.html
@@ -9,7 +9,6 @@
           <div class="page-header page-header-bleed-right page-header-bleed-left">
             <h1>Storage</h1>
           </div>
-          <alerts alerts="alerts"></alerts>
           <div ng-if="!renderOptions.showGetStarted" class="data-toolbar">
             <div class="data-toolbar-filter">
               <project-filter></project-filter>
@@ -19,6 +18,7 @@
       </div><!-- /middle-header-->
       <div class="middle-content">
         <div class="container-fluid">
+          <alerts alerts="alerts"></alerts>
           <div class="row">
             <div class="col-md-12">
               <div class="section-header page-header-bleed-right page-header-bleed-left">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2304,7 +2304,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<h1>Config Maps</h1>\n" +
     "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!renderOptions.showGetStarted\" class=\"data-toolbar\">\n" +
     "<div class=\"data-toolbar-filter\">\n" +
     "<project-filter></project-filter>\n" +
@@ -2314,6 +2313,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<div ng-if=\"!loaded\">Loading...</div>\n" +
@@ -3610,7 +3610,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<h1>Routes</h1>\n" +
     "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!renderOptions.showGetStarted\" class=\"data-toolbar\">\n" +
     "<div class=\"data-toolbar-filter\">\n" +
     "<project-filter></project-filter>\n" +
@@ -3620,6 +3619,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<table class=\"table table-bordered table-hover table-mobile\">\n" +
@@ -3958,7 +3958,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
     "<h1>Builds</h1>\n" +
     "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!renderOptions.showGetStarted\" class=\"data-toolbar\">\n" +
     "<div class=\"data-toolbar-filter\">\n" +
     "<project-filter></project-filter>\n" +
@@ -3968,6 +3967,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<table class=\"table table-bordered table-hover table-mobile\">\n" +
@@ -5035,7 +5035,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
     "<h1>Deployments</h1>\n" +
     "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!renderOptions.showGetStarted\" class=\"data-toolbar\">\n" +
     "<div class=\"data-toolbar-filter\">\n" +
     "<project-filter></project-filter>\n" +
@@ -5045,6 +5044,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<h3 ng-if=\"(deployments | hashSize) || (replicaSets | hashSize)\">Deployment Configurations</h3>\n" +
@@ -8996,11 +8996,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
     "<h1>Events</h1>\n" +
     "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\" ng-if=\"projectContext\">\n" +
     "<events project-context=\"projectContext\" ng-if=\"projectContext\"></events>\n" +
@@ -9025,7 +9025,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
     "<h1>Image Streams</h1>\n" +
     "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"data-toolbar\">\n" +
     "<div class=\"data-toolbar-filter\">\n" +
     "<project-filter></project-filter>\n" +
@@ -9035,6 +9034,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<table class=\"table table-bordered table-hover table-mobile\">\n" +
@@ -9178,12 +9178,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</a>\n" +
     "</span>\n" +
     "</h1>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"middle-content\" persist-tab-state>\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "</div>\n" +
@@ -9635,7 +9635,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<events-badge project-context=\"projectContext\" ng-if=\"projectContext\" class=\"pull-right\" sidebar-collapsed=\"renderOptions.collapseEventsSidebar\"></events-badge>\n" +
     "</h1>\n" +
     "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"data-toolbar\">\n" +
     "<ui-select class=\"data-toolbar-dropdown\" ng-model=\"kindSelector.selected\" theme=\"bootstrap\" search-enabled=\"true\" ng-disabled=\"kindSelector.disabled\" title=\"Choose a resource\">\n" +
     "<ui-select-match placeholder=\"Choose a resource\">{{$select.selected.label ? $select.selected.label : ($select.selected.kind | humanizeKind : true)}}</ui-select-match>\n" +
@@ -9667,6 +9666,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<div ng-if=\"kindSelector.selected.kind === 'All' || kindSelector.selected.kind === 'Pods'\">\n" +
@@ -9995,7 +9995,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
     "<h1>Other Resources</h1>\n" +
     "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"data-toolbar other-resources-toolbar\">\n" +
     "<ui-select class=\"data-toolbar-dropdown\" ng-model=\"kindSelector.selected\" theme=\"bootstrap\" search-enabled=\"true\" ng-disabled=\"kindSelector.disabled\" title=\"Choose a resource\">\n" +
     "<ui-select-match placeholder=\"Choose a resource to list...\">{{$select.selected.kind | humanizeKind : true}}</ui-select-match>\n" +
@@ -10012,6 +10011,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<table class=\"table table-bordered table-mobile\" ng-class=\"{ 'table-empty': (resources | hashSize) === 0 }\">\n" +
@@ -10605,12 +10605,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<h1>\n" +
     "Pipelines\n" +
     "</h1>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"middle-content pipelines-page\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<div ng-if=\"!(buildConfigs | hashSize)\" class=\"mar-top-lg\">\n" +
@@ -10706,7 +10706,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
     "<h1>Pods</h1>\n" +
     "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!renderOptions.showGetStarted\" class=\"data-toolbar\">\n" +
     "<div class=\"data-toolbar-filter\">\n" +
     "<project-filter></project-filter>\n" +
@@ -10716,6 +10715,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<pods-table pods=\"pods\" empty-message=\"emptyMessage\"></pods-table>\n" +
@@ -11073,11 +11073,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"clusterQuotas | hashSize\">Cluster </span>Quota\n" +
     "</h1>\n" +
     "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<div ng-if=\"!(quotas | hashSize) && !(clusterQuotas | hashSize)\" class=\"mar-top-xl\">\n" +
@@ -11327,11 +11327,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<h1>Secrets</h1>\n" +
     "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!loaded\" class=\"mar-top-xl\">Loading...</div>\n" +
     "<div ng-if=\"loaded\" class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
@@ -11434,7 +11434,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
     "<h1>Services</h1>\n" +
     "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"data-toolbar\">\n" +
     "<div class=\"data-toolbar-filter\">\n" +
     "<project-filter></project-filter>\n" +
@@ -11444,6 +11443,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<table class=\"table table-bordered table-hover table-mobile\">\n" +
@@ -11844,7 +11844,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
     "<h1>Storage</h1>\n" +
     "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!renderOptions.showGetStarted\" class=\"data-toolbar\">\n" +
     "<div class=\"data-toolbar-filter\">\n" +
     "<project-filter></project-filter>\n" +
@@ -11854,6 +11853,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<div class=\"section-header page-header-bleed-right page-header-bleed-left\">\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3895,7 +3895,7 @@ a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;borde
 .tasks .task-content .task-title{margin-right:10px}
 .tasks .task-content .task-links{font-size:13px;font-weight:300;white-space:nowrap}
 .tasks .task-expanded-details{margin-top:20px}
-.tasks .task-expanded-details .alert{margin-bottom:0}
+.tasks .task-expanded-details .alert{margin-bottom:7px}
 label.required:before{content:'*';position:absolute;left:10px}
 .btn-group-xs>.btn,.btn-xs{padding:0 4px}
 .btn-group-lg>.btn,.btn-lg{line-height:1.334}


### PR DESCRIPTION
30px margin between the bottom of `.page-header` border and the alerts

Fixes https://github.com/openshift/origin-web-console/issues/949

<img width="842" alt="screen shot 2016-11-29 at 3 32 20 pm" src="https://cloud.githubusercontent.com/assets/1874151/20730073/b3d9eca8-b652-11e6-96a0-8956339e035a.png">
* * *
<img width="936" alt="screen shot 2016-11-29 at 3 37 10 pm" src="https://cloud.githubusercontent.com/assets/1874151/20730074/b3da59ae-b652-11e6-95c6-3811f16b0106.png">
* * *
<img width="854" alt="screen shot 2016-11-29 at 3 23 29 pm" src="https://cloud.githubusercontent.com/assets/1874151/20730076/b3e09c92-b652-11e6-9855-8e9abe698fba.png">
* * *
<img width="883" alt="screen shot 2016-11-29 at 4 00 26 pm" src="https://cloud.githubusercontent.com/assets/1874151/20730075/b3dfe3ec-b652-11e6-9348-b23521151546.png">
* * *
<img width="936" alt="screen shot 2016-11-29 at 3 49 22 pm" src="https://cloud.githubusercontent.com/assets/1874151/20730214/2f5bff56-b653-11e6-9c2f-d104439a17e6.png">
* * *
<img width="944" alt="screen shot 2016-11-29 at 3 41 24 pm" src="https://cloud.githubusercontent.com/assets/1874151/20730078/b3e7500a-b652-11e6-8a13-242f5069f444.png">
* * *
<img width="937" alt="screen shot 2016-11-29 at 3 39 19 pm" src="https://cloud.githubusercontent.com/assets/1874151/20730079/b3ec3322-b652-11e6-95cc-bc4212ac157d.png">
* * *
<img width="838" alt="screen shot 2016-11-29 at 3 35 20 pm" src="https://cloud.githubusercontent.com/assets/1874151/20730080/b3edc4ee-b652-11e6-9f35-d0ee7566e809.png">
* * *
<img width="843" alt="screen shot 2016-11-29 at 3 34 38 pm" src="https://cloud.githubusercontent.com/assets/1874151/20730081/b3f27764-b652-11e6-8548-f70d62c223c8.png">
* * *
<img width="766" alt="screen shot 2016-11-29 at 3 30 45 pm" src="https://cloud.githubusercontent.com/assets/1874151/20730082/b3f3d12c-b652-11e6-95bd-44f4e3e27151.png">
