### PR TITLE
Show pod metrics donut to right of sparkline

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -301,9 +301,17 @@ mark {
     }
   }
   .metrics-full {
+    h2:not(.has-limit) {
+      border-bottom: 1px solid #d1d1d1;
+      margin-bottom: 0;
+      padding-bottom: 15px;
+    }
     .metrics-donut,
     .metrics-sparkline {
       margin-top: 20px;
+    }
+    .metrics-sparkline {
+      margin-left: -10px;
     }
   }
 

--- a/app/views/directives/deployment-metrics.html
+++ b/app/views/directives/deployment-metrics.html
@@ -46,12 +46,12 @@
   </div>
 
   <div ng-repeat="metric in metrics" ng-show="!noData && !metricsError" class="metrics-full">
-    <h3 class="metric-label">
+    <h2 class="metric-label">
       {{metric.label}}
       <small ng-if="showAverage">
         Average per pod
       </small>
-    </h3>
+    </h2>
 
     <!-- Sparkline -->
     <div ng-attr-id="{{metric.chartID}}" class="metrics-sparkline"></div>

--- a/app/views/directives/pod-metrics.html
+++ b/app/views/directives/pod-metrics.html
@@ -47,36 +47,35 @@
   </div>
 
   <div ng-repeat="metric in metrics" ng-if="!noData && !metricsError" class="metrics-full">
-    <h3 class="metric-label">
+    <h2 ng-class="{ 'has-limit': metric.datasets[0].total }">
       {{metric.label}}
       <small ng-if="pod.spec.containers.length > 1">
         <span ng-if="metric.containerMetric">Container Metrics</span>
         <span ng-if="!metric.containerMetric">Pod Metrics</span>
       </small>
-      <small ng-if="deployment">
-        Total for All Pods
-      </small>
-     </h3>
+     </h2>
 
     <!-- Show a summary of usage above the charts like the patternfly utilization card. -->
     <!-- Reuse the utilization card styles, but only here. -->
     <div ng-if="metric.datasets[0].total" class="utilization-trend-chart-pf">
-      <div class="current-values" ng-if="metric.datasets[0].available >= 0">
-        <h1 class="available-count pull-left">
-          {{metric.datasets[0].available}}
-        </h1>
-        <div class="available-text pull-left">
-          <div>Available of</div>
-          <div>{{metric.datasets[0].total}} {{metric.units}}</div>
+      <div class="current-values">
+        <div ng-if="metric.datasets[0].available >= 0">
+          <h1 class="available-count pull-left">
+            {{metric.datasets[0].available}}
+          </h1>
+          <div class="available-text pull-left">
+            <div>Available of</div>
+            <div>{{metric.datasets[0].total}} {{metric.units}}</div>
+          </div>
         </div>
-      </div>
-      <div class="current-values" ng-if="metric.datasets[0].available < 0">
-        <h1 class="available-count pull-left">
-          {{metric.datasets[0].available | abs}}
-        </h1>
-        <div class="available-text pull-left">
-          <div><strong>Over limit of</strong></div>
-          <div>{{metric.datasets[0].total}} {{metric.units}}</div>
+        <div ng-if="metric.datasets[0].available < 0">
+          <h1 class="available-count pull-left">
+            {{metric.datasets[0].available | abs}}
+          </h1>
+          <div class="available-text pull-left">
+            <div><strong>Over limit of</strong></div>
+            <div>{{metric.datasets[0].total}} {{metric.units}}</div>
+          </div>
         </div>
       </div>
     </div>
@@ -84,10 +83,16 @@
     <!-- Clear floats so top margin works on the charts below. -->
     <div style="clear: both;"></div>
 
-    <!-- Donut -->
-    <div ng-if="metric.datasets[0].total" ng-attr-id="{{metric.chartPrefix + uniqueID}}-donut" class="metrics-donut"></div>
+    <div class="row">
+      <!-- Donut -->
+      <div ng-if="metric.datasets[0].total" ng-class="{ 'col-sm-12 col-md-3 col-md-push-9': !stackDonut }">
+        <div ng-attr-id="{{metric.chartPrefix + uniqueID}}-donut" class="metrics-donut"></div>
+      </div>
 
-    <!-- Sparkline -->
-    <div ng-attr-id="{{metric.chartPrefix + uniqueID}}-sparkline" class="metrics-sparkline"></div>
+      <!-- Sparkline -->
+      <div class="col-sm-12" ng-class="{ 'col-md-9': hasLimits && !stackDonut, 'col-md-pull-3': metric.datasets[0].total && !stackDonut}">
+        <div ng-attr-id="{{metric.chartPrefix + uniqueID}}-sparkline" class="metrics-sparkline"></div>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/monitoring.html
+++ b/app/views/monitoring.html
@@ -141,7 +141,7 @@
                       </log-viewer>
                       <!-- Until the metrics directive pulls the metrics from the time range of the life of the pod, hide the metrics for old stuff -->
                       <div class="mar-top-lg" ng-if="metricsAvailable">
-                        <pod-metrics pod="pod" alerts="alerts"></pod-metrics>
+                        <pod-metrics pod="pod" stack-donut="!renderOptions.collapseEventsSidebar" alerts="alerts"></pod-metrics>
                       </div>
                     </div>
                   </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10743,7 +10743,7 @@ b(c.resource, c.kind);
 }, b.prototype.removeResourceChangedCallback = function(a) {
 this.callbacks.remove(a);
 }, new b();
-} ]), angular.module("openshiftConsole").directive("podMetrics", [ "$interval", "$parse", "$timeout", "$q", "$rootScope", "ChartsService", "ConversionService", "MetricsService", "usageValueFilter", function(a, b, c, d, e, f, g, h, i) {
+} ]), angular.module("openshiftConsole").directive("podMetrics", [ "$filter", "$interval", "$parse", "$timeout", "$q", "$rootScope", "ChartsService", "ConversionService", "MetricsService", "usageValueFilter", function(a, b, c, d, e, f, g, h, i, j) {
 return {
 restrict:"E",
 scope:{
@@ -10751,27 +10751,28 @@ pod:"=",
 sparklineWidth:"=?",
 sparklineHeight:"=?",
 includedMetrics:"=?",
+stackDonut:"=?",
 alerts:"=?"
 },
 templateUrl:"views/directives/pod-metrics.html",
-link:function(j) {
-function k(a) {
-if (!j.pod) return null;
-var b = j.options.selectedContainer;
+link:function(k) {
+function l(a) {
+if (!k.pod) return null;
+var b = k.options.selectedContainer;
 switch (a) {
 case "memory/usage":
-var c = y(b);
-if (c) return g.bytesToMiB(i(c));
+var c = z(b);
+if (c) return h.bytesToMiB(j(c));
 break;
 
 case "cpu/usage_rate":
-var d = z(b);
-if (d) return _.round(1e3 * i(d));
+var d = A(b);
+if (d) return _.round(1e3 * j(d));
 }
 return null;
 }
-function l(a) {
-var b, d = {}, e = _.some(a.datasets, function(a) {
+function m(a) {
+var b, c = {}, e = _.some(a.datasets, function(a) {
 return !a.data;
 });
 if (!e) {
@@ -10779,141 +10780,141 @@ a.totalUsed = 0;
 var f = 0;
 angular.forEach(a.datasets, function(e) {
 var g = e.id, h = e.data;
-b = [ "dates" ], d[g] = [ e.label || g ], e.total = k(g);
+b = [ "dates" ], c[g] = [ e.label || g ], e.total = l(g), e.total && (k.hasLimits = !0);
 var i = _.last(h).value;
-isNaN(i) && (i = 0), a.convert && (i = a.convert(i)), e.used = i, e.total && (e.available = e.total - e.used), a.totalUsed += e.used, angular.forEach(h, function(c) {
-if (b.push(c.start), void 0 === c.value || null === c.value) d[g].push(c.value); else {
-var e = a.convert ? a.convert(c.value) :c.value;
+isNaN(i) && (i = 0), a.convert && (i = a.convert(i)), e.used = i, e.total && (e.available = e.total - e.used), a.totalUsed += e.used, angular.forEach(h, function(d) {
+if (b.push(d.start), void 0 === d.value || null === d.value) c[g].push(d.value); else {
+var e = a.convert ? a.convert(d.value) :d.value;
 switch (g) {
 case "memory/usage":
 case "network/rx":
 case "network/tx":
-d[g].push(d3.round(e, 2));
+c[g].push(d3.round(e, 2));
 break;
 
 default:
-d[g].push(d3.round(e));
+c[g].push(d3.round(e));
 }
 f = Math.max(e, f);
 }
 }), e.used = _.round(e.used), e.total = _.round(e.total), e.available = _.round(e.available);
-var j, l;
-e.total && (l = {
+var j, m;
+e.total && (m = {
 type:"donut",
 columns:[ [ "Used", e.used ], [ "Available", Math.max(e.available, 0) ] ],
 colors:{
 Used:e.available > 0 ? "#0088ce" :"#ec7a08",
 Available:"#d1d1d1"
 }
-}, w[g] ? w[g].load(l) :(j = D(a), j.data = l, c(function() {
-w[g] = c3.generate(j);
+}, x[g] ? x[g].load(m) :(j = F(a), j.data = m, d(function() {
+x[g] = c3.generate(j);
 })));
 }), a.totalUsed = _.round(a.totalUsed, 1);
-var g, h = [ b ].concat(_.values(d)), i = {
+var g, h = [ b ].concat(_.values(c)), i = {
 type:a.chartType || "spline",
 x:"dates",
 columns:h
 }, j = a.chartPrefix + "sparkline";
-x[j] ? x[j].load(i) :(g = E(a), g.data = i, a.chartDataColors && (g.color = {
+y[j] ? y[j].load(i) :(g = G(a), g.data = i, a.chartDataColors && (g.color = {
 pattern:a.chartDataColors
-}), c(function() {
-C || (x[j] = c3.generate(g));
+}), d(function() {
+D || (y[j] = c3.generate(g));
 }));
 }
 }
-function m() {
-return "-" + j.options.timeRange.value + "mn";
-}
 function n() {
-return 60 * j.options.timeRange.value * 1e3;
+return "-" + k.options.timeRange.value + "mn";
 }
 function o() {
-return Math.floor(n() / B) + "ms";
+return 60 * k.options.timeRange.value * 1e3;
 }
-function p(a, b, c) {
+function p() {
+return Math.floor(o() / C) + "ms";
+}
+function q(a, b, c) {
 var d, e = {
 metric:b.id,
-bucketDuration:o()
+bucketDuration:p()
 };
-return b.data && b.data.length ? (d = _.last(b.data), e.start = d.end) :e.start = c, j.pod ? _.assign(e, {
-namespace:j.pod.metadata.namespace,
-pod:j.pod,
-containerName:a.containerMetric ? j.options.selectedContainer.name :"pod"
+return b.data && b.data.length ? (d = _.last(b.data), e.start = d.end) :e.start = c, k.pod ? _.assign(e, {
+namespace:k.pod.metadata.namespace,
+pod:k.pod,
+containerName:a.containerMetric ? k.options.selectedContainer.name :"pod"
 }) :null;
 }
-function q() {
-F = 0;
+function r() {
+H = 0;
 }
-function r(a) {
-if (!C) {
-if (F++, j.noData) return void (j.metricsError = {
+function s(a) {
+if (!D) {
+if (H++, k.noData) return void (k.metricsError = {
 status:_.get(a, "status", 0),
 details:_.get(a, "data.errorMsg") || _.get(a, "statusText") || "Status code " + _.get(a, "status", 0)
 });
-if (!(F < 2)) {
-var b = "metrics-failed-" + j.uniqueID;
-j.alerts[b] = {
+if (!(H < 2)) {
+var b = "metrics-failed-" + k.uniqueID;
+k.alerts[b] = {
 type:"error",
-message:"An error occurred updating metrics for pod " + _.get(j, "pod.metadata.name", "<unknown>") + ".",
+message:"An error occurred updating metrics for pod " + _.get(k, "pod.metadata.name", "<unknown>") + ".",
 links:[ {
 href:"",
 label:"Retry",
 onClick:function() {
-delete j.alerts[b], F = 1, u();
+delete k.alerts[b], H = 1, v();
 }
 } ]
 };
 }
 }
 }
-function s() {
-return !(j.metricsError || F > 1) && (j.pod && _.get(j, "options.selectedContainer"));
+function t() {
+return !(k.metricsError || H > 1) && (k.pod && _.get(k, "options.selectedContainer"));
 }
-function t(a, b) {
-j.noData = !1;
+function u(a, b) {
+k.noData = !1;
 var c = _.initial(b.data);
-return a.data ? void (a.data = _.chain(a.data).takeRight(B).concat(c).value()) :void (a.data = c);
+return a.data ? void (a.data = _.chain(a.data).takeRight(C).concat(c).value()) :void (a.data = c);
 }
-function u() {
-if (s()) {
-var a = m(), b = [];
-angular.forEach(j.metrics, function(c) {
-var e = [];
+function v() {
+if (t()) {
+var a = n(), b = [];
+angular.forEach(k.metrics, function(c) {
+var d = [];
 angular.forEach(c.datasets, function(b) {
-var d = p(c, b, a);
-if (d) {
-var f = h.get(d);
-e.push(f);
+var e = q(c, b, a);
+if (e) {
+var f = i.get(e);
+d.push(f);
 }
-}), b = b.concat(e), d.all(e).then(function(a) {
-C || (angular.forEach(a, function(a) {
+}), b = b.concat(d), e.all(d).then(function(a) {
+D || (angular.forEach(a, function(a) {
 if (a) {
 var b = _.find(c.datasets, {
 id:a.metricID
 });
-t(b, a);
+u(b, a);
 }
-}), l(c));
+}), m(c));
 });
-}), d.all(b).then(q, r)["finally"](function() {
-j.loaded = !0;
+}), e.all(b).then(r, s)["finally"](function() {
+k.loaded = !0;
 });
 }
 }
-j.includedMetrics = j.includedMetrics || [ "cpu", "memory", "network" ];
-var v, w = {}, x = {}, y = b("resources.limits.memory"), z = b("resources.limits.cpu"), A = 6e4, B = 30, C = !1;
-j.uniqueID = _.uniqueId("metrics-chart-"), j.metrics = [], _.includes(j.includedMetrics, "memory") && j.metrics.push({
+k.includedMetrics = k.includedMetrics || [ "cpu", "memory", "network" ];
+var w, x = {}, y = {}, z = c("resources.limits.memory"), A = c("resources.limits.cpu"), B = 6e4, C = 30, D = !1;
+k.uniqueID = _.uniqueId("metrics-chart-"), k.metrics = [], _.includes(k.includedMetrics, "memory") && k.metrics.push({
 label:"Memory",
 units:"MiB",
 chartPrefix:"memory-",
-convert:g.bytesToMiB,
+convert:h.bytesToMiB,
 containerMetric:!0,
 datasets:[ {
 id:"memory/usage",
 label:"Memory",
 data:[]
 } ]
-}), _.includes(j.includedMetrics, "cpu") && j.metrics.push({
+}), _.includes(k.includedMetrics, "cpu") && k.metrics.push({
 label:"CPU",
 units:"millicores",
 chartPrefix:"cpu-",
@@ -10924,12 +10925,12 @@ id:"cpu/usage_rate",
 label:"CPU",
 data:[]
 } ]
-}), _.includes(j.includedMetrics, "network") && j.metrics.push({
+}), _.includes(k.includedMetrics, "network") && k.metrics.push({
 label:"Network",
 units:"KiB/s",
 chartPrefix:"network-",
 chartType:"spline",
-convert:g.bytesToKiB,
+convert:h.bytesToKiB,
 datasets:[ {
 id:"network/tx_rate",
 label:"Sent",
@@ -10939,9 +10940,9 @@ id:"network/rx_rate",
 label:"Received",
 data:[]
 } ]
-}), j.loaded = !1, j.noData = !0, h.getMetricsURL().then(function(a) {
-j.metricsURL = a;
-}), j.options = {
+}), k.loaded = !1, k.noData = !0, i.getMetricsURL().then(function(a) {
+k.metricsURL = a;
+}), k.options = {
 rangeOptions:[ {
 label:"Last hour",
 value:60
@@ -10958,13 +10959,13 @@ value:4320
 label:"Last week",
 value:10080
 } ]
-}, j.options.timeRange = _.head(j.options.rangeOptions);
-var D = function(a) {
-var b = "#" + a.chartPrefix + j.uniqueID + "-donut";
+}, k.options.timeRange = _.head(k.options.rangeOptions);
+var E = a("upperFirst"), F = function(a) {
+var b = "#" + a.chartPrefix + k.uniqueID + "-donut";
 return {
 bindto:b,
 onrendered:function() {
-f.updateDonutCenterText(b, a.datasets[0].used, a.units);
+g.updateDonutCenterText(b, a.datasets[0].used, E(a.units) + " Used");
 },
 donut:{
 label:{
@@ -10980,9 +10981,9 @@ height:175,
 widht:175
 }
 };
-}, E = function(a) {
+}, G = function(a) {
 return {
-bindto:"#" + a.chartPrefix + j.uniqueID + "-sparkline",
+bindto:"#" + a.chartPrefix + k.uniqueID + "-sparkline",
 axis:{
 x:{
 show:!0,
@@ -11019,8 +11020,8 @@ point:{
 show:!1
 },
 size:{
-height:j.sparklineHeight || 175,
-width:j.sparklineWidth
+height:k.sparklineHeight || 175,
+width:k.sparklineWidth
 },
 tooltip:{
 format:{
@@ -11030,25 +11031,29 @@ return d3.round(b, 2) + " " + a.units;
 }
 }
 };
-}, F = 0;
-j.$watch("options", function() {
-_.each(j.metrics, function(a) {
+}, H = 0;
+k.$watch("options", function() {
+_.each(k.metrics, function(a) {
 _.each(a.datasets, function(a) {
 delete a.data;
 });
-}), delete j.metricsError, u();
-}, !0), v = a(u, A, !1), e.$on("metrics.charts.resize", function() {
-c(function() {
+}), delete k.metricsError, v();
+}, !0), w = b(v, B, !1), f.$on("metrics.charts.resize", function() {
 _.each(x, function(a) {
+setTimeout(function() {
 a.flush();
 });
-}, 0);
-}), j.$on("$destroy", function() {
-v && (a.cancel(v), v = null), angular.forEach(w, function(a) {
+}), _.each(y, function(a) {
+setTimeout(function() {
+a.flush();
+});
+});
+}), k.$on("$destroy", function() {
+w && (b.cancel(w), w = null), angular.forEach(x, function(a) {
 a.destroy();
-}), w = null, angular.forEach(x, function(a) {
+}), x = null, angular.forEach(y, function(a) {
 a.destroy();
-}), x = null, C = !0;
+}), y = null, D = !0;
 });
 }
 };

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6092,12 +6092,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "</div>\n" +
     "<div ng-repeat=\"metric in metrics\" ng-show=\"!noData && !metricsError\" class=\"metrics-full\">\n" +
-    "<h3 class=\"metric-label\">\n" +
+    "<h2 class=\"metric-label\">\n" +
     "{{metric.label}}\n" +
     "<small ng-if=\"showAverage\">\n" +
     "Average per pod\n" +
     "</small>\n" +
-    "</h3>\n" +
+    "</h2>\n" +
     "\n" +
     "<div ng-attr-id=\"{{metric.chartID}}\" class=\"metrics-sparkline\"></div>\n" +
     "</div>\n" +
@@ -7744,20 +7744,18 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "</div>\n" +
     "<div ng-repeat=\"metric in metrics\" ng-if=\"!noData && !metricsError\" class=\"metrics-full\">\n" +
-    "<h3 class=\"metric-label\">\n" +
+    "<h2 ng-class=\"{ 'has-limit': metric.datasets[0].total }\">\n" +
     "{{metric.label}}\n" +
     "<small ng-if=\"pod.spec.containers.length > 1\">\n" +
     "<span ng-if=\"metric.containerMetric\">Container Metrics</span>\n" +
     "<span ng-if=\"!metric.containerMetric\">Pod Metrics</span>\n" +
     "</small>\n" +
-    "<small ng-if=\"deployment\">\n" +
-    "Total for All Pods\n" +
-    "</small>\n" +
-    "</h3>\n" +
+    "</h2>\n" +
     "\n" +
     "\n" +
     "<div ng-if=\"metric.datasets[0].total\" class=\"utilization-trend-chart-pf\">\n" +
-    "<div class=\"current-values\" ng-if=\"metric.datasets[0].available >= 0\">\n" +
+    "<div class=\"current-values\">\n" +
+    "<div ng-if=\"metric.datasets[0].available >= 0\">\n" +
     "<h1 class=\"available-count pull-left\">\n" +
     "{{metric.datasets[0].available}}\n" +
     "</h1>\n" +
@@ -7766,7 +7764,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div>{{metric.datasets[0].total}} {{metric.units}}</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"current-values\" ng-if=\"metric.datasets[0].available < 0\">\n" +
+    "<div ng-if=\"metric.datasets[0].available < 0\">\n" +
     "<h1 class=\"available-count pull-left\">\n" +
     "{{metric.datasets[0].available | abs}}\n" +
     "</h1>\n" +
@@ -7776,12 +7774,19 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
+    "</div>\n" +
     "\n" +
     "<div style=\"clear: both\"></div>\n" +
+    "<div class=\"row\">\n" +
     "\n" +
-    "<div ng-if=\"metric.datasets[0].total\" ng-attr-id=\"{{metric.chartPrefix + uniqueID}}-donut\" class=\"metrics-donut\"></div>\n" +
+    "<div ng-if=\"metric.datasets[0].total\" ng-class=\"{ 'col-sm-12 col-md-3 col-md-push-9': !stackDonut }\">\n" +
+    "<div ng-attr-id=\"{{metric.chartPrefix + uniqueID}}-donut\" class=\"metrics-donut\"></div>\n" +
+    "</div>\n" +
     "\n" +
+    "<div class=\"col-sm-12\" ng-class=\"{ 'col-md-9': hasLimits && !stackDonut, 'col-md-pull-3': metric.datasets[0].total && !stackDonut}\">\n" +
     "<div ng-attr-id=\"{{metric.chartPrefix + uniqueID}}-sparkline\" class=\"metrics-sparkline\"></div>\n" +
+    "</div>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>"
   );
@@ -9691,7 +9696,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</log-viewer>\n" +
     "\n" +
     "<div class=\"mar-top-lg\" ng-if=\"metricsAvailable\">\n" +
-    "<pod-metrics pod=\"pod\" alerts=\"alerts\"></pod-metrics>\n" +
+    "<pod-metrics pod=\"pod\" stack-donut=\"!renderOptions.collapseEventsSidebar\" alerts=\"alerts\"></pod-metrics>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3798,7 +3798,9 @@ mark{padding:0;background-color:rgba(252,248,160,.5)}
 @media (min-width:768px){.metrics .metrics-options .form-group{display:inline-block}
 .metrics .metrics-options .select-container{margin-right:10px}
 }
+.metrics .metrics-full h2:not(.has-limit){border-bottom:1px solid #d1d1d1;margin-bottom:0;padding-bottom:15px}
 .metrics .metrics-full .metrics-donut,.metrics .metrics-full .metrics-sparkline{margin-top:20px}
+.metrics .metrics-full .metrics-sparkline{margin-left:-10px}
 @media (max-width:500px){.metrics .metrics-sparkline .c3-axis-x .tick{display:none}
 }
 @media (max-width:550px){.monitoring-page .metrics-sparkline .c3-axis-x .tick{display:none}


### PR DESCRIPTION
Place the pod metrics donut to the right of the sparkline at wider screen widths to make better use of the screen space. At mobile, still place the donut above the sparkline.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1387286
Fixes #912 

![screen shot 2016-12-05 at 8 29 49 am](https://cloud.githubusercontent.com/assets/1167259/20886870/287afcba-bac6-11e6-8c43-7a7824fa854d.png)

@jwforres PTAL
@smarterclayton @stevekuznetsov @jupierce CC