### PR TITLE
Show CPU usage as cores rather than millicores

### DIFF
--- a/app/scripts/directives/deploymentMetrics.js
+++ b/app/scripts/directives/deploymentMetrics.js
@@ -62,7 +62,8 @@ angular.module('openshiftConsole')
           chartID: "memory-" + scope.uniqueID
         }, {
           label: "CPU",
-          units: "millicores",
+          units: "cores",
+          convert: ConversionService.millicoresToCores,
           descriptor: 'cpu/usage_rate',
           type: 'pod_container',
           chartID: "cpu-" + scope.uniqueID

--- a/app/scripts/services/convert.js
+++ b/app/scripts/services/convert.js
@@ -15,12 +15,20 @@ angular.module("openshiftConsole")
         return value;
       }
 
-      // Round to one decimal place
       return value / 1024;
+    };
+
+    var millicoresToCores = function(value) {
+      if (!value) {
+        return value;
+      }
+
+      return value / 1000;
     };
 
     return {
       bytesToMiB: bytesToMiB,
-      bytesToKiB: bytesToKiB
+      bytesToKiB: bytesToKiB,
+      millicoresToCores: millicoresToCores
     };
   });

--- a/app/scripts/services/metricsCharts.js
+++ b/app/scripts/services/metricsCharts.js
@@ -11,6 +11,8 @@ angular.module("openshiftConsole")
       switch (metricID) {
       case 'memory/usage':
         return _.round(ConversionService.bytesToMiB(point.value), 2);
+      case 'cpu/usage_rate':
+        return ConversionService.millicoresToCores(point.value);
       case 'network/rx_rate':
       case 'network/tx_rate':
         return _.round(ConversionService.bytesToKiB(point.value), 2);
@@ -80,11 +82,6 @@ angular.module("openshiftConsole")
                 left: 0,
                 top: 20,
                 bottom: 0
-              },
-              tick: {
-                format: function(value) {
-                  return d3.round(value, 3);
-                }
               }
             }
           },
@@ -97,7 +94,8 @@ angular.module("openshiftConsole")
           tooltip: {
             format: {
               value: function(value) {
-                return d3.round(value, 2) + " " + units;
+                var precision = units === 'cores' ? 3 : 2;
+                return d3.round(value, precision) + " " + units;
               }
             },
           }
@@ -126,7 +124,7 @@ angular.module("openshiftConsole")
       },
 
       formatUsage: function(usage) {
-        if (usage < 0.01) {
+        if (usage < 0.001) {
           return '0';
         }
 


### PR DESCRIPTION
Cores is a more universally understood unit than millicores.

Related to https://github.com/openshift/origin/issues/7768

![screen shot 2016-12-12 at 9 33 58 am](https://cloud.githubusercontent.com/assets/1167259/21102945/59cd960a-c04e-11e6-824b-b8e2341a78b3.png)

![screen shot 2016-12-12 at 9 34 28 am](https://cloud.githubusercontent.com/assets/1167259/21102954/64a33422-c04e-11e6-887d-dc9aebcf1fee.png)

![screen shot 2016-12-12 at 9 34 42 am](https://cloud.githubusercontent.com/assets/1167259/21102960/68fbf00e-c04e-11e6-982d-b22f153bb83e.png)
