### PR TITLE
Improve Git URL error messages

### DIFF
--- a/app/views/create/fromimage.html
+++ b/app/views/create/fromimage.html
@@ -75,7 +75,10 @@
                               'col-lg-12': !advancedOptions}">
                               <div class="form-group">
                                 <label for="sourceUrl" class="required">Git Repository URL</label>
-                                <div ng-class="{'has-warning': form.sourceUrl.$touched && !sourceURLPattern.test(buildConfig.sourceUrl), 'has-error': (form.sourceUrl.$error.required && form.sourceUrl.$dirty)}">
+                                <div ng-class="{
+                                  'has-warning': buildConfig.sourceUrl && form.sourceUrl.$touched && !sourceURLPattern.test(buildConfig.sourceUrl),
+                                  'has-error': (form.sourceUrl.$error.required && form.sourceUrl.$dirty)
+                                }">
                                   <!-- Unfortunately, we can't set type="url" because some valid values don't pass browser validation. -->
                                   <input class="form-control"
                                     id="sourceUrl"

--- a/app/views/edit/build-config.html
+++ b/app/views/edit/build-config.html
@@ -30,7 +30,10 @@
                               'col-lg-12': !view.advancedOptions}">
                               <div class="form-group">
                                 <label for="sourceUrl" class="required">Git Repository URL</label>
-                                <div>
+                                <div ng-class="{
+                                  'has-warning': form.sourceUrl.$touched && !sourceURLPattern.test(updatedBuildConfig.spec.source.git.uri),
+                                  'has-error': form.sourceUrl.$touched && form.sourceUrl.$error.required
+                                }">
                                   <!-- Unfortunately, we can't set type="url" because some valid values don't pass browser validation. -->
                                   <input class="form-control"
                                     id="sourceUrl"
@@ -46,6 +49,9 @@
                                 <div class="help-block" id="source-url-help">
                                   Git URL of the source code to build.
                                   <span ng-if="!view.advancedOptions">If your Git repository is private, view the <a href="" ng-click="view.advancedOptions = true">advanced options</a> to set up authentication.</span>
+                                </div>
+                                <div class="has-error" ng-if="form.sourceUrl.$touched && form.sourceUrl.$error.required">
+                                  <span class="help-block">A Git repository URL is required.</span>
                                 </div>
                                 <div class="has-warning" ng-if="updatedBuildConfig.spec.source.git.uri && form.sourceUrl.$touched && !sourceURLPattern.test(updatedBuildConfig.spec.source.git.uri)">
                                   <span class="help-block">This might not be a valid Git URL. Check that it is the correct URL to a remote Git repository.</span>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4807,7 +4807,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "                              'col-lg-12': !advancedOptions}\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"sourceUrl\" class=\"required\">Git Repository URL</label>\n" +
-    "<div ng-class=\"{'has-warning': form.sourceUrl.$touched && !sourceURLPattern.test(buildConfig.sourceUrl), 'has-error': (form.sourceUrl.$error.required && form.sourceUrl.$dirty)}\">\n" +
+    "<div ng-class=\"{\n" +
+    "                                  'has-warning': buildConfig.sourceUrl && form.sourceUrl.$touched && !sourceURLPattern.test(buildConfig.sourceUrl),\n" +
+    "                                  'has-error': (form.sourceUrl.$error.required && form.sourceUrl.$dirty)\n" +
+    "                                }\">\n" +
     "\n" +
     "<input class=\"form-control\" id=\"sourceUrl\" name=\"sourceUrl\" type=\"text\" required aria-describedby=\"from_source_help\" ng-model=\"buildConfig.sourceUrl\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\">\n" +
     "</div>\n" +
@@ -8500,13 +8503,19 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "                              'col-lg-12': !view.advancedOptions}\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"sourceUrl\" class=\"required\">Git Repository URL</label>\n" +
-    "<div>\n" +
+    "<div ng-class=\"{\n" +
+    "                                  'has-warning': form.sourceUrl.$touched && !sourceURLPattern.test(updatedBuildConfig.spec.source.git.uri),\n" +
+    "                                  'has-error': form.sourceUrl.$touched && form.sourceUrl.$error.required\n" +
+    "                                }\">\n" +
     "\n" +
     "<input class=\"form-control\" id=\"sourceUrl\" name=\"sourceUrl\" ng-model=\"updatedBuildConfig.spec.source.git.uri\" type=\"text\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"source-url-help\" required>\n" +
     "</div>\n" +
     "<div class=\"help-block\" id=\"source-url-help\">\n" +
     "Git URL of the source code to build.\n" +
     "<span ng-if=\"!view.advancedOptions\">If your Git repository is private, view the <a href=\"\" ng-click=\"view.advancedOptions = true\">advanced options</a> to set up authentication.</span>\n" +
+    "</div>\n" +
+    "<div class=\"has-error\" ng-if=\"form.sourceUrl.$touched && form.sourceUrl.$error.required\">\n" +
+    "<span class=\"help-block\">A Git repository URL is required.</span>\n" +
     "</div>\n" +
     "<div class=\"has-warning\" ng-if=\"updatedBuildConfig.spec.source.git.uri && form.sourceUrl.$touched && !sourceURLPattern.test(updatedBuildConfig.spec.source.git.uri)\">\n" +
     "<span class=\"help-block\">This might not be a valid Git URL. Check that it is the correct URL to a remote Git repository.</span>\n" +


### PR DESCRIPTION
Previously if you tabbed through the Git URL field without setting a
value, it would highlight the input orange without any text explaining.
Change it to NOT highlight the field until the user types something. If
the user types something and removes it, highlight the field red and
show a required field error. This is consistent with other forms like
"New Project" and the "Name" field just above Git repository on the "Add
to Project" page.

Also add a missing required field message to the build config editor if
you remove the Git URL.