### PR TITLE
Match warning severity in service group notifications

### DIFF
--- a/app/scripts/directives/serviceGroupNotifications.js
+++ b/app/scripts/directives/serviceGroupNotifications.js
@@ -175,7 +175,7 @@ angular.module('openshiftConsole')
 
             var alertID = "pod_warning" + groupID;
             var alert = {
-              type: "warning",
+              type: warning.severity || 'warning',
               message: warning.message
             };
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12354,7 +12354,7 @@ t(c, a);
 var c = _.head(a);
 if (c) {
 var f = "pod_warning" + b, i = {
-type:"warning",
+type:c.severity || "warning",
 message:c.message
 };
 switch (c.reason) {


### PR DESCRIPTION
If the pod donut shows red, the corresponding overview alert should be an error alert.

<img width="606" alt="screen shot 2016-12-01 at 3 56 53 pm" src="https://cloud.githubusercontent.com/assets/1167259/20812367/3dcd0d90-b7df-11e6-843c-d583bf51c2ca.png">

@jwforres PTAL
