### PR TITLE
Show the same current usage value regardless of time range

### DIFF
--- a/app/scripts/services/metrics.js
+++ b/app/scripts/services/metrics.js
@@ -219,6 +219,34 @@ angular.module("openshiftConsole")
         });
       },
 
+      getCurrentUsage: function(config) {
+        return getRequestURL(config).then(function(url) {
+          if (!url) {
+            return null;
+          }
+
+          // Request one data point for the last minute.
+          var params = {
+            bucketDuration: '1mn',
+            start: '-1mn'
+          };
+
+          return $http.get(url, {
+            auth: {},
+            headers: {
+              Accept: 'application/json',
+              'Hawkular-Tenant': config.namespace
+            },
+            params: params
+          }).then(function(response) {
+            return _.assign(response, {
+              metricID: config.metric,
+              usage: _.head(normalize(response.data))
+            });
+          });
+        });
+      },
+
       // Get metrics data for a collection of pods (memory, CPU, network send and received).
       //
       // config keyword arguments

--- a/dist/scripts/vendor.js
+++ b/dist/scripts/vendor.js
@@ -29499,23 +29499,23 @@ var d = a.sDecimal;
 d && Qa(d);
 }
 function h(a) {
-ob(a, "ordering", "bSort"), ob(a, "orderMulti", "bSortMulti"), ob(a, "orderClasses", "bSortClasses"), ob(a, "orderCellsTop", "bSortCellsTop"), ob(a, "order", "aaSorting"), ob(a, "orderFixed", "aaSortingFixed"), ob(a, "paging", "bPaginate"), ob(a, "pagingType", "sPaginationType"), ob(a, "pageLength", "iDisplayLength"), ob(a, "searching", "bFilter"), "boolean" == typeof a.sScrollX && (a.sScrollX = a.sScrollX ? "100%" :""), "boolean" == typeof a.scrollX && (a.scrollX = a.scrollX ? "100%" :"");
+nb(a, "ordering", "bSort"), nb(a, "orderMulti", "bSortMulti"), nb(a, "orderClasses", "bSortClasses"), nb(a, "orderCellsTop", "bSortCellsTop"), nb(a, "order", "aaSorting"), nb(a, "orderFixed", "aaSortingFixed"), nb(a, "paging", "bPaginate"), nb(a, "pagingType", "sPaginationType"), nb(a, "pageLength", "iDisplayLength"), nb(a, "searching", "bFilter"), "boolean" == typeof a.sScrollX && (a.sScrollX = a.sScrollX ? "100%" :""), "boolean" == typeof a.scrollX && (a.scrollX = a.scrollX ? "100%" :"");
 var b = a.aoSearchCols;
 if (b) for (var c = 0, d = b.length; c < d; c++) b[c] && f(Wa.models.oSearch, b[c]);
 }
 function i(b) {
-ob(b, "orderable", "bSortable"), ob(b, "orderData", "aDataSort"), ob(b, "orderSequence", "asSorting"), ob(b, "orderDataType", "sortDataType");
+nb(b, "orderable", "bSortable"), nb(b, "orderData", "aDataSort"), nb(b, "orderSequence", "asSorting"), nb(b, "orderDataType", "sortDataType");
 var c = b.aDataSort;
 c && !a.isArray(c) && (b.aDataSort = [ c ]);
 }
-function j(b) {
+function j(c) {
 if (!Wa.__browser) {
-var c = {};
-Wa.__browser = c;
-var d = a("<div/>").css({
+var d = {};
+Wa.__browser = d;
+var e = a("<div/>").css({
 position:"fixed",
 top:0,
-left:0,
+left:a(b).scrollLeft() * -1,
 height:1,
 width:1,
 overflow:"hidden"
@@ -29528,10 +29528,10 @@ overflow:"scroll"
 }).append(a("<div/>").css({
 width:"100%",
 height:10
-}))).appendTo("body"), e = d.children(), f = e.children();
-c.barWidth = e[0].offsetWidth - e[0].clientWidth, c.bScrollOversize = 100 === f[0].offsetWidth && 100 !== e[0].clientWidth, c.bScrollbarLeft = 1 !== Math.round(f.offset().left), c.bBounding = !!d[0].getBoundingClientRect().width, d.remove();
+}))).appendTo("body"), f = e.children(), g = f.children();
+d.barWidth = f[0].offsetWidth - f[0].clientWidth, d.bScrollOversize = 100 === g[0].offsetWidth && 100 !== f[0].clientWidth, d.bScrollbarLeft = 1 !== Math.round(g.offset().left), d.bBounding = !!e[0].getBoundingClientRect().width, e.remove();
 }
-a.extend(b.oBrowser, Wa.__browser), b.oScroll.iBarWidth = Wa.__browser.barWidth;
+a.extend(c.oBrowser, Wa.__browser), c.oScroll.iBarWidth = Wa.__browser.barWidth;
 }
 function k(a, b, c, e, f, g) {
 var h, i = e, j = !1;
@@ -29669,7 +29669,7 @@ col:c
 }
 function A(b) {
 return a.map(b.match(/(\\.|[^\.])+/g) || [ "" ], function(a) {
-return a.replace(/\\./g, ".");
+return a.replace(/\\\./g, ".");
 });
 }
 function B(b) {
@@ -29694,13 +29694,13 @@ return a[b];
 var e = function(b, c, f) {
 var g, h, i, j;
 if ("" !== f) for (var k = A(f), l = 0, m = k.length; l < m; l++) {
-if (g = k[l].match(pb), h = k[l].match(qb), g) {
-if (k[l] = k[l].replace(pb, ""), "" !== k[l] && (b = b[k[l]]), i = [], k.splice(0, l + 1), j = k.join("."), a.isArray(b)) for (var n = 0, o = b.length; n < o; n++) i.push(e(b[n], c, j));
+if (g = k[l].match(ob), h = k[l].match(pb), g) {
+if (k[l] = k[l].replace(ob, ""), "" !== k[l] && (b = b[k[l]]), i = [], k.splice(0, l + 1), j = k.join("."), a.isArray(b)) for (var n = 0, o = b.length; n < o; n++) i.push(e(b[n], c, j));
 var p = g[0].substring(1, g[0].length - 1);
 b = "" === p ? i :i.join(p);
 break;
 }
-if (h) k[l] = k[l].replace(qb, ""), b = b[k[l]](); else {
+if (h) k[l] = k[l].replace(pb, ""), b = b[k[l]](); else {
 if (null === b || b[k[l]] === d) return d;
 b = b[k[l]];
 }
@@ -29722,20 +29722,20 @@ a[b] = c;
 };
 var c = function(b, e, f) {
 for (var g, h, i, j, k, l = A(f), m = l[l.length - 1], n = 0, o = l.length - 1; n < o; n++) {
-if (h = l[n].match(pb), i = l[n].match(qb), h) {
-if (l[n] = l[n].replace(pb, ""), b[l[n]] = [], g = l.slice(), g.splice(0, n + 1), k = g.join("."), a.isArray(e)) for (var p = 0, q = e.length; p < q; p++) j = {}, c(j, e[p], k), b[l[n]].push(j); else b[l[n]] = e;
+if (h = l[n].match(ob), i = l[n].match(pb), h) {
+if (l[n] = l[n].replace(ob, ""), b[l[n]] = [], g = l.slice(), g.splice(0, n + 1), k = g.join("."), a.isArray(e)) for (var p = 0, q = e.length; p < q; p++) j = {}, c(j, e[p], k), b[l[n]].push(j); else b[l[n]] = e;
 return;
 }
-i && (l[n] = l[n].replace(qb, ""), b = b[l[n]](e)), null !== b[l[n]] && b[l[n]] !== d || (b[l[n]] = {}), b = b[l[n]];
+i && (l[n] = l[n].replace(pb, ""), b = b[l[n]](e)), null !== b[l[n]] && b[l[n]] !== d || (b[l[n]] = {}), b = b[l[n]];
 }
-m.match(qb) ? b = b[m.replace(qb, "")](e) :b[m.replace(pb, "")] = e;
+m.match(pb) ? b = b[m.replace(pb, "")](e) :b[m.replace(ob, "")] = e;
 };
 return function(a, d) {
 return c(a, d, b);
 };
 }
 function D(a) {
-return ib(a.aoData, "_aData");
+return hb(a.aoData, "_aData");
 }
 function E(a) {
 a.aoData.length = 0, a.aiDisplayMaster.length = 0, a.aiDisplay.length = 0, a.aIds = {};
@@ -29809,7 +29809,7 @@ if (d) {
 var f = b.rowIdFn(e);
 if (f && (d.id = f), e.DT_RowClass) {
 var g = e.DT_RowClass.split(" ");
-c.__rowc = c.__rowc ? nb(c.__rowc.concat(g)) :g, a(d).removeClass(c.__rowc.join(" ")).addClass(e.DT_RowClass);
+c.__rowc = c.__rowc ? mb(c.__rowc.concat(g)) :g, a(d).removeClass(c.__rowc.join(" ")).addClass(e.DT_RowClass);
 }
 e.DT_RowAttr && a(d).attr(e.DT_RowAttr), e.DT_RowData && a(d).data(e.DT_RowData);
 }
@@ -29980,7 +29980,7 @@ name:a,
 value:b
 });
 };
-p("sEcho", b.iDraw), p("iColumns", h), p("sColumns", ib(g, "sName").join(",")), p("iDisplayStart", n), p("iDisplayLength", o);
+p("sEcho", b.iDraw), p("iColumns", h), p("sColumns", hb(g, "sName").join(",")), p("iDisplayStart", n), p("iDisplayLength", o);
 var q = {
 draw:b.iDraw,
 columns:[],
@@ -30041,7 +30041,7 @@ bRegex:g.bRegex,
 bSmart:g.bSmart,
 bCaseInsensitive:g.bCaseInsensitive
 }), b._iDisplayStart = 0, M(b));
-}, m = null !== b.searchDelay ? b.searchDelay :"ssp" === Oa(b) ? 400 :0, n = a("input", k).val(g.sSearch).attr("placeholder", f.sSearchPlaceholder).bind("keyup.DT search.DT input.DT paste.DT cut.DT", m ? vb(l, m) :l).bind("keypress.DT", function(a) {
+}, m = null !== b.searchDelay ? b.searchDelay :"ssp" === Oa(b) ? 400 :0, n = a("input", k).val(g.sSearch).attr("placeholder", f.sSearchPlaceholder).on("keyup.DT search.DT input.DT paste.DT cut.DT", m ? ub(l, m) :l).on("keypress.DT", function(a) {
 if (13 == a.keyCode) return !1;
 }).attr("aria-controls", e);
 return a(b.nTable).on("search.dt.DT", function(a, d) {
@@ -30070,14 +30070,20 @@ f.length = 0, a.merge(f, i);
 }
 }
 function Z(a, b, c, d, e, f) {
-if ("" !== b) for (var g, h = a.aiDisplay, i = _(b, d, e, f), j = h.length - 1; j >= 0; j--) g = a.aoData[h[j]]._aFilterData[c], i.test(g) || h.splice(j, 1);
+if ("" !== b) {
+for (var g, h = [], i = a.aiDisplay, j = _(b, d, e, f), k = 0; k < i.length; k++) g = a.aoData[i[k]]._aFilterData[c], j.test(g) && h.push(i[k]);
+a.aiDisplay = h;
+}
 }
 function $(a, b, c, d, e, f) {
-var g, h, i, j = _(b, d, e, f), k = a.oPreviousSearch.sSearch, l = a.aiDisplayMaster;
-if (0 !== Wa.ext.search.length && (c = !0), h = aa(a), b.length <= 0) a.aiDisplay = l.slice(); else for ((h || c || k.length > b.length || 0 !== b.indexOf(k) || a.bSorted) && (a.aiDisplay = l.slice()), g = a.aiDisplay, i = g.length - 1; i >= 0; i--) j.test(a.aoData[g[i]]._sFilterRow) || g.splice(i, 1);
+var g, h, i, j = _(b, d, e, f), k = a.oPreviousSearch.sSearch, l = a.aiDisplayMaster, m = [];
+if (0 !== Wa.ext.search.length && (c = !0), h = aa(a), b.length <= 0) a.aiDisplay = l.slice(); else {
+for ((h || c || k.length > b.length || 0 !== b.indexOf(k) || a.bSorted) && (a.aiDisplay = l.slice()), g = a.aiDisplay, i = 0; i < g.length; i++) j.test(a.aoData[g[i]]._sFilterRow) && m.push(g[i]);
+a.aiDisplay = m;
+}
 }
 function _(b, c, d, e) {
-if (b = c ? b :rb(b), d) {
+if (b = c ? b :qb(b), d) {
 var f = a.map(b.match(/"[^"]+"|[^ ]+/g) || [ "" ], function(a) {
 if ('"' === a.charAt(0)) {
 var b = a.match(/^"(.*)"$/);
@@ -30092,7 +30098,7 @@ return new RegExp(b, e ? "i" :"");
 function aa(a) {
 var b, c, d, e, f, g, h, i, j = a.aoColumns, k = Wa.ext.type.search, l = !1;
 for (c = 0, e = a.aoData.length; c < e; c++) if (i = a.aoData[c], !i._aFilterData) {
-for (g = [], d = 0, f = j.length; d < f; d++) b = j[d], b.bSearchable ? (h = y(a, c, d, "filter"), k[b.sType] && (h = k[b.sType](h)), null === h && (h = ""), "string" != typeof h && h.toString && (h = h.toString())) :h = "", h.indexOf && h.indexOf("&") !== -1 && (sb.innerHTML = h, h = tb ? sb.textContent :sb.innerText), h.replace && (h = h.replace(/[\r\n]/g, "")), g.push(h);
+for (g = [], d = 0, f = j.length; d < f; d++) b = j[d], b.bSearchable ? (h = y(a, c, d, "filter"), k[b.sType] && (h = k[b.sType](h)), null === h && (h = ""), "string" != typeof h && h.toString && (h = h.toString())) :h = "", h.indexOf && h.indexOf("&") !== -1 && (rb.innerHTML = h, h = sb ? rb.textContent :rb.innerText), h.replace && (h = h.replace(/[\r\n]/g, "")), g.push(h);
 i._aFilterData = g, i._sFilterRow = g.join("  "), l = !0;
 }
 return l;
@@ -30164,9 +30170,9 @@ name:d + "_length",
 "class":c.sLengthSelect
 }), j = 0, k = g.length; j < k; j++) i[0][j] = new Option(h[j], g[j]);
 var l = a("<div><label/></div>").addClass(c.sLength);
-return b.aanFeatures.l || (l[0].id = d + "_length"), l.children().append(b.oLanguage.sLengthMenu.replace("_MENU_", i[0].outerHTML)), a("select", l).val(b._iDisplayLength).bind("change.DT", function(c) {
+return b.aanFeatures.l || (l[0].id = d + "_length"), l.children().append(b.oLanguage.sLengthMenu.replace("_MENU_", i[0].outerHTML)), a("select", l).val(b._iDisplayLength).on("change.DT", function(c) {
 ia(b, a(this).val()), M(b);
-}), a(b.nTable).bind("length.dt.DT", function(c, d, e) {
+}), a(b.nTable).on("length.dt.DT", function(c, d, e) {
 b === d && a("select", l).val(e);
 }), l[0];
 }
@@ -30248,7 +30254,7 @@ sName:"scrolling"
 }), o[0];
 }
 function pa(b) {
-var c, e, f, g, h, i, j, k, l, m = b.oScroll, p = m.sX, q = m.sXInner, r = m.sY, s = m.iBarWidth, t = a(b.nScrollHead), u = t[0].style, v = t.children("div"), w = v[0].style, x = v.children("table"), y = b.nScrollBody, z = a(y), A = y.style, B = a(b.nScrollFoot), C = B.children("div"), D = C.children("table"), E = a(b.nTHead), F = a(b.nTable), G = F[0], H = G.style, I = b.nTFoot ? a(b.nTFoot) :null, J = b.oBrowser, K = J.bScrollOversize, L = ib(b.aoColumns, "nTh"), M = [], N = [], O = [], P = [], R = function(a) {
+var c, e, f, g, h, i, j, k, l, m = b.oScroll, p = m.sX, q = m.sXInner, r = m.sY, s = m.iBarWidth, t = a(b.nScrollHead), u = t[0].style, v = t.children("div"), w = v[0].style, x = v.children("table"), y = b.nScrollBody, z = a(y), A = y.style, B = a(b.nScrollFoot), C = B.children("div"), D = C.children("table"), E = a(b.nTHead), F = a(b.nTable), G = F[0], H = G.style, I = b.nTFoot ? a(b.nTFoot) :null, J = b.oBrowser, K = J.bScrollOversize, L = hb(b.aoColumns, "nTh"), M = [], N = [], O = [], P = [], R = function(a) {
 var b = a.style;
 b.paddingTop = "0", b.paddingBottom = "0", b.borderTopWidth = "0", b.borderBottomWidth = "0", b.height = 0;
 }, S = y.scrollHeight > y.clientHeight;
@@ -30318,7 +30324,7 @@ g.style.width = va(D), C.remove();
 }
 if (t && (g.style.width = va(t)), (t || k) && !c._reszEvt) {
 var H = function() {
-a(b).bind("resize.DT-" + c.sInstance, vb(function() {
+a(b).on("resize.DT-" + c.sInstance, ub(function() {
 n(c);
 }));
 };
@@ -30337,7 +30343,7 @@ var e = b.aoData[d];
 return e.nTr ? e.anCells[c] :a("<td/>").html(y(b, d, c, "display"))[0];
 }
 function ua(a, b) {
-for (var c, d = -1, e = -1, f = 0, g = a.aoData.length; f < g; f++) c = y(a, f, b, "display") + "", c = c.replace(ub, ""), c = c.replace(/&nbsp;/g, " "), c.length > d && (d = c.length, e = f);
+for (var c, d = -1, e = -1, f = 0, g = a.aoData.length; f < g; f++) c = y(a, f, b, "display") + "", c = c.replace(tb, ""), c = c.replace(/&nbsp;/g, " "), c.length > d && (d = c.length, e = f);
 return e;
 }
 function va(a) {
@@ -30386,7 +30392,7 @@ var e = b._idx;
 return e === d && (e = a.inArray(b[1], j)), e + 1 < j.length ? e + 1 :c ? null :0;
 };
 if ("number" == typeof i[0] && (i = b.aaSorting = [ i ]), e && b.oFeatures.bSortMulti) {
-var l = a.inArray(c, ib(i, "0"));
+var l = a.inArray(c, hb(i, "0"));
 l !== -1 ? (g = k(i[l], !0), null === g && 1 === i.length && (g = 0), null === g ? i.splice(l, 1) :(i[l][1] = j[g], i[l]._idx = g)) :(i.push([ c, j[0], 0 ]), i[i.length - 1]._idx = 0);
 } else i.length && i[0][0] == c ? (g = k(i[0]), i.length = 1, i[0][1] = j[g], i[0]._idx = g) :(i.length = 0, i.push([ c, j[0] ]), i[0]._idx = 0);
 N(b), "function" == typeof f && f(b);
@@ -30402,8 +30408,8 @@ za(a, c, b.shiftKey, d), "ssp" !== Oa(a) && na(a, !1);
 function Ba(b) {
 var c, d, e, f = b.aLastSort, g = b.oClasses.sSortColumn, h = wa(b), i = b.oFeatures;
 if (i.bSort && i.bSortClasses) {
-for (c = 0, d = f.length; c < d; c++) e = f[c].src, a(ib(b.aoData, "anCells", e)).removeClass(g + (c < 2 ? c + 1 :3));
-for (c = 0, d = h.length; c < d; c++) e = h[c].src, a(ib(b.aoData, "anCells", e)).addClass(g + (c < 2 ? c + 1 :3));
+for (c = 0, d = f.length; c < d; c++) e = f[c].src, a(hb(b.aoData, "anCells", e)).removeClass(g + (c < 2 ? c + 1 :3));
+for (c = 0, d = h.length; c < d; c++) e = h[c].src, a(hb(b.aoData, "anCells", e)).addClass(g + (c < 2 ? c + 1 :3));
 }
 b.aLastSort = h;
 }
@@ -30430,29 +30436,28 @@ search:ba(b.aoPreSearchCols[c])
 La(b, "aoStateSaveParams", "stateSaveParams", [ b, c ]), b.oSavedState = c, b.fnStateSaveCallback.call(b.oInstance, b, c);
 }
 }
-function Ea(b, c) {
-var e, f, g = b.aoColumns;
-if (b.oFeatures.bStateSave) {
-var h = b.fnStateLoadCallback.call(b.oInstance, b);
-if (h && h.time) {
-var i = La(b, "aoStateLoadParams", "stateLoadParams", [ b, h ]);
-if (a.inArray(!1, i) === -1) {
-var j = b.iStateDuration;
-if (!(j > 0 && h.time < +new Date() - 1e3 * j) && g.length === h.columns.length) {
-for (b.oLoadedState = a.extend(!0, {}, h), h.start !== d && (b._iDisplayStart = h.start, b.iInitDisplayStart = h.start), h.length !== d && (b._iDisplayLength = h.length), h.order !== d && (b.aaSorting = [], a.each(h.order, function(a, c) {
-b.aaSorting.push(c[0] >= g.length ? [ 0, c[1] ] :c);
-})), h.search !== d && a.extend(b.oPreviousSearch, ca(h.search)), e = 0, f = h.columns.length; e < f; e++) {
-var k = h.columns[e];
-k.visible !== d && (g[e].bVisible = k.visible), k.search !== d && a.extend(b.aoPreSearchCols[e], ca(k.search));
+function Ea(b, c, e) {
+var f, g, h = b.aoColumns, i = function(c) {
+if (!c || !c.time) return void e();
+var i = La(b, "aoStateLoadParams", "stateLoadParams", [ b, j ]);
+if (a.inArray(!1, i) !== -1) return void e();
+var k = b.iStateDuration;
+if (k > 0 && c.time < +new Date() - 1e3 * k) return void e();
+if (c.columns && h.length !== c.columns.length) return void e();
+if (b.oLoadedState = a.extend(!0, {}, j), c.start !== d && (b._iDisplayStart = c.start, b.iInitDisplayStart = c.start), c.length !== d && (b._iDisplayLength = c.length), c.order !== d && (b.aaSorting = [], a.each(c.order, function(a, c) {
+b.aaSorting.push(c[0] >= h.length ? [ 0, c[1] ] :c);
+})), c.search !== d && a.extend(b.oPreviousSearch, ca(c.search)), c.columns) for (f = 0, g = c.columns.length; f < g; f++) {
+var l = c.columns[f];
+l.visible !== d && (h[f].bVisible = l.visible), l.search !== d && a.extend(b.aoPreSearchCols[f], ca(l.search));
 }
-La(b, "aoStateLoaded", "stateLoaded", [ b, h ]);
-}
-}
-}
-}
+La(b, "aoStateLoaded", "stateLoaded", [ b, j ]), e();
+};
+if (!b.oFeatures.bStateSave) return void e();
+var j = b.fnStateLoadCallback.call(b.oInstance, b, i);
+j !== d && i(j);
 }
 function Fa(b) {
-var c = Wa.settings, d = a.inArray(b, ib(c, "nTable"));
+var c = Wa.settings, d = a.inArray(b, hb(c, "nTable"));
 return d !== -1 ? c[d] :null;
 }
 function Ga(a, c, d, e) {
@@ -30475,11 +30480,11 @@ for (var f in c) c.hasOwnProperty(f) && (e = c[f], a.isPlainObject(e) ? (a.isPla
 return b;
 }
 function Ja(b, c, d) {
-a(b).bind("click.DT", c, function(a) {
+a(b).on("click.DT", c, function(a) {
 b.blur(), d(a);
-}).bind("keypress.DT", c, function(a) {
+}).on("keypress.DT", c, function(a) {
 13 === a.which && (a.preventDefault(), d(a));
-}).bind("selectstart.DT", function() {
+}).on("selectstart.DT", function() {
 return !1;
 });
 }
@@ -30511,22 +30516,22 @@ function Oa(a) {
 return a.oFeatures.bServerSide ? "ssp" :a.ajax || a.sAjaxSource ? "ajax" :"dom";
 }
 function Pa(a, b) {
-var c = [], d = Sb.numbers_length, e = Math.floor(d / 2);
-return b <= d ? c = kb(0, b) :a <= e ? (c = kb(0, d - 2), c.push("ellipsis"), c.push(b - 1)) :a >= b - 1 - e ? (c = kb(b - (d - 2), b), c.splice(0, 0, "ellipsis"), c.splice(0, 0, 0)) :(c = kb(a - e + 2, a + e - 1), c.push("ellipsis"), c.push(b - 1), c.splice(0, 0, "ellipsis"), c.splice(0, 0, 0)), c.DT_el = "span", c;
+var c = [], d = Rb.numbers_length, e = Math.floor(d / 2);
+return b <= d ? c = jb(0, b) :a <= e ? (c = jb(0, d - 2), c.push("ellipsis"), c.push(b - 1)) :a >= b - 1 - e ? (c = jb(b - (d - 2), b), c.splice(0, 0, "ellipsis"), c.splice(0, 0, 0)) :(c = jb(a - e + 2, a + e - 1), c.push("ellipsis"), c.push(b - 1), c.splice(0, 0, "ellipsis"), c.splice(0, 0, 0)), c.DT_el = "span", c;
 }
 function Qa(b) {
 a.each({
 num:function(a) {
-return Tb(a, b);
+return Sb(a, b);
 },
 "num-fmt":function(a) {
-return Tb(a, b, bb);
+return Sb(a, b, ab);
 },
 "html-num":function(a) {
-return Tb(a, b, Za);
+return Sb(a, b, Za);
 },
 "html-num-fmt":function(a) {
-return Tb(a, b, Za, bb);
+return Sb(a, b, Za, ab);
 }
 }, function(a, c) {
 Sa.type.order[a + b + "-pre"] = c, a.match(/^html\-/) && (Sa.type.search[a + b] = Sa.type.search.html);
@@ -30643,7 +30648,7 @@ var F = a.isArray(p.iDeferLoading);
 D._iRecordsDisplay = F ? p.iDeferLoading[0] :p.iDeferLoading, D._iRecordsTotal = F ? p.iDeferLoading[1] :p.iDeferLoading;
 }
 var G = D.oLanguage;
-a.extend(!0, G, p.oLanguage), "" !== G.sUrl && (a.ajax({
+a.extend(!0, G, p.oLanguage), G.sUrl && (a.ajax({
 dataType:"json",
 url:G.sUrl,
 success:function(b) {
@@ -30679,10 +30684,10 @@ filter:null !== f ? a + ".@data-" + f :d
 }
 });
 }
-var N = D.oFeatures;
-if (p.bStateSave && (N.bStateSave = !0, Ea(D, p), Ka(D, "aoDrawCallback", Da, "state_save")), p.aaSorting === d) {
-var O = D.aaSorting;
-for (q = 0, n = O.length; q < n; q++) O[q][1] = D.aoColumns[q].asSorting[0];
+var N = D.oFeatures, O = function() {
+if (p.aaSorting === d) {
+var b = D.aaSorting;
+for (q = 0, n = b.length; q < n; q++) b[q][1] = D.aoColumns[q].asSorting[0];
 }
 Ba(D), N.bSort && Ka(D, "aoDrawCallback", function() {
 if (D.bSorted) {
@@ -30694,51 +30699,53 @@ c[b.src] = b.dir;
 }), Ka(D, "aoDrawCallback", function() {
 (D.bSorted || "ssp" === Oa(D) || N.bDeferRender) && Ba(D);
 }, "sc");
-var R = x.children("caption").each(function() {
-this._captionSide = x.css("caption-side");
-}), S = x.children("thead");
-0 === S.length && (S = a("<thead/>").appendTo(this)), D.nTHead = S[0];
-var T = x.children("tbody");
-0 === T.length && (T = a("<tbody/>").appendTo(this)), D.nTBody = T[0];
-var U = x.children("tfoot");
-if (0 === U.length && R.length > 0 && ("" !== D.oScroll.sX || "" !== D.oScroll.sY) && (U = a("<tfoot/>").appendTo(this)), 0 === U.length || 0 === U.children().length ? x.addClass(E.sNoFooter) :U.length > 0 && (D.nTFoot = U[0], P(D.aoFooter, D.nTFoot)), p.aaData) for (q = 0; q < p.aaData.length; q++) u(D, p.aaData[q]); else (D.bDeferLoading || "dom" == Oa(D)) && v(D, a(D.nTBody).children("tr"));
+var c = x.children("caption").each(function() {
+this._captionSide = a(this).css("caption-side");
+}), e = x.children("thead");
+0 === e.length && (e = a("<thead/>").appendTo(x)), D.nTHead = e[0];
+var f = x.children("tbody");
+0 === f.length && (f = a("<tbody/>").appendTo(x)), D.nTBody = f[0];
+var g = x.children("tfoot");
+if (0 === g.length && c.length > 0 && ("" !== D.oScroll.sX || "" !== D.oScroll.sY) && (g = a("<tfoot/>").appendTo(x)), 0 === g.length || 0 === g.children().length ? x.addClass(E.sNoFooter) :g.length > 0 && (D.nTFoot = g[0], P(D.aoFooter, D.nTFoot)), p.aaData) for (q = 0; q < p.aaData.length; q++) u(D, p.aaData[q]); else (D.bDeferLoading || "dom" == Oa(D)) && v(D, a(D.nTBody).children("tr"));
 D.aiDisplay = D.aiDisplayMaster.slice(), D.bInitialised = !0, s === !1 && ga(D);
+};
+p.bStateSave ? (N.bStateSave = !0, Ka(D, "aoDrawCallback", Da, "state_save"), Ea(D, p, O)) :O();
 }), c = null, this;
-}, Xa = {}, Ya = /[\r\n]/g, Za = /<.*?>/g, $a = /^[\w\+\-]/, _a = /[\w\+\-]$/, ab = new RegExp("(\\" + [ "/", ".", "*", "+", "?", "|", "(", ")", "[", "]", "{", "}", "\\", "$", "^", "-" ].join("|\\") + ")", "g"), bb = /[',$£€¥%\u2009\u202F\u20BD\u20a9\u20BArfk]/gi, cb = function(a) {
+}, Xa = {}, Ya = /[\r\n]/g, Za = /<.*?>/g, $a = /^\d{2,4}[\.\/\-]\d{1,2}[\.\/\-]\d{1,2}([T ]{1}\d{1,2}[:\.]\d{2}([\.:]\d{2})?)?$/, _a = new RegExp("(\\" + [ "/", ".", "*", "+", "?", "|", "(", ")", "[", "]", "{", "}", "\\", "$", "^", "-" ].join("|\\") + ")", "g"), ab = /[',$£€¥%\u2009\u202F\u20BD\u20a9\u20BArfk]/gi, bb = function(a) {
 return !a || a === !0 || "-" === a;
-}, db = function(a) {
+}, cb = function(a) {
 var b = parseInt(a, 10);
 return !isNaN(b) && isFinite(a) ? b :null;
-}, eb = function(a, b) {
-return Xa[b] || (Xa[b] = new RegExp(rb(b), "g")), "string" == typeof a && "." !== b ? a.replace(/\./g, "").replace(Xa[b], ".") :a;
-}, fb = function(a, b, c) {
+}, db = function(a, b) {
+return Xa[b] || (Xa[b] = new RegExp(qb(b), "g")), "string" == typeof a && "." !== b ? a.replace(/\./g, "").replace(Xa[b], ".") :a;
+}, eb = function(a, b, c) {
 var d = "string" == typeof a;
-return !!cb(a) || (b && d && (a = eb(a, b)), c && d && (a = a.replace(bb, "")), !isNaN(parseFloat(a)) && isFinite(a));
-}, gb = function(a) {
-return cb(a) || "string" == typeof a;
+return !!bb(a) || (b && d && (a = db(a, b)), c && d && (a = a.replace(ab, "")), !isNaN(parseFloat(a)) && isFinite(a));
+}, fb = function(a) {
+return bb(a) || "string" == typeof a;
+}, gb = function(a, b, c) {
+if (bb(a)) return !0;
+var d = fb(a);
+return d ? !!eb(lb(a), b, c) || null :null;
 }, hb = function(a, b, c) {
-if (cb(a)) return !0;
-var d = gb(a);
-return d ? !!fb(mb(a), b, c) || null :null;
-}, ib = function(a, b, c) {
 var e = [], f = 0, g = a.length;
 if (c !== d) for (;f < g; f++) a[f] && a[f][b] && e.push(a[f][b][c]); else for (;f < g; f++) a[f] && e.push(a[f][b]);
 return e;
-}, jb = function(a, b, c, e) {
+}, ib = function(a, b, c, e) {
 var f = [], g = 0, h = b.length;
 if (e !== d) for (;g < h; g++) a[b[g]][c] && f.push(a[b[g]][c][e]); else for (;g < h; g++) f.push(a[b[g]][c]);
 return f;
-}, kb = function(a, b) {
+}, jb = function(a, b) {
 var c, e = [];
 b === d ? (b = 0, c = a) :(c = b, b = a);
 for (var f = b; f < c; f++) e.push(f);
 return e;
-}, lb = function(a) {
+}, kb = function(a) {
 for (var b = [], c = 0, d = a.length; c < d; c++) a[c] && b.push(a[c]);
 return b;
-}, mb = function(a) {
+}, lb = function(a) {
 return a.replace(Za, "");
-}, nb = function(a) {
+}, mb = function(a) {
 var b, c, d, e = [], f = a.length, g = 0;
 a:for (c = 0; c < f; c++) {
 for (b = a[c], d = 0; d < g; d++) if (e[d] === b) continue a;
@@ -30757,12 +30764,12 @@ c = d, a.apply(b, h);
 };
 },
 escapeRegex:function(a) {
-return a.replace(ab, "\\$1");
+return a.replace(_a, "\\$1");
 }
 };
-var ob = function(a, b, c) {
+var nb = function(a, b, c) {
 a[b] !== d && (a[c] = a[b]);
-}, pb = /\[.*?\]$/, qb = /\(\)$/, rb = Wa.util.escapeRegex, sb = a("<div>")[0], tb = sb.textContent !== d, ub = /<.*?>/g, vb = Wa.util.throttle, wb = [], xb = Array.prototype, yb = function(b) {
+}, ob = /\[.*?\]$/, pb = /\(\)$/, qb = Wa.util.escapeRegex, rb = a("<div>")[0], sb = rb.textContent !== d, tb = /<.*?>/g, ub = Wa.util.throttle, vb = [], wb = Array.prototype, xb = function(b) {
 var c, d, e = Wa.settings, f = a.map(e, function(a, b) {
 return a.nTable;
 });
@@ -30773,20 +30780,20 @@ return c = a.inArray(this, f), c !== -1 ? e[c] :null;
 Ta = function(b, c) {
 if (!(this instanceof Ta)) return new Ta(b, c);
 var d = [], e = function(a) {
-var b = yb(a);
+var b = xb(a);
 b && (d = d.concat(b));
 };
 if (a.isArray(b)) for (var f = 0, g = b.length; f < g; f++) e(b[f]); else e(b);
-this.context = nb(d), c && a.merge(this, c), this.selector = {
+this.context = mb(d), c && a.merge(this, c), this.selector = {
 rows:null,
 cols:null,
 opts:null
-}, Ta.extend(this, this, wb);
+}, Ta.extend(this, this, vb);
 }, Wa.Api = Ta, a.extend(Ta.prototype, {
 any:function() {
 return 0 !== this.count();
 },
-concat:xb.concat,
+concat:wb.concat,
 context:[],
 count:function() {
 return this.flatten().length;
@@ -30801,15 +30808,15 @@ return b.length > a ? new Ta(b[a], this[a]) :null;
 },
 filter:function(a) {
 var b = [];
-if (xb.filter) b = xb.filter.call(this, a, this); else for (var c = 0, d = this.length; c < d; c++) a.call(this, this[c], c, this) && b.push(this[c]);
+if (wb.filter) b = wb.filter.call(this, a, this); else for (var c = 0, d = this.length; c < d; c++) a.call(this, this[c], c, this) && b.push(this[c]);
 return new Ta(this.context, b);
 },
 flatten:function() {
 var a = [];
 return new Ta(this.context, a.concat.apply(a, this.toArray()));
 },
-join:xb.join,
-indexOf:xb.indexOf || function(a, b) {
+join:wb.join,
+indexOf:wb.indexOf || function(a, b) {
 for (var c = b || 0, d = this.length; c < d; c++) if (this[c] === a) return c;
 return -1;
 },
@@ -30817,7 +30824,7 @@ iterator:function(a, b, c, e) {
 var f, g, h, i, j, k, l, m, n = [], o = this.context, p = this.selector;
 for ("string" == typeof a && (e = c, c = b, b = a, a = !1), g = 0, h = o.length; g < h; g++) {
 var q = new Ta(o[g]);
-if ("table" === b) f = c.call(q, o[g], g), f !== d && n.push(f); else if ("columns" === b || "rows" === b) f = c.call(q, o[g], this[g], g), f !== d && n.push(f); else if ("column" === b || "column-rows" === b || "row" === b || "cell" === b) for (l = this[g], "column-rows" === b && (k = Eb(o[g], p.opts)), i = 0, j = l.length; i < j; i++) m = l[i], f = "cell" === b ? c.call(q, o[g], m.row, m.column, g, i) :c.call(q, o[g], m, g, i, k), f !== d && n.push(f);
+if ("table" === b) f = c.call(q, o[g], g), f !== d && n.push(f); else if ("columns" === b || "rows" === b) f = c.call(q, o[g], this[g], g), f !== d && n.push(f); else if ("column" === b || "column-rows" === b || "row" === b || "cell" === b) for (l = this[g], "column-rows" === b && (k = Db(o[g], p.opts)), i = 0, j = l.length; i < j; i++) m = l[i], f = "cell" === b ? c.call(q, o[g], m.row, m.column, g, i) :c.call(q, o[g], m, g, i, k), f !== d && n.push(f);
 }
 if (n.length || e) {
 var r = new Ta(o, a ? n.concat.apply([], n) :n), s = r.selector;
@@ -30825,13 +30832,13 @@ return s.rows = p.rows, s.cols = p.cols, s.opts = p.opts, r;
 }
 return this;
 },
-lastIndexOf:xb.lastIndexOf || function(a, b) {
+lastIndexOf:wb.lastIndexOf || function(a, b) {
 return this.indexOf.apply(this.toArray.reverse(), arguments);
 },
 length:0,
 map:function(a) {
 var b = [];
-if (xb.map) b = xb.map.call(this, a, this); else for (var c = 0, d = this.length; c < d; c++) b.push(a.call(this, this[c], c));
+if (wb.map) b = wb.map.call(this, a, this); else for (var c = 0, d = this.length; c < d; c++) b.push(a.call(this, this[c], c));
 return new Ta(this.context, b);
 },
 pluck:function(a) {
@@ -30839,21 +30846,21 @@ return this.map(function(b) {
 return b[a];
 });
 },
-pop:xb.pop,
-push:xb.push,
-reduce:xb.reduce || function(a, b) {
+pop:wb.pop,
+push:wb.push,
+reduce:wb.reduce || function(a, b) {
 return k(this, a, b, 0, this.length, 1);
 },
-reduceRight:xb.reduceRight || function(a, b) {
+reduceRight:wb.reduceRight || function(a, b) {
 return k(this, a, b, this.length - 1, -1, -1);
 },
-reverse:xb.reverse,
+reverse:wb.reverse,
 selector:null,
-shift:xb.shift,
-sort:xb.sort,
-splice:xb.splice,
+shift:wb.shift,
+sort:wb.sort,
+splice:wb.splice,
 toArray:function() {
-return xb.slice.call(this);
+return wb.slice.call(this);
 },
 to$:function() {
 return a(this);
@@ -30862,9 +30869,9 @@ toJQuery:function() {
 return a(this);
 },
 unique:function() {
-return new Ta(this.context, nb(this));
+return new Ta(this.context, mb(this));
 },
-unshift:xb.unshift
+unshift:wb.unshift
 }), Ta.extend = function(b, c, d) {
 if (d.length && c && (c instanceof Ta || c.__dt_wrapper)) {
 var e, f, g, h = function(a, b, c) {
@@ -30877,7 +30884,7 @@ for (e = 0, f = d.length; e < f; e++) g = d[e], c[g.name] = "function" == typeof
 }
 }, Ta.register = Ua = function(b, c) {
 if (a.isArray(b)) for (var d = 0, e = b.length; d < e; d++) Ta.register(b[d], c); else {
-var f, g, h, i, j = b.split("."), k = wb, l = function(a, b) {
+var f, g, h, i, j = b.split("."), k = vb, l = function(a, b) {
 for (var c = 0, d = a.length; c < d; c++) if (a[c].name === b) return a[c];
 return null;
 };
@@ -30898,7 +30905,7 @@ var b = e.apply(this, arguments);
 return b === this ? this :b instanceof Ta ? b.length ? a.isArray(b[0]) ? new Ta(b.context, b[0]) :b[0] :d :b;
 });
 };
-var zb = function(b, c) {
+var yb = function(b, c) {
 if ("number" == typeof b) return [ c[b] ];
 var d = a.map(c, function(a, b) {
 return a.nTable;
@@ -30909,7 +30916,7 @@ return c[e];
 }).toArray();
 };
 Ua("tables()", function(a) {
-return a ? new Ta(zb(a, this.context)) :this;
+return a ? new Ta(yb(a, this.context)) :this;
 }), Ua("table()", function(a) {
 var b = this.tables(a), c = b.context;
 return c.length ? new Ta(c[0]) :b;
@@ -30959,7 +30966,7 @@ return a === d ? 0 !== this.context.length ? this.context[0]._iDisplayLength :d 
 ia(b, a);
 });
 });
-var Ab = function(a, b, c) {
+var zb = function(a, b, c) {
 if (c) {
 var d = new Ta(a);
 d.one("draw", function() {
@@ -30984,7 +30991,7 @@ var a = this.context;
 if (a.length > 0) return a[0].oAjaxData;
 }), Ua("ajax.reload()", function(a, b) {
 return this.iterator("table", function(c) {
-Ab(c, b === !1, a);
+zb(c, b === !1, a);
 });
 }), Ua("ajax.url()", function(b) {
 var c = this.context;
@@ -30993,43 +31000,42 @@ a.isPlainObject(c.ajax) ? c.ajax.url = b :c.ajax = b;
 });
 }), Ua("ajax.url().load()", function(a, b) {
 return this.iterator("table", function(c) {
-Ab(c, b === !1, a);
+zb(c, b === !1, a);
 });
 });
-var Bb = function(b, c, e, f, g) {
+var Ab = function(b, c, e, f, g) {
 var h, i, j, k, l, m, n = [], o = typeof c;
-for (c && "string" !== o && "function" !== o && c.length !== d || (c = [ c ]), j = 0, k = c.length; j < k; j++) for (i = c[j] && c[j].split ? c[j].split(",") :[ c[j] ], l = 0, m = i.length; l < m; l++) h = e("string" == typeof i[l] ? a.trim(i[l]) :i[l]), h && h.length && (n = n.concat(h));
+for (c && "string" !== o && "function" !== o && c.length !== d || (c = [ c ]), j = 0, k = c.length; j < k; j++) for (i = c[j] && c[j].split && !c[j].match(/[\[\(:]/) ? c[j].split(",") :[ c[j] ], l = 0, m = i.length; l < m; l++) h = e("string" == typeof i[l] ? a.trim(i[l]) :i[l]), h && h.length && (n = n.concat(h));
 var p = Sa.selector[b];
 if (p.length) for (j = 0, k = p.length; j < k; j++) n = p[j](f, g, n);
-return nb(n);
-}, Cb = function(b) {
+return mb(n);
+}, Bb = function(b) {
 return b || (b = {}), b.filter && b.search === d && (b.search = b.filter), a.extend({
 search:"none",
 order:"current",
 page:"all"
 }, b);
-}, Db = function(a) {
+}, Cb = function(a) {
 for (var b = 0, c = a.length; b < c; b++) if (a[b].length > 0) return a[0] = a[b], a[0].length = 1, a.length = 1, a.context = [ a.context[b] ], a;
 return a.length = 0, a;
-}, Eb = function(b, c) {
+}, Db = function(b, c) {
 var d, e, f, g = [], h = b.aiDisplay, i = b.aiDisplayMaster, j = c.search, k = c.order, l = c.page;
-if ("ssp" == Oa(b)) return "removed" === j ? [] :kb(0, i.length);
+if ("ssp" == Oa(b)) return "removed" === j ? [] :jb(0, i.length);
 if ("current" == l) for (d = b._iDisplayStart, e = b.fnDisplayEnd(); d < e; d++) g.push(h[d]); else if ("current" == k || "applied" == k) g = "none" == j ? i.slice() :"applied" == j ? h.slice() :a.map(i, function(b, c) {
 return a.inArray(b, h) === -1 ? b :null;
 }); else if ("index" == k || "original" == k) for (d = 0, e = b.aoData.length; d < e; d++) "none" == j ? g.push(d) :(f = a.inArray(d, h), (f === -1 && "removed" == j || f >= 0 && "applied" == j) && g.push(d));
 return g;
-}, Fb = function(b, c, e) {
-var f = function(c) {
-var f = db(c);
-if (null !== f && !e) return [ f ];
-var g = Eb(b, e);
-if (null !== f && a.inArray(f, g) !== -1) return [ f ];
-if (!c) return g;
-if ("function" == typeof c) return a.map(g, function(a) {
+}, Eb = function(b, c, e) {
+var f, g = function(c) {
+var g = cb(c);
+if (null !== g && !e) return [ g ];
+if (f || (f = Db(b, e)), null !== g && a.inArray(g, f) !== -1) return [ g ];
+if (null === c || c === d || "" === c) return f;
+if ("function" == typeof c) return a.map(f, function(a) {
 var d = b.aoData[a];
 return c(a, d._aData, d.nTr) ? a :null;
 });
-var h = lb(jb(b.aoData, g, "nTr"));
+var h = kb(ib(b.aoData, f, "nTr"));
 if (c.nodeName) {
 if (c._DT_RowIndex !== d) return [ c._DT_RowIndex ];
 if (c._DT_CellIndex) return [ c._DT_CellIndex.row ];
@@ -31044,12 +31050,12 @@ return a(h).filter(c).map(function() {
 return this._DT_RowIndex;
 }).toArray();
 };
-return Bb("row", c, f, b, e);
+return Ab("row", c, g, b, e);
 };
 Ua("rows()", function(b, c) {
-b === d ? b = "" :a.isPlainObject(b) && (c = b, b = ""), c = Cb(c);
+b === d ? b = "" :a.isPlainObject(b) && (c = b, b = ""), c = Bb(c);
 var e = this.iterator("table", function(a) {
-return Fb(a, b, c);
+return Eb(a, b, c);
 }, 1);
 return e.selector.rows = b, e.selector.opts = c, e;
 }), Ua("rows().nodes()", function() {
@@ -31058,7 +31064,7 @@ return a.aoData[b].nTr || d;
 }, 1);
 }), Ua("rows().data()", function() {
 return this.iterator(!0, "rows", function(a, b) {
-return jb(a.aoData, b, "_aData");
+return ib(a.aoData, b, "_aData");
 }, 1);
 }), Va("rows().cache()", "row().cache()", function(a) {
 return this.iterator("row", function(b, c) {
@@ -31098,7 +31104,7 @@ return f;
 }, 1), d = this.rows(-1);
 return d.pop(), a.merge(d, c), d;
 }), Ua("row()", function(a, b) {
-return Db(this.rows(a, b));
+return Cb(this.rows(a, b));
 }), Ua("row().data()", function(a) {
 var b = this.context;
 return a === d ? b.length && this.length ? b[0].aoData[this[0]]._aData :d :(b[0].aoData[this[0]]._aData = a, G(b[0], this[0], "data"), this);
@@ -31112,29 +31118,29 @@ return b.nodeName && "TR" === b.nodeName.toUpperCase() ? v(a, b)[0] :u(a, b);
 });
 return this.row(c[0]);
 });
-var Gb = function(b, c, d, e) {
+var Fb = function(b, c, d, e) {
 var f = [], g = function(c, d) {
 if (a.isArray(c) || c instanceof a) for (var e = 0, h = c.length; e < h; e++) g(c[e], d); else if (c.nodeName && "tr" === c.nodeName.toLowerCase()) f.push(c); else {
 var i = a("<tr><td/></tr>").addClass(d);
 a("td", i).addClass(d).html(c)[0].colSpan = q(b), f.push(i[0]);
 }
 };
-g(d, e), c._details && c._details.remove(), c._details = a(f), c._detailsShow && c._details.insertAfter(c.nTr);
-}, Hb = function(a, b) {
+g(d, e), c._details && c._details.detach(), c._details = a(f), c._detailsShow && c._details.insertAfter(c.nTr);
+}, Gb = function(a, b) {
 var c = a.context;
 if (c.length) {
 var e = c[0].aoData[b !== d ? b :a[0]];
 e && e._details && (e._details.remove(), e._detailsShow = d, e._details = d);
 }
-}, Ib = function(a, b) {
+}, Hb = function(a, b) {
 var c = a.context;
 if (c.length && a.length) {
 var d = c[0].aoData[a[0]];
-d._details && (d._detailsShow = b, b ? d._details.insertAfter(d.nTr) :d._details.detach(), Jb(c[0]));
+d._details && (d._detailsShow = b, b ? d._details.insertAfter(d.nTr) :d._details.detach(), Ib(c[0]));
 }
-}, Jb = function(a) {
+}, Ib = function(a) {
 var b = new Ta(a), c = ".dt.DT_details", d = "draw" + c, e = "column-visibility" + c, f = "destroy" + c, g = a.aoData;
-b.off(d + " " + e + " " + f), ib(g, "_details").length > 0 && (b.on(d, function(c, d) {
+b.off(d + " " + e + " " + f), hb(g, "_details").length > 0 && (b.on(d, function(c, d) {
 a === d && b.rows({
 page:"current"
 }).eq(0).each(function(a) {
@@ -31144,37 +31150,37 @@ b._detailsShow && b._details.insertAfter(b.nTr);
 }), b.on(e, function(b, c, d, e) {
 if (a === c) for (var f, h = q(c), i = 0, j = g.length; i < j; i++) f = g[i], f._details && f._details.children("td[colspan]").attr("colspan", h);
 }), b.on(f, function(c, d) {
-if (a === d) for (var e = 0, f = g.length; e < f; e++) g[e]._details && Hb(b, e);
+if (a === d) for (var e = 0, f = g.length; e < f; e++) g[e]._details && Gb(b, e);
 }));
-}, Kb = "", Lb = Kb + "row().child", Mb = Lb + "()";
-Ua(Mb, function(a, b) {
+}, Jb = "", Kb = Jb + "row().child", Lb = Kb + "()";
+Ua(Lb, function(a, b) {
 var c = this.context;
-return a === d ? c.length && this.length ? c[0].aoData[this[0]]._details :d :(a === !0 ? this.child.show() :a === !1 ? Hb(this) :c.length && this.length && Gb(c[0], c[0].aoData[this[0]], a, b), this);
-}), Ua([ Lb + ".show()", Mb + ".show()" ], function(a) {
-return Ib(this, !0), this;
-}), Ua([ Lb + ".hide()", Mb + ".hide()" ], function() {
-return Ib(this, !1), this;
-}), Ua([ Lb + ".remove()", Mb + ".remove()" ], function() {
-return Hb(this), this;
-}), Ua(Lb + ".isShown()", function() {
+return a === d ? c.length && this.length ? c[0].aoData[this[0]]._details :d :(a === !0 ? this.child.show() :a === !1 ? Gb(this) :c.length && this.length && Fb(c[0], c[0].aoData[this[0]], a, b), this);
+}), Ua([ Kb + ".show()", Lb + ".show()" ], function(a) {
+return Hb(this, !0), this;
+}), Ua([ Kb + ".hide()", Lb + ".hide()" ], function() {
+return Hb(this, !1), this;
+}), Ua([ Kb + ".remove()", Lb + ".remove()" ], function() {
+return Gb(this), this;
+}), Ua(Kb + ".isShown()", function() {
 var a = this.context;
 return !(!a.length || !this.length) && (a[0].aoData[this[0]]._detailsShow || !1);
 });
-var Nb = /^(.+):(name|visIdx|visible)$/, Ob = function(a, b, c, d, e) {
+var Mb = /^([^:]+):(name|visIdx|visible)$/, Nb = function(a, b, c, d, e) {
 for (var f = [], g = 0, h = e.length; g < h; g++) f.push(y(a, e[g], b));
 return f;
-}, Pb = function(b, c, d) {
-var e = b.aoColumns, f = ib(e, "sName"), g = ib(e, "nTh"), h = function(c) {
-var h = db(c);
-if ("" === c) return kb(e.length);
+}, Ob = function(b, c, d) {
+var e = b.aoColumns, f = hb(e, "sName"), g = hb(e, "nTh"), h = function(c) {
+var h = cb(c);
+if ("" === c) return jb(e.length);
 if (null !== h) return [ h >= 0 ? h :e.length + h ];
 if ("function" == typeof c) {
-var i = Eb(b, d);
+var i = Db(b, d);
 return a.map(e, function(a, d) {
-return c(d, Ob(b, d, 0, 0, i), g[d]) ? d :null;
+return c(d, Nb(b, d, 0, 0, i), g[d]) ? d :null;
 });
 }
-var j = "string" == typeof c ? c.match(Nb) :"";
+var j = "string" == typeof c ? c.match(Mb) :"";
 if (j) switch (j[2]) {
 case "visIdx":
 case "visible":
@@ -31203,22 +31209,22 @@ if (m.length || !c.nodeName) return m;
 var n = a(c).closest("*[data-dt-column]");
 return n.length ? [ n.data("dt-column") ] :[];
 };
-return Bb("column", c, h, b, d);
-}, Qb = function(b, c, e) {
+return Ab("column", c, h, b, d);
+}, Pb = function(b, c, e) {
 var f, g, h, i, j = b.aoColumns, k = j[c], l = b.aoData;
 if (e === d) return k.bVisible;
 if (k.bVisible !== e) {
 if (e) {
-var m = a.inArray(!0, ib(j, "bVisible"), c + 1);
+var m = a.inArray(!0, hb(j, "bVisible"), c + 1);
 for (g = 0, h = l.length; g < h; g++) i = l[g].nTr, f = l[g].anCells, i && i.insertBefore(f[c], f[m] || null);
-} else a(ib(b.aoData, "anCells", c)).detach();
+} else a(hb(b.aoData, "anCells", c)).detach();
 k.bVisible = e, L(b, b.aoHeader), L(b, b.aoFooter), Da(b);
 }
 };
 Ua("columns()", function(b, c) {
-b === d ? b = "" :a.isPlainObject(b) && (c = b, b = ""), c = Cb(c);
+b === d ? b = "" :a.isPlainObject(b) && (c = b, b = ""), c = Bb(c);
 var e = this.iterator("table", function(a) {
-return Pb(a, b, c);
+return Ob(a, b, c);
 }, 1);
 return e.selector.cols = b, e.selector.opts = c, e;
 }), Va("columns().header()", "column().header()", function(a, b) {
@@ -31230,22 +31236,22 @@ return this.iterator("column", function(a, b) {
 return a.aoColumns[b].nTf;
 }, 1);
 }), Va("columns().data()", "column().data()", function() {
-return this.iterator("column-rows", Ob, 1);
+return this.iterator("column-rows", Nb, 1);
 }), Va("columns().dataSrc()", "column().dataSrc()", function() {
 return this.iterator("column", function(a, b) {
 return a.aoColumns[b].mData;
 }, 1);
 }), Va("columns().cache()", "column().cache()", function(a) {
 return this.iterator("column-rows", function(b, c, d, e, f) {
-return jb(b.aoData, f, "search" === a ? "_aFilterData" :"_aSortData", c);
+return ib(b.aoData, f, "search" === a ? "_aFilterData" :"_aSortData", c);
 }, 1);
 }), Va("columns().nodes()", "column().nodes()", function() {
 return this.iterator("column-rows", function(a, b, c, d, e) {
-return jb(a.aoData, e, "anCells", b);
+return ib(a.aoData, e, "anCells", b);
 }, 1);
 }), Va("columns().visible()", "column().visible()", function(a, b) {
 var c = this.iterator("column", function(b, c) {
-return a === d ? b.aoColumns[c].bVisible :void Qb(b, c, a);
+return a === d ? b.aoColumns[c].bVisible :void Pb(b, c, a);
 });
 return a !== d && (this.iterator("column", function(c, d) {
 La(c, null, "column-visibility", [ c, d, a, b ]);
@@ -31265,10 +31271,10 @@ if ("fromVisible" === a || "toData" === a) return o(c, b);
 if ("fromData" === a || "toVisible" === a) return p(c, b);
 }
 }), Ua("column()", function(a, b) {
-return Db(this.columns(a, b));
+return Cb(this.columns(a, b));
 });
-var Rb = function(b, c, e) {
-var f, g, h, i, j, k, l, m = b.aoData, n = Eb(b, e), o = lb(jb(m, n, "anCells")), p = a([].concat.apply([], o)), q = b.aoColumns.length, r = function(c) {
+var Qb = function(b, c, e) {
+var f, g, h, i, j, k, l, m = b.aoData, n = Db(b, e), o = kb(ib(m, n, "anCells")), p = a([].concat.apply([], o)), q = b.aoColumns.length, r = function(c) {
 var e = "function" == typeof c;
 if (null === c || c === d || e) {
 for (g = [], h = 0, i = n.length; h < i; h++) for (f = n[h], j = 0; j < q; j++) k = {
@@ -31289,11 +31295,11 @@ row:l.data("dt-row"),
 column:l.data("dt-column")
 } ] :[]);
 };
-return Bb("cell", c, r, b, e);
+return Ab("cell", c, r, b, e);
 };
 Ua("cells()", function(b, c, e) {
 if (a.isPlainObject(b) && (b.row === d ? (e = b, b = null) :(e = c, c = null)), a.isPlainObject(c) && (e = c, c = null), null === c || c === d) return this.iterator("table", function(a) {
-return Rb(a, b, Cb(e));
+return Qb(a, b, Bb(e));
 });
 var f, g, h, i, j, k = this.columns(c, e), l = this.rows(b, e), m = this.iterator("table", function(a, b) {
 for (f = [], g = 0, h = l[b].length; g < h; g++) for (i = 0, j = k[b].length; i < j; i++) f.push({
@@ -31337,7 +31343,7 @@ return this.iterator("cell", function(b, c, d) {
 G(b, c, a, d);
 });
 }), Ua("cell()", function(a, b, c) {
-return Db(this.cells(a, b, c));
+return Cb(this.cells(a, b, c));
 }), Ua("cell().data()", function(a) {
 var b = this.context, c = this[0];
 return a === d ? b.length && c.length ? y(b[0], c[0].row, c[0].column) :d :(z(b[0], c[0].row, c[0].column, a), G(b[0], c[0].row, "data", c[0].column), this);
@@ -31405,10 +31411,10 @@ for (var b, c, d = Wa.version.split("."), e = a.split("."), f = 0, g = e.length;
 return !0;
 }, Wa.isDataTable = Wa.fnIsDataTable = function(b) {
 var c = a(b).get(0), d = !1;
-return a.each(Wa.settings, function(b, e) {
+return b instanceof Wa.Api || (a.each(Wa.settings, function(b, e) {
 var f = e.nScrollHead ? a("table", e.nScrollHead)[0] :null, g = e.nScrollFoot ? a("table", e.nScrollFoot)[0] :null;
 e.nTable !== c && f !== c && g !== c || (d = !0);
-}), d;
+}), d);
 }, Wa.tables = Wa.fnTables = function(b) {
 var c = !1;
 a.isPlainObject(b) && (c = b.api, b = b.visible);
@@ -31422,7 +31428,9 @@ return a([].concat(e.filter(b).toArray(), e.find(b).toArray()));
 }), a.each([ "on", "one", "off" ], function(b, c) {
 Ua(c + "()", function() {
 var b = Array.prototype.slice.call(arguments);
-b[0].match(/\.dt\b/) || (b[0] += ".dt");
+b[0] = a.map(b[0].split(/\s/), function(a) {
+return a.match(/\.dt\b/) ? a :a + ".dt";
+}).join(" ");
 var d = a(this.tables().nodes());
 return d[c].apply(d, b), this;
 });
@@ -31437,14 +31445,14 @@ var a = this.context;
 return a.length ? a[0].oInit :null;
 }), Ua("data()", function() {
 return this.iterator("table", function(a) {
-return ib(a.aoData, "_aData");
+return hb(a.aoData, "_aData");
 }).flatten();
 }), Ua("destroy()", function(c) {
 return c = c || !1, this.iterator("table", function(d) {
 var e, f = d.nTableWrapper.parentNode, g = d.oClasses, h = d.nTable, i = d.nTBody, j = d.nTHead, k = d.nTFoot, l = a(h), m = a(i), n = a(d.nTableWrapper), o = a.map(d.aoData, function(a) {
 return a.nTr;
 });
-d.bDestroying = !0, La(d, "aoDestroyCallback", "destroy", [ d ]), c || new Ta(d).columns().visible(!0), n.unbind(".DT").find(":not(tbody *)").unbind(".DT"), a(b).unbind(".DT-" + d.sInstance), h != j.parentNode && (l.children("thead").detach(), l.append(j)), k && h != k.parentNode && (l.children("tfoot").detach(), l.append(k)), d.aaSorting = [], d.aaSortingFixed = [], Ba(d), a(o).removeClass(d.asStripeClasses.join(" ")), a("th, td", j).removeClass(g.sSortable + " " + g.sSortableAsc + " " + g.sSortableDesc + " " + g.sSortableNone), d.bJUI && (a("th span." + g.sSortIcon + ", td span." + g.sSortIcon, j).detach(), a("th, td", j).each(function() {
+d.bDestroying = !0, La(d, "aoDestroyCallback", "destroy", [ d ]), c || new Ta(d).columns().visible(!0), n.off(".DT").find(":not(tbody *)").off(".DT"), a(b).off(".DT-" + d.sInstance), h != j.parentNode && (l.children("thead").detach(), l.append(j)), k && h != k.parentNode && (l.children("tfoot").detach(), l.append(k)), d.aaSorting = [], d.aaSortingFixed = [], Ba(d), a(o).removeClass(d.asStripeClasses.join(" ")), a("th, td", j).removeClass(g.sSortable + " " + g.sSortableAsc + " " + g.sSortableDesc + " " + g.sSortableNone), d.bJUI && (a("th span." + g.sSortIcon + ", td span." + g.sSortIcon, j).detach(), a("th, td", j).each(function() {
 var b = a("div." + g.sSortJUIWrapper, this);
 a(this).append(b.contents()), b.detach();
 })), m.children().detach(), m.append(o);
@@ -31465,7 +31473,7 @@ a.call(e[b](g, "cell" === b ? h :c, "cell" === b ? c :d), g, h, i, j);
 }), Ua("i18n()", function(b, c, e) {
 var f = this.context[0], g = B(b)(f.oLanguage);
 return g === d && (g = c), e !== d && a.isPlainObject(g) && (g = g[e] !== d ? g[e] :g._), g.replace("%d", e);
-}), Wa.version = "1.10.12", Wa.settings = [], Wa.models = {}, Wa.models.oSearch = {
+}), Wa.version = "1.10.13", Wa.settings = [], Wa.models = {}, Wa.models.oSearch = {
 bCaseInsensitive:!0,
 sSearch:"",
 bRegex:!1,
@@ -31854,8 +31862,8 @@ sJUIHeader:e + " ui-corner-tl ui-corner-tr",
 sJUIFooter:e + " ui-corner-bl ui-corner-br"
 });
 }();
-var Sb = Wa.ext.pager;
-a.extend(Sb, {
+var Rb = Wa.ext.pager;
+a.extend(Rb, {
 simple:function(a, b) {
 return [ "previous", "next" ];
 },
@@ -31871,99 +31879,102 @@ return [ "previous", Pa(a, b), "next" ];
 full_numbers:function(a, b) {
 return [ "first", "previous", Pa(a, b), "next", "last" ];
 },
+first_last_numbers:function(a, b) {
+return [ "first", Pa(a, b), "last" ];
+},
 _numbers:Pa,
 numbers_length:7
 }), a.extend(!0, Wa.ext.renderer, {
 pageButton:{
-_:function(b, d, e, f, g, h) {
-var i, j, k, l = b.oClasses, m = b.oLanguage.oPaginate, n = b.oLanguage.oAria.paginate || {}, o = 0, p = function(c, d) {
-var f, k, q, r, s = function(a) {
+_:function(b, e, f, g, h, i) {
+var j, k, l, m = b.oClasses, n = b.oLanguage.oPaginate, o = b.oLanguage.oAria.paginate || {}, p = 0, q = function(c, d) {
+var e, g, l, r, s = function(a) {
 la(b, a.data.action, !0);
 };
-for (f = 0, k = d.length; f < k; f++) if (r = d[f], a.isArray(r)) {
+for (e = 0, g = d.length; e < g; e++) if (r = d[e], a.isArray(r)) {
 var t = a("<" + (r.DT_el || "div") + "/>").appendTo(c);
-p(t, r);
+q(t, r);
 } else {
-switch (i = null, j = "", r) {
+switch (j = null, k = "", r) {
 case "ellipsis":
 c.append('<span class="ellipsis">&#x2026;</span>');
 break;
 
 case "first":
-i = m.sFirst, j = r + (g > 0 ? "" :" " + l.sPageButtonDisabled);
+j = n.sFirst, k = r + (h > 0 ? "" :" " + m.sPageButtonDisabled);
 break;
 
 case "previous":
-i = m.sPrevious, j = r + (g > 0 ? "" :" " + l.sPageButtonDisabled);
+j = n.sPrevious, k = r + (h > 0 ? "" :" " + m.sPageButtonDisabled);
 break;
 
 case "next":
-i = m.sNext, j = r + (g < h - 1 ? "" :" " + l.sPageButtonDisabled);
+j = n.sNext, k = r + (h < i - 1 ? "" :" " + m.sPageButtonDisabled);
 break;
 
 case "last":
-i = m.sLast, j = r + (g < h - 1 ? "" :" " + l.sPageButtonDisabled);
+j = n.sLast, k = r + (h < i - 1 ? "" :" " + m.sPageButtonDisabled);
 break;
 
 default:
-i = r + 1, j = g === r ? l.sPageButtonActive :"";
+j = r + 1, k = h === r ? m.sPageButtonActive :"";
 }
-null !== i && (q = a("<a>", {
-"class":l.sPageButton + " " + j,
+null !== j && (l = a("<a>", {
+"class":m.sPageButton + " " + k,
 "aria-controls":b.sTableId,
-"aria-label":n[r],
-"data-dt-idx":o,
+"aria-label":o[r],
+"data-dt-idx":p,
 tabindex:b.iTabIndex,
-id:0 === e && "string" == typeof r ? b.sTableId + "_" + r :null
-}).html(i).appendTo(c), Ja(q, {
+id:0 === f && "string" == typeof r ? b.sTableId + "_" + r :null
+}).html(j).appendTo(c), Ja(l, {
 action:r
-}, s), o++);
+}, s), p++);
 }
 };
 try {
-k = a(d).find(c.activeElement).data("dt-idx");
-} catch (q) {}
-p(a(d).empty(), f), k && a(d).find("[data-dt-idx=" + k + "]").focus();
+l = a(e).find(c.activeElement).data("dt-idx");
+} catch (r) {}
+q(a(e).empty(), g), l !== d && a(e).find("[data-dt-idx=" + l + "]").focus();
 }
 }
 }), a.extend(Wa.ext.type.detect, [ function(a, b) {
 var c = b.oLanguage.sDecimal;
-return fb(a, c) ? "num" + c :null;
+return eb(a, c) ? "num" + c :null;
 }, function(a, b) {
-if (a && !(a instanceof Date) && (!$a.test(a) || !_a.test(a))) return null;
+if (a && !(a instanceof Date) && !$a.test(a)) return null;
 var c = Date.parse(a);
-return null !== c && !isNaN(c) || cb(a) ? "date" :null;
+return null !== c && !isNaN(c) || bb(a) ? "date" :null;
 }, function(a, b) {
 var c = b.oLanguage.sDecimal;
-return fb(a, c, !0) ? "num-fmt" + c :null;
+return eb(a, c, !0) ? "num-fmt" + c :null;
 }, function(a, b) {
 var c = b.oLanguage.sDecimal;
-return hb(a, c) ? "html-num" + c :null;
+return gb(a, c) ? "html-num" + c :null;
 }, function(a, b) {
 var c = b.oLanguage.sDecimal;
-return hb(a, c, !0) ? "html-num-fmt" + c :null;
+return gb(a, c, !0) ? "html-num-fmt" + c :null;
 }, function(a, b) {
-return cb(a) || "string" == typeof a && a.indexOf("<") !== -1 ? "html" :null;
+return bb(a) || "string" == typeof a && a.indexOf("<") !== -1 ? "html" :null;
 } ]), a.extend(Wa.ext.type.search, {
 html:function(a) {
-return cb(a) ? a :"string" == typeof a ? a.replace(Ya, " ").replace(Za, "") :"";
+return bb(a) ? a :"string" == typeof a ? a.replace(Ya, " ").replace(Za, "") :"";
 },
 string:function(a) {
-return cb(a) ? a :"string" == typeof a ? a.replace(Ya, " ") :a;
+return bb(a) ? a :"string" == typeof a ? a.replace(Ya, " ") :a;
 }
 });
-var Tb = function(a, b, c, d) {
-return 0 === a || a && "-" !== a ? (b && (a = eb(a, b)), a.replace && (c && (a = a.replace(c, "")), d && (a = a.replace(d, ""))), 1 * a) :-(1 / 0);
+var Sb = function(a, b, c, d) {
+return 0 === a || a && "-" !== a ? (b && (a = db(a, b)), a.replace && (c && (a = a.replace(c, "")), d && (a = a.replace(d, ""))), 1 * a) :-(1 / 0);
 };
 a.extend(Sa.type.order, {
 "date-pre":function(a) {
-return Date.parse(a) || 0;
+return Date.parse(a) || -(1 / 0);
 },
 "html-pre":function(a) {
-return cb(a) ? "" :a.replace ? a.replace(/<.*?>/g, "").toLowerCase() :a + "";
+return bb(a) ? "" :a.replace ? a.replace(/<.*?>/g, "").toLowerCase() :a + "";
 },
 "string-pre":function(a) {
-return cb(a) ? "" :"string" == typeof a ? a.toLowerCase() :a.toString ? a.toString() :"";
+return bb(a) ? "" :"string" == typeof a ? a.toLowerCase() :a.toString ? a.toString() :"";
 },
 "string-asc":function(a, b) {
 return a < b ? -1 :a > b ? 1 :0;
@@ -31991,7 +32002,7 @@ c.removeClass(e.sSortAsc + " " + e.sSortDesc).addClass("asc" == h[i] ? e.sSortAs
 }
 }
 });
-var Ub = function(a) {
+var Tb = function(a) {
 return "string" == typeof a ? a.replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;") :a;
 };
 return Wa.render = {
@@ -32000,8 +32011,8 @@ return {
 display:function(f) {
 if ("number" != typeof f && "string" != typeof f) return f;
 var g = f < 0 ? "-" :"", h = parseFloat(f);
-if (isNaN(h)) return Ub(f);
-f = Math.abs(h);
+if (isNaN(h)) return Tb(f);
+h = h.toFixed(c), f = Math.abs(h);
 var i = parseInt(f, 10), j = c ? b + (f - i).toFixed(c).substring(2) :"";
 return g + (d || "") + i.toString().replace(/\B(?=(\d{3})+(?!\d))/g, a) + j + (e || "");
 }
@@ -32009,7 +32020,7 @@ return g + (d || "") + i.toString().replace(/\B(?=(\d{3})+(?!\d))/g, a) + j + (e
 },
 text:function() {
 return {
-display:Ub
+display:Tb
 };
 }
 }, a.extend(Wa.ext.internal, {
@@ -32060,7 +32071,7 @@ _fnFilterCustom:Y,
 _fnFilterColumn:Z,
 _fnFilter:$,
 _fnFilterCreateSearch:_,
-_fnEscapeRegex:rb,
+_fnEscapeRegex:qb,
 _fnFilterData:aa,
 _fnFeatureHtmlInfo:da,
 _fnUpdateInfo:ea,
@@ -32077,7 +32088,7 @@ _fnFeatureHtmlTable:oa,
 _fnScrollDraw:pa,
 _fnApplyToChildren:qa,
 _fnCalculateColumnWidths:ra,
-_fnThrottle:vb,
+_fnThrottle:ub,
 _fnConvertToWidth:sa,
 _fnGetWidestNode:ta,
 _fnGetMaxLenString:ua,


### PR DESCRIPTION
Make a separate request for the last minute of usage when showing the
pod metrics donut. This will show consistent values for current usage
regardless of the selected time range.

Fixes https://github.com/openshift/origin/issues/5471

@jwforres PTAL