### PR TITLE
Make tabs work with one tap on iOS

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -477,6 +477,14 @@ angular
         }
       });
     }, 1000);
+  })
+  .run(function(IS_IOS) {
+    if (IS_IOS) {
+      // Add a class for iOS devices. This lets us disable some hover effects
+      // since iOS will treat the first tap as a hover if it changes the DOM
+      // content (e.g. using :before pseudo-elements).
+      $('body').addClass('ios');
+    }
   });
 
 hawtioPluginLoader.addModule('openshiftConsole');

--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -31,6 +31,16 @@
   }
 }
 
+// Prevent having to tap tabs twice on iOS.
+.ios .nav-tabs > {
+  li > a:hover:before {
+    content: none;
+  }
+  li.active > a:before {
+    content: '';
+  }
+}
+
 .console-os {
   .wrap > .container { // For projects list page
     margin-top: 35px;

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -558,6 +558,8 @@ var e = $(this).data("timestamp"), f = $(this).data("omit-single"), g = $(this).
 return h ? b(e, null) || d :a(e, null, f, g) || d;
 });
 }, 1e3);
+} ]).run([ "IS_IOS", function(a) {
+a && $("body").addClass("ios");
 } ]), hawtioPluginLoader.addModule("openshiftConsole"), hawtioPluginLoader.registerPreBootstrapTask(function(a) {
 if (_.get(window, "OPENSHIFT_CONFIG.api.k8s.resources")) return void a();
 var b = {

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3726,6 +3726,8 @@ code.command{display:inline-block;line-height:1.3;margin-right:2px}
 body{padding-right:0px!important}
 .modal-open{overflow-y:auto}
 }
+.ios .nav-tabs li>a:hover:before{content:none}
+.ios .nav-tabs li.active>a:before{content:''}
 .console-os .wrap>.container{margin-top:35px;margin-bottom:80px}
 .console-os .wrap>.container h1{margin:10px 0 20px}
 @media (min-width:992px){.console-os .middle .container-fluid{margin-left:10px;margin-right:10px}


### PR DESCRIPTION
Remove the `a:hover:before` pseudo-class on tabs so that iOS doesn't treat the first tap as a hover.

Fixes #811