### PR TITLE
Improve accessibility: use ng-repeat on <tr> instead of <tbody>

### DIFF
--- a/app/styles/_tables.less
+++ b/app/styles/_tables.less
@@ -92,7 +92,7 @@
 
 @media (max-width: @screen-xs-max) {
   .table-mobile {
-    border-top: 2px solid @table-border-color;
+    border-top-width: 0;
     // so that .word-break() will work
     table-layout: fixed;
     colgroup, col {
@@ -117,10 +117,8 @@
       }
     }
     > tbody {
-      + tbody {
-        border-top-width: 2px;
-      }
       > tr {
+        border-top: 2px solid @table-border-color;
         > td {
            /* Behave like a row */
           border: none;

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -187,8 +187,8 @@
                         <tbody ng-if="(builds | hashSize) == 0">
                           <tr><td colspan="3"><em>{{emptyMessage}}</em></td></tr>
                         </tbody>
-                        <tbody ng-repeat="build in orderedBuilds">
-                          <tr>
+                        <tbody ng-if="(builds | hashSize) > 0">
+                          <tr ng-repeat="build in orderedBuilds">
                             <td data-title="Build">
                               <!-- Build number and link -->
                               <span ng-if="build | annotation : 'buildNumber'">

--- a/app/views/browse/config-maps.html
+++ b/app/views/browse/config-maps.html
@@ -44,8 +44,8 @@
                   <tbody ng-if="(configMaps | hashSize) == 0">
                     <tr><td colspan="3"><em>No config maps to show</em></td></tr>
                   </tbody>
-                  <tbody ng-repeat="configMap in configMaps">
-                    <tr>
+                  <tbody ng-if="(configMaps | hashSize) > 0">
+                    <tr ng-repeat="configMap in configMaps">
                       <td data-title="Name">
                         <a href="{{configMap | navigateResourceURL}}">{{configMap.metadata.name}}</a>
                       </td>

--- a/app/views/browse/deployment-config.html
+++ b/app/views/browse/deployment-config.html
@@ -144,8 +144,8 @@
                       <tbody ng-if="(deployments | hashSize) == 0">
                         <tr><td colspan="4"><em>{{emptyMessage}}</em></td></tr>
                       </tbody>
-                      <tbody ng-repeat="deployment in orderedDeployments">
-                        <tr>
+                      <tbody ng-if="(deployments | hashSize) > 0">
+                        <tr ng-repeat="deployment in orderedDeployments">
                           <td data-title="Deployment">
                             <!-- Deployment number and link -->
                             <span ng-if="deployment | annotation : 'deploymentVersion'">

--- a/app/views/browse/deployment.html
+++ b/app/views/browse/deployment.html
@@ -97,8 +97,8 @@
                           <th>Created</th>
                         </tr>
                       </thead>
-                      <tbody ng-repeat="replicaSet in replicaSetsForDeployment">
-                        <tr>
+                      <tbody>
+                        <tr ng-repeat="replicaSet in replicaSetsForDeployment">
                           <td data-title="Version">
                             #{{replicaSet | annotation : 'deployment.kubernetes.io/revision'}}
                           </td>

--- a/app/views/browse/imagestream.html
+++ b/app/views/browse/imagestream.html
@@ -66,8 +66,8 @@
                 <tbody ng-if="(tagsByName | hashSize) == 0">
                   <tr><td colspan="5"><em>{{emptyMessage}}</em></td></tr>
                 </tbody>
-                <tbody ng-repeat-start="tag in tagsByName | orderBy : 'name'">
-                  <tr>
+                <tbody ng-if="(tagsByName | hashSize) > 0">
+                  <tr ng-repeat="tag in tagsByName | orderBy : 'name'">
                     <td data-title="Tag"><a href="{{imageStream | navigateResourceURL}}/{{tag.name}}">{{tag.name}}</a></td>
                     <td data-title="From">
                       <!-- this value can get long when its an ImageStreamImage. Use max width and class truncate to elide some
@@ -123,9 +123,7 @@
                       </div>
                     </td>
                   </tr>
-                </tbody>
-                <tbody ng-repeat="item in tag.status.items" ng-if="tagShowOlder[tag.name] && !$first && item.image">
-                  <tr>
+                  <tr ng-repeat="item in tag.status.items" ng-if="tagShowOlder[tag.name] && !$first && item.image">
                     <td data-title="Tag"><span class="hidden-xs">&nbsp;</span><span class="visible-xs">{{tag.name}}</span></td>
                     <td class="hidden-xs">&nbsp;</td>
                     <td data-title="Older Image">
@@ -141,7 +139,6 @@
                     </td>
                   </tr>
                 </tbody>
-                <tbody ng-repeat-end style="display: none;"></tbody>
               </table>
             </div><!-- /col-* -->
           </div>

--- a/app/views/browse/routes.html
+++ b/app/views/browse/routes.html
@@ -44,8 +44,8 @@
                 <tbody ng-if="(routes | hashSize) == 0">
                   <tr><td colspan="5"><em>{{emptyMessage || 'No routes to show'}}</em></td></tr>
                 </tbody>
-                <tbody ng-repeat="route in routes | orderObjectsByDate : true">
-                  <tr>
+                <tbody ng-if="(routes | hashSize) > 0">
+                  <tr ng-repeat="route in routes | orderObjectsByDate : true">
                     <td data-title="{{ customNameHeader || 'Name' }}">
                       <a href="{{route | navigateResourceURL}}">{{route.metadata.name}}</a>
                       <route-warnings ng-if="route.spec.to.kind !== 'Service' || services"

--- a/app/views/builds.html
+++ b/app/views/builds.html
@@ -43,9 +43,9 @@
                 <tbody ng-if="!(latestByConfig | hashSize)">
                   <tr><td colspan="6"><em>{{emptyMessage}}</em></td></tr>
                 </tbody>
-                <tbody ng-repeat="(buildConfigName, latestBuild) in latestByConfig">
+                <tbody ng-if="(latestByConfig | hashSize)">
                   <!-- Build config with no builds-->
-                  <tr ng-if="!latestBuild">
+                  <tr ng-repeat="(buildConfigName, latestBuild) in latestByConfig" ng-if="!latestBuild">
                     <td data-title="Name">
                       <a href="{{buildConfigs[buildConfigName] | navigateResourceURL}}">{{buildConfigName}}</a>
                     </td>

--- a/app/views/deployments.html
+++ b/app/views/deployments.html
@@ -44,7 +44,8 @@
                   <!-- If there are no deployment configs and no replication controllers owned by a deployment config -->
                   <tr><td colspan="5"><em>{{emptyMessage}}</em></td></tr>
                 </tbody>
-                <tbody ng-repeat="(dcName, replicationControllersForDC) in replicationControllersByDC" ng-if="dcName && (deploymentConfigs[dcName] || !unfilteredDeploymentConfigs[dcName])">
+                <tbody ng-if="!showEmptyMessage()">
+                  <tr ng-repeat-start="(dcName, replicationControllersForDC) in replicationControllersByDC" ng-if="dcName && (deploymentConfigs[dcName] || !unfilteredDeploymentConfigs[dcName])" style="display: none;"></tr>
                   <!-- Deployment config with no replication controllers -->
                   <tr ng-if="(replicationControllersForDC | hashSize) == 0 && dcName">
                     <td data-title="Name">
@@ -102,6 +103,7 @@
                       </span>
                     </td>
                   </tr>
+                  <tr ng-repeat-end style="display: none;"></tr>
                 </tbody>
               </table>
               <div ng-if="deployments | hashSize">
@@ -116,8 +118,8 @@
                       <th>Strategy</th>
                     </tr>
                   </thead>
-                  <tbody ng-repeat="deployment in deployments | orderObjectsByDate : true">
-                    <tr>
+                  <tbody>
+                    <tr ng-repeat="deployment in deployments | orderObjectsByDate : true">
                       <td data-title="Name">
                         <a ng-href="{{deployment | navigateResourceURL}}">{{deployment.metadata.name}}</a>
                       </td>
@@ -152,8 +154,8 @@
                       <th>Created</th>
                     </tr>
                   </thead>
-                  <tbody ng-repeat="replicaSet in replicaSets | orderObjectsByDate : true">
-                    <tr>
+                  <tbody>
+                    <tr ng-repeat="replicaSet in replicaSets | orderObjectsByDate : true">
                       <td data-title="Name">
                         <a ng-href="{{replicaSet | navigateResourceURL}}">{{replicaSet.metadata.name}}</a>
                       </td>
@@ -178,10 +180,10 @@
                     </tr>
                   </thead>
                   <tbody ng-if="(replicationControllersByDC[''] | hashSize) === 0"><tr><td colspan="3"><em>No replication controllers to show</em></td></tr></tbody>
-                  <tbody ng-repeat="deployment in replicationControllersByDC[''] | orderObjectsByDate : true">
+                  <tbody ng-if="(replicationControllersByDC[''] | hashSize) > 0">
                     <!-- We only show this if there are replication controllers but the active filter is hiding them, otherwise the RC table doesn't show
                          at all -->
-                    <tr>
+                    <tr ng-repeat="deployment in replicationControllersByDC[''] | orderObjectsByDate : true">
                       <td data-title="Name">
                         <a ng-href="{{deployment | navigateResourceURL}}">{{deployment.metadata.name}}</a>
                       </td>

--- a/app/views/directives/events.html
+++ b/app/views/directives/events.html
@@ -64,8 +64,8 @@
         </td>
       </tr>
     </tbody>
-    <tbody ng-repeat="event in filteredEvents">
-      <tr>
+    <tbody ng-if="(filteredEvents | hashSize) > 0">
+      <tr ng-repeat="event in filteredEvents">
         <td data-title="Time" class="nowrap">{{event.lastTimestamp | date:'mediumTime'}}</td>
         <td ng-if="!resourceKind || !resourceName" data-title="Name">
           <div class="hidden-xs-block visible-sm-block visible-md-block hidden-lg-block">

--- a/app/views/directives/pods-table.html
+++ b/app/views/directives/pods-table.html
@@ -12,8 +12,8 @@
   <tbody ng-if="(pods | hashSize) == 0">
     <tr><td colspan="6"><em>{{emptyMessage || 'No pods to show'}}</em></td></tr>
   </tbody>
-  <tbody ng-repeat="pod in pods | orderObjectsByDate : true">
-    <tr>
+  <tbody ng-if="(pods | hashSize) > 0">
+    <tr ng-repeat="pod in pods | orderObjectsByDate : true">
       <td data-title="{{customNameHeader || 'Name'}}">
         <a href="{{pod | navigateResourceURL}}">{{pod.metadata.name}}</a>
         <span ng-if="pod | isDebugPod">

--- a/app/views/directives/traffic-table.html
+++ b/app/views/directives/traffic-table.html
@@ -14,9 +14,9 @@
   <tbody ng-if="(portsByRoute | hashSize) == 0">
     <tr><td colspan="7"><em>{{emptyMessage || 'No routes or ports to show'}}</em></td></tr>
   </tbody>
-  <tbody ng-if="(portsByRoute | hashSize) > 0" ng-repeat-start="(routeName,ports) in portsByRoute" style="display:none;"></tbody>
-  <tbody ng-repeat="port in ports" ng-if="routeName !== ''">
-    <tr>
+  <tbody ng-if="(portsByRoute | hashSize) > 0">
+    <tr ng-repeat-start="(routeName,ports) in portsByRoute" style="display: none;"></tr>
+    <tr ng-repeat="port in ports" ng-if="routeName !== ''">
       <td data-title="{{customNameHeader || 'Route'}}{{ showNodePorts ? ' / Node Port' : '' }}">
         <a href="{{routes[routeName] | navigateResourceURL}}">{{routes[routeName].metadata.name}}</a>
         <route-warnings ng-if="routes[routeName].spec.to.kind !== 'Service' || services"
@@ -54,10 +54,8 @@
         <span ng-if="!routes[routeName].spec.tls.termination">&nbsp;</span>
       </td>
     </tr>
-  </tbody>
-  <tbody ng-repeat-end style="display:none;"></tbody>
-  <tbody ng-repeat="port in portsByRoute['']">
-    <tr>
+    <tr ng-repeat-end style="display: none;"></tr>
+    <tr ng-repeat="port in portsByRoute['']">
       <td data-title="{{customNameHeader || 'Route'}}{{ showNodePorts ? ' / Node Port' : '' }}">
         <span ng-if="!port.nodePort" class="text-muted">none</span>
         <span ng-if="port.nodePort">{{port.nodePort}}</span>

--- a/app/views/images.html
+++ b/app/views/images.html
@@ -40,8 +40,8 @@
                 <tbody ng-if="(imageStreams | hashSize) == 0">
                   <tr><td colspan="4"><em>{{emptyMessage}}</em></td></tr>
                 </tbody>
-                <tbody ng-repeat="imageStream in imageStreams | orderObjectsByDate : true">
-                  <tr>
+                <tbody ng-if="(imageStreams | hashSize) > 0">
+                  <tr ng-repeat="imageStream in imageStreams | orderObjectsByDate : true">
                     <td data-title="Name"><a href="{{imageStream | navigateResourceURL}}">{{imageStream.metadata.name}}</a></td>
                     <td data-title="Docker Repo">
                       <span ng-if="!imageStream.status.dockerImageRepository && !imageStream.spec.dockerImageRepository"><em>unknown</em></span>

--- a/app/views/other-resources.html
+++ b/app/views/other-resources.html
@@ -40,8 +40,8 @@
                 <tbody ng-if="(resources | hashSize) == 0">
                   <tr><td colspan="4"><em>{{emptyMessage}}</em></td></tr>
                 </tbody>
-                <tbody ng-repeat="resource in resources | orderObjectsByDate : true">
-                  <tr>
+                <tbody ng-if="(resources | hashSize) > 0">
+                  <tr ng-repeat="resource in resources | orderObjectsByDate : true">
                     <td data-title="Name">{{resource.metadata.name}}</td>
                     <td data-title="Created"><span am-time-ago="resource.metadata.creationTimestamp"></span></td>
                     <td data-title="Labels">

--- a/app/views/secrets.html
+++ b/app/views/secrets.html
@@ -45,8 +45,8 @@
                   <!-- If there are no deployment configs and no replication controllers owned by a deployment config -->
                   <tr><td colspan="3"><em>No secrets</em></td></tr>
                 </tbody>
-                <tbody ng-repeat="secret in secretsByType.source | orderBy : 'metadata.name'">
-                  <tr ng-if="secret">
+                <tbody ng-if="secretsByType.source.length > 0">
+                  <tr ng-if="secret" ng-repeat="secret in secretsByType.source | orderBy : 'metadata.name'">
                     <td data-title="Name">
                       <a ng-href="{{secret | navigateResourceURL}}">{{secret.metadata.name}}</a>
                     </td>
@@ -73,8 +73,8 @@
                       <th>Created</th>
                     </tr>
                   </thead>
-                  <tbody ng-repeat="secret in secretsByType.image | orderBy : 'metadata.name'">
-                    <tr>
+                  <tbody>
+                    <tr ng-repeat="secret in secretsByType.image | orderBy : 'metadata.name'">
                       <td data-title="Name">
                         <a ng-href="{{secret | navigateResourceURL}}">{{secret.metadata.name}}</a>
                       </td>
@@ -102,8 +102,8 @@
                       <th>Created</th>
                     </tr>
                   </thead>
-                  <tbody ng-repeat="secret in secretsByType.other | orderBy : 'metadata.name'">
-                    <tr>
+                  <tbody>
+                    <tr ng-repeat="secret in secretsByType.other | orderBy : 'metadata.name'">
                       <td data-title="Name">
                         <a ng-href="{{secret | navigateResourceURL}}">{{secret.metadata.name}}</a>
                       </td>

--- a/app/views/services.html
+++ b/app/views/services.html
@@ -42,8 +42,8 @@
                 <tbody ng-if="(services | hashSize) == 0">
                   <tr><td colspan="6"><em>{{emptyMessage}}</em></td></tr>
                 </tbody>
-                <tbody ng-repeat="service in services | orderObjectsByDate : true">
-                  <tr>
+                <tbody ng-if="(services | hashSize) > 0">
+                  <tr ng-repeat="service in services | orderObjectsByDate : true">
                     <td data-title="Name"><a href="{{service | navigateResourceURL}}">{{service.metadata.name}}</a></td>
                     <td data-title="Cluster IP">{{service.spec.clusterIP}}</td>
                     <td data-title="External IP">

--- a/app/views/storage.html
+++ b/app/views/storage.html
@@ -50,8 +50,8 @@
                 <tbody ng-if="(pvcs | hashSize) === 0">
                   <tr><td colspan="5"><em>{{emptyMessage}}</em></td></tr>
                 </tbody>
-                <tbody ng-repeat="pvc in pvcs | orderObjectsByDate : true">
-                  <tr>
+                <tbody ng-if="(pvcs | hashSize) > 0">
+                  <tr ng-repeat="pvc in pvcs | orderObjectsByDate : true">
                     <td data-title="Name"><a ng-href="{{pvc | navigateResourceURL}}">{{pvc.metadata.name}}</a></td>
                     <td data-title="Status">
                       <status-icon status="pvc.status.phase" disable-animation></status-icon>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1904,8 +1904,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tbody ng-if=\"(builds | hashSize) == 0\">\n" +
     "<tr><td colspan=\"3\"><em>{{emptyMessage}}</em></td></tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat=\"build in orderedBuilds\">\n" +
-    "<tr>\n" +
+    "<tbody ng-if=\"(builds | hashSize) > 0\">\n" +
+    "<tr ng-repeat=\"build in orderedBuilds\">\n" +
     "<td data-title=\"Build\">\n" +
     "\n" +
     "<span ng-if=\"build | annotation : 'buildNumber'\">\n" +
@@ -2395,8 +2395,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tbody ng-if=\"(configMaps | hashSize) == 0\">\n" +
     "<tr><td colspan=\"3\"><em>No config maps to show</em></td></tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat=\"configMap in configMaps\">\n" +
-    "<tr>\n" +
+    "<tbody ng-if=\"(configMaps | hashSize) > 0\">\n" +
+    "<tr ng-repeat=\"configMap in configMaps\">\n" +
     "<td data-title=\"Name\">\n" +
     "<a href=\"{{configMap | navigateResourceURL}}\">{{configMap.metadata.name}}</a>\n" +
     "</td>\n" +
@@ -2542,8 +2542,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tbody ng-if=\"(deployments | hashSize) == 0\">\n" +
     "<tr><td colspan=\"4\"><em>{{emptyMessage}}</em></td></tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat=\"deployment in orderedDeployments\">\n" +
-    "<tr>\n" +
+    "<tbody ng-if=\"(deployments | hashSize) > 0\">\n" +
+    "<tr ng-repeat=\"deployment in orderedDeployments\">\n" +
     "<td data-title=\"Deployment\">\n" +
     "\n" +
     "<span ng-if=\"deployment | annotation : 'deploymentVersion'\">\n" +
@@ -2820,8 +2820,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<th>Created</th>\n" +
     "</tr>\n" +
     "</thead>\n" +
-    "<tbody ng-repeat=\"replicaSet in replicaSetsForDeployment\">\n" +
-    "<tr>\n" +
+    "<tbody>\n" +
+    "<tr ng-repeat=\"replicaSet in replicaSetsForDeployment\">\n" +
     "<td data-title=\"Version\">\n" +
     "#{{replicaSet | annotation : 'deployment.kubernetes.io/revision'}}\n" +
     "</td>\n" +
@@ -3079,8 +3079,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tbody ng-if=\"(tagsByName | hashSize) == 0\">\n" +
     "<tr><td colspan=\"5\"><em>{{emptyMessage}}</em></td></tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat-start=\"tag in tagsByName | orderBy : 'name'\">\n" +
-    "<tr>\n" +
+    "<tbody ng-if=\"(tagsByName | hashSize) > 0\">\n" +
+    "<tr ng-repeat=\"tag in tagsByName | orderBy : 'name'\">\n" +
     "<td data-title=\"Tag\"><a href=\"{{imageStream | navigateResourceURL}}/{{tag.name}}\">{{tag.name}}</a></td>\n" +
     "<td data-title=\"From\">\n" +
     "\n" +
@@ -3131,9 +3131,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</td>\n" +
     "</tr>\n" +
-    "</tbody>\n" +
-    "<tbody ng-repeat=\"item in tag.status.items\" ng-if=\"tagShowOlder[tag.name] && !$first && item.image\">\n" +
-    "<tr>\n" +
+    "<tr ng-repeat=\"item in tag.status.items\" ng-if=\"tagShowOlder[tag.name] && !$first && item.image\">\n" +
     "<td data-title=\"Tag\"><span class=\"hidden-xs\">&nbsp;</span><span class=\"visible-xs\">{{tag.name}}</span></td>\n" +
     "<td class=\"hidden-xs\">&nbsp;</td>\n" +
     "<td data-title=\"Older Image\">\n" +
@@ -3149,7 +3147,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</td>\n" +
     "</tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat-end style=\"display: none\"></tbody>\n" +
     "</table>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -3740,8 +3737,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tbody ng-if=\"(routes | hashSize) == 0\">\n" +
     "<tr><td colspan=\"5\"><em>{{emptyMessage || 'No routes to show'}}</em></td></tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat=\"route in routes | orderObjectsByDate : true\">\n" +
-    "<tr>\n" +
+    "<tbody ng-if=\"(routes | hashSize) > 0\">\n" +
+    "<tr ng-repeat=\"route in routes | orderObjectsByDate : true\">\n" +
     "<td data-title=\"{{ customNameHeader || 'Name' }}\">\n" +
     "<a href=\"{{route | navigateResourceURL}}\">{{route.metadata.name}}</a>\n" +
     "<route-warnings ng-if=\"route.spec.to.kind !== 'Service' || services\" route=\"route\" service=\"services[route.spec.to.name]\">\n" +
@@ -4029,9 +4026,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tbody ng-if=\"!(latestByConfig | hashSize)\">\n" +
     "<tr><td colspan=\"6\"><em>{{emptyMessage}}</em></td></tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat=\"(buildConfigName, latestBuild) in latestByConfig\">\n" +
+    "<tbody ng-if=\"(latestByConfig | hashSize)\">\n" +
     "\n" +
-    "<tr ng-if=\"!latestBuild\">\n" +
+    "<tr ng-repeat=\"(buildConfigName, latestBuild) in latestByConfig\" ng-if=\"!latestBuild\">\n" +
     "<td data-title=\"Name\">\n" +
     "<a href=\"{{buildConfigs[buildConfigName] | navigateResourceURL}}\">{{buildConfigName}}</a>\n" +
     "</td>\n" +
@@ -5171,7 +5168,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<tr><td colspan=\"5\"><em>{{emptyMessage}}</em></td></tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat=\"(dcName, replicationControllersForDC) in replicationControllersByDC\" ng-if=\"dcName && (deploymentConfigs[dcName] || !unfilteredDeploymentConfigs[dcName])\">\n" +
+    "<tbody ng-if=\"!showEmptyMessage()\">\n" +
+    "<tr ng-repeat-start=\"(dcName, replicationControllersForDC) in replicationControllersByDC\" ng-if=\"dcName && (deploymentConfigs[dcName] || !unfilteredDeploymentConfigs[dcName])\" style=\"display: none\"></tr>\n" +
     "\n" +
     "<tr ng-if=\"(replicationControllersForDC | hashSize) == 0 && dcName\">\n" +
     "<td data-title=\"Name\">\n" +
@@ -5229,6 +5227,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</td>\n" +
     "</tr>\n" +
+    "<tr ng-repeat-end style=\"display: none\"></tr>\n" +
     "</tbody>\n" +
     "</table>\n" +
     "<div ng-if=\"deployments | hashSize\">\n" +
@@ -5243,8 +5242,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<th>Strategy</th>\n" +
     "</tr>\n" +
     "</thead>\n" +
-    "<tbody ng-repeat=\"deployment in deployments | orderObjectsByDate : true\">\n" +
-    "<tr>\n" +
+    "<tbody>\n" +
+    "<tr ng-repeat=\"deployment in deployments | orderObjectsByDate : true\">\n" +
     "<td data-title=\"Name\">\n" +
     "<a ng-href=\"{{deployment | navigateResourceURL}}\">{{deployment.metadata.name}}</a>\n" +
     "</td>\n" +
@@ -5279,8 +5278,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<th>Created</th>\n" +
     "</tr>\n" +
     "</thead>\n" +
-    "<tbody ng-repeat=\"replicaSet in replicaSets | orderObjectsByDate : true\">\n" +
-    "<tr>\n" +
+    "<tbody>\n" +
+    "<tr ng-repeat=\"replicaSet in replicaSets | orderObjectsByDate : true\">\n" +
     "<td data-title=\"Name\">\n" +
     "<a ng-href=\"{{replicaSet | navigateResourceURL}}\">{{replicaSet.metadata.name}}</a>\n" +
     "</td>\n" +
@@ -5305,9 +5304,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</tr>\n" +
     "</thead>\n" +
     "<tbody ng-if=\"(replicationControllersByDC[''] | hashSize) === 0\"><tr><td colspan=\"3\"><em>No replication controllers to show</em></td></tr></tbody>\n" +
-    "<tbody ng-repeat=\"deployment in replicationControllersByDC[''] | orderObjectsByDate : true\">\n" +
+    "<tbody ng-if=\"(replicationControllersByDC[''] | hashSize) > 0\">\n" +
     "\n" +
-    "<tr>\n" +
+    "<tr ng-repeat=\"deployment in replicationControllersByDC[''] | orderObjectsByDate : true\">\n" +
     "<td data-title=\"Name\">\n" +
     "<a ng-href=\"{{deployment | navigateResourceURL}}\">{{deployment.metadata.name}}</a>\n" +
     "</td>\n" +
@@ -6716,8 +6715,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</td>\n" +
     "</tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat=\"event in filteredEvents\">\n" +
-    "<tr>\n" +
+    "<tbody ng-if=\"(filteredEvents | hashSize) > 0\">\n" +
+    "<tr ng-repeat=\"event in filteredEvents\">\n" +
     "<td data-title=\"Time\" class=\"nowrap\">{{event.lastTimestamp | date:'mediumTime'}}</td>\n" +
     "<td ng-if=\"!resourceKind || !resourceName\" data-title=\"Name\">\n" +
     "<div class=\"hidden-xs-block visible-sm-block visible-md-block hidden-lg-block\">\n" +
@@ -8138,8 +8137,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tbody ng-if=\"(pods | hashSize) == 0\">\n" +
     "<tr><td colspan=\"6\"><em>{{emptyMessage || 'No pods to show'}}</em></td></tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat=\"pod in pods | orderObjectsByDate : true\">\n" +
-    "<tr>\n" +
+    "<tbody ng-if=\"(pods | hashSize) > 0\">\n" +
+    "<tr ng-repeat=\"pod in pods | orderObjectsByDate : true\">\n" +
     "<td data-title=\"{{customNameHeader || 'Name'}}\">\n" +
     "<a href=\"{{pod | navigateResourceURL}}\">{{pod.metadata.name}}</a>\n" +
     "<span ng-if=\"pod | isDebugPod\">\n" +
@@ -8280,9 +8279,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tbody ng-if=\"(portsByRoute | hashSize) == 0\">\n" +
     "<tr><td colspan=\"7\"><em>{{emptyMessage || 'No routes or ports to show'}}</em></td></tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-if=\"(portsByRoute | hashSize) > 0\" ng-repeat-start=\"(routeName,ports) in portsByRoute\" style=\"display:none\"></tbody>\n" +
-    "<tbody ng-repeat=\"port in ports\" ng-if=\"routeName !== ''\">\n" +
-    "<tr>\n" +
+    "<tbody ng-if=\"(portsByRoute | hashSize) > 0\">\n" +
+    "<tr ng-repeat-start=\"(routeName,ports) in portsByRoute\" style=\"display: none\"></tr>\n" +
+    "<tr ng-repeat=\"port in ports\" ng-if=\"routeName !== ''\">\n" +
     "<td data-title=\"{{customNameHeader || 'Route'}}{{ showNodePorts ? ' / Node Port' : '' }}\">\n" +
     "<a href=\"{{routes[routeName] | navigateResourceURL}}\">{{routes[routeName].metadata.name}}</a>\n" +
     "<route-warnings ng-if=\"routes[routeName].spec.to.kind !== 'Service' || services\" route=\"routes[routeName]\" service=\"services[routes[routeName].spec.to.name]\">\n" +
@@ -8318,10 +8317,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"!routes[routeName].spec.tls.termination\">&nbsp;</span>\n" +
     "</td>\n" +
     "</tr>\n" +
-    "</tbody>\n" +
-    "<tbody ng-repeat-end style=\"display:none\"></tbody>\n" +
-    "<tbody ng-repeat=\"port in portsByRoute['']\">\n" +
-    "<tr>\n" +
+    "<tr ng-repeat-end style=\"display: none\"></tr>\n" +
+    "<tr ng-repeat=\"port in portsByRoute['']\">\n" +
     "<td data-title=\"{{customNameHeader || 'Route'}}{{ showNodePorts ? ' / Node Port' : '' }}\">\n" +
     "<span ng-if=\"!port.nodePort\" class=\"text-muted\">none</span>\n" +
     "<span ng-if=\"port.nodePort\">{{port.nodePort}}</span>\n" +
@@ -9446,8 +9443,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tbody ng-if=\"(imageStreams | hashSize) == 0\">\n" +
     "<tr><td colspan=\"4\"><em>{{emptyMessage}}</em></td></tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat=\"imageStream in imageStreams | orderObjectsByDate : true\">\n" +
-    "<tr>\n" +
+    "<tbody ng-if=\"(imageStreams | hashSize) > 0\">\n" +
+    "<tr ng-repeat=\"imageStream in imageStreams | orderObjectsByDate : true\">\n" +
     "<td data-title=\"Name\"><a href=\"{{imageStream | navigateResourceURL}}\">{{imageStream.metadata.name}}</a></td>\n" +
     "<td data-title=\"Docker Repo\">\n" +
     "<span ng-if=\"!imageStream.status.dockerImageRepository && !imageStream.spec.dockerImageRepository\"><em>unknown</em></span>\n" +
@@ -10488,8 +10485,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tbody ng-if=\"(resources | hashSize) == 0\">\n" +
     "<tr><td colspan=\"4\"><em>{{emptyMessage}}</em></td></tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat=\"resource in resources | orderObjectsByDate : true\">\n" +
-    "<tr>\n" +
+    "<tbody ng-if=\"(resources | hashSize) > 0\">\n" +
+    "<tr ng-repeat=\"resource in resources | orderObjectsByDate : true\">\n" +
     "<td data-title=\"Name\">{{resource.metadata.name}}</td>\n" +
     "<td data-title=\"Created\"><span am-time-ago=\"resource.metadata.creationTimestamp\"></span></td>\n" +
     "<td data-title=\"Labels\">\n" +
@@ -11859,8 +11856,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<tr><td colspan=\"3\"><em>No secrets</em></td></tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat=\"secret in secretsByType.source | orderBy : 'metadata.name'\">\n" +
-    "<tr ng-if=\"secret\">\n" +
+    "<tbody ng-if=\"secretsByType.source.length > 0\">\n" +
+    "<tr ng-if=\"secret\" ng-repeat=\"secret in secretsByType.source | orderBy : 'metadata.name'\">\n" +
     "<td data-title=\"Name\">\n" +
     "<a ng-href=\"{{secret | navigateResourceURL}}\">{{secret.metadata.name}}</a>\n" +
     "</td>\n" +
@@ -11887,8 +11884,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<th>Created</th>\n" +
     "</tr>\n" +
     "</thead>\n" +
-    "<tbody ng-repeat=\"secret in secretsByType.image | orderBy : 'metadata.name'\">\n" +
-    "<tr>\n" +
+    "<tbody>\n" +
+    "<tr ng-repeat=\"secret in secretsByType.image | orderBy : 'metadata.name'\">\n" +
     "<td data-title=\"Name\">\n" +
     "<a ng-href=\"{{secret | navigateResourceURL}}\">{{secret.metadata.name}}</a>\n" +
     "</td>\n" +
@@ -11916,8 +11913,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<th>Created</th>\n" +
     "</tr>\n" +
     "</thead>\n" +
-    "<tbody ng-repeat=\"secret in secretsByType.other | orderBy : 'metadata.name'\">\n" +
-    "<tr>\n" +
+    "<tbody>\n" +
+    "<tr ng-repeat=\"secret in secretsByType.other | orderBy : 'metadata.name'\">\n" +
     "<td data-title=\"Name\">\n" +
     "<a ng-href=\"{{secret | navigateResourceURL}}\">{{secret.metadata.name}}</a>\n" +
     "</td>\n" +
@@ -11985,8 +11982,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tbody ng-if=\"(services | hashSize) == 0\">\n" +
     "<tr><td colspan=\"6\"><em>{{emptyMessage}}</em></td></tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat=\"service in services | orderObjectsByDate : true\">\n" +
-    "<tr>\n" +
+    "<tbody ng-if=\"(services | hashSize) > 0\">\n" +
+    "<tr ng-repeat=\"service in services | orderObjectsByDate : true\">\n" +
     "<td data-title=\"Name\"><a href=\"{{service | navigateResourceURL}}\">{{service.metadata.name}}</a></td>\n" +
     "<td data-title=\"Cluster IP\">{{service.spec.clusterIP}}</td>\n" +
     "<td data-title=\"External IP\">\n" +
@@ -12410,8 +12407,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tbody ng-if=\"(pvcs | hashSize) === 0\">\n" +
     "<tr><td colspan=\"5\"><em>{{emptyMessage}}</em></td></tr>\n" +
     "</tbody>\n" +
-    "<tbody ng-repeat=\"pvc in pvcs | orderObjectsByDate : true\">\n" +
-    "<tr>\n" +
+    "<tbody ng-if=\"(pvcs | hashSize) > 0\">\n" +
+    "<tr ng-repeat=\"pvc in pvcs | orderObjectsByDate : true\">\n" +
     "<td data-title=\"Name\"><a ng-href=\"{{pvc | navigateResourceURL}}\">{{pvc.metadata.name}}</a></td>\n" +
     "<td data-title=\"Status\">\n" +
     "<status-icon status=\"pvc.status.phase\" disable-animation></status-icon>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4938,13 +4938,13 @@ body,html{margin:0;padding:0}
 @media (min-width:768px){.events .data-toolbar .filter-controls,.events .data-toolbar .sort-group{display:inline-block}
 .events .data-toolbar .search-pf{margin-bottom:0;width:300px}
 }
-@media (max-width:767px){.table-mobile{border-top:2px solid #d1d1d1;table-layout:fixed}
+@media (max-width:767px){.table-mobile{border-top-width:0;table-layout:fixed}
 .table-mobile col,.table-mobile colgroup{display:none}
 .table-mobile tbody,.table-mobile td,.table-mobile th,.table-mobile thead,.table-mobile tr{display:block}
 .table-mobile thead tr{position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0,0,0,0);border:0}
 .table-mobile.table-empty{border:0}
 .table-mobile.table-empty>tbody>tr>td{border:0;padding-left:0}
-.table-mobile>tbody+tbody{border-top-width:2px}
+.table-mobile>tbody>tr{border-top:2px solid #d1d1d1}
 .table-mobile>tbody>tr>td{border:none;border-bottom:1px solid #dedede;padding:3px 6px 2px 35%;position:relative}
 .table-mobile>tbody>tr>td:last-child{border-bottom:none}
 .table-mobile>tbody>tr>td:before{content:attr(data-title);position:absolute;top:8px;left:6px;width:35%;padding-right:10px;white-space:nowrap}


### PR DESCRIPTION
This patch repeats table rows rather than table bodies for any list of
data displayed in a table.

It also resolves the issue of a double top-border on tables when there are
nested ng-repeat loops. (In these cases, a double top border was
appearing due to the need for a sibling <tr> element to contain the
outer loop. This extra element caused the css rule "tbody > tr + tr" to
apply a top-border to the first visible <tr> element as well, making the
table's already existing top-border redundant).

![deployments-table](https://cloud.githubusercontent.com/assets/3902875/21240900/4d447798-c2db-11e6-9c36-0e66a6368583.png)

@spadgett @jwforres @rhamilto @sg00dwin 