### PR TITLE
Fix tile overlap when a service has multiple pods

### DIFF
--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -160,11 +160,6 @@
     }
     .service-group-body {
       margin-top: 0;
-      .overview-services .primary-service {
-        .deployment-block {
-          .flex-display(@display: flex);
-        }
-      }
     }
     .alert-wrapper .alert {
       margin-bottom: @service-group-vertical-margin;

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4349,9 +4349,8 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview .standalone-service .service-group-body .overview-services .overview-tile{margin-top:0}
 .overview .standalone-service overview-service-group{width:100%}
 .overview .standalone-service .service-group>div{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;height:100%}
-.overview .standalone-service .service-group-body .overview-services .primary-service .deployment-block{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex}
-.overview .standalone-service .alert-wrapper .alert{margin-bottom:6px;margin-top:0}
 .overview .standalone-service .service-group-body{margin-top:0;display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;width:100%}
+.overview .standalone-service .alert-wrapper .alert{margin-bottom:6px;margin-top:0}
 .overview .standalone-service .service-group-body .overview-services{-webkit-flex-direction:row;-moz-flex-direction:row;-ms-flex-direction:row;flex-direction:row}
 .overview .standalone-service .service-group-body .overview-services .no-child-services-message,.overview .standalone-service .service-group-body .overview-services overview-service{max-width:none;margin-top:0}
 .overview .standalone-service .service-group-body .overview-services .no-child-services-block{display:none}


### PR DESCRIPTION
Remove redundant flex style for `.primary-service .deployment-block` which was overriding the `display: block` style for `.service-multiple-targets` because it was more specific. The `.deployment-block` already has the flex style set here

https://github.com/openshift/origin-web-console/blob/10c6ca8502411aaecd08360233749493c2915fc8/app/styles/_overview.less#L316-L317

See https://github.com/openshift/origin-web-console/issues/1011#issuecomment-266011901, fixes #1011 

Note that this stacks the tiles, which was the original intent, although not ideal. If you have a lot of pods, it won't scale that well. We should try to do something better in https://trello.com/c/QxbqJsoK

![screen shot 2016-12-09 at 8 38 00 am](https://cloud.githubusercontent.com/assets/1167259/21050794/d652a0c8-bdea-11e6-84e1-f1e3efd4b1f7.png)