### PR TITLE
Fix error displaying catalog in openshift namespace

### DIFF
--- a/app/scripts/controllers/create.js
+++ b/app/scripts/controllers/create.js
@@ -49,22 +49,30 @@ angular.module('openshiftConsole')
         $scope.context = context;
         // Update project breadcrumb with display name.
         $scope.breadcrumbs[0].title = $filter('displayName')(project);
-        // List templates in the project namespace as well as the shared `openshift` namespace.
-        DataService.list("templates", context, function(templates) {
-          $scope.projectTemplates = templates.by('metadata.name');
+
+        // List image streams and templates in the both the shared `openshift`
+        // namespace and the project namespace.
+        DataService.list("imagestreams", {namespace: "openshift"}, function(imageStreams) {
+          $scope.openshiftImageStreams = imageStreams.by("metadata.name");
         });
 
         DataService.list("templates", {namespace: "openshift"}, function(templates) {
           $scope.openshiftTemplates = templates.by("metadata.name");
         });
 
-        // List image streams in the project namespace as well as the shared `openshift` namespace.
-        DataService.list("imagestreams", context, function(imageStreams) {
-          $scope.projectImageStreams = imageStreams.by("metadata.name");
-        });
+        // If the current namespace is `openshift`, don't request the same
+        // templates and image streams again.
+        if ($routeParams.project === 'openshift') {
+          $scope.projectImageStreams = [];
+          $scope.projectTemplates = [];
+        } else {
+          DataService.list("imagestreams", context, function(imageStreams) {
+            $scope.projectImageStreams = imageStreams.by("metadata.name");
+          });
 
-        DataService.list("imagestreams", {namespace: "openshift"}, function(imageStreams) {
-          $scope.openshiftImageStreams = imageStreams.by("metadata.name");
-        });
+          DataService.list("templates", context, function(templates) {
+            $scope.projectTemplates = templates.by("metadata.name");
+          });
+        }
       }));
   });

--- a/app/scripts/controllers/create/browseCategory.js
+++ b/app/scripts/controllers/create/browseCategory.js
@@ -100,22 +100,29 @@ angular.module('openshiftConsole')
         // Update project breadcrumb with display name.
         $scope.breadcrumbs[0].title = $filter('displayName')(project);
 
-        // List templates in the project namespace as well as the shared `openshift` namespace.
-        DataService.list("templates", context, function(templates) {
-          $scope.projectTemplates = templates.by("metadata.name");
+        // List image streams and templates in the both the shared `openshift`
+        // namespace and the project namespace.
+        DataService.list("imagestreams", {namespace: "openshift"}, function(imageStreams) {
+          $scope.openshiftImageStreams = imageStreams.by("metadata.name");
         });
 
         DataService.list("templates", {namespace: "openshift"}, function(templates) {
           $scope.openshiftTemplates = templates.by("metadata.name");
         });
 
-        // List image streams in the project namespace as well as the shared `openshift` namespace.
-        DataService.list("imagestreams", context, function(imageStreams) {
-          $scope.projectImageStreams = imageStreams.by("metadata.name");
-        });
+        // If the current namespace is `openshift`, don't request the same
+        // templates and image streams again.
+        if ($routeParams.project === 'openshift') {
+          $scope.projectImageStreams = [];
+          $scope.projectTemplates = [];
+        } else {
+          DataService.list("imagestreams", context, function(imageStreams) {
+            $scope.projectImageStreams = imageStreams.by("metadata.name");
+          });
 
-        DataService.list("imagestreams", {namespace: "openshift"}, function(imageStreams) {
-          $scope.openshiftImageStreams = imageStreams.by("metadata.name");
-        });
+          DataService.list("templates", context, function(templates) {
+            $scope.projectTemplates = templates.by("metadata.name");
+          });
+        }
       }));
   });

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7494,19 +7494,19 @@ link:"project/" + a.projectName + "/create/category/" + q.id
 }), a.breadcrumbs.push({
 title:a.category.label
 }), void m.get(e.project).then(_.spread(function(c, d) {
-a.project = c, a.context = d, a.breadcrumbs[0].title = b("displayName")(c), j.list("templates", d, function(b) {
-a.projectTemplates = b.by("metadata.name");
+a.project = c, a.context = d, a.breadcrumbs[0].title = b("displayName")(c), j.list("imagestreams", {
+namespace:"openshift"
+}, function(b) {
+a.openshiftImageStreams = b.by("metadata.name");
 }), j.list("templates", {
 namespace:"openshift"
 }, function(b) {
 a.openshiftTemplates = b.by("metadata.name");
-}), j.list("imagestreams", d, function(b) {
+}), "openshift" === e.project ? (a.projectImageStreams = [], a.projectTemplates = []) :(j.list("imagestreams", d, function(b) {
 a.projectImageStreams = b.by("metadata.name");
-}), j.list("imagestreams", {
-namespace:"openshift"
-}, function(b) {
-a.openshiftImageStreams = b.by("metadata.name");
-});
+}), j.list("templates", d, function(b) {
+a.projectTemplates = b.by("metadata.name");
+}));
 })));
 } ]), angular.module("openshiftConsole").controller("CreateFromImageController", [ "$scope", "Logger", "$q", "$routeParams", "APIService", "DataService", "ProjectsService", "Navigate", "ApplicationGenerator", "LimitRangesService", "MetricsService", "HPAService", "QuotaService", "SecretsService", "ImagesService", "TaskList", "failureObjectNameFilter", "$filter", "$parse", "$uibModal", "SOURCE_URL_PATTERN", "keyValueEditorUtils", function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) {
 var w = r("displayName"), x = r("humanize");
@@ -8063,19 +8063,19 @@ link:"project/" + a.projectName
 }, {
 title:"Add to Project"
 } ], m.get(e.project).then(_.spread(function(c, d) {
-a.project = c, a.context = d, a.breadcrumbs[0].title = b("displayName")(c), j.list("templates", d, function(b) {
-a.projectTemplates = b.by("metadata.name");
+a.project = c, a.context = d, a.breadcrumbs[0].title = b("displayName")(c), j.list("imagestreams", {
+namespace:"openshift"
+}, function(b) {
+a.openshiftImageStreams = b.by("metadata.name");
 }), j.list("templates", {
 namespace:"openshift"
 }, function(b) {
 a.openshiftTemplates = b.by("metadata.name");
-}), j.list("imagestreams", d, function(b) {
+}), "openshift" === e.project ? (a.projectImageStreams = [], a.projectTemplates = []) :(j.list("imagestreams", d, function(b) {
 a.projectImageStreams = b.by("metadata.name");
-}), j.list("imagestreams", {
-namespace:"openshift"
-}, function(b) {
-a.openshiftImageStreams = b.by("metadata.name");
-});
+}), j.list("templates", d, function(b) {
+a.projectTemplates = b.by("metadata.name");
+}));
 }));
 } ]), angular.module("openshiftConsole").controller("CreateProjectController", [ "$scope", "$location", "AuthService", "DataService", "AlertMessageService", function(a, b, c, d, e) {
 a.alerts = {}, c.withUser(), e.getAlerts().forEach(function(b) {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/12094

@jwforres PTAL. We were getting a "duplicates in a repeater" error because multiple templates with the same UID were in the `ng-repeat` (each template twice).