### PR TITLE
Redirect to overview when updating Template in fromFile

### DIFF
--- a/app/scripts/directives/fromFile.js
+++ b/app/scripts/directives/fromFile.js
@@ -158,7 +158,12 @@ angular.module("openshiftConsole")
               openTemplateProcessModal();
             // Else if any resources already exist
             } else if (!_.isEmpty($scope.updateResources)) {
-              confirmReplace();
+              $scope.updateTemplate = $scope.updateResources.length === 1 && $scope.updateResources[0].kind === "Template";
+              if ($scope.updateTemplate) {
+                openTemplateProcessModal();
+              } else {
+                confirmReplace();
+              }
             } else {
               QuotaService.getLatestQuotaAlerts($scope.createResources, $scope.context).then(showWarningsOrCreate);
             }

--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -900,6 +900,10 @@ a.disabled-link {
   p {
     font-size: @font-size-large + 1;
   }
+  .help-block {
+    margin-top: 0px;
+    margin-bottom: 10px;
+  }
 }
 
 // Disable numeric highlighting in YAML and Dockerfile modes because of bugs

--- a/app/views/modals/process-template.html
+++ b/app/views/modals/process-template.html
@@ -1,6 +1,6 @@
 <div class="modal-resource-action">
   <div class="modal-body">
-    <h1>Add Template</h1>
+    <h1>{{updateTemplate ? "Update" : "Add"}} Template</h1>
     <p>What would you like to do?</p>
 
     <div>
@@ -13,9 +13,9 @@
     <div>
       <label>
         <input type="checkbox" ng-model="templateOptions.add"/>
-        <strong>Save template</strong>
+        <strong>{{updateTemplate ? "Update" : "Save"}} template</strong>
       </label>
-      <span id="helpBlock" class="help-block">Save the template to the project. This will make the template available to anyone who can view the project.</span> 
+      <span id="helpBlock" class="help-block">{{updateTemplate ? "This will overwrite the current version of the template." : "Save the template to the project. This will make the template available to anyone who can view the project."}}</span>
     </div>
   </div>
   <div class="modal-footer">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -9426,7 +9426,7 @@ var c = [];
 l.errorOccured = !1, _.forEach(l.resourceList, function(a) {
 return m(a) ? void c.push(r(a)) :(l.errorOccured = !0, !1);
 }), a.all(c).then(function() {
-l.errorOccured || (1 === l.createResources.length && "Template" === l.resourceList[0].kind ? n() :_.isEmpty(l.updateResources) ? k.getLatestQuotaAlerts(l.createResources, l.context).then(B) :o());
+l.errorOccured || (1 === l.createResources.length && "Template" === l.resourceList[0].kind ? n() :_.isEmpty(l.updateResources) ? k.getLatestQuotaAlerts(l.createResources, l.context).then(B) :(l.updateTemplate = 1 === l.updateResources.length && "Template" === l.updateResources[0].kind, l.updateTemplate ? n() :o()));
 });
 }
 };

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -9793,7 +9793,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   $templateCache.put('views/modals/process-template.html',
     "<div class=\"modal-resource-action\">\n" +
     "<div class=\"modal-body\">\n" +
-    "<h1>Add Template</h1>\n" +
+    "<h1>{{updateTemplate ? \"Update\" : \"Add\"}} Template</h1>\n" +
     "<p>What would you like to do?</p>\n" +
     "<div>\n" +
     "<label>\n" +
@@ -9805,9 +9805,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div>\n" +
     "<label>\n" +
     "<input type=\"checkbox\" ng-model=\"templateOptions.add\"/>\n" +
-    "<strong>Save template</strong>\n" +
+    "<strong>{{updateTemplate ? \"Update\" : \"Save\"}} template</strong>\n" +
     "</label>\n" +
-    "<span id=\"helpBlock\" class=\"help-block\">Save the template to the project. This will make the template available to anyone who can view the project.</span>\n" +
+    "<span id=\"helpBlock\" class=\"help-block\">{{updateTemplate ? \"This will overwrite the current version of the template.\" : \"Save the template to the project. This will make the template available to anyone who can view the project.\"}}</span>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"modal-footer\">\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3931,6 +3931,7 @@ a.disabled-link:active,a.disabled-link:focus,a.disabled-link:hover{color:#bbb;te
 .modal-resource-action{background-color:#f1f1f1}
 .modal-resource-action h1{font-size:21px;font-weight:500;margin-bottom:20px;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .modal-resource-action p{font-size:16px}
+.modal-resource-action .help-block{margin-top:0px;margin-bottom:10px}
 .ace_editor.dockerfile-mode .ace_constant.ace_numeric,.editor.yaml-mode .ace_constant.ace_numeric{color:inherit}
 .edit-yaml h1{line-height:1.3}
 .edit-yaml .editor{line-height:1.5;width:100%;min-height:140px;height:50vh}


### PR DESCRIPTION
This is fixes the case when user updates the Template in the fromFile page and he is redirected to the `fromTemplate` page. By setting the template process option to `false` user will be redirected to the overview page.

@jwforres PTAL