### PR TITLE
Adding bottom margin on .middle-content container to give space between content and browser edge. And address log-viewer white bg

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -1140,10 +1140,6 @@ pre.clipped {
   }
 }
 
-labels + .resource-details {
-  margin-top: 10px;
-}
-
 .ace-bordered {
   border: 1px solid #8b8d8f;
   &.ace-read-only {

--- a/app/styles/_substructure.less
+++ b/app/styles/_substructure.less
@@ -26,14 +26,19 @@ html,body {
     .flex-direction(@direction: column);
     .flex-display(@display: flex);
     &.no-sidebar {
-      .container {
-        padding-bottom: @grid-gutter-width; // add spacing so content isn't next to bottom edge
         h1 {
           margin: 10px 0 20px;
         }
-      }
       .middle {
         padding-top: 30px;
+      }
+    }
+    &.chromeless {
+      // prevent chromeless log-viewer from having margin or padding
+      .middle-content,
+      .middle-header {
+        margin:0 !important;
+        padding:0 !important;
       }
     }
   }
@@ -74,11 +79,17 @@ html,body {
         }
         .middle-content {
           .flex(@columns: 1 1 auto);
+          // default 50px space beneath content
+          padding-bottom: @middle-content-bottom-margin;
           position: relative;
           width: 100%;
         }
       }
     }
+  }
+  & .overview .middle .middle-section .middle-container .middle-content {
+      // reduce 20px to account for overview tiles bottom margin
+      padding-bottom: (@middle-content-bottom-margin - 20px);
   }
 }
 .header-toolbar {
@@ -263,5 +274,40 @@ html,body {
         }
       }
     }
+  }
+}
+
+
+// Removal of varying bottom-margin from ui elements that are positioned last within the
+// middle-content area in order to achieve consistent bottom spacing across all pages
+.middle-content {
+  annotations {
+    &:last-child,
+    p {
+      margin-bottom: 0;
+    }
+  }
+  pods-table {
+    display: block;
+    .gutter-bottom();
+  }
+  .table:last-child {
+    margin-bottom: 0;
+  }
+  .tab-content {
+    .key-value-editor-entry:last-child .form-group,
+    key-value-editor + button.btn {
+      margin-bottom: 0;
+    }
+  }
+}
+// Isolated to specific pages
+project-page {
+  &.image registry-image-config > :last-child > dl,
+  &.image registry-image-meta .dl-horizontal,
+  &.membership .content-pane > .item-row:nth-last-child(2),
+  &.monitoring .col-md-12 > :last-child .list-view-pf,
+  &.pod .log-view {
+    margin-bottom: 0;
   }
 }

--- a/app/styles/_tables.less
+++ b/app/styles/_tables.less
@@ -79,8 +79,6 @@
     display: inline-block;
   }
   @media (min-width: @screen-sm-min) {
-    // Only needed at larger sizes since form-group has a bottom margin at mobile.
-    .gutter-bottom;
     .filter-controls, .sort-group {
       // Inline controls at wider widths.
       display: inline-block;
@@ -164,6 +162,9 @@ td[role="presentation"].arrow:after {
   border-left: 1px solid @table-border-color;
   border-right: 1px solid @table-border-color;
   background-color: #f9f9f9;
+  .form-group {
+    margin-bottom: 5px;
+  }
 }
 
 // table for events

--- a/app/styles/_variables.less
+++ b/app/styles/_variables.less
@@ -40,6 +40,7 @@
 @link-hover-color-bright: lighten(@link-color, 13%);
 @list-view-expanded-bg: #f5f5f5;
 @log-bg-color: #101214;
+@middle-content-bottom-margin: @grid-gutter-width;
 @navbar-header-offset: 2px;
 @navbar-os-header-height-desktop: 60px;
 @navbar-os-header-height-mobile: 46px;

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -432,11 +432,11 @@
                   <uib-tab heading="Environment" active="selectedTab.environment" ng-if="buildConfig && !(buildConfig | isJenkinsPipelineStrategy)">
                     <uib-tab-heading>Environment</uib-tab-heading>
                     <h3>Environment Variables</h3>
-                    <div style="margin-top: -5px;" ng-if="BCEnvVarsFromImage.length">
+                    <p ng-if="BCEnvVarsFromImage.length">
                       The builder image has additional environment variables defined.  Variables defined below will overwrite any from the image with the same name.
                       <a href="" ng-click="expand.imageEnv = true" ng-if="!expand.imageEnv">Show Image Environment Variables</a>
                       <a href="" ng-click="expand.imageEnv = false" ng-if="expand.imageEnv">Hide Image Environment Variables</a>
-                    </div>
+                    </p>
                     <key-value-editor
                       ng-if="expand.imageEnv"
                       entries="BCEnvVarsFromImage"

--- a/app/views/browse/image.html
+++ b/app/views/browse/image.html
@@ -1,5 +1,5 @@
 <project-header class="top-header"></project-header>
-  <project-page>
+  <project-page class="image">
 
   <!-- Middle section -->
   <div class="middle-section">

--- a/app/views/browse/imagestream.html
+++ b/app/views/browse/imagestream.html
@@ -53,7 +53,7 @@
                 </dl>
                 <annotations annotations="imageStream.metadata.annotations"></annotations>
               </div>
-              <table class="table table-bordered table-hover table-mobile">
+              <table class="table table-bordered table-hover table-mobile mar-top-xl">
                 <thead>
                   <tr>
                     <th>Tag</th>

--- a/app/views/browse/pod.html
+++ b/app/views/browse/pod.html
@@ -1,5 +1,5 @@
 <project-header class="top-header"></project-header>
-  <project-page>
+  <project-page class="pod">
 
     <!-- Middle section -->
     <div class="middle-section">
@@ -142,7 +142,7 @@
 
                         <alerts ng-if="selectedTerminalContainer.status === 'disconnected'" alerts="terminalDisconnectAlert"></alerts>
 
-                        <div class="mar-left-xl mar-bottom-lg">
+                        <div class="mar-left-xl">
                           <div class="row">
                             <div class="pad-left-none pad-bottom-md col-sm-6 col-lg-4">
                               <span ng-if="pod.spec.containers.length === 1">

--- a/app/views/browse/route.html
+++ b/app/views/browse/route.html
@@ -192,8 +192,8 @@
                   </dl>
                   <div ng-if="!route.spec.tls"><em>TLS is not enabled for this route</em></div>
                 </div>
+                <annotations annotations="route.metadata.annotations"></annotations>
               </div>
-              <annotations annotations="route.metadata.annotations"></annotations>
             </div><!-- /col-* -->
           </div>
         </div>

--- a/app/views/browse/secret.html
+++ b/app/views/browse/secret.html
@@ -74,8 +74,8 @@
                     </div>
                   </div>
                 </dl>
+                <annotations annotations="secret.metadata.annotations"></annotations>
               </div>
-              <annotations annotations="secret.metadata.annotations"></annotations>
             </div><!-- /col-* -->
           </div>
         </div>

--- a/app/views/browse/service.html
+++ b/app/views/browse/service.html
@@ -95,9 +95,9 @@
                     <div>
                       <traffic-table ports-by-route="portsByRoute" routes="routesForService" services="services" show-node-ports="showNodePorts" custom-name-header="'Route'"></traffic-table>
                     </div>
-                    <div style="margin:-10px 0 10px 0;">
+                    <p>
                       Learn more about <a ng-href="{{'route-types' | helpLink}}" target="_blank">routes</a> and <a ng-href="{{'services' | helpLink}}" target="_blank">services</a>
-                    </div>
+                    </p>
                     <h3>Pods</h3>
                     <div>
                       <pods-table pods="podsForService" active-pods="podsWithEndpoints" custom-name-header="'Pod'" pod-failure-reasons="podFailureReasons"></pods-table>

--- a/app/views/directives/annotations.html
+++ b/app/views/directives/annotations.html
@@ -1,28 +1,26 @@
-<div class="gutter-bottom">
-  <p>
-    <a href="" ng-click="toggleAnnotations()" ng-if="!expandAnnotations">Show Annotations</a>
-    <a href="" ng-click="toggleAnnotations()" ng-if="expandAnnotations">Hide Annotations</a>
-  </p>
-  <div ng-if="expandAnnotations">
-    <div ng-if="annotations" class="table-responsive">
-      <table class="table table-bordered table-bordered-columns key-value-table">
-        <tbody>
-          <tr ng-repeat="(annotationKey, annotationValue) in annotations">
-            <td class="key">{{annotationKey}}</td>
-            <td class="value">
-              <truncate-long-text
-                  content="annotationValue | prettifyJSON"
-                  limit="500"
-                  newlineLimit="20"
-                  expandable="true">
-              </truncate-long-text>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <p ng-if="!annotations">
-      There are no annotations on this resource.
-    </p>
+<p>
+  <a href="" ng-click="toggleAnnotations()" ng-if="!expandAnnotations">Show Annotations</a>
+  <a href="" ng-click="toggleAnnotations()" ng-if="expandAnnotations">Hide Annotations</a>
+</p>
+<div ng-if="expandAnnotations">
+  <div ng-if="annotations" class="table-responsive">
+    <table class="table table-bordered table-bordered-columns key-value-table table-top-margin">
+      <tbody>
+        <tr ng-repeat="(annotationKey, annotationValue) in annotations">
+          <td class="key">{{annotationKey}}</td>
+          <td class="value">
+            <truncate-long-text
+                content="annotationValue | prettifyJSON"
+                limit="500"
+                newlineLimit="20"
+                expandable="true">
+            </truncate-long-text>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
+  <p ng-if="!annotations">
+    There are no annotations on this resource.
+  </p>
 </div>

--- a/app/views/membership.html
+++ b/app/views/membership.html
@@ -265,7 +265,6 @@
 
                 <div
                   ng-if="mode.edit"
-                  class="item-row"
                   row mobile="column">
                   <div class="col-name hidden-xs">&nbsp;</div>
                   <div

--- a/app/views/monitoring.html
+++ b/app/views/monitoring.html
@@ -1,5 +1,5 @@
 <project-header class="top-header"></project-header>
-  <project-page>
+  <project-page class="monitoring">
 
     <!-- Middle section -->
     <div class="middle-section monitoring-page"

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2140,11 +2140,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<uib-tab heading=\"Environment\" active=\"selectedTab.environment\" ng-if=\"buildConfig && !(buildConfig | isJenkinsPipelineStrategy)\">\n" +
     "<uib-tab-heading>Environment</uib-tab-heading>\n" +
     "<h3>Environment Variables</h3>\n" +
-    "<div style=\"margin-top: -5px\" ng-if=\"BCEnvVarsFromImage.length\">\n" +
+    "<p ng-if=\"BCEnvVarsFromImage.length\">\n" +
     "The builder image has additional environment variables defined. Variables defined below will overwrite any from the image with the same name.\n" +
     "<a href=\"\" ng-click=\"expand.imageEnv = true\" ng-if=\"!expand.imageEnv\">Show Image Environment Variables</a>\n" +
     "<a href=\"\" ng-click=\"expand.imageEnv = false\" ng-if=\"expand.imageEnv\">Hide Image Environment Variables</a>\n" +
-    "</div>\n" +
+    "</p>\n" +
     "<key-value-editor ng-if=\"expand.imageEnv\" entries=\"BCEnvVarsFromImage\" key-placeholder=\"Name\" value-placeholder=\"Value\" is-readonly cannot-add cannot-sort cannot-delete show-header></key-value-editor>\n" +
     "<ng-form name=\"forms.bcEnvVars\">\n" +
     "<div ng-if=\"'buildconfigs' | canI : 'update'\">\n" +
@@ -2964,7 +2964,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/browse/image.html',
     "<project-header class=\"top-header\"></project-header>\n" +
-    "<project-page>\n" +
+    "<project-page class=\"image\">\n" +
     "\n" +
     "<div class=\"middle-section\">\n" +
     "<div class=\"middle-container\">\n" +
@@ -3066,7 +3066,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</dl>\n" +
     "<annotations annotations=\"imageStream.metadata.annotations\"></annotations>\n" +
     "</div>\n" +
-    "<table class=\"table table-bordered table-hover table-mobile\">\n" +
+    "<table class=\"table table-bordered table-hover table-mobile mar-top-xl\">\n" +
     "<thead>\n" +
     "<tr>\n" +
     "<th>Tag</th>\n" +
@@ -3245,7 +3245,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/browse/pod.html',
     "<project-header class=\"top-header\"></project-header>\n" +
-    "<project-page>\n" +
+    "<project-page class=\"pod\">\n" +
     "\n" +
     "<div class=\"middle-section\">\n" +
     "<div class=\"middle-container\">\n" +
@@ -3339,7 +3339,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "When you navigate away from this pod, any open terminal connections will be closed. This will kill any foreground processes you started from the terminal.\n" +
     "</div>\n" +
     "<alerts ng-if=\"selectedTerminalContainer.status === 'disconnected'\" alerts=\"terminalDisconnectAlert\"></alerts>\n" +
-    "<div class=\"mar-left-xl mar-bottom-lg\">\n" +
+    "<div class=\"mar-left-xl\">\n" +
     "<div class=\"row\">\n" +
     "<div class=\"pad-left-none pad-bottom-md col-sm-6 col-lg-4\">\n" +
     "<span ng-if=\"pod.spec.containers.length === 1\">\n" +
@@ -3682,8 +3682,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</dl>\n" +
     "<div ng-if=\"!route.spec.tls\"><em>TLS is not enabled for this route</em></div>\n" +
     "</div>\n" +
-    "</div>\n" +
     "<annotations annotations=\"route.metadata.annotations\"></annotations>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -3859,8 +3859,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</dl>\n" +
-    "</div>\n" +
     "<annotations annotations=\"secret.metadata.annotations\"></annotations>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -3959,9 +3959,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div>\n" +
     "<traffic-table ports-by-route=\"portsByRoute\" routes=\"routesForService\" services=\"services\" show-node-ports=\"showNodePorts\" custom-name-header=\"'Route'\"></traffic-table>\n" +
     "</div>\n" +
-    "<div style=\"margin:-10px 0 10px 0\">\n" +
+    "<p>\n" +
     "Learn more about <a ng-href=\"{{'route-types' | helpLink}}\" target=\"_blank\">routes</a> and <a ng-href=\"{{'services' | helpLink}}\" target=\"_blank\">services</a>\n" +
-    "</div>\n" +
+    "</p>\n" +
     "<h3>Pods</h3>\n" +
     "<div>\n" +
     "<pods-table pods=\"podsForService\" active-pods=\"podsWithEndpoints\" custom-name-header=\"'Pod'\" pod-failure-reasons=\"podFailureReasons\"></pods-table>\n" +
@@ -5758,14 +5758,13 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/directives/annotations.html',
-    "<div class=\"gutter-bottom\">\n" +
     "<p>\n" +
     "<a href=\"\" ng-click=\"toggleAnnotations()\" ng-if=\"!expandAnnotations\">Show Annotations</a>\n" +
     "<a href=\"\" ng-click=\"toggleAnnotations()\" ng-if=\"expandAnnotations\">Hide Annotations</a>\n" +
     "</p>\n" +
     "<div ng-if=\"expandAnnotations\">\n" +
     "<div ng-if=\"annotations\" class=\"table-responsive\">\n" +
-    "<table class=\"table table-bordered table-bordered-columns key-value-table\">\n" +
+    "<table class=\"table table-bordered table-bordered-columns key-value-table table-top-margin\">\n" +
     "<tbody>\n" +
     "<tr ng-repeat=\"(annotationKey, annotationValue) in annotations\">\n" +
     "<td class=\"key\">{{annotationKey}}</td>\n" +
@@ -5780,7 +5779,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p ng-if=\"!annotations\">\n" +
     "There are no annotations on this resource.\n" +
     "</p>\n" +
-    "</div>\n" +
     "</div>"
   );
 
@@ -9687,7 +9685,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</ng-form>\n" +
-    "<div ng-if=\"mode.edit\" class=\"item-row\" row mobile=\"column\">\n" +
+    "<div ng-if=\"mode.edit\" row mobile=\"column\">\n" +
     "<div class=\"col-name hidden-xs\">&nbsp;</div>\n" +
     "<div class=\"action-set\" flex row tablet=\"column\" mobile=\"column\">\n" +
     "<div class=\"col-roles hidden-xs\" flex>&nbsp;</div>\n" +
@@ -10059,7 +10057,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/monitoring.html',
     "<project-header class=\"top-header\"></project-header>\n" +
-    "<project-page>\n" +
+    "<project-page class=\"monitoring\">\n" +
     "\n" +
     "<div class=\"middle-section monitoring-page\" ng-class=\"{ 'sidebar-open': !renderOptions.collapseEventsSidebar }\">\n" +
     "<div class=\"middle-container\">\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3581,7 +3581,6 @@ to{transform:rotate(359deg)}
 .copy-to-clipboard input.form-control:read-only{background-color:#fff;color:#363636}
 .copy-to-clipboard-multiline{position:relative;width:100%}
 .copy-to-clipboard-multiline a{box-shadow:none;position:absolute;right:0;top:0}
-.card-pf,.tile{box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09)}
 .copy-to-clipboard-multiline pre{background-color:#fff;max-width:100%;overflow-x:auto}
 .input-group-addon.wildcard-prefix{padding-left:10px}
 .editor-examples{padding:19px;margin-bottom:20px;border:1px solid #d1d1d1}
@@ -3589,6 +3588,7 @@ to{transform:rotate(359deg)}
 .compute-resource{margin-bottom:5px}
 @media (max-width:767px){.compute-resource .inline-select{margin-top:5px}
 }
+.card-pf{box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09)}
 .card-pf .image-icon,.card-pf .template-icon{font-size:28px;line-height:1;margin-right:15px;opacity:.38}
 .card-pf-badge{color:#999;font-size:11px;text-transform:uppercase}
 .card-pf-body{margin-bottom:0}
@@ -3989,7 +3989,6 @@ pre.clipped.scroll{max-height:150px;overflow:auto;width:100%}
 @media (max-width:768px){.k8s-label,.k8s-label .label-pair{width:100%}
 .k8s-label .label{display:block;min-width:50px}
 }
-labels+.resource-details{margin-top:10px}
 .ace-bordered{border:1px solid #8b8d8f}
 .ace-bordered.ace-read-only{border-color:#d1d1d1;background-color:#fafafa}
 .action-divider{color:#9c9c9c}
@@ -4862,9 +4861,9 @@ body,html{margin:0;padding:0}
 .console-os{background-color:#fff}
 .console-os .top-header{display:flex;position:relative;height:46px}
 .console-os .wrap{height:100vh;margin-top:-46px;padding-top:46px;position:relative;width:100%;-webkit-backface-visibility:hidden;-moz-backface-visibility:hidden;backface-visibility:hidden;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex}
-.console-os .wrap.no-sidebar .container{padding-bottom:40px}
-.console-os .wrap.no-sidebar .container h1{margin:10px 0 20px}
+.console-os .wrap.no-sidebar h1{margin:10px 0 20px}
 .console-os .wrap.no-sidebar .middle{padding-top:30px}
+.console-os .wrap.chromeless .middle-content,.console-os .wrap.chromeless .middle-header{margin:0!important;padding:0!important}
 .console-os .middle,.console-os .sidebar-left,.console-os .sidebar-right{-webkit-flex:0 0 auto;-moz-flex:0 0 auto;-ms-flex:0 0 auto;flex:0 0 auto;width:100%;position:relative}
 .console-os .sidebar-left{background:#30363d;padding:0;position:relative}
 @media (max-width:767px){.console-os .sidebar-left{border-top:0;padding-left:0;padding-right:0}
@@ -4874,7 +4873,8 @@ body,html{margin:0;padding:0}
 .console-os .middle .middle-section{position:absolute;top:0;left:0;height:100%;width:100%}
 .console-os .middle .middle-section .middle-container{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;height:100%}
 .console-os .middle .middle-section .middle-container .middle-header{-webkit-flex:0 0 auto;-moz-flex:0 0 auto;-ms-flex:0 0 auto;flex:0 0 auto;margin-bottom:20px}
-.console-os .middle .middle-section .middle-container .middle-content{-webkit-flex:1 1 auto;-moz-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;position:relative;width:100%}
+.console-os .middle .middle-section .middle-container .middle-content{-webkit-flex:1 1 auto;-moz-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;padding-bottom:40px;position:relative;width:100%}
+.console-os .overview .middle .middle-section .middle-container .middle-content{padding-bottom:20px}
 .header-toolbar{background-color:#fff;border-bottom:1px solid #e4e4e4}
 .surface-shaded{background-color:#f2f2f2}
 @media (min-width:768px){.layout-pf-alt-fixed .nav-pf-vertical-alt{position:fixed;bottom:0;overflow:visible}
@@ -4898,6 +4898,7 @@ body,html{margin:0;padding:0}
 .right-section .right-container .right-header{-webkit-flex:0 0 auto;-moz-flex:0 0 auto;-ms-flex:0 0 auto;flex:0 0 auto;width:100%}
 .right-section .right-container .right-content{-webkit-flex:1 1 auto;-moz-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;position:relative;overflow-x:hidden;overflow-y:auto;width:100%}
 }
+.middle-content .tab-content .key-value-editor-entry:last-child .form-group,.middle-content .tab-content key-value-editor+button.btn,.middle-content .table:last-child,.middle-content annotations p,.middle-content annotations:last-child,project-page.image registry-image-config>:last-child>dl,project-page.image registry-image-meta .dl-horizontal,project-page.membership .content-pane>.item-row:nth-last-child(2),project-page.monitoring .col-md-12>:last-child .list-view-pf,project-page.pod .log-view{margin-bottom:0}
 @media (min-width:992px){.console-os .sidebar-right{-webkit-flex:0 0 310px;-moz-flex:0 0 310px;-ms-flex:0 0 310px;flex:0 0 310px}
 .console-os .sidebar-right .right-section{width:310px}
 }
@@ -4911,6 +4912,8 @@ body,html{margin:0;padding:0}
 .console-os .wrap.show-sidebar-right .sidebar-right{-webkit-flex:0 0 480px;-moz-flex:0 0 480px;-ms-flex:0 0 480px;flex:0 0 480px}
 .console-os .wrap.show-sidebar-right .sidebar-right .right-section{width:480px}
 }
+.middle-content pods-table{display:block;padding-bottom:20px}
+.middle-content pods-table.gutter-bottom-2x{padding-bottom:40px}
 .table{background-color:#fff}
 .table.table-bordered>tbody>tr>td,.table.table-bordered>thead>tr>th{border-left:0;border-right:0;padding-bottom:8px;padding-top:8px;vertical-align:middle}
 .table.table-bordered.table-bordered-columns>tbody>tr>td,.table.table-bordered.table-bordered-columns>thead>tr>th{border:1px solid #d1d1d1}
@@ -4924,9 +4927,7 @@ body,html{margin:0;padding:0}
 .events .data-toolbar .search-pf{margin-bottom:10px;width:100%}
 .events .data-toolbar .sort-label{margin-right:4px;vertical-align:-1px}
 .events .data-toolbar .sort-controls{display:inline-block}
-@media (min-width:768px){.events .data-toolbar{padding-bottom:20px}
-.events .data-toolbar.gutter-bottom-2x{padding-bottom:40px}
-.events .data-toolbar .filter-controls,.events .data-toolbar .sort-group{display:inline-block}
+@media (min-width:768px){.events .data-toolbar .filter-controls,.events .data-toolbar .sort-group{display:inline-block}
 .events .data-toolbar .search-pf{margin-bottom:0;width:300px}
 }
 @media (max-width:767px){.table-mobile{border-top:2px solid #d1d1d1;table-layout:fixed}
@@ -4944,6 +4945,7 @@ td[role=presentation].arrow:after{content:"\2193"}
 @media (min-width:768px){td[role=presentation].arrow:after{content:"\2192"}
 }
 .table-filter-wrapper{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;padding:10px 10px 5px;border-top:1px solid #d1d1d1;border-left:1px solid #d1d1d1;border-right:1px solid #d1d1d1;background-color:#f9f9f9}
+.table-filter-wrapper .form-group{margin-bottom:5px}
 .events-table{table-layout:fixed}
 .events-table th#time{width:90px}
 .events-table th#kind-name{width:190px}
@@ -4958,7 +4960,7 @@ td[role=presentation].arrow:after{content:"\2193"}
 .key-value-table>tbody>tr>td.value .truncated-content{white-space:pre}
 .table-word-break-all td{word-break:break-all;word-break:break-word;overflow-wrap:break-word}
 .table-word-break-all td.word-break-normal{word-break:normal;overflow-wrap:normal}
-.tile{background:#fff;padding:20px;margin-bottom:20px;word-wrap:break-word;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;overflow-x:hidden}
+.tile{background:#fff;box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09);padding:20px;margin-bottom:20px;word-wrap:break-word;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;overflow-x:hidden}
 .tile h1,.tile h2,.tile h3{margin:10.5px 0px}
 .tile-click{cursor:pointer;position:relative}
 .tile-click:hover .image-icon,.tile-click:hover .template-icon{opacity:.75}


### PR DESCRIPTION

Fixes openshift#994
Fixes openshift#1002
Fixes openshift#993

Added `.gutter-bottom.gutter-bottom-2x()` to `.middle-content` since there was no rule that applied default spacing within the the main content panel. And removed it from annotations that was no longer needed.

<img width="1091" alt="screen shot 2016-12-07 at 5 06 19 pm" src="https://cloud.githubusercontent.com/assets/1874151/20988962/f183f89c-bca0-11e6-968f-6464dadd0d82.png">

<img width="1039" alt="screen shot 2016-12-07 at 5 22 16 pm" src="https://cloud.githubusercontent.com/assets/1874151/20989171/bfcd0770-bca1-11e6-8636-e190c21e352b.png">

<img width="1078" alt="screen shot 2016-12-07 at 5 21 11 pm" src="https://cloud.githubusercontent.com/assets/1874151/20989169/bfcc3962-bca1-11e6-8838-ce2141b5a181.png">

<img width="1075" alt="screen shot 2016-12-07 at 5 20 57 pm" src="https://cloud.githubusercontent.com/assets/1874151/20989172/bfcd5612-bca1-11e6-805b-8062df278756.png">

<img width="1044" alt="screen shot 2016-12-07 at 5 24 53 pm" src="https://cloud.githubusercontent.com/assets/1874151/20989285/25ad96ea-bca2-11e6-96a0-a2d1157c5e5a.png">

<img width="1044" alt="screen shot 2016-12-07 at 5 24 17 pm" src="https://cloud.githubusercontent.com/assets/1874151/20989286/25ad9686-bca2-11e6-88da-4e385ceabf2c.png">

<img width="1028" alt="screen shot 2016-12-07 at 5 24 01 pm" src="https://cloud.githubusercontent.com/assets/1874151/20989287/25b1f33e-bca2-11e6-9c07-db0e5c4dae82.png">
