### PR TITLE
Replace select tag with ui-select - part 2

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -581,6 +581,45 @@ label.checkbox {
   }
 }
 
+.compute-resource {
+  .resource-size {
+    display: flex;
+    height: 27px;
+    .resource-amount {
+      width: 70%;
+      input {
+        width: 100%;
+      }
+    }
+    .resource-unit {
+      width: 30%;
+      .ui-select-container {
+        height: 27px;
+      }
+      .ui-select-choices,
+      .ui-select-toggle {
+        width: 100%;
+      }
+    }
+    @media (min-width: @screen-sm-min) {
+      .resource-amount {
+        width: 80%;
+      }
+      .resource-unit {
+        width: 20%;
+      }
+    }
+    @media (min-width: @screen-md-min) {
+      .resource-amount {
+        width: 85%;
+      }
+      .resource-unit {
+        width: 15%;
+      }
+    }
+  }
+}
+
 .next-steps {
   .tile {
     margin-bottom: 0;

--- a/app/styles/_log.less
+++ b/app/styles/_log.less
@@ -11,6 +11,19 @@
     .text-muted();
     margin: 0 2px;
   }
+  .ui-select-container {
+    min-width: 150px;
+    max-width: 250px;
+    margin: 0 5px;
+  }
+  .container-details {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    .container-state {
+      margin-right: 5px;
+    }
+  }
   .log-actions {
     form {
       display: inline-block;
@@ -30,7 +43,6 @@
     .log-timestamps {
       .small();
       display: inline-block;
-      margin-left: 3px;
     }
     .log-actions {
       .pull-right();
@@ -40,6 +52,11 @@
 }
 .log-size-warning {
   margin: 0;
+}
+@media (max-width: @screen-sm-max) {
+  .log-size-warning {
+    margin-top: 20px;
+  }
 }
 .log-view {
   background-color: @log-bg-color;

--- a/app/views/_compute-resource.html
+++ b/app/views/_compute-resource.html
@@ -1,22 +1,27 @@
 <ng-form name="form">
   <fieldset class="form-inline compute-resource">
     <label ng-if="label">{{label}}</label>
-    <div ng-class="{ 'has-error': form.$invalid }">
-      <label class="sr-only" ng-attr-for="{{id}}">Amount</label>
-      <input type="number"
-             name="amount"
-             ng-attr-id="{{id}}"
-             ng-model="amount"
-             min="0"
-             ng-attr-placeholder="{{placeholder}}"
-             class="form-control"
-             ng-attr-aria-describedby="{{description ? id + '-help' : undefined}}">
-      <label class="sr-only" ng-attr-for="{{id}}-unit">Unit</label>
-      <select ng-model="unit"
-              ng-options="option.value as option.label for option in units"
-              ng-attr-id="{{id}}-unit"
-              class="form-control inline-select">
-      </select>
+    <div class="resource-size" ng-class="{ 'has-error': form.$invalid }">
+      <div class="resource-amount">
+        <label class="sr-only" ng-attr-for="{{id}}">Amount</label>
+        <input type="number"
+               name="amount"
+               ng-attr-id="{{id}}"
+               ng-model="amount"
+               min="0"
+               ng-attr-placeholder="{{placeholder}}"
+               class="form-control"
+               ng-attr-aria-describedby="{{description ? id + '-help' : undefined}}">
+      </div>
+      <div class="resource-unit">
+        <label class="sr-only" ng-attr-for="{{id}}-unit">Unit</label>
+        <ui-select search-enabled="false" ng-model="unit" input-id="{{id}}-unit">
+          <ui-select-match>{{$select.selected.label}}</ui-select-match>
+          <ui-select-choices repeat="option.value as option in units">
+            {{option.label}}
+          </ui-select-choices>
+        </ui-select>
+      </div>
     </div>
     <div ng-if="description" class="help-block" ng-attr-id="{{id}}-help">
       {{description}}

--- a/app/views/browse/pod.html
+++ b/app/views/browse/pod.html
@@ -83,7 +83,6 @@
 
                   <uib-tab active="selectedTab.logs" ng-if="'pods/log' | canI : 'get'">
                     <uib-tab-heading>Logs</uib-tab-heading>
-
                     <log-viewer
                       ng-if="selectedTab.logs"
                       follow-affix-top="390"
@@ -94,28 +93,29 @@
                       empty="logEmpty"
                       run="logCanRun">
 
-                      <label for="selectLogContainer">Container:</label>
+                      <span class="container-details">
+                        <label for="selectLogContainer">Container:</label>
 
-                      <span ng-if="pod.spec.containers.length === 1">
-                        {{pod.spec.containers[0].name}}
-                      </span>
+                        <span ng-if="pod.spec.containers.length === 1">
+                          {{pod.spec.containers[0].name}}
+                        </span>
 
-                      <select
-                        id="selectLogContainer"
-                        ng-if="pod.spec.containers.length > 1"
-                        ng-model="logOptions.container"
-                        ng-options="container.name as container.name for container in pod.spec.containers"
-                        ng-init="logOptions.container = pod.spec.containers[0].name">
-                      </select>
+                        <ui-select ng-init="logOptions.container = pod.spec.containers[0].name" ng-show="pod.spec.containers.length > 1" ng-model="logOptions.container" input-id="selectLogContainer">
+                          <ui-select-match>{{$select.selected.name}}</ui-select-match>
+                          <ui-select-choices repeat="container.name as container in pod.spec.containers">
+                            <div ng-bind-html="container.name | highlight : $select.search"></div>
+                          </ui-select-choices>
+                        </ui-select>
 
-                      <span ng-if="containerStateReason || containerStatusKey">
-                        <span class="dash">&mdash;</span>
-                        <status-icon status="containerStateReason || (containerStatusKey | capitalize)"></status-icon>
-                        <span>{{containerStateReason || containerStatusKey | sentenceCase}}</span>
-                      </span>
+                        <span class="container-state" ng-if="containerStateReason || containerStatusKey">
+                          <span class="dash">&mdash;</span>
+                          <status-icon status="containerStateReason || (containerStatusKey | capitalize)"></status-icon>
+                          <span>{{containerStateReason || containerStatusKey | sentenceCase}}</span>
+                        </span>
 
-                      <span ng-if="containerStartTime && !logEmpty">
-                        <span class="log-timestamps">Log from {{containerStartTime  | date : 'medium'}} <span ng-if="containerEndTime">to {{containerEndTime  | date : 'medium'}}</span></span>
+                        <span ng-if="containerStartTime && !logEmpty">
+                          <span class="log-timestamps">Log from {{containerStartTime  | date : 'medium'}} <span ng-if="containerEndTime">to {{containerEndTime  | date : 'medium'}}</span></span>
+                        </span>
                       </span>
 
                     </log-viewer>

--- a/app/views/directives/deployment-metrics.html
+++ b/app/views/directives/deployment-metrics.html
@@ -9,20 +9,24 @@
         <span ng-show="containers.length === 1">
           {{options.selectedContainer.name}}
         </span>
-        <select id="selectContainer"
-                ng-show="containers.length > 1"
-                ng-model="options.selectedContainer"
-                ng-options="container.name for container in containers track by container.name">
-        </select>
+        <ui-select ng-show="containers.length > 1" ng-model="options.selectedContainer" input-id="selectContainer">
+          <ui-select-match>{{$select.selected.name}}</ui-select-match>
+          <ui-select-choices repeat="container in containers | filter : { name: $select.search }">
+            <div ng-bind-html="container.name | highlight : $select.search"></div>
+          </ui-select-choices>
+        </ui-select>
       </div>
     </div>
     <div class="form-group">
       <label for="timeRange">Time Range:</label>
-      <select id="timeRange"
-              ng-model="options.timeRange"
-              ng-options="range.label for range in options.rangeOptions"
-              ng-disabled="metricsError">
-      </select>
+      <div class="select-range">
+        <ui-select ng-model="options.timeRange" search-enabled="false" ng-disabled="metricsError" input-id="timeRange">
+          <ui-select-match>{{$select.selected.label}}</ui-select-match>
+          <ui-select-choices repeat="range in options.rangeOptions">
+            {{range.label}}
+          </ui-select-choices>
+        </ui-select>
+      </div>
     </div>
   </div>
 

--- a/app/views/directives/osc-persistent-volume-claim.html
+++ b/app/views/directives/osc-persistent-volume-claim.html
@@ -93,24 +93,28 @@
     <div class="form-group">
       <fieldset class="form-inline compute-resource">
       <label class="required">Size</label>
-      <div ng-class="{ 'has-error': form.$invalid }">
-        <label class="sr-only">Amount</label>
-        <input type="number"
-               name="amount"
-               ng-attr-id="claim-amount"
-               ng-model="claim.amount"
-               ng-required="true"
-               min="0"
-               ng-attr-placeholder="10"
-               class="form-control"
-               ng-attr-aria-describedby="claim-capacity-help">
-        <label class="sr-only" >Unit</label>
-        <select ng-model="claim.unit"
-                name="unit"
-                ng-options="option.value as option.label for option in units"
-                ng-attr-id="claim-capacity-unit"
-                class="form-control inline-select">
-        </select>
+      <div class="resource-size" ng-class="{ 'has-error': form.$invalid }">
+        <div class="resource-amount">
+          <label class="sr-only">Amount</label>
+          <input type="number"
+                 name="amount"
+                 ng-attr-id="claim-amount"
+                 ng-model="claim.amount"
+                 ng-required="true"
+                 min="0"
+                 ng-attr-placeholder="10"
+                 class="form-control"
+                 ng-attr-aria-describedby="claim-capacity-help">
+        </div>
+        <div class="resource-unit">
+          <label class="sr-only" >Unit</label>
+          <ui-select search-enabled="false" ng-model="claim.unit" input-id="claim-capacity-unit">
+            <ui-select-match>{{$select.selected.label}}</ui-select-match>
+            <ui-select-choices repeat="option.value as option in units">
+              {{option.label}}
+            </ui-select-choices>
+          </ui-select>
+        </div>
        </div>
        <div id="claim-capacity-help" class="help-block">
          Desired storage capacity.

--- a/app/views/directives/pod-metrics.html
+++ b/app/views/directives/pod-metrics.html
@@ -21,7 +21,7 @@
     <div class="form-group">
       <label for="timeRange">Time Range:</label>
       <div class="select-range">
-        <ui-select ng-model="options.timeRange" search-enabled="false" input-id="timeRange">
+        <ui-select ng-model="options.timeRange" search-enabled="false" ng-disabled="metricsError" input-id="timeRange">
           <ui-select-match>{{$select.selected.label}}</ui-select-match>
           <ui-select-choices repeat="range in options.rangeOptions">
             {{range.label}}

--- a/app/views/edit/build-config.html
+++ b/app/views/edit/build-config.html
@@ -235,13 +235,12 @@
                       <h3 ng-class="{ 'with-divider': !sources.none }">Jenkins Pipeline Configuration</h3>
                       <div class="form-group" ng-if="buildConfig.spec.source.type === 'Git'">
                         <label for="jenkinsfile-type">Jenkinsfile Type</label>
-                        <select
-                          id="jenkinsfile-type"
-                          class="form-control"
-                          ng-model="jenkinsfileOptions.type"
-                          ng-options="type.id as type.title for type in jenkinsfileTypes"
-                          aria-describedby="jenkinsfile-type-help">
-                        </select>
+                        <ui-select search-enabled="false" ng-model="jenkinsfileOptions.type" input-id="jenkinsfile-type" aria-describedby="jenkinsfile-type-help">
+                          <ui-select-match>{{$select.selected.title}}</ui-select-match>
+                          <ui-select-choices repeat="type.id as type in jenkinsfileTypes">
+                            {{type.title}}
+                          </ui-select-choices>
+                        </ui-select>
                         <div class="help-block" id="jenkinsfile-type-help">
                           Use a Jenkinsfile from the source repository or specify the
                           Jenkinsfile content directly in the build configuration.

--- a/app/views/monitoring.html
+++ b/app/views/monitoring.html
@@ -114,28 +114,19 @@
                         fixed-height="250"
                         full-log-url="(pod | navigateResourceURL) + '?view=chromeless'">
 
-                        <label for="selectLogContainer">Container:</label>
+                        <span class="container-details">
+                          <label for="selectLogContainer">Container:</label>
 
-                        <span ng-if="pod.spec.containers.length === 1">
-                          {{pod.spec.containers[0].name}}
-                        </span>
+                          <span ng-if="pod.spec.containers.length === 1">
+                            {{pod.spec.containers[0].name}}
+                          </span>
 
-                        <select
-                          id="selectLogContainer"
-                          ng-if="pod.spec.containers.length > 1"
-                          ng-model="logOptions.pods[pod.metadata.name].container"
-                          ng-options="container.name as container.name for container in pod.spec.containers"
-                          ng-init="logOptions.pods[pod.metadata.name].container = pod.spec.containers[0].name">
-                        </select>
-
-                        <span ng-if="containerStateReason || containerStatusKey">
-                          <span class="dash">&mdash;</span>
-                          <status-icon status="containerStateReason || (containerStatusKey | capitalize)"></status-icon>
-                          <span>{{containerStateReason || containerStatusKey | sentenceCase}}</span>
-                        </span>
-
-                        <span ng-if="containerStartTime && !logEmpty.pods[pod.metadata.name]">
-                          <span class="log-timestamps">Log from {{containerStartTime  | date : 'medium'}} <span ng-if="containerEndTime">to {{containerEndTime  | date : 'medium'}}</span></span>
+                          <ui-select ng-init="logOptions.pods[pod.metadata.name].container = pod.spec.containers[0].name" ng-show="pod.spec.containers.length > 1" ng-model="logOptions.pods[pod.metadata.name].container" input-id="selectLogContainer">
+                            <ui-select-match>{{$select.selected.name}}</ui-select-match>
+                            <ui-select-choices repeat="container.name as container in pod.spec.containers">
+                              <div ng-bind-html="container.name | highlight : $select.search"></div>
+                            </ui-select-choices>
+                          </ui-select>
                         </span>
 
                       </log-viewer>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -72,12 +72,20 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<ng-form name=\"form\">\n" +
     "<fieldset class=\"form-inline compute-resource\">\n" +
     "<label ng-if=\"label\">{{label}}</label>\n" +
-    "<div ng-class=\"{ 'has-error': form.$invalid }\">\n" +
+    "<div class=\"resource-size\" ng-class=\"{ 'has-error': form.$invalid }\">\n" +
+    "<div class=\"resource-amount\">\n" +
     "<label class=\"sr-only\" ng-attr-for=\"{{id}}\">Amount</label>\n" +
     "<input type=\"number\" name=\"amount\" ng-attr-id=\"{{id}}\" ng-model=\"amount\" min=\"0\" ng-attr-placeholder=\"{{placeholder}}\" class=\"form-control\" ng-attr-aria-describedby=\"{{description ? id + '-help' : undefined}}\">\n" +
+    "</div>\n" +
+    "<div class=\"resource-unit\">\n" +
     "<label class=\"sr-only\" ng-attr-for=\"{{id}}-unit\">Unit</label>\n" +
-    "<select ng-model=\"unit\" ng-options=\"option.value as option.label for option in units\" ng-attr-id=\"{{id}}-unit\" class=\"form-control inline-select\">\n" +
-    "</select>\n" +
+    "<ui-select search-enabled=\"false\" ng-model=\"unit\" input-id=\"{{id}}-unit\">\n" +
+    "<ui-select-match>{{$select.selected.label}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"option.value as option in units\">\n" +
+    "{{option.label}}\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"description\" class=\"help-block\" ng-attr-id=\"{{id}}-help\">\n" +
     "{{description}}\n" +
@@ -3310,19 +3318,25 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<uib-tab active=\"selectedTab.logs\" ng-if=\"'pods/log' | canI : 'get'\">\n" +
     "<uib-tab-heading>Logs</uib-tab-heading>\n" +
     "<log-viewer ng-if=\"selectedTab.logs\" follow-affix-top=\"390\" follow-affix-bottom=\"90\" object=\"pod\" context=\"projectContext\" options=\"logOptions\" empty=\"logEmpty\" run=\"logCanRun\">\n" +
+    "<span class=\"container-details\">\n" +
     "<label for=\"selectLogContainer\">Container:</label>\n" +
     "<span ng-if=\"pod.spec.containers.length === 1\">\n" +
     "{{pod.spec.containers[0].name}}\n" +
     "</span>\n" +
-    "<select id=\"selectLogContainer\" ng-if=\"pod.spec.containers.length > 1\" ng-model=\"logOptions.container\" ng-options=\"container.name as container.name for container in pod.spec.containers\" ng-init=\"logOptions.container = pod.spec.containers[0].name\">\n" +
-    "</select>\n" +
-    "<span ng-if=\"containerStateReason || containerStatusKey\">\n" +
+    "<ui-select ng-init=\"logOptions.container = pod.spec.containers[0].name\" ng-show=\"pod.spec.containers.length > 1\" ng-model=\"logOptions.container\" input-id=\"selectLogContainer\">\n" +
+    "<ui-select-match>{{$select.selected.name}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"container.name as container in pod.spec.containers\">\n" +
+    "<div ng-bind-html=\"container.name | highlight : $select.search\"></div>\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "<span class=\"container-state\" ng-if=\"containerStateReason || containerStatusKey\">\n" +
     "<span class=\"dash\">&mdash;</span>\n" +
     "<status-icon status=\"containerStateReason || (containerStatusKey | capitalize)\"></status-icon>\n" +
     "<span>{{containerStateReason || containerStatusKey | sentenceCase}}</span>\n" +
     "</span>\n" +
     "<span ng-if=\"containerStartTime && !logEmpty\">\n" +
     "<span class=\"log-timestamps\">Log from {{containerStartTime | date : 'medium'}} <span ng-if=\"containerEndTime\">to {{containerEndTime | date : 'medium'}}</span></span>\n" +
+    "</span>\n" +
     "</span>\n" +
     "</log-viewer>\n" +
     "</uib-tab>\n" +
@@ -6274,14 +6288,24 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-show=\"containers.length === 1\">\n" +
     "{{options.selectedContainer.name}}\n" +
     "</span>\n" +
-    "<select id=\"selectContainer\" ng-show=\"containers.length > 1\" ng-model=\"options.selectedContainer\" ng-options=\"container.name for container in containers track by container.name\">\n" +
-    "</select>\n" +
+    "<ui-select ng-show=\"containers.length > 1\" ng-model=\"options.selectedContainer\" input-id=\"selectContainer\">\n" +
+    "<ui-select-match>{{$select.selected.name}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"container in containers | filter : { name: $select.search }\">\n" +
+    "<div ng-bind-html=\"container.name | highlight : $select.search\"></div>\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"timeRange\">Time Range:</label>\n" +
-    "<select id=\"timeRange\" ng-model=\"options.timeRange\" ng-options=\"range.label for range in options.rangeOptions\" ng-disabled=\"metricsError\">\n" +
-    "</select>\n" +
+    "<div class=\"select-range\">\n" +
+    "<ui-select ng-model=\"options.timeRange\" search-enabled=\"false\" ng-disabled=\"metricsError\" input-id=\"timeRange\">\n" +
+    "<ui-select-match>{{$select.selected.label}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"range in options.rangeOptions\">\n" +
+    "{{range.label}}\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "<ellipsis-pulser color=\"dark\" size=\"sm\" msg=\"Loading metrics\" ng-if=\"!loaded\"></ellipsis-pulser>\n" +
@@ -7534,12 +7558,20 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"form-group\">\n" +
     "<fieldset class=\"form-inline compute-resource\">\n" +
     "<label class=\"required\">Size</label>\n" +
-    "<div ng-class=\"{ 'has-error': form.$invalid }\">\n" +
+    "<div class=\"resource-size\" ng-class=\"{ 'has-error': form.$invalid }\">\n" +
+    "<div class=\"resource-amount\">\n" +
     "<label class=\"sr-only\">Amount</label>\n" +
     "<input type=\"number\" name=\"amount\" ng-attr-id=\"claim-amount\" ng-model=\"claim.amount\" ng-required=\"true\" min=\"0\" ng-attr-placeholder=\"10\" class=\"form-control\" ng-attr-aria-describedby=\"claim-capacity-help\">\n" +
+    "</div>\n" +
+    "<div class=\"resource-unit\">\n" +
     "<label class=\"sr-only\">Unit</label>\n" +
-    "<select ng-model=\"claim.unit\" name=\"unit\" ng-options=\"option.value as option.label for option in units\" ng-attr-id=\"claim-capacity-unit\" class=\"form-control inline-select\">\n" +
-    "</select>\n" +
+    "<ui-select search-enabled=\"false\" ng-model=\"claim.unit\" input-id=\"claim-capacity-unit\">\n" +
+    "<ui-select-match>{{$select.selected.label}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"option.value as option in units\">\n" +
+    "{{option.label}}\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "</div>\n" +
     "</div>\n" +
     "<div id=\"claim-capacity-help\" class=\"help-block\">\n" +
     "Desired storage capacity.\n" +
@@ -8049,7 +8081,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"form-group\">\n" +
     "<label for=\"timeRange\">Time Range:</label>\n" +
     "<div class=\"select-range\">\n" +
-    "<ui-select ng-model=\"options.timeRange\" search-enabled=\"false\" input-id=\"timeRange\">\n" +
+    "<ui-select ng-model=\"options.timeRange\" search-enabled=\"false\" ng-disabled=\"metricsError\" input-id=\"timeRange\">\n" +
     "<ui-select-match>{{$select.selected.label}}</ui-select-match>\n" +
     "<ui-select-choices repeat=\"range in options.rangeOptions\">\n" +
     "{{range.label}}\n" +
@@ -8595,8 +8627,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<h3 ng-class=\"{ 'with-divider': !sources.none }\">Jenkins Pipeline Configuration</h3>\n" +
     "<div class=\"form-group\" ng-if=\"buildConfig.spec.source.type === 'Git'\">\n" +
     "<label for=\"jenkinsfile-type\">Jenkinsfile Type</label>\n" +
-    "<select id=\"jenkinsfile-type\" class=\"form-control\" ng-model=\"jenkinsfileOptions.type\" ng-options=\"type.id as type.title for type in jenkinsfileTypes\" aria-describedby=\"jenkinsfile-type-help\">\n" +
-    "</select>\n" +
+    "<ui-select search-enabled=\"false\" ng-model=\"jenkinsfileOptions.type\" input-id=\"jenkinsfile-type\" aria-describedby=\"jenkinsfile-type-help\">\n" +
+    "<ui-select-match>{{$select.selected.title}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"type.id as type in jenkinsfileTypes\">\n" +
+    "{{type.title}}\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
     "<div class=\"help-block\" id=\"jenkinsfile-type-help\">\n" +
     "Use a Jenkinsfile from the source repository or specify the Jenkinsfile content directly in the build configuration.\n" +
     "</div>\n" +
@@ -10178,19 +10214,17 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div ng-repeat-end ng-if=\"expanded.pods[pod.metadata.name]\" class=\"list-group-expanded-section\" ng-class=\"{'expanded': expanded.pods[pod.metadata.name]}\">\n" +
     "<log-viewer ng-if=\"'pods/log' | canI : 'get'\" object=\"pod\" context=\"projectContext\" options=\"logOptions.pods[pod.metadata.name]\" empty=\"logEmpty.pods[pod.metadata.name]\" run=\"logCanRun.pods[pod.metadata.name]\" fixed-height=\"250\" full-log-url=\"(pod | navigateResourceURL) + '?view=chromeless'\">\n" +
+    "<span class=\"container-details\">\n" +
     "<label for=\"selectLogContainer\">Container:</label>\n" +
     "<span ng-if=\"pod.spec.containers.length === 1\">\n" +
     "{{pod.spec.containers[0].name}}\n" +
     "</span>\n" +
-    "<select id=\"selectLogContainer\" ng-if=\"pod.spec.containers.length > 1\" ng-model=\"logOptions.pods[pod.metadata.name].container\" ng-options=\"container.name as container.name for container in pod.spec.containers\" ng-init=\"logOptions.pods[pod.metadata.name].container = pod.spec.containers[0].name\">\n" +
-    "</select>\n" +
-    "<span ng-if=\"containerStateReason || containerStatusKey\">\n" +
-    "<span class=\"dash\">&mdash;</span>\n" +
-    "<status-icon status=\"containerStateReason || (containerStatusKey | capitalize)\"></status-icon>\n" +
-    "<span>{{containerStateReason || containerStatusKey | sentenceCase}}</span>\n" +
-    "</span>\n" +
-    "<span ng-if=\"containerStartTime && !logEmpty.pods[pod.metadata.name]\">\n" +
-    "<span class=\"log-timestamps\">Log from {{containerStartTime | date : 'medium'}} <span ng-if=\"containerEndTime\">to {{containerEndTime | date : 'medium'}}</span></span>\n" +
+    "<ui-select ng-init=\"logOptions.pods[pod.metadata.name].container = pod.spec.containers[0].name\" ng-show=\"pod.spec.containers.length > 1\" ng-model=\"logOptions.pods[pod.metadata.name].container\" input-id=\"selectLogContainer\">\n" +
+    "<ui-select-match>{{$select.selected.name}}</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"container.name as container in pod.spec.containers\">\n" +
+    "<div ng-bind-html=\"container.name | highlight : $select.search\"></div>\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
     "</span>\n" +
     "</log-viewer>\n" +
     "\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -1,8 +1,8 @@
 div.code,pre,textarea{overflow:auto}
+.c3 svg,html{-webkit-tap-highlight-color:transparent}
 .text-left,caption,th{text-align:left}
 .btn,.datepicker table{-webkit-user-select:none;-moz-user-select:none}
 .navbar-fixed-bottom .navbar-collapse,.navbar-fixed-top .navbar-collapse,.pre-scrollable{max-height:340px}
-.c3 svg,html{-webkit-tap-highlight-color:transparent}
 .list-view-pf-top-align .list-view-pf-actions,.list-view-pf-top-align .list-view-pf-checkbox{align-self:flex-start}
 @font-face{font-family:"Open Sans";font-style:normal;font-weight:300;src:url(../styles/fonts/OpenSans-Light-webfont.eot);src:url(../styles/fonts/OpenSans-Light-webfont.eot?#iefix) format("embedded-opentype"),url(../styles/fonts/OpenSans-Light-webfont.woff) format("woff"),url(../styles/fonts/OpenSans-Light-webfont.ttf) format("truetype"),url(../styles/fonts/OpenSans-Light-webfont.svg#OpenSansLight) format("svg")}
 @font-face{font-family:"Open Sans";font-style:normal;font-weight:400;src:url(../styles/fonts/OpenSans-Regular-webfont.eot);src:url(../styles/fonts/OpenSans-Regular-webfont.eot?#iefix) format("embedded-opentype"),url(../styles/fonts/OpenSans-Regular-webfont.woff) format("woff"),url(../styles/fonts/OpenSans-Regular-webfont.ttf) format("truetype"),url(../styles/fonts/OpenSans-Regular-webfont.svg#OpenSansRegular) format("svg")}
@@ -946,7 +946,7 @@ select[multiple].input-group-sm>.form-control,select[multiple].input-group-sm>.i
 .navbar-collapse.in{overflow-y:visible}
 .navbar-fixed-bottom .navbar-collapse,.navbar-fixed-top .navbar-collapse,.navbar-static-top .navbar-collapse{padding-left:0;padding-right:0}
 }
-.embed-responsive,.modal,.modal-open,.progress{overflow:hidden}
+.carousel-inner,.embed-responsive,.modal,.modal-open,.progress{overflow:hidden}
 @media (max-device-width:480px) and (orientation:landscape){.navbar-fixed-bottom .navbar-collapse,.navbar-fixed-top .navbar-collapse{max-height:200px}
 }
 .container-fluid>.navbar-collapse,.container-fluid>.navbar-header,.container>.navbar-collapse,.container>.navbar-header{margin-right:-20px;margin-left:-20px}
@@ -1331,7 +1331,7 @@ button.close{padding:0;cursor:pointer;background:0 0;border:0;-webkit-appearance
 .popover.bottom>.arrow:after{content:" ";top:1px;margin-left:-10px;border-top-width:0;border-bottom-color:#fff}
 .popover.left>.arrow{top:50%;right:-11px;margin-top:-11px;border-right-width:0;border-left-color:#bbb}
 .popover.left>.arrow:after{right:1px;border-right-width:0;border-left-color:#fff}
-.carousel-inner{overflow:hidden;width:100%}
+.carousel-inner{width:100%}
 .carousel-inner>.item{display:none;position:relative;-webkit-transition:.6s ease-in-out left;-o-transition:.6s ease-in-out left;transition:.6s ease-in-out left}
 @media all and (transform-3d),(-webkit-transform-3d){.carousel-inner>.item{-webkit-transition:-webkit-transform .6s ease-in-out;-moz-transition:-moz-transform .6s ease-in-out;-o-transition:-o-transform .6s ease-in-out;transition:transform .6s ease-in-out;-webkit-backface-visibility:hidden;-moz-backface-visibility:hidden;backface-visibility:hidden;-webkit-perspective:1000px;-moz-perspective:1000px;perspective:1000px}
 .carousel-inner>.item.active.right,.carousel-inner>.item.next{-webkit-transform:translate3d(100%,0,0);transform:translate3d(100%,0,0);left:0}
@@ -3561,6 +3561,7 @@ to{transform:rotate(359deg)}
 .key-value-editor .key-value-editor-header,.key-value-editor .key-value-editor-input{float:left;padding-right:5px;width:50%}
 .word-break{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .word-break-all{word-break:break-all;word-break:break-word;overflow-wrap:break-word}
+.events-table td,.modal-resource-action h1,.resource-description,.row-cards-pf-flex .card-pf-body p{word-break:break-word;word-wrap:break-word}
 .pre-wrap{white-space:pre-wrap}
 .visible-xlg-inline-block{display:none!important}
 @media (max-width:767px){.td-long-string{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
@@ -3603,7 +3604,7 @@ to{transform:rotate(359deg)}
 .row-cards-pf-flex:before{display:none}
 .row-cards-pf-flex .card-pf,.row-cards-pf-flex [class^=col]{display:flex;flex-direction:column}
 .row-cards-pf-flex .card-pf,.row-cards-pf-flex .card-pf-body{flex-grow:1}
-.row-cards-pf-flex .card-pf-body p{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
+.row-cards-pf-flex .card-pf-body p{overflow-wrap:break-word;min-width:0}
 .row-cards-pf-flex .card-pf-body-with-version{display:flex;flex-direction:column;justify-content:space-between}
 .row-cards-pf-flex .card-pf-footer .btn{margin-bottom:10px}
 .row-cards-pf-flex .card-pf-title{line-height:1.3;margin:0;overflow:hidden;text-overflow:ellipsis}
@@ -3874,6 +3875,18 @@ label.checkbox{font-weight:400}
 .osc-form .template-options .form-group .parameter-input-wrapper .resize-input .fa-compress,.osc-form .template-options .form-group .parameter-input-wrapper .resize-input .fa-expand{transform:rotate(90deg)}
 .osc-form .template-options .form-group .parameter-input-wrapper input,.osc-form .template-options .form-group .parameter-input-wrapper textarea{padding-right:20px}
 .osc-form .template-options .help-block{margin-bottom:5px}
+.compute-resource .resource-size{display:flex;height:27px}
+.compute-resource .resource-size .resource-amount{width:70%}
+.compute-resource .resource-size .resource-amount input{width:100%}
+.compute-resource .resource-size .resource-unit{width:30%}
+.compute-resource .resource-size .resource-unit .ui-select-container{height:27px}
+.compute-resource .resource-size .resource-unit .ui-select-choices,.compute-resource .resource-size .resource-unit .ui-select-toggle{width:100%}
+@media (min-width:768px){.compute-resource .resource-size .resource-amount{width:80%}
+.compute-resource .resource-size .resource-unit{width:20%}
+}
+@media (min-width:992px){.compute-resource .resource-size .resource-amount{width:85%}
+.compute-resource .resource-size .resource-unit{width:15%}
+}
 .next-steps .tile{margin-bottom:0}
 .next-steps .tile.tile-status{margin-top:0}
 .command-args textarea{resize:none}
@@ -3895,7 +3908,7 @@ label.checkbox{font-weight:400}
 .attention-message,.tasks,div.code,pre.code{background-color:#fff}
 .template-message .resource-description{margin-bottom:0;font-size:12px}
 .resource-metadata,.tasks{margin-bottom:20px}
-.resource-description{margin-bottom:20px;white-space:pre-wrap;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
+.resource-description{margin-bottom:20px;white-space:pre-wrap;overflow-wrap:break-word;min-width:0}
 .tasks{font-weight:400;padding:20px;position:relative}
 .tasks.success{border:1px solid #3f9c35;border-left:3px solid #3f9c35}
 .tasks.failure{border:1px solid #c00;border-left:3px solid #c00}
@@ -3943,7 +3956,7 @@ a.disabled-link:active,a.disabled-link:focus,a.disabled-link:hover{color:#bbb;te
 .actions-dropdown-kebab:active,.actions-dropdown-kebab:focus,.actions-dropdown-kebab:hover{color:#000}
 .header-actions{font-size:84%}
 .modal-resource-action{background-color:#f1f1f1}
-.modal-resource-action h1{font-size:21px;font-weight:500;margin-bottom:20px;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
+.modal-resource-action h1{font-size:21px;font-weight:500;margin-bottom:20px;overflow-wrap:break-word;min-width:0}
 .modal-resource-action p{font-size:16px}
 .modal-resource-action .help-block{margin-top:0px;margin-bottom:10px}
 .ace_editor.dockerfile-mode .ace_constant.ace_numeric,.editor.yaml-mode .ace_constant.ace_numeric{color:inherit}
@@ -4857,7 +4870,6 @@ dl.secret-data dd{margin-left:180px}
 .events-sidebar .right-content .event .event-details .event-reason{order:2}
 .events-sidebar .right-content .event .event-details .event-timestamp{text-align:right;margin-left:5px;min-width:100px}
 }
-.events-table td,.log-line-text{word-wrap:break-word;min-width:0}
 .events-sidebar .right-content .event.highlight+.event{border-top:1px solid #d1d1d1}
 .events-badge{font-size:14px}
 .events-badge:hover{text-decoration:none}
@@ -4961,7 +4973,7 @@ td[role=presentation].arrow:after{content:"\2193"}
 .events-table th#severity{width:10px;padding:0}
 .events-table th#reason{width:150px}
 .events-table th#message,.key-value-table>tbody>tr>td.value{width:100%}
-.events-table td{word-break:break-word;overflow-wrap:break-word}
+.events-table td{overflow-wrap:break-word;min-width:0}
 .events-table .pficon{vertical-align:middle}
 .events-table .severity-icon-td{padding-left:0;padding-right:0}
 .key-value-table>tbody>tr>td.key{padding-right:10px;vertical-align:top}
@@ -5116,13 +5128,18 @@ a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;borde
 .log-header{margin-bottom:3px;margin-top:20px}
 .log-header label{margin-bottom:0}
 .log-header .dash{color:#9c9c9c;margin:0 2px}
+.log-header .ui-select-container{min-width:150px;max-width:250px;margin:0 5px}
+.log-header .container-details{display:inline-flex;align-items:center;flex-wrap:wrap}
+.log-header .container-details .container-state{margin-right:5px}
 .log-header .log-actions form{display:inline-block}
 .log-header .log-timestamps{color:#9c9c9c;display:block}
 @media (min-width:768px){.log-header .log-status{display:inline}
-.log-header .log-timestamps{font-size:84%;display:inline-block;margin-left:3px}
+.log-header .log-timestamps{font-size:84%;display:inline-block}
 .log-header .log-actions{float:right!important;float:right;margin-left:5px}
 }
 .log-size-warning{margin:0}
+@media (max-width:991px){.log-size-warning{margin-top:20px}
+}
 .log-view{background-color:#101214;font-family:Menlo,Monaco,Consolas,monospace;position:relative}
 .log-end-msg,.log-view .log-scroll a{font-family:"Open Sans",Helvetica,Arial,sans-serif}
 .log-view pre,.log-view pre code{background-color:transparent;border:0;margin-bottom:0;overflow:visible;padding:0 10px}
@@ -5157,7 +5174,7 @@ a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;borde
 .log-line:hover{background-color:#22262b;color:#ededed}
 .log-line-number:before{content:attr(data-line-number)}
 .log-line-number{-ms-user-select:none;border-right:1px #272b30 solid;padding-right:10px;vertical-align:top;white-space:nowrap;width:60px;color:#72767b}
-.log-line-text{padding:0 10px;white-space:pre-wrap;width:100%;word-break:break-word;overflow-wrap:break-word}
+.log-line-text{padding:0 10px;white-space:pre-wrap;width:100%;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .log-line-text::-moz-selection{color:#101214;background:#e5e5e5}
 .table-log-pods{background-color:#fff;border:1px solid #D1D1D1}
 .table-log-pods>tbody+tbody{border-top-width:1px}


### PR DESCRIPTION
This is the first part of work which is moving all remaining select tags to ui-select, which contains :
- select container for logs (monitoring page, pod browse page)
- selecting jenkinsfile type on BC editor
- pod browse page -> metrics tab
- selecting compute resource unit on `_compute-resource.html` and `osc-persistant-colume-claim` directive

@spadgett PTAL

Closes https://github.com/openshift/origin-web-console/issues/785