### PR TITLE
Move padding-bottom to the middle-content child element so that it doesn't…

### DIFF
--- a/app/styles/_substructure.less
+++ b/app/styles/_substructure.less
@@ -79,17 +79,20 @@ html,body {
         }
         .middle-content {
           .flex(@columns: 1 1 auto);
-          // default 50px space beneath content
-          padding-bottom: @middle-content-bottom-margin;
           position: relative;
           width: 100%;
         }
       }
     }
   }
-  & .overview .middle .middle-section .middle-container .middle-content {
-      // reduce 20px to account for overview tiles bottom margin
-      padding-bottom: (@middle-content-bottom-margin - 20px);
+  .middle .middle-content > .container-fluid {
+    // default 40px space beneath content
+    padding-bottom: @middle-content-bottom-margin;
+  }
+  & .overview .middle-content > .container-fluid,
+  .no-sidebar .middle-content > .container {
+    // reduce 20px to account for tile bottom margin
+    padding-bottom: (@middle-content-bottom-margin - 20px);
   }
 }
 .header-toolbar {

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4881,8 +4881,9 @@ body,html{margin:0;padding:0}
 .console-os .middle .middle-section{position:absolute;top:0;left:0;height:100%;width:100%}
 .console-os .middle .middle-section .middle-container{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;height:100%}
 .console-os .middle .middle-section .middle-container .middle-header{-webkit-flex:0 0 auto;-moz-flex:0 0 auto;-ms-flex:0 0 auto;flex:0 0 auto;margin-bottom:20px}
-.console-os .middle .middle-section .middle-container .middle-content{-webkit-flex:1 1 auto;-moz-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;padding-bottom:40px;position:relative;width:100%}
-.console-os .overview .middle .middle-section .middle-container .middle-content{padding-bottom:20px}
+.console-os .middle .middle-section .middle-container .middle-content{-webkit-flex:1 1 auto;-moz-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;position:relative;width:100%}
+.console-os .middle .middle-content>.container-fluid{padding-bottom:40px}
+.console-os .no-sidebar .middle-content>.container,.console-os .overview .middle-content>.container-fluid{padding-bottom:20px}
 .header-toolbar{background-color:#fff;border-bottom:1px solid #e4e4e4}
 .surface-shaded{background-color:#f2f2f2}
 @media (min-width:768px){.layout-pf-alt-fixed .nav-pf-vertical-alt{position:fixed;bottom:0;overflow:visible}


### PR DESCRIPTION
 create a white block at the bottom of gray background pages.

Fixes https://github.com/openshift/origin-web-console/issues/1054

<img width="325" alt="screen shot 2016-12-19 at 4 53 35 pm" src="https://cloud.githubusercontent.com/assets/1874151/21330496/be918c5a-c60b-11e6-85c7-4d0f5113a0de.png">


<img width="322" alt="screen shot 2016-12-19 at 4 35 53 pm" src="https://cloud.githubusercontent.com/assets/1874151/21330287/c66254a6-c60a-11e6-98bc-9a59de6c65da.png">

<img width="329" alt="screen shot 2016-12-19 at 4 28 20 pm" src="https://cloud.githubusercontent.com/assets/1874151/21330286/c661e390-c60a-11e6-8b4a-c61edeadad55.png">


