### PR TITLE
Let users save logs

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -36,6 +36,7 @@
     "Clipboard": false,
     "$": false,
     "_" : false,
-    "URITemplate": false
+    "URITemplate": false,
+    "saveAs": false
   }
 }

--- a/app/index.html
+++ b/app/index.html
@@ -153,6 +153,7 @@
     <script src="bower_components/js-yaml/dist/js-yaml.js"></script>
     <script src="bower_components/angular-moment/angular-moment.js"></script>
     <script src="bower_components/angular-utf8-base64/angular-utf8-base64.js"></script>
+    <script src="bower_components/file-saver/FileSaver.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 
@@ -209,6 +210,7 @@
         <script src="scripts/services/labels.js"></script>
         <script src="scripts/services/catalog.js"></script>
         <script src="scripts/services/modals.js"></script>
+        <script src="scripts/services/cliHelp.js"></script>
         <script src="scripts/controllers/projects.js"></script>
         <script src="scripts/controllers/pods.js"></script>
         <script src="scripts/controllers/pod.js"></script>
@@ -269,6 +271,7 @@
         <script src="scripts/controllers/modals/createSecretModal.js"></script>
         <script src="scripts/controllers/modals/confirmModal.js"></script>
         <script src="scripts/controllers/modals/confirmScale.js"></script>
+        <script src="scripts/controllers/modals/confirmSaveLog.js"></script>
         <script src="scripts/controllers/modals/deleteModal.js"></script>
         <script src="scripts/controllers/modals/debugTerminal.js"></script>
         <script src="scripts/controllers/modals/confirmReplaceModal.js"></script>

--- a/app/scripts/controllers/modals/confirmModal.js
+++ b/app/scripts/controllers/modals/confirmModal.js
@@ -15,7 +15,7 @@ angular.module('openshiftConsole')
     // content supplied in the following forms:
     // heading: modalConfig.message
     // content: modalConfig.details (plain text ONLY, no user imput)
-    // content: modalConfig.detailsHtml (pre-sanitized, see _.escape() or _.template('<%- %>') )
+    // content: modalConfig.detailsMarkup (pre-sanitized, see _.escape() or _.template('<%- %>') )
     _.extend($scope, modalConfig);
 
     $scope.confirm = function() {

--- a/app/scripts/controllers/modals/confirmSaveLog.js
+++ b/app/scripts/controllers/modals/confirmSaveLog.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * @ngdoc controller
+ * @name openshiftConsole.controller:ConfirmSaveLogController
+ * @description
+ *
+ * Shows a confirmation dialog before saving a partial log for a pod,
+ * replication controller, or build. The dialog contains the CLI command to get
+ * the full log.
+ */
+angular.module('openshiftConsole')
+  .controller('ConfirmSaveLogController',
+              function($scope,
+                       $uibModalInstance,
+                       object,
+                       CLIHelp) {
+    $scope.object = object;
+    $scope.command = CLIHelp.getLogsCommand(object);
+
+    $scope.save = function() {
+      $uibModalInstance.close('save');
+    };
+
+    $scope.cancel = function() {
+      $uibModalInstance.dismiss('cancel');
+    };
+  });

--- a/app/scripts/services/cliHelp.js
+++ b/app/scripts/services/cliHelp.js
@@ -1,0 +1,56 @@
+'use strict';
+
+angular.module("openshiftConsole")
+  .factory("CLIHelp", function($filter) {
+    var annotation = $filter('annotation');
+
+    // Gets the logs command for an API object.
+    //
+    // object - a pod, deployment config, replication controller, build config, or build
+    // containerName - container name for the pod (optional)
+    var getLogsCommand = function(object, /* optional */ containerName) {
+      if (!object) {
+        return null;
+      }
+
+      var command, name, version;
+      switch (object.kind) {
+        case 'Pod':
+          command = 'oc logs ' + object.metadata.name;
+          if (containerName) {
+            command += ' -c ' + containerName;
+          }
+          break;
+        case 'DeploymentConfig':
+          command = 'oc logs dc/' + object.metadata.name;
+          break;
+        case 'ReplicationController':
+          name = annotation(object, 'deploymentConfig');
+          version = annotation(object, 'deploymentVersion');
+          if (name && version) {
+            command = 'oc logs --version ' + version + ' dc/' + name;
+          } else {
+            command = 'oc logs rc/' + object.metadata.name;
+          }
+          break;
+        case 'BuildConfig':
+          command = 'oc logs bc/' + object.metadata.name;
+          break;
+        case 'Build':
+          name = annotation(object, 'buildConfig');
+          version = annotation(object, 'buildNumber');
+          command = 'oc logs --version ' + version + ' bc/' + name;
+          break;
+        default:
+          return null;
+      }
+      command += ' -n ' + object.metadata.namespace;
+
+      return command;
+    };
+
+    return {
+      getLogsCommand: getLogsCommand
+    };
+  });
+

--- a/app/scripts/services/modals.js
+++ b/app/scripts/services/modals.js
@@ -18,6 +18,19 @@ angular.module("openshiftConsole")
         return modalInstance.result;
       },
 
+      confirmSaveLog: function(object) {
+        var modalInstance = $uibModal.open({
+          animation: true,
+          templateUrl: 'views/modals/confirm-save-log.html',
+          controller: 'ConfirmSaveLogController',
+          resolve: {
+            object: object
+          }
+        });
+
+        return modalInstance.result;
+      },
+
       showJenkinsfileExamples: function() {
         $uibModal.open({
           animation: true,

--- a/app/views/directives/logs/_log-viewer.html
+++ b/app/views/directives/logs/_log-viewer.html
@@ -16,13 +16,20 @@
       </form>
       <span ng-if="state && state !== 'empty'" class="action-divider">|</span>
     </span>
+    <span ng-if="canSave && state && state !== 'empty'">
+      <a href=""
+         ng-click="saveLog()"
+         role="button">
+         Save
+         <i class="fa fa-download"></i></a>
+      <span ng-if="state && state !== 'empty'" class="action-divider">|</span>
+    </span>
     <a ng-if="state && state !== 'empty'"
        href=""
        ng-click="goChromeless(options, fullLogUrl)"
        role="button">
-       Expand Log
-       <i class="fa fa-external-link"></i>
-    </a>
+       Expand
+       <i class="fa fa-external-link"></i></a>
   </div>
 </div>
 

--- a/app/views/modals/confirm-save-log.html
+++ b/app/views/modals/confirm-save-log.html
@@ -1,0 +1,17 @@
+<div class="modal-resource-action">
+  <div class="modal-body">
+    <h1>Save partial log for <strong>{{object.metadata.name}}</strong>?</h1>
+    <div class="mar-bottom-xl">
+      The log might not be complete. Continuing will save only the content currently displayed.
+      <span ng-if="command">To get the complete log, run the command</span>
+    </div>
+    <copy-to-clipboard ng-if="command" display-wide="true" clipboard-text="command"></copy-to-clipboard>
+    <div class="mar-top-xl">
+      Learn more about the <a href="command-line" target="_blank">command line tools</a>.
+    </div>
+  </div>
+  <div class="modal-footer">
+      <button class="btn btn-lg btn-primary" type="button" ng-click="save()">Save</button>
+      <button class="btn btn-lg btn-default" type="button" ng-click="cancel()">Cancel</button>
+  </div>
+</div>

--- a/bower.json
+++ b/bower.json
@@ -44,7 +44,8 @@
     "angular-inview": "1.5.7",
     "js-yaml": "3.6.1",
     "angular-moment": "1.0.0",
-    "angular-utf8-base64": "0.0.5"
+    "angular-utf8-base64": "0.0.5",
+    "file-saver": "1.3.3"
   },
   "devDependencies": {
     "angular-mocks": "1.3.20",

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4100,6 +4100,17 @@ modalConfig:b
 });
 return c.result;
 },
+confirmSaveLog:function(b) {
+var c = a.open({
+animation:!0,
+templateUrl:"views/modals/confirm-save-log.html",
+controller:"ConfirmSaveLogController",
+resolve:{
+object:b
+}
+});
+return c.result;
+},
 showJenkinsfileExamples:function() {
 a.open({
 animation:!0,
@@ -4114,6 +4125,39 @@ templateUrl:"views/modals/about-compute-units-modal.html",
 controller:"AboutComputeUnitsModalController"
 });
 }
+};
+} ]), angular.module("openshiftConsole").factory("CLIHelp", [ "$filter", function(a) {
+var b = a("annotation"), c = function(a, c) {
+if (!a) return null;
+var d, e, f;
+switch (a.kind) {
+case "Pod":
+d = "oc logs " + a.metadata.name, c && (d += " -c " + c);
+break;
+
+case "DeploymentConfig":
+d = "oc logs dc/" + a.metadata.name;
+break;
+
+case "ReplicationController":
+e = b(a, "deploymentConfig"), f = b(a, "deploymentVersion"), d = e && f ? "oc logs --version " + f + " dc/" + e :"oc logs rc/" + a.metadata.name;
+break;
+
+case "BuildConfig":
+d = "oc logs bc/" + a.metadata.name;
+break;
+
+case "Build":
+e = b(a, "buildConfig"), f = b(a, "buildNumber"), d = "oc logs --version " + f + " bc/" + e;
+break;
+
+default:
+return null;
+}
+return d += " -n " + a.metadata.namespace;
+};
+return {
+getLogsCommand:c
 };
 } ]), angular.module("openshiftConsole").controller("ProjectsController", [ "$scope", "$filter", "$location", "$route", "$timeout", "AlertMessageService", "AuthService", "DataService", "KeywordService", "Logger", "ProjectsService", function(a, b, c, d, e, f, g, h, i, j, k) {
 var l, m, n = [], o = [];
@@ -8669,6 +8713,12 @@ b.close("confirmScale");
 }, a.cancel = function() {
 b.dismiss("cancel");
 };
+} ]), angular.module("openshiftConsole").controller("ConfirmSaveLogController", [ "$scope", "$uibModalInstance", "object", "CLIHelp", function(a, b, c, d) {
+a.object = c, a.command = d.getLogsCommand(c), a.save = function() {
+b.close("save");
+}, a.cancel = function() {
+b.dismiss("cancel");
+};
 } ]), angular.module("openshiftConsole").controller("DeleteModalController", [ "$scope", "$uibModalInstance", function(a, b) {
 a["delete"] = function() {
 b.close("delete");
@@ -11553,15 +11603,15 @@ a.destroy();
 });
 }
 };
-} ]), angular.module("openshiftConsole").directive("logViewer", [ "$sce", "$timeout", "$window", "$filter", "AuthService", "APIService", "APIDiscovery", "DataService", "logLinks", "BREAKPOINTS", function(a, b, c, d, e, f, g, h, i, j) {
-var k = $(window), l = function(a) {
+} ]), angular.module("openshiftConsole").directive("logViewer", [ "$sce", "$timeout", "$window", "$filter", "AuthService", "APIService", "APIDiscovery", "DataService", "ModalsService", "logLinks", "BREAKPOINTS", function(a, b, c, d, e, f, g, h, i, j, k) {
+var l = $(window), m = function(a) {
 return a.replace(/https?:\/\/[A-Za-z0-9._%+-]+\S*[^\s.;,(){}<>"\u201d\u2019]/gm, function(a) {
 return '<a href="' + a + '" target="_blank">' + a + "</a>";
 });
-}, m = $('<tr class="log-line"><td class="log-line-number"></td><td class="log-line-text"></td></tr>').get(0), n = function(a, b) {
-var c = m.cloneNode(!0);
+}, n = $('<tr class="log-line"><td class="log-line-number"></td><td class="log-line-text"></td></tr>').get(0), o = function(a, b) {
+var c = n.cloneNode(!0);
 c.firstChild.setAttribute("data-line-number", a);
-var d = ansi_up.escape_for_html(b), e = ansi_up.ansi_to_html(d), f = l(e);
+var d = ansi_up.escape_for_html(b), e = ansi_up.ansi_to_html(d), f = m(e);
 return c.lastChild.innerHTML = f, c;
 };
 return {
@@ -11581,63 +11631,63 @@ chromeless:"=?",
 empty:"=?",
 run:"=?"
 },
-controller:[ "$scope", function(l) {
-var m, o, p, q, r, s = document.documentElement;
-l.logViewerID = _.uniqueId("log-viewer"), l.empty = !0;
+controller:[ "$scope", function(i) {
+var m, n, p, q, r, s = document.documentElement;
+i.logViewerID = _.uniqueId("log-viewer"), i.empty = !0;
 var t, u;
-"ReplicationController" === l.object.kind ? (t = "deploymentconfigs/log", u = d("annotation")(l.object, "deploymentConfig")) :(t = f.kindToResource(l.object.kind) + "/log", u = l.object.metadata.name);
+"ReplicationController" === i.object.kind ? (t = "deploymentconfigs/log", u = d("annotation")(i.object, "deploymentConfig")) :(t = f.kindToResource(i.object.kind) + "/log", u = i.object.metadata.name);
 var v = function() {
-q = window.innerWidth < j.screenSmMin && !l.fixedHeight ? null :o;
+q = window.innerWidth < k.screenSmMin && !i.fixedHeight ? null :n;
 }, w = function() {
-l.$apply(function() {
+i.$apply(function() {
 var a = m.getBoundingClientRect();
-l.fixedHeight ? l.showScrollLinks = a && a.height > l.fixedHeight :l.showScrollLinks = a && (a.top < 0 || a.bottom > s.clientHeight);
+i.fixedHeight ? i.showScrollLinks = a && a.height > i.fixedHeight :i.showScrollLinks = a && (a.top < 0 || a.bottom > s.clientHeight);
 });
 }, x = !1, y = function() {
-x ? x = !1 :l.$evalAsync(function() {
-l.autoScrollActive = !1;
+x ? x = !1 :i.$evalAsync(function() {
+i.autoScrollActive = !1;
 });
 }, z = function() {
-p.off("scroll", y), k.off("scroll", y), window.innerWidth <= j.screenSmMin && !l.fixedHeight ? k.on("scroll", y) :p.on("scroll", y);
+p.off("scroll", y), l.off("scroll", y), window.innerWidth <= k.screenSmMin && !i.fixedHeight ? l.on("scroll", y) :p.on("scroll", y);
 }, A = function() {
-l.fixedHeight || (window.innerWidth < j.screenSmMin && !l.fixedHeight ? r.removeClass("target-logger-node").affix({
+i.fixedHeight || (window.innerWidth < k.screenSmMin && !i.fixedHeight ? r.removeClass("target-logger-node").affix({
 target:window,
 offset:{
-top:l.followAffixTop || 0,
-bottom:l.followAffixBottom || 0
+top:i.followAffixTop || 0,
+bottom:i.followAffixBottom || 0
 }
 }) :r.addClass("target-logger-node").affix({
 target:p,
 offset:{
-top:l.followAffixTop || 0,
-bottom:l.followAffixBottom || 0
+top:i.followAffixTop || 0,
+bottom:i.followAffixBottom || 0
 }
 }));
 }, B = function(a) {
-var b = $("#" + l.logViewerID + " .log-view-output"), c = b.offset().top;
+var b = $("#" + i.logViewerID + " .log-view-output"), c = b.offset().top;
 if (!(c < 0)) {
-var d = $(".ellipsis-pulser").outerHeight(!0), e = l.fixedHeight ? l.fixedHeight :Math.floor($(window).height() - c - d);
-l.chromeless || l.fixedHeight || (e -= 35), a ? b.animate({
+var d = $(".ellipsis-pulser").outerHeight(!0), e = i.fixedHeight ? i.fixedHeight :Math.floor($(window).height() - c - d);
+i.chromeless || i.fixedHeight || (e -= 35), a ? b.animate({
 "min-height":e + "px"
-}, "fast") :b.css("min-height", e + "px"), l.fixedHeight && b.css("max-height", e);
+}, "fast") :b.css("min-height", e + "px"), i.fixedHeight && b.css("max-height", e);
 }
 }, C = _.debounce(function() {
 B(!0), v(), z(), w(), A(), y();
 }, 100);
-k.on("resize", C);
+l.on("resize", C);
 var D, E = function() {
-x = !0, i.scrollBottom(q);
+x = !0, j.scrollBottom(q);
 }, F = function() {
-l.autoScrollActive = !l.autoScrollActive, l.autoScrollActive && E();
+i.autoScrollActive = !i.autoScrollActive, i.autoScrollActive && E();
 }, G = document.createDocumentFragment(), H = _.debounce(function() {
-m.appendChild(G), G = document.createDocumentFragment(), l.autoScrollActive && E(), l.showScrollLinks || w();
+m.appendChild(G), G = document.createDocumentFragment(), i.autoScrollActive && E(), i.showScrollLinks || w();
 }, 100, {
 maxWait:300
 }), I = function(a) {
 D && (D.stop(), D = null), a || (H.cancel(), m && (m.innerHTML = ""), G = document.createDocumentFragment());
 }, J = function() {
-if (I(), l.run) {
-angular.extend(l, {
+if (I(), i.run) {
+angular.extend(i, {
 loading:!0,
 autoScroll:!1,
 limitReached:!1,
@@ -11647,82 +11697,91 @@ var a = angular.extend({
 follow:!0,
 tailLines:5e3,
 limitBytes:10485760
-}, l.options);
-D = h.createStream(t, u, l.context, a);
+}, i.options);
+D = h.createStream(t, u, i.context, a);
 var c = 0, d = function(a) {
-c++, G.appendChild(n(c, a)), H();
+c++, G.appendChild(o(c, a)), H();
 };
 D.onMessage(function(b, e, f) {
-l.$evalAsync(function() {
-l.empty = !1, "logs" !== l.state && (l.state = "logs", setTimeout(B));
-}), b && (a.limitBytes && f >= a.limitBytes && (l.$evalAsync(function() {
-l.limitReached = !0, l.loading = !1;
-}), I(!0)), d(b), !l.largeLog && c >= a.tailLines && l.$evalAsync(function() {
-l.largeLog = !0;
+i.$evalAsync(function() {
+i.empty = !1, "logs" !== i.state && (i.state = "logs", setTimeout(B));
+}), b && (a.limitBytes && f >= a.limitBytes && (i.$evalAsync(function() {
+i.limitReached = !0, i.loading = !1;
+}), I(!0)), d(b), !i.largeLog && c >= a.tailLines && i.$evalAsync(function() {
+i.largeLog = !0;
 }));
 }), D.onClose(function() {
-D = null, l.$evalAsync(function() {
-l.autoScrollActive = !1, 0 !== c || l.emptyStateMessage || (l.state = "empty", l.emptyStateMessage = "The logs are no longer available or could not be loaded.");
+D = null, i.$evalAsync(function() {
+i.autoScrollActive = !1, 0 !== c || i.emptyStateMessage || (i.state = "empty", i.emptyStateMessage = "The logs are no longer available or could not be loaded.");
 }), b(function() {
-l.loading = !1;
+i.loading = !1;
 }, 100);
 }), D.onError(function() {
-D = null, l.$evalAsync(function() {
-angular.extend(l, {
+D = null, i.$evalAsync(function() {
+angular.extend(i, {
 loading:!1,
 autoScroll:!1
-}), 0 === c ? (l.state = "empty", l.emptyStateMessage = "The logs are no longer available or could not be loaded.") :l.errorWhileRunning = !0;
+}), 0 === c ? (i.state = "empty", i.emptyStateMessage = "The logs are no longer available or could not be loaded.") :i.errorWhileRunning = !0;
 });
 }), D.start();
 }
 };
 return g.getLoggingURL().then(function(b) {
-var d = _.get(l.context, "project.metadata.name"), f = _.get(l.options, "container");
-d && f && u && b && (angular.extend(l, {
+var d = _.get(i.context, "project.metadata.name"), f = _.get(i.options, "container");
+d && f && u && b && (angular.extend(i, {
 kibanaAuthUrl:a.trustAsResourceUrl(URI(b).segment("auth").segment("token").normalizePathname().toString()),
 access_token:e.UserStore().getToken()
-}), l.$watchGroup([ "context.project.metadata.name", "options.container", "name" ], function() {
-angular.extend(l, {
-kibanaArchiveUrl:a.trustAsResourceUrl(i.archiveUri({
-namespace:l.context.project.metadata.name,
-namespaceUid:l.context.project.metadata.uid,
+}), i.$watchGroup([ "context.project.metadata.name", "options.container", "name" ], function() {
+angular.extend(i, {
+kibanaArchiveUrl:a.trustAsResourceUrl(j.archiveUri({
+namespace:i.context.project.metadata.name,
+namespaceUid:i.context.project.metadata.uid,
 podname:u,
-containername:l.options.container,
+containername:i.options.container,
 backlink:URI.encode(c.location.href)
 }))
 });
 }));
 }), this.cacheScrollableNode = function(a) {
-o = a, p = $(o);
+n = a, p = $(n);
 }, this.cacheLogNode = function(a) {
 m = a;
 }, this.cacheAffixable = function(a) {
 r = $(a);
 }, this.start = function() {
 v(), z(), A();
-}, angular.extend(l, {
+}, angular.extend(i, {
 ready:!0,
 loading:!0,
 autoScroll:!1,
 state:!1,
 onScrollBottom:function() {
-i.scrollBottom(q);
+j.scrollBottom(q);
 },
 onScrollTop:function() {
-l.autoScrollActive = !1, i.scrollTop(q);
+i.autoScrollActive = !1, j.scrollTop(q);
 },
 toggleAutoScroll:F,
-goChromeless:i.chromelessLink,
+goChromeless:j.chromelessLink,
 restartLogs:J
-}), l.$on("$destroy", function() {
-I(), k.off("resize", C), k.off("scroll", y), p.off("scroll", y);
-}), "deploymentconfigs/logs" !== t || u ? void l.$watchGroup([ "name", "options.container", "run" ], J) :(l.state = "empty", void (l.emptyStateMessage = "Logs are not available for this replication controller because it was not generated from a deployment configuration."));
+}), i.$on("$destroy", function() {
+I(), l.off("resize", C), l.off("scroll", y), p.off("scroll", y);
+}), "deploymentconfigs/logs" !== t || u ? void i.$watchGroup([ "name", "options.container", "run" ], J) :(i.state = "empty", void (i.emptyStateMessage = "Logs are not available for this replication controller because it was not generated from a deployment configuration."));
 } ],
 require:"logViewer",
 link:function(a, c, d, e) {
 b(function() {
 e.cacheScrollableNode(document.getElementById(a.fixedHeight ? a.logViewerID + "-fixed-scrollable" :"container-main")), e.cacheLogNode(document.getElementById(a.logViewerID + "-logContent")), e.cacheAffixable(document.getElementById(a.logViewerID + "-affixedFollow")), e.start();
 }, 0);
+var f = function() {
+var b = $(c).find(".log-line-text").text(), d = _.get(a, "object.metadata.name", "openshift") + ".log", e = new Blob([ b ], {
+type:"text/plain;charset=utf-8"
+});
+saveAs(e, d);
+};
+a.canSave = !!new Blob(), a.saveLog = function() {
+return a.largeLog ? void i.confirmSaveLog(a.object).then(f) :void f();
+};
 }
 };
 } ]), angular.module("openshiftConsole").directive("statusIcon", function() {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7080,10 +7080,15 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</form>\n" +
     "<span ng-if=\"state && state !== 'empty'\" class=\"action-divider\">|</span>\n" +
     "</span>\n" +
+    "<span ng-if=\"canSave && state && state !== 'empty'\">\n" +
+    "<a href=\"\" ng-click=\"saveLog()\" role=\"button\">\n" +
+    "Save\n" +
+    "<i class=\"fa fa-download\"></i></a>\n" +
+    "<span ng-if=\"state && state !== 'empty'\" class=\"action-divider\">|</span>\n" +
+    "</span>\n" +
     "<a ng-if=\"state && state !== 'empty'\" href=\"\" ng-click=\"goChromeless(options, fullLogUrl)\" role=\"button\">\n" +
-    "Expand Log\n" +
-    "<i class=\"fa fa-external-link\"></i>\n" +
-    "</a>\n" +
+    "Expand\n" +
+    "<i class=\"fa fa-external-link\"></i></a>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"largeLog\" class=\"alert alert-info log-size-warning\">\n" +
@@ -9767,6 +9772,27 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"modal-footer\">\n" +
     "<button class=\"btn btn-lg btn-primary\" type=\"button\" ng-click=\"replace();\">Replace</button>\n" +
     "<button class=\"btn btn-lg btn-default\" type=\"button\" ng-click=\"cancel();\">Cancel</button>\n" +
+    "</div>\n" +
+    "</div>"
+  );
+
+
+  $templateCache.put('views/modals/confirm-save-log.html',
+    "<div class=\"modal-resource-action\">\n" +
+    "<div class=\"modal-body\">\n" +
+    "<h1>Save partial log for <strong>{{object.metadata.name}}</strong>?</h1>\n" +
+    "<div class=\"mar-bottom-xl\">\n" +
+    "The log might not be complete. Continuing will save only the content currently displayed.\n" +
+    "<span ng-if=\"command\">To get the complete log, run the command</span>\n" +
+    "</div>\n" +
+    "<copy-to-clipboard ng-if=\"command\" display-wide=\"true\" clipboard-text=\"command\"></copy-to-clipboard>\n" +
+    "<div class=\"mar-top-xl\">\n" +
+    "Learn more about the <a href=\"command-line\" target=\"_blank\">command line tools</a>.\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"modal-footer\">\n" +
+    "<button class=\"btn btn-lg btn-primary\" type=\"button\" ng-click=\"save()\">Save</button>\n" +
+    "<button class=\"btn btn-lg btn-default\" type=\"button\" ng-click=\"cancel()\">Cancel</button>\n" +
     "</div>\n" +
     "</div>"
   );

--- a/dist/scripts/vendor.js
+++ b/dist/scripts/vendor.js
@@ -56109,3 +56109,68 @@ urldecode:b.decode,
 urlencode:b.encode
 };
 }());
+
+var saveAs = saveAs || function(a) {
+"use strict";
+if (!("undefined" == typeof a || "undefined" != typeof navigator && /MSIE [1-9]\./.test(navigator.userAgent))) {
+var b = a.document, c = function() {
+return a.URL || a.webkitURL || a;
+}, d = b.createElementNS("http://www.w3.org/1999/xhtml", "a"), e = "download" in d, f = function(a) {
+var b = new MouseEvent("click");
+a.dispatchEvent(b);
+}, g = /constructor/i.test(a.HTMLElement) || a.safari, h = /CriOS\/[\d]+/.test(navigator.userAgent), i = function(b) {
+(a.setImmediate || a.setTimeout)(function() {
+throw b;
+}, 0);
+}, j = "application/octet-stream", k = 4e4, l = function(a) {
+var b = function() {
+"string" == typeof a ? c().revokeObjectURL(a) :a.remove();
+};
+setTimeout(b, k);
+}, m = function(a, b, c) {
+b = [].concat(b);
+for (var d = b.length; d--; ) {
+var e = a["on" + b[d]];
+if ("function" == typeof e) try {
+e.call(a, c || a);
+} catch (f) {
+i(f);
+}
+}
+}, n = function(a) {
+return /^\s*(?:text\/\S*|application\/xml|\S*\/\S*\+xml)\s*;.*charset\s*=\s*utf-8/i.test(a.type) ? new Blob([ String.fromCharCode(65279), a ], {
+type:a.type
+}) :a;
+}, o = function(b, i, k) {
+k || (b = n(b));
+var o, p = this, q = b.type, r = q === j, s = function() {
+m(p, "writestart progress write writeend".split(" "));
+}, t = function() {
+if ((h || r && g) && a.FileReader) {
+var d = new FileReader();
+return d.onloadend = function() {
+var b = h ? d.result :d.result.replace(/^data:[^;]*;/, "data:attachment/file;"), c = a.open(b, "_blank");
+c || (a.location.href = b), b = void 0, p.readyState = p.DONE, s();
+}, d.readAsDataURL(b), void (p.readyState = p.INIT);
+}
+if (o || (o = c().createObjectURL(b)), r) a.location.href = o; else {
+var e = a.open(o, "_blank");
+e || (a.location.href = o);
+}
+p.readyState = p.DONE, s(), l(o);
+};
+return p.readyState = p.INIT, e ? (o = c().createObjectURL(b), void setTimeout(function() {
+d.href = o, d.download = i, f(d), s(), l(o), p.readyState = p.DONE;
+})) :void t();
+}, p = o.prototype, q = function(a, b, c) {
+return new o(a, b || a.name || "download", c);
+};
+return "undefined" != typeof navigator && navigator.msSaveOrOpenBlob ? function(a, b, c) {
+return b = b || a.name || "download", c || (a = n(a)), navigator.msSaveOrOpenBlob(a, b);
+} :(p.abort = function() {}, p.readyState = p.INIT = 0, p.WRITING = 1, p.DONE = 2, p.error = p.onwritestart = p.onprogress = p.onwrite = p.onabort = p.onerror = p.onwriteend = null, q);
+}
+}("undefined" != typeof self && self || "undefined" != typeof window && window || this.content);
+
+"undefined" != typeof module && module.exports ? module.exports.saveAs = saveAs :"undefined" != typeof define && null !== define && null !== define.amd && define("FileSaver.js", function() {
+return saveAs;
+});

--- a/test/spec/services/cliHelpSpec.js
+++ b/test/spec/services/cliHelpSpec.js
@@ -1,0 +1,158 @@
+"use strict";
+
+describe("CLIHelp", function() {
+  var CLIHelp;
+
+  beforeEach(function() {
+    inject(function(_CLIHelp_) {
+      CLIHelp = _CLIHelp_;
+    });
+  });
+
+  describe("#getLogsCommand", function() {
+    var testPod = {
+      apiVersion: "v1",
+      kind: "Pod",
+      metadata: {
+        name: "lonely-pod",
+        namespace: "my-project",
+      },
+      spec: {
+        containers: [
+          {
+            name: "hello-openshift",
+            image: "openshift/hello-openshift",
+            ports: [
+              {
+                containerPort: 8080,
+                protocol: "TCP"
+              }
+            ],
+            resources: {},
+          }
+        ],
+      },
+      status: {}
+    };
+
+    var testDC = {
+      apiVersion: "v1",
+      kind: "DeploymentConfig",
+      metadata: {
+        name: "my-deployment-config",
+        namespace: "my-project"
+      },
+      // spec and status aren't used by CLIHelp
+      spec: {},
+      status: {}
+    };
+
+    var testRC = {
+      apiVersion: "v1",
+      kind: "ReplicationController",
+      metadata: {
+        name: "my-deployment-config-3",
+        namespace: "my-project",
+        annotations: {
+          "openshift.io/deployment-config.name": "my-deployment-config",
+          "openshift.io/deployment-config.latest-version": 3
+        }
+      },
+      // spec and status aren't used by CLIHelp
+      spec: {},
+      status: {}
+    };
+
+    var vanillaRC = {
+      apiVersion: "v1",
+      kind: "ReplicationController",
+      metadata: {
+        name: "my-replication-controller",
+        namespace: "my-project",
+      },
+      // spec and status aren't used by CLIHelp
+      spec: {},
+      status: {}
+    };
+
+    var testBC = {
+      apiVersion: "v1",
+      kind: "BuildConfig",
+      metadata: {
+        name: "my-build",
+        namespace: "my-project"
+      },
+      // spec and status aren't used by CLIHelp
+      spec: {},
+      status: {}
+    };
+
+    var testBuild = {
+      apiVersion: "v1",
+      kind: "Build",
+      metadata: {
+        name: "my-build-3",
+        namespace: "my-project",
+        annotations: {
+          "openshift.io/build-config.name": "my-build",
+          "openshift.io/build.number": 3
+        }
+      },
+      // spec and status aren't used by CLIHelp
+      spec: {},
+      status: {}
+    };
+
+    it("should get the logs command for a pod", function() {
+      var command = CLIHelp.getLogsCommand(testPod);
+      expect(command).toEqual('oc logs lonely-pod -n my-project');
+    });
+
+    it("should get the logs command for a pod given a container name", function() {
+      var command = CLIHelp.getLogsCommand(testPod, 'hello-openshift');
+      expect(command).toEqual('oc logs lonely-pod -c hello-openshift -n my-project');
+    });
+
+    it("should get the logs command for a deployment config", function() {
+      var command = CLIHelp.getLogsCommand(testDC);
+      expect(command).toEqual('oc logs dc/my-deployment-config -n my-project');
+    });
+
+    it("should get the logs command for a replication controller owned by a deployment config", function() {
+      var command = CLIHelp.getLogsCommand(testRC);
+      expect(command).toEqual('oc logs --version 3 dc/my-deployment-config -n my-project');
+    });
+
+    it("should get the logs command for a replication controller NOT owned by a deployment config", function() {
+      var command = CLIHelp.getLogsCommand(vanillaRC);
+      expect(command).toEqual('oc logs rc/my-replication-controller -n my-project');
+    });
+
+    it("should get the logs command for a build config", function() {
+      var command = CLIHelp.getLogsCommand(testBC);
+      expect(command).toEqual('oc logs bc/my-build -n my-project');
+    });
+
+    it("should get the logs command for a build", function() {
+      var command = CLIHelp.getLogsCommand(testBuild);
+      expect(command).toEqual('oc logs --version 3 bc/my-build -n my-project');
+    });
+
+    it("should return null when object is null", function() {
+      var command = CLIHelp.getLogsCommand();
+      expect(command).toBeNull();
+    });
+
+    it("should return null for other kinds", function() {
+      var command = CLIHelp.getLogsCommand({
+        apiVersion: 'v1',
+        kind: 'UnknownKind',
+        metadata: {
+          name: 'unknown-object',
+          namespace: 'my-project'
+        }
+      });
+      expect(command).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Adds a "Save" link to the log viewer that saves the log contents as a file. Closes #356

https://trello.com/c/OaF7o3U3

Saves just the log text for logs that have links or colors. Does not add in the line numbers.

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/21197791/c0979d8c-c20a-11e6-811e-8f249aa1480e.png)

Uses library https://github.com/eligrey/FileSaver.js which is very small (< 200 lines of code). See browser support here:

  https://github.com/eligrey/FileSaver.js#supported-browsers

Tested with Chrome, Firefox, Safari, IE, and iOS. On iOS, it opens a new window with the plain log text:

<img width="487" alt="screen shot 2016-12-14 at 2 22 54 pm" src="https://cloud.githubusercontent.com/assets/1167259/21197868/06b4bbec-c20b-11e6-9d8b-1988730e7ff0.png">

cc @benjaminapetersen 
