### PR TITLE
CLI and About menu items should have same ordering on mobile

### DIFF
--- a/app/scripts/extensions/nav/dropdownMobile.js
+++ b/app/scripts/extensions/nav/dropdownMobile.js
@@ -17,8 +17,8 @@ angular.module('openshiftConsole')
           type: 'dom',
           node: [
             '<li>',
-              '<a href="about">',
-                '<span class="pficon pficon-info fa-fw" aria-hidden="true"></span> About',
+              '<a href="command-line">',
+                '<span class="fa fa-terminal" aria-hidden="true"></span> Command Line Tools',
               '</a>',
             '</li>'
           ].join('')
@@ -26,8 +26,8 @@ angular.module('openshiftConsole')
           type: 'dom',
           node: [
             '<li>',
-              '<a href="command-line">',
-                '<span class="fa fa-terminal" aria-hidden="true"></span> Command Line Tools',
+              '<a href="about">',
+                '<span class="pficon pficon-info fa-fw" aria-hidden="true"></span> About',
               '</a>',
             '</li>'
           ].join('')

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -14307,10 +14307,10 @@ type:"dom",
 node:[ "<li>", "<a href=\"{{'default' | helpLink}}\">", '<span class="fa fa-book fa-fw" aria-hidden="true"></span> Documentation', "</a>", "</li>" ].join("")
 }, {
 type:"dom",
-node:[ "<li>", '<a href="about">', '<span class="pficon pficon-info fa-fw" aria-hidden="true"></span> About', "</a>", "</li>" ].join("")
+node:[ "<li>", '<a href="command-line">', '<span class="fa fa-terminal" aria-hidden="true"></span> Command Line Tools', "</a>", "</li>" ].join("")
 }, {
 type:"dom",
-node:[ "<li>", '<a href="command-line">', '<span class="fa fa-terminal" aria-hidden="true"></span> Command Line Tools', "</a>", "</li>" ].join("")
+node:[ "<li>", '<a href="about">', '<span class="pficon pficon-info fa-fw" aria-hidden="true"></span> About', "</a>", "</li>" ].join("")
 }, {
 type:"dom",
 node:_.template([ "<li>", '<a href="logout">', '<span class="pficon pficon-user fa-fw" aria-hidden="true"></span>', 'Log out <span class="username"><%= userName %></span>', "</a>", "</li>" ].join(""))({


### PR DESCRIPTION
Currently they have a different order at mobile vs full screen.

@jwforres PTAL