### PR TITLE
Show correct image stream name on deploy image

### DIFF
--- a/app/views/directives/deploy-image.html
+++ b/app/views/directives/deploy-image.html
@@ -73,7 +73,8 @@
         administrator.
       </div>
       <h2>
-        {{app.name}}<span ng-if="import.tag">:{{import.tag}}</span>
+        <span ng-if="mode === 'dockerImage'">{{import.name}}</span>
+        <span ng-if="mode === 'istag'">{{istag.imageStream}}<span ng-if="import.tag">:{{import.tag}}</span></span>
         <small>
           <span ng-if="import.result.ref.registry">from {{import.result.ref.registry}},</span>
           <span am-time-ago="import.image.dockerImageMetadata.Created"></span>,

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5906,7 +5906,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<strong>root</strong> user which might not be permitted by your cluster administrator.\n" +
     "</div>\n" +
     "<h2>\n" +
-    "{{app.name}}<span ng-if=\"import.tag\">:{{import.tag}}</span>\n" +
+    "<span ng-if=\"mode === 'dockerImage'\">{{import.name}}</span>\n" +
+    "<span ng-if=\"mode === 'istag'\">{{istag.imageStream}}<span ng-if=\"import.tag\">:{{import.tag}}</span></span>\n" +
     "<small>\n" +
     "<span ng-if=\"import.result.ref.registry\">from {{import.result.ref.registry}},</span>\n" +
     "<span am-time-ago=\"import.image.dockerImageMetadata.Created\"></span>,\n" +


### PR DESCRIPTION
If I deploy from an image stream image and customize the app name, don't
change the image stream name in the summary header.

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/20842823/d0d77c54-b886-11e6-9afd-82b41cd32420.png)

Fixes #973
@jwforres PTAL