### PR TITLE
Adjust pipeline-stage widths to accommodate more stages based on browser widths

### DIFF
--- a/app/styles/_pipeline.less
+++ b/app/styles/_pipeline.less
@@ -261,7 +261,7 @@
   .pipeline .pipeline-stage {
     padding-right: (@pipeline-padding * 5.2);
     padding-bottom: (@pipeline-padding + 5);
-    width: 50%;
+    width: (100% / 2);
     &:before {
       bottom: auto;
       content: '\2192';
@@ -286,7 +286,7 @@
   .build-summary {
     border-bottom-width: 0;
     border-right: 1px solid @build-pipeline-border-color;
-    .flex(@columns: 0 0 175px);
+    .flex(@columns: 0 0 125px);
     .flex-direction(@direction: column);
     .justify-content(@justify: center);
   }
@@ -294,13 +294,24 @@
 
 @media (min-width: @screen-md-min) {
   .pipeline .pipeline-stage {
-    width: 33.333333%;
+    width: (100% / 4);
   }
 }
 
 @media (min-width: @screen-lg-min) {
   .pipeline .pipeline-stage {
-    width: 25%;
+    width: (100% / 5);
+  }
+}
+@media (min-width: (@screen-lg-min + 200)) {
+  .pipeline .pipeline-stage {
+    width: (100% / 6);
+  }
+}
+
+@media (min-width: @screen-xlg-min) {
+  .pipeline .pipeline-stage {
+    width: (100% / 7);
   }
 }
 

--- a/app/views/directives/_build-pipeline-expanded.html
+++ b/app/views/directives/_build-pipeline-expanded.html
@@ -31,7 +31,7 @@
     <div class="pipeline">
       <div class="pipeline-stage" ng-repeat="stage in jenkinsStatus.stages track by stage.id">
         <div column class="pipeline-stage-column">
-          <div class="pipeline-stage-name" ng-class="build.status.phase">
+          <div title="{{stage.name}}" class="pipeline-stage-name" ng-class="build.status.phase">
             {{stage.name}}
           </div>
           <pipeline-status ng-if="stage.status" status="stage.status"></pipeline-status>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5247,7 +5247,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"pipeline\">\n" +
     "<div class=\"pipeline-stage\" ng-repeat=\"stage in jenkinsStatus.stages track by stage.id\">\n" +
     "<div column class=\"pipeline-stage-column\">\n" +
-    "<div class=\"pipeline-stage-name\" ng-class=\"build.status.phase\">\n" +
+    "<div title=\"{{stage.name}}\" class=\"pipeline-stage-name\" ng-class=\"build.status.phase\">\n" +
     "{{stage.name}}\n" +
     "</div>\n" +
     "<pipeline-status ng-if=\"stage.status\" status=\"stage.status\"></pipeline-status>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4578,12 +4578,16 @@ to{background-color:transparent}
 @media (min-width:600px){.build-links,.build-timestamp{padding-top:0}
 .build-pipeline{-webkit-flex-direction:row;-moz-flex-direction:row;-ms-flex-direction:row;flex-direction:row;display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex}
 .build-pipeline .build-name{white-space:nowrap}
-.build-summary{border-bottom-width:0;border-right:1px solid #d1d1d1;-webkit-flex:0 0 175px;-moz-flex:0 0 175px;-ms-flex:0 0 175px;flex:0 0 175px;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;-webkit-justify-content:center;-moz-justify-content:center;justify-content:center}
+.build-summary{border-bottom-width:0;border-right:1px solid #d1d1d1;-webkit-flex:0 0 125px;-moz-flex:0 0 125px;-ms-flex:0 0 125px;flex:0 0 125px;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;-webkit-justify-content:center;-moz-justify-content:center;justify-content:center}
 }
 .console-os .top-header,.pipeline-status-bar{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex}
-@media (min-width:992px){.pipeline .pipeline-stage{width:33.333333%}
+@media (min-width:992px){.pipeline .pipeline-stage{width:25%}
 }
-@media (min-width:1200px){.pipeline .pipeline-stage{width:25%}
+@media (min-width:1200px){.pipeline .pipeline-stage{width:20%}
+}
+@media (min-width:1400px){.pipeline .pipeline-stage{width:16.66666667%}
+}
+@media (min-width:1600px){.pipeline .pipeline-stage{width:14.28571429%}
 }
 .pipeline-status-bar .clip1:before,.pipeline-status-bar .clip2:before,.pipeline-status-bar .pipeline-line:before{background-color:#d1d1d1}
 .pipeline-status-bar .inner-circle-fill{background-color:#fff;opacity:0}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin-web-console/issues/925

Changes to allow space for more stages to fit inline before wrapping. 

**Current number of stages within single row before wrapping.**

- less than 992px    - 2 stages
- 992px to 1199px  - 3 stages
- more than 1200px - 4 stages

**Proposed number of stages within single row before wrapping.**

- less than 992px - 2 stages
- 992px to 1199px - 4 stages
- 1200px to 1399px - 5 stages
- 1400px to 1599px - 6 stages
- more than 1600px - 7 stages

Stage widths are percentages. The least number of character spaces before the ellipsis is 20 and a `title attribute` is added to stage name and shown on hover.


**4 stages when > 992px**
<img width="807" alt="screen shot 2016-12-02 at 4 38 40 pm" src="https://cloud.githubusercontent.com/assets/1874151/20896785/56efff24-baed-11e6-8903-909535c12965.png">

**5 stages when > 1200px**
<img width="1062" alt="screen shot 2016-12-02 at 4 38 04 pm" src="https://cloud.githubusercontent.com/assets/1874151/20896786/56eff8e4-baed-11e6-9e80-68d1d6d0a472.png">

**6 stages when > 1400px**
<img width="1184" alt="screen shot 2016-12-02 at 4 37 28 pm" src="https://cloud.githubusercontent.com/assets/1874151/20896788/56f3003e-baed-11e6-9c4f-35bb23d882dc.png">

**7 stages when > 1600px**
<img width="1330" alt="screen shot 2016-12-02 at 4 37 08 pm" src="https://cloud.githubusercontent.com/assets/1874151/20896784/56ee23fc-baed-11e6-8087-ae3ca86bd324.png">

