### PR TITLE
Preserve line breaks in project descriptions

### DIFF
--- a/app/styles/_projects.less
+++ b/app/styles/_projects.less
@@ -31,6 +31,14 @@
   }
 }
 
+.project-description {
+  .highlighted-content,
+  .truncated-content {
+    white-space: pre-line;
+    .word-break();
+  }
+}
+
 .project-info {
   &.list-group-item {
     border-bottom: 0;

--- a/app/views/projects.html
+++ b/app/views/projects.html
@@ -113,8 +113,8 @@
                             </div>
                             <div class="list-view-pf-additional-info project-additional-info">
                               <span class="list-group-item-text project-description">
-                                <truncate-long-text ng-if="!keywords.length" content="project | description" limit="265" use-word-boundary="true"></truncate-long-text>
-                                <span ng-if="keywords.length" ng-bind-html="project | description | truncate : 1000 | highlightKeywords : keywords"></span>
+                                <truncate-long-text ng-if="!keywords.length" content="project | description" limit="265" newline-limit="10" use-word-boundary="true"></truncate-long-text>
+                                <span class="highlighted-content" ng-if="keywords.length" ng-bind-html="project | description | truncate : 1000 | highlightKeywords : keywords"></span>
                               </span>
                             </div>
                           </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -11250,8 +11250,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"list-view-pf-additional-info project-additional-info\">\n" +
     "<span class=\"list-group-item-text project-description\">\n" +
-    "<truncate-long-text ng-if=\"!keywords.length\" content=\"project | description\" limit=\"265\" use-word-boundary=\"true\"></truncate-long-text>\n" +
-    "<span ng-if=\"keywords.length\" ng-bind-html=\"project | description | truncate : 1000 | highlightKeywords : keywords\"></span>\n" +
+    "<truncate-long-text ng-if=\"!keywords.length\" content=\"project | description\" limit=\"265\" newline-limit=\"10\" use-word-boundary=\"true\"></truncate-long-text>\n" +
+    "<span class=\"highlighted-content\" ng-if=\"keywords.length\" ng-bind-html=\"project | description | truncate : 1000 | highlightKeywords : keywords\"></span>\n" +
     "</span>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5166,6 +5166,7 @@ a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;borde
 @media (min-width:992px){.project-actions{margin-top:0}
 .project-additional-info.list-view-pf-additional-info{width:55%}
 }
+.project-description .highlighted-content,.project-description .truncated-content{white-space:pre-line;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .project-info.list-group-item{border-bottom:0;border-color:#e0e0e0;padding:10px 20px}
 .project-info .list-view-pf-description{width:100%}
 .project-info .list-view-pf-main-info{display:block}


### PR DESCRIPTION
Resolves https://github.com/openshift/origin/issues/12194

Limits line breaks to 10 for the truncated display (does not apply to the highlighted text display).  Also adds word-break for long, unbroken strings so they do not break the layout.

![screen shot 2016-12-09 at 1 55 28 pm](https://cloud.githubusercontent.com/assets/895728/21060940/1f750d90-be18-11e6-9c35-f84e3e72cc73.PNG)
![screen shot 2016-12-09 at 1 55 35 pm](https://cloud.githubusercontent.com/assets/895728/21060941/1f76340e-be18-11e6-885f-f0609dce0d51.PNG)
![screen shot 2016-12-09 at 1 55 45 pm](https://cloud.githubusercontent.com/assets/895728/21060942/1f76fcae-be18-11e6-997a-b6b7186fa3aa.PNG)
![screen shot 2016-12-09 at 1 56 43 pm](https://cloud.githubusercontent.com/assets/895728/21060939/1f747060-be18-11e6-9eae-bfa84be5106e.PNG)

@jwforres or @spadgett, PTAL