### PR TITLE
Replace select tag with ui-select - part 1

### DIFF
--- a/app/scripts/directives/oscRouting.js
+++ b/app/scripts/directives/oscRouting.js
@@ -46,6 +46,11 @@ angular.module("openshiftConsole")
           var termination = _.get($scope, 'route.tls.termination');
           return !termination || termination === 'passthrough';
         };
+        $scope.insecureTrafficOptions = [
+          {value: '', label: 'None'},
+          {value: 'Allow', label: 'Allow'},
+          {value: 'Redirect', label: 'Redirect'}
+        ];
       },
       link: function(scope, element, attrs, formCtl) {
         scope.form = formCtl;
@@ -142,6 +147,11 @@ angular.module("openshiftConsole")
         scope.$watch('secureRoute', function(newValue, oldValue) {
           if (newValue === oldValue) {
             return;
+          }
+
+          // Set the default behavior of insecure connections to 'None'
+          if (newValue && !_.get(scope, 'route.tls.insecureEdgeTerminationPolicy')) {
+            _.set(scope, 'route.tls.insecureEdgeTerminationPolicy', scope.insecureTrafficOptions[0]);
           }
 
           var termination = _.get(scope, 'route.tls.termination');

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -1022,6 +1022,20 @@ angular.module('openshiftConsole')
       }
     };
   })
+  .filter('humanizeTLSTermination', function () {
+    return function(termination) {
+      switch (termination) {
+        case 'edge':
+          return 'Edge';
+        case 'passthrough':
+          return 'Passthrough';
+        case 'reencrypt':
+          return 'Re-encrypt';
+        default:
+          return termination;
+      }
+    };
+  })
   .filter('humanizeKind', function (startCaseFilter) {
     // Changes "ReplicationController" to "replication controller".
     // If useTitleCase, returns "Replication Controller".

--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -263,15 +263,26 @@ mark {
     .form-group {
       margin-bottom: 0;
     }
-    .select-container {
+    .select-container,
+    .select-range {
       display: inline-block;
+      vertical-align: middle;
     }
     @media (min-width: @screen-sm-min) {
       .form-group {
         display: inline-block;
+        vertical-align: middle;
       }
       .select-container {
         margin-right: 10px;
+      }
+    }
+    @media (max-width: @screen-xs-max) {
+      .form-group {
+        padding-bottom: 10px;
+        label {
+          width: 100px;
+        }
       }
     }
   }

--- a/app/views/browse/route.html
+++ b/app/views/browse/route.html
@@ -146,7 +146,7 @@
                   <h4>TLS Settings</h4>
                   <dl class="dl-horizontal left" ng-if="route.spec.tls">
                     <dt>Termination Type:</dt>
-                    <dd>{{route.spec.tls.termination}}</dd>
+                    <dd>{{route.spec.tls.termination | humanizeTLSTermination}}</dd>
                     <dt ng-if-start="route.spec.tls.termination === 'edge'">Insecure Traffic:</dt>
                     <dd ng-if-end>{{route.spec.tls.insecureEdgeTerminationPolicy || 'None'}}</dd>
                     <dt>Certificate:</dt>

--- a/app/views/browse/routes.html
+++ b/app/views/browse/routes.html
@@ -83,7 +83,7 @@
                     </td>
                     <!-- Use shorter Termination title for table-mobile to avoid overlapping text. -->
                     <td data-title="Termination">
-                      {{route.spec.tls.termination}}
+                      {{route.spec.tls.termination | humanizeTLSTermination}}
                       <span ng-if="!route.spec.tls.termination">&nbsp;</span>
                     </td>
                   </tr>

--- a/app/views/create/fromimage.html
+++ b/app/views/create/fromimage.html
@@ -298,12 +298,12 @@
                               >
                               <div class="form-group">
                                 <label for="scale-type">Strategy</label>
-                                <select ng-model="scaling.autoscale"
-                                        ng-options="option.value as option.label for option in scaling.autoscaleOptions"
-                                        id="scale-type"
-                                        class="form-control"
-                                        aria-describedby="scale-type-help">
-                                </select>
+                                <ui-select ng-model="scaling.autoscale" input-id="scale-type" search-enabled="false" aria-describedby="scale-type-help">
+                                  <ui-select-match>{{$select.selected.label}}</ui-select-match>
+                                  <ui-select-choices repeat="option.value as option in scaling.autoscaleOptions">
+                                    {{option.label}}
+                                  </ui-select-choices>
+                                </ui-select>
                                 <div class="help-block" id="scale-type-help">
                                   Scale replicas manually or automatically based on CPU usage.
                                 </div>

--- a/app/views/directives/osc-routing-service.html
+++ b/app/views/directives/osc-routing-service.html
@@ -4,14 +4,12 @@
       <label for="{{id}}-service-select" class="required">
         Service
       </label>
-      <select
-          id="{{id}}-service-select"
-          ng-model="model.service"
-          ng-options="service as service.metadata.name for service in services"
-          required
-          class="form-control"
-          ng-attr-aria-describedby="{{id}}-service-help">
-      </select>
+      <ui-select ng-model="model.service" input-id="{{id}}-service-select" aria-describedby="{{id}}-service-help" required>
+        <ui-select-match>{{$select.selected.metadata.name}}</ui-select-match>
+        <ui-select-choices repeat="service in (services | filter : {metadata: { name: $select.search }}) track by (service | uid)">
+           <div ng-bind-html="service.metadata.name | highlight : $select.search"></div>
+        </ui-select-choices>
+      </ui-select>
       <div>
         <span ng-attr-id="{{id}}-service-help" class="help-block">
           <span ng-if="!isAlternate">Service to route to.</span>

--- a/app/views/directives/osc-routing.html
+++ b/app/views/directives/osc-routing.html
@@ -120,14 +120,12 @@
     <!-- Target Port -->
     <div ng-if="route.portOptions.length" class="form-group">
       <label for="routeTargetPort">Target Port</label>
-      <select
-          id="routeTargetPort"
-          ng-if="route.portOptions.length"
-          ng-model="route.targetPort"
-          ng-options="portOption.port as portOption.label for portOption in route.portOptions"
-          class="form-control"
-          aria-describedby="target-port-help">
-      </select>
+      <ui-select ng-if="route.portOptions.length" ng-model="route.targetPort" input-id="routeTargetPort" search-enabled="false" aria-describedby="target-port-help">
+        <ui-select-match>{{$select.selected.label}}</ui-select-match>
+        <ui-select-choices repeat="portOption.port as portOption in route.portOptions">
+          {{portOption.label}}
+        </ui-select-choices>
+      </ui-select>
       <div>
         <span id="target-port-help" class="help-block">
           Target port for traffic.
@@ -170,12 +168,13 @@
     <div ng-show="secureRoute">
       <!-- TLS Termination -->
       <div class="form-group">
-        <label>TLS Termination</label>
-        <select ng-model="route.tls.termination" class="form-control">
-          <option value="edge">Edge</option>
-          <option value="passthrough">Passthrough</option>
-          <option value="reencrypt">Re-encrypt</option>
-        </select>
+        <label for="tlsTermination">TLS Termination</label>
+        <ui-select ng-model="route.tls.termination" input-id="tlsTermination" search-enabled="false">
+          <ui-select-match>{{$select.selected | humanizeTLSTermination}}</ui-select-match>
+          <ui-select-choices repeat="option in ['edge', 'passthrough', 'reencrypt']">
+            {{option | humanizeTLSTermination}}
+          </ui-select-choices>
+        </ui-select>
         <div class="learn-more-block help-block">
           <a href="{{'route-types' | helpLink}}" target="_blank">Learn More&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></a>
         </div>
@@ -183,16 +182,13 @@
 
       <!-- Insecure Edge Termination Policy -->
       <div class="form-group">
-        <label>Insecure Traffic</label>
-        <select
-            ng-model="route.tls.insecureEdgeTerminationPolicy"
-            ng-disabled="route.tls.termination !== 'edge'"
-            class="form-control"
-            aria-describedby="route-insecure-policy-help">
-          <option value="">None</option>
-          <option value="Allow">Allow</option>
-          <option value="Redirect">Redirect</option>
-        </select>
+        <label for="insecureTraffic">Insecure Traffic</label>
+        <ui-select ng-model="route.tls.insecureEdgeTerminationPolicy" ng-disabled="route.tls.termination !== 'edge'" input-id="insecureTraffic" aria-describedby="route-insecure-policy-help" search-enabled="false">
+          <ui-select-match>{{$select.selected.label}}</ui-select-match>
+          <ui-select-choices repeat="option.value as option in insecureTrafficOptions">
+            {{option.label}}
+          </ui-select-choices>
+        </ui-select>
         <div>
           <span id="route-insecure-policy-help" class="help-block">
             Policy for traffic on insecure schemes like HTTP for edge termination.

--- a/app/views/directives/pod-metrics.html
+++ b/app/views/directives/pod-metrics.html
@@ -7,21 +7,24 @@
         <span ng-show="pod.spec.containers.length === 1">
           {{pod.spec.containers[0].name}}
         </span>
-        <select id="selectContainer"
-                ng-show="pod.spec.containers.length > 1"
-                ng-init="options.selectedContainer = pod.spec.containers[0]"
-                ng-model="options.selectedContainer"
-                ng-options="container.name for container in pod.spec.containers track by container.name">
-        </select>
+        <ui-select ng-init="options.selectedContainer = pod.spec.containers[0]" ng-show="pod.spec.containers.length > 1" ng-model="options.selectedContainer" input-id="selectContainer">
+          <ui-select-match>{{$select.selected.name}}</ui-select-match>
+          <ui-select-choices repeat="container in pod.spec.containers | filter : { name: $select.search }">
+            <div ng-bind-html="container.name | highlight : $select.search"></div>
+          </ui-select-choices>
+        </ui-select>
       </div>
     </div>
     <div class="form-group">
       <label for="timeRange">Time Range:</label>
-      <select id="timeRange"
-              ng-model="options.timeRange"
-              ng-options="range.label for range in options.rangeOptions"
-              ng-disabled="metricsError">
-      </select>
+      <div class="select-range">
+        <ui-select ng-model="options.timeRange" search-enabled="false" input-id="timeRange">
+          <ui-select-match>{{$select.selected.label}}</ui-select-match>
+          <ui-select-choices repeat="range in options.rangeOptions">
+            {{range.label}}
+          </ui-select-choices>
+        </ui-select>
+      </div>
     </div>
   </div>
 

--- a/app/views/directives/traffic-table.html
+++ b/app/views/directives/traffic-table.html
@@ -50,7 +50,7 @@
       </td>
       <!-- Use shorter Termination title for table-mobile to avoid overlapping text. -->
       <td data-title="Termination">
-        {{routes[routeName].spec.tls.termination}}
+        {{routes[routeName].spec.tls.termination | humanizeTLSTermination}}
         <span ng-if="!routes[routeName].spec.tls.termination">&nbsp;</span>
       </td>
     </tr>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -9827,7 +9827,16 @@ controller:[ "$scope", function(a) {
 a.disableCertificateInputs = function() {
 var b = _.get(a, "route.tls.termination");
 return !b || "passthrough" === b;
-};
+}, a.insecureTrafficOptions = [ {
+value:"",
+label:"None"
+}, {
+value:"Allow",
+label:"Allow"
+}, {
+value:"Redirect",
+label:"Redirect"
+} ];
 } ],
 link:function(b, c, d, e) {
 b.form = e, b.disableWildcards = a.DISABLE_WILDCARD_ROUTES, b.disableWildcards ? b.hostnamePattern = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/ :b.hostnamePattern = /^(\*(\.[a-z0-9]([-a-z0-9]*[a-z0-9]))+|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$/;
@@ -9857,6 +9866,7 @@ b.secureRoute = !!_.get(b, "route.tls.termination"), b.showCertificatesNotUsedWa
 var h;
 b.$watch("secureRoute", function(a, c) {
 if (a !== c) {
+a && !_.get(b, "route.tls.insecureEdgeTerminationPolicy") && _.set(b, "route.tls.insecureEdgeTerminationPolicy", b.insecureTrafficOptions[0]);
 var d = _.get(b, "route.tls.termination");
 !b.securetRoute && d && (h = d, delete b.route.tls.termination), b.secureRoute && !d && _.set(b, "route.tls.termination", h || "edge");
 }
@@ -13706,6 +13716,22 @@ return _.get(a, "spec.strategy.customParams", {});
 
 default:
 return null;
+}
+};
+}).filter("humanizeTLSTermination", function() {
+return function(a) {
+switch (a) {
+case "edge":
+return "Edge";
+
+case "passthrough":
+return "Passthrough";
+
+case "reencrypt":
+return "Re-encrypt";
+
+default:
+return a;
 }
 };
 }).filter("humanizeKind", [ "startCaseFilter", function(a) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3610,7 +3610,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<h4>TLS Settings</h4>\n" +
     "<dl class=\"dl-horizontal left\" ng-if=\"route.spec.tls\">\n" +
     "<dt>Termination Type:</dt>\n" +
-    "<dd>{{route.spec.tls.termination}}</dd>\n" +
+    "<dd>{{route.spec.tls.termination | humanizeTLSTermination}}</dd>\n" +
     "<dt ng-if-start=\"route.spec.tls.termination === 'edge'\">Insecure Traffic:</dt>\n" +
     "<dd ng-if-end>{{route.spec.tls.insecureEdgeTerminationPolicy || 'None'}}</dd>\n" +
     "<dt>Certificate:</dt>\n" +
@@ -3750,7 +3750,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</td>\n" +
     "\n" +
     "<td data-title=\"Termination\">\n" +
-    "{{route.spec.tls.termination}}\n" +
+    "{{route.spec.tls.termination | humanizeTLSTermination}}\n" +
     "<span ng-if=\"!route.spec.tls.termination\">&nbsp;</span>\n" +
     "</td>\n" +
     "</tr>\n" +
@@ -4897,8 +4897,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<osc-form-section header=\"Scaling\" about-title=\"Scaling\" about=\"Scaling defines the number of running instances of your built image.\" expand=\"true\" can-toggle=\"false\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"scale-type\">Strategy</label>\n" +
-    "<select ng-model=\"scaling.autoscale\" ng-options=\"option.value as option.label for option in scaling.autoscaleOptions\" id=\"scale-type\" class=\"form-control\" aria-describedby=\"scale-type-help\">\n" +
-    "</select>\n" +
+    "<ui-select ng-model=\"scaling.autoscale\" input-id=\"scale-type\" search-enabled=\"false\" aria-describedby=\"scale-type-help\">\n" +
+    "<ui-select-match>{{$select.selected.label}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"option.value as option in scaling.autoscaleOptions\">\n" +
+    "{{option.label}}\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
     "<div class=\"help-block\" id=\"scale-type-help\">\n" +
     "Scale replicas manually or automatically based on CPU usage.\n" +
     "</div>\n" +
@@ -7515,8 +7519,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<label for=\"{{id}}-service-select\" class=\"required\">\n" +
     "Service\n" +
     "</label>\n" +
-    "<select id=\"{{id}}-service-select\" ng-model=\"model.service\" ng-options=\"service as service.metadata.name for service in services\" required class=\"form-control\" ng-attr-aria-describedby=\"{{id}}-service-help\">\n" +
-    "</select>\n" +
+    "<ui-select ng-model=\"model.service\" input-id=\"{{id}}-service-select\" aria-describedby=\"{{id}}-service-help\" required>\n" +
+    "<ui-select-match>{{$select.selected.metadata.name}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"service in (services | filter : {metadata: { name: $select.search }}) track by (service | uid)\">\n" +
+    "<div ng-bind-html=\"service.metadata.name | highlight : $select.search\"></div>\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
     "<div>\n" +
     "<span ng-attr-id=\"{{id}}-service-help\" class=\"help-block\">\n" +
     "<span ng-if=\"!isAlternate\">Service to route to.</span>\n" +
@@ -7631,8 +7639,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<div ng-if=\"route.portOptions.length\" class=\"form-group\">\n" +
     "<label for=\"routeTargetPort\">Target Port</label>\n" +
-    "<select id=\"routeTargetPort\" ng-if=\"route.portOptions.length\" ng-model=\"route.targetPort\" ng-options=\"portOption.port as portOption.label for portOption in route.portOptions\" class=\"form-control\" aria-describedby=\"target-port-help\">\n" +
-    "</select>\n" +
+    "<ui-select ng-if=\"route.portOptions.length\" ng-model=\"route.targetPort\" input-id=\"routeTargetPort\" search-enabled=\"false\" aria-describedby=\"target-port-help\">\n" +
+    "<ui-select-match>{{$select.selected.label}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"portOption.port as portOption in route.portOptions\">\n" +
+    "{{portOption.label}}\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
     "<div>\n" +
     "<span id=\"target-port-help\" class=\"help-block\">\n" +
     "Target port for traffic.\n" +
@@ -7669,24 +7681,26 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-show=\"secureRoute\">\n" +
     "\n" +
     "<div class=\"form-group\">\n" +
-    "<label>TLS Termination</label>\n" +
-    "<select ng-model=\"route.tls.termination\" class=\"form-control\">\n" +
-    "<option value=\"edge\">Edge</option>\n" +
-    "<option value=\"passthrough\">Passthrough</option>\n" +
-    "<option value=\"reencrypt\">Re-encrypt</option>\n" +
-    "</select>\n" +
+    "<label for=\"tlsTermination\">TLS Termination</label>\n" +
+    "<ui-select ng-model=\"route.tls.termination\" input-id=\"tlsTermination\" search-enabled=\"false\">\n" +
+    "<ui-select-match>{{$select.selected | humanizeTLSTermination}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"option in ['edge', 'passthrough', 'reencrypt']\">\n" +
+    "{{option | humanizeTLSTermination}}\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
     "<div class=\"learn-more-block help-block\">\n" +
     "<a href=\"{{'route-types' | helpLink}}\" target=\"_blank\">Learn More&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></a>\n" +
     "</div>\n" +
     "</div>\n" +
     "\n" +
     "<div class=\"form-group\">\n" +
-    "<label>Insecure Traffic</label>\n" +
-    "<select ng-model=\"route.tls.insecureEdgeTerminationPolicy\" ng-disabled=\"route.tls.termination !== 'edge'\" class=\"form-control\" aria-describedby=\"route-insecure-policy-help\">\n" +
-    "<option value=\"\">None</option>\n" +
-    "<option value=\"Allow\">Allow</option>\n" +
-    "<option value=\"Redirect\">Redirect</option>\n" +
-    "</select>\n" +
+    "<label for=\"insecureTraffic\">Insecure Traffic</label>\n" +
+    "<ui-select ng-model=\"route.tls.insecureEdgeTerminationPolicy\" ng-disabled=\"route.tls.termination !== 'edge'\" input-id=\"insecureTraffic\" aria-describedby=\"route-insecure-policy-help\" search-enabled=\"false\">\n" +
+    "<ui-select-match>{{$select.selected.label}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"option.value as option in insecureTrafficOptions\">\n" +
+    "{{option.label}}\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
     "<div>\n" +
     "<span id=\"route-insecure-policy-help\" class=\"help-block\">\n" +
     "Policy for traffic on insecure schemes like HTTP for edge termination.\n" +
@@ -7929,14 +7943,24 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-show=\"pod.spec.containers.length === 1\">\n" +
     "{{pod.spec.containers[0].name}}\n" +
     "</span>\n" +
-    "<select id=\"selectContainer\" ng-show=\"pod.spec.containers.length > 1\" ng-init=\"options.selectedContainer = pod.spec.containers[0]\" ng-model=\"options.selectedContainer\" ng-options=\"container.name for container in pod.spec.containers track by container.name\">\n" +
-    "</select>\n" +
+    "<ui-select ng-init=\"options.selectedContainer = pod.spec.containers[0]\" ng-show=\"pod.spec.containers.length > 1\" ng-model=\"options.selectedContainer\" input-id=\"selectContainer\">\n" +
+    "<ui-select-match>{{$select.selected.name}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"container in pod.spec.containers | filter : { name: $select.search }\">\n" +
+    "<div ng-bind-html=\"container.name | highlight : $select.search\"></div>\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"timeRange\">Time Range:</label>\n" +
-    "<select id=\"timeRange\" ng-model=\"options.timeRange\" ng-options=\"range.label for range in options.rangeOptions\" ng-disabled=\"metricsError\">\n" +
-    "</select>\n" +
+    "<div class=\"select-range\">\n" +
+    "<ui-select ng-model=\"options.timeRange\" search-enabled=\"false\" input-id=\"timeRange\">\n" +
+    "<ui-select-match>{{$select.selected.label}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"range in options.rangeOptions\">\n" +
+    "{{range.label}}\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "<ellipsis-pulser color=\"dark\" size=\"sm\" msg=\"Loading metrics\" ng-if=\"!loaded\"></ellipsis-pulser>\n" +
@@ -8195,7 +8219,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</td>\n" +
     "\n" +
     "<td data-title=\"Termination\">\n" +
-    "{{routes[routeName].spec.tls.termination}}\n" +
+    "{{routes[routeName].spec.tls.termination | humanizeTLSTermination}}\n" +
     "<span ng-if=\"!routes[routeName].spec.tls.termination\">&nbsp;</span>\n" +
     "</td>\n" +
     "</tr>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3788,9 +3788,12 @@ mark{padding:0;background-color:rgba(252,248,160,.5)}
 .build-trends-responsive .build-trends-container .avg-duration{margin-right:30px}
 .build-trends-responsive .build-trends-container .avg-duration-text{vertical-align:top;font-size:12px}
 .metrics .metrics-options .form-group{margin-bottom:0}
-.metrics .metrics-options .select-container{display:inline-block}
-@media (min-width:768px){.metrics .metrics-options .form-group{display:inline-block}
+.metrics .metrics-options .select-container,.metrics .metrics-options .select-range{display:inline-block;vertical-align:middle}
+@media (min-width:768px){.metrics .metrics-options .form-group{display:inline-block;vertical-align:middle}
 .metrics .metrics-options .select-container{margin-right:10px}
+}
+@media (max-width:767px){.metrics .metrics-options .form-group{padding-bottom:10px}
+.metrics .metrics-options .form-group label{width:100px}
 }
 .metrics .metrics-full h2:not(.has-limit){border-bottom:1px solid #d1d1d1;margin-bottom:0;padding-bottom:15px}
 .metrics .metrics-full .metrics-donut,.metrics .metrics-full .metrics-sparkline{margin-top:20px}


### PR DESCRIPTION
This is the first part of work which is moving all our `select` tags to `ui-select`
So far it contains the :

- fromimage page
- create route page
- pod browse page -> metrics tab

I've added the `input-id` attribute as suggested and also the `aria-describedby` in case the help text is below the select-box.

@spadgett PTAL