### PR TITLE
Follow logs automatically

### DIFF
--- a/app/scripts/directives/logViewer.js
+++ b/app/scripts/directives/logViewer.js
@@ -194,7 +194,8 @@ angular.module('openshiftConsole')
               var fill = $scope.fixedHeight ? $scope.fixedHeight : Math.floor($(window).height() - contentTop - pulserHeight);
               if (!$scope.chromeless && !$scope.fixedHeight) {
                 // Add some bottom margin if not chromeless.
-                fill = fill - 35;
+                // 40px, same as `@middle-content-bottom-margin`
+                fill = fill - 40;
               }
               if (animate) {
                 content.animate({ 'min-height': fill +'px' }, 'fast');

--- a/app/scripts/directives/logViewer.js
+++ b/app/scripts/directives/logViewer.js
@@ -60,7 +60,6 @@ angular.module('openshiftConsole')
         templateUrl: 'views/directives/logs/_log-viewer.html',
         scope: {
           followAffixTop: '=?',
-          followAffixBottom: '=?',
           object: '=',
           fullLogUrl: '=?',
           name: '=',
@@ -168,8 +167,7 @@ angular.module('openshiftConsole')
                   .affix({
                     target:  window,
                     offset: {
-                        top:  $scope.followAffixTop || 0, // 390,
-                        bottom: $scope.followAffixBottom || 0 // 90
+                      top:  $scope.followAffixTop || 0 // 390
                     }
                   });
               } else {
@@ -178,8 +176,7 @@ angular.module('openshiftConsole')
                   .affix({
                     target:  $cachedScrollableNode,
                     offset: {
-                        top: $scope.followAffixTop || 0, // 390,
-                        bottom: $scope.followAffixBottom || 0 // 90
+                      top: $scope.followAffixTop || 0 // 390
                     }
                   });
               }
@@ -289,7 +286,7 @@ angular.module('openshiftConsole')
 
               angular.extend($scope, {
                 loading: true,
-                autoScroll: false,
+                autoScrollActive: true,
                 limitReached: false,
                 showScrollLinks: false
               });
@@ -374,7 +371,7 @@ angular.module('openshiftConsole')
                 $scope.$evalAsync(function() {
                   angular.extend($scope, {
                     loading: false,
-                    autoScroll: false
+                    autoScrollActive: false
                   });
                   // if logs err before we get anything, will show an empty state message
                   if(lastLineNumber === 0) {
@@ -460,7 +457,7 @@ angular.module('openshiftConsole')
             angular.extend($scope, {
               ready: true,
               loading: true,
-              autoScroll: false,
+              autoScrollActive: true,
               state: false, // show nothing initially to avoid flicker
               onScrollBottom: function() {
                 logLinks.scrollBottom(scrollableDOMNode);

--- a/app/styles/_variables.less
+++ b/app/styles/_variables.less
@@ -40,6 +40,8 @@
 @link-hover-color-bright: lighten(@link-color, 13%);
 @list-view-expanded-bg: #f5f5f5;
 @log-bg-color: #101214;
+// The log viewer needs to be udpated if this value changes.  It accounts for
+// bottom margin when resizing the log in JavaScript.
 @middle-content-bottom-margin: @grid-gutter-width;
 @navbar-header-offset: 2px;
 @navbar-os-header-height-desktop: 60px;

--- a/app/views/browse/build.html
+++ b/app/views/browse/build.html
@@ -120,7 +120,6 @@
                       <log-viewer
                         ng-if="selectedTab.logs"
                         follow-affix-top="390"
-                        follow-affix-bottom="90"
                         object="build"
                         context="projectContext"
                         options="logOptions"

--- a/app/views/browse/pod.html
+++ b/app/views/browse/pod.html
@@ -86,7 +86,6 @@
                     <log-viewer
                       ng-if="selectedTab.logs"
                       follow-affix-top="390"
-                      follow-affix-bottom="90"
                       object="pod"
                       context="projectContext"
                       options="logOptions"

--- a/app/views/browse/replica-set.html
+++ b/app/views/browse/replica-set.html
@@ -133,7 +133,6 @@
                     <log-viewer
                       ng-if="selectedTab.logs"
                       follow-affix-top="390"
-                      follow-affix-bottom="90"
                       object="replicaSet"
                       context="projectContext"
                       options="logOptions"

--- a/app/views/directives/logs/_log-viewer.html
+++ b/app/views/directives/logs/_log-viewer.html
@@ -68,14 +68,13 @@
 <div ng-show="state=='logs'">
   <div class="log-view" id="{{logViewerID}}" ng-class="{'log-fixed-height': fixedHeight}">
     <div
-      ng-show="showScrollLinks"
       id="{{logViewerID}}-affixedFollow"
       class="log-scroll log-scroll-top">
       <a ng-if="loading" href="" ng-click="toggleAutoScroll()">
         <span ng-if="!autoScrollActive">Follow</span>
-        <span ng-if="autoScrollActive">Stop following</span>
+        <span ng-if="autoScrollActive">Stop Following</span>
       </a>
-      <a ng-if="!loading" href="" ng-click="onScrollBottom()">
+      <a ng-if="!loading" href="" ng-show="showScrollLinks" ng-click="onScrollBottom()">
         Go to End
       </a>
     </div>

--- a/app/views/directives/logs/_log-viewer.html
+++ b/app/views/directives/logs/_log-viewer.html
@@ -66,7 +66,7 @@
 
 <!-- must be ng-show rather than ng-if, else DOM is not rendered in time to cache nodes -->
 <div ng-show="state=='logs'">
-  <div class="log-view" id="{{logViewerID}}" ng-class="{'log-fixed-height': fixedHeight}">
+  <div class="log-view" ng-attr-id="{{logViewerID}}" ng-class="{'log-fixed-height': fixedHeight}">
     <div
       id="{{logViewerID}}-affixedFollow"
       class="log-scroll log-scroll-top">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -11690,7 +11690,7 @@ top:i.followAffixTop || 0
 var b = $("#" + i.logViewerID + " .log-view-output"), c = b.offset().top;
 if (!(c < 0)) {
 var d = $(".ellipsis-pulser").outerHeight(!0), e = i.fixedHeight ? i.fixedHeight :Math.floor($(window).height() - c - d);
-i.chromeless || i.fixedHeight || (e -= 35), a ? b.animate({
+i.chromeless || i.fixedHeight || (e -= 40), a ? b.animate({
 "min-height":e + "px"
 }, "fast") :b.css("min-height", e + "px"), i.fixedHeight && b.css("max-height", e);
 }

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -11646,7 +11646,6 @@ transclude:!0,
 templateUrl:"views/directives/logs/_log-viewer.html",
 scope:{
 followAffixTop:"=?",
-followAffixBottom:"=?",
 object:"=",
 fullLogUrl:"=?",
 name:"=",
@@ -11679,14 +11678,12 @@ p.off("scroll", y), m.off("scroll", y), window.innerWidth <= l.screenSmMin && !i
 i.fixedHeight || (window.innerWidth < l.screenSmMin && !i.fixedHeight ? r.removeClass("target-logger-node").affix({
 target:window,
 offset:{
-top:i.followAffixTop || 0,
-bottom:i.followAffixBottom || 0
+top:i.followAffixTop || 0
 }
 }) :r.addClass("target-logger-node").affix({
 target:p,
 offset:{
-top:i.followAffixTop || 0,
-bottom:i.followAffixBottom || 0
+top:i.followAffixTop || 0
 }
 }));
 }, B = function(a) {
@@ -11715,7 +11712,7 @@ D && (D.stop(), D = null), a || (H.cancel(), j && (j.innerHTML = ""), G = docume
 if (I(), i.run) {
 angular.extend(i, {
 loading:!0,
-autoScroll:!1,
+autoScrollActive:!0,
 limitReached:!1,
 showScrollLinks:!1
 });
@@ -11746,7 +11743,7 @@ i.loading = !1;
 D = null, i.$evalAsync(function() {
 angular.extend(i, {
 loading:!1,
-autoScroll:!1
+autoScrollActive:!1
 }), 0 === c ? (i.state = "empty", i.emptyStateMessage = "The logs are no longer available or could not be loaded.") :i.errorWhileRunning = !0;
 });
 }), D.start();
@@ -11779,7 +11776,7 @@ v(), z(), A();
 }, angular.extend(i, {
 ready:!0,
 loading:!0,
-autoScroll:!1,
+autoScrollActive:!0,
 state:!1,
 onScrollBottom:function() {
 k.scrollBottom(q);

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7141,7 +7141,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "\n" +
     "<div ng-show=\"state=='logs'\">\n" +
-    "<div class=\"log-view\" id=\"{{logViewerID}}\" ng-class=\"{'log-fixed-height': fixedHeight}\">\n" +
+    "<div class=\"log-view\" ng-attr-id=\"{{logViewerID}}\" ng-class=\"{'log-fixed-height': fixedHeight}\">\n" +
     "<div id=\"{{logViewerID}}-affixedFollow\" class=\"log-scroll log-scroll-top\">\n" +
     "<a ng-if=\"loading\" href=\"\" ng-click=\"toggleAutoScroll()\">\n" +
     "<span ng-if=\"!autoScrollActive\">Follow</span>\n" +

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2256,7 +2256,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</uib-tab>\n" +
     "<uib-tab active=\"selectedTab.logs\" ng-if=\"!(build | isJenkinsPipelineStrategy) && ('builds/log' | canI : 'get')\">\n" +
     "<uib-tab-heading>Logs</uib-tab-heading>\n" +
-    "<log-viewer ng-if=\"selectedTab.logs\" follow-affix-top=\"390\" follow-affix-bottom=\"90\" object=\"build\" context=\"projectContext\" options=\"logOptions\" empty=\"logEmpty\" run=\"logCanRun\">\n" +
+    "<log-viewer ng-if=\"selectedTab.logs\" follow-affix-top=\"390\" object=\"build\" context=\"projectContext\" options=\"logOptions\" empty=\"logEmpty\" run=\"logCanRun\">\n" +
     "<label>Status:</label>\n" +
     "<status-icon status=\"build.status.phase\"></status-icon>\n" +
     "<span class=\"space-after\">{{build.status.phase}}</span>\n" +
@@ -3317,7 +3317,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</uib-tab>\n" +
     "<uib-tab active=\"selectedTab.logs\" ng-if=\"'pods/log' | canI : 'get'\">\n" +
     "<uib-tab-heading>Logs</uib-tab-heading>\n" +
-    "<log-viewer ng-if=\"selectedTab.logs\" follow-affix-top=\"390\" follow-affix-bottom=\"90\" object=\"pod\" context=\"projectContext\" options=\"logOptions\" empty=\"logEmpty\" run=\"logCanRun\">\n" +
+    "<log-viewer ng-if=\"selectedTab.logs\" follow-affix-top=\"390\" object=\"pod\" context=\"projectContext\" options=\"logOptions\" empty=\"logEmpty\" run=\"logCanRun\">\n" +
     "<span class=\"container-details\">\n" +
     "<label for=\"selectLogContainer\">Container:</label>\n" +
     "<span ng-if=\"pod.spec.containers.length === 1\">\n" +
@@ -3487,7 +3487,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</uib-tab>\n" +
     "<uib-tab ng-if=\"deploymentConfigName && logOptions.version && ('deploymentconfigs/log' | canI : 'get')\" active=\"selectedTab.logs\">\n" +
     "<uib-tab-heading>Logs</uib-tab-heading>\n" +
-    "<log-viewer ng-if=\"selectedTab.logs\" follow-affix-top=\"390\" follow-affix-bottom=\"90\" object=\"replicaSet\" context=\"projectContext\" options=\"logOptions\" empty=\"logEmpty\" run=\"logCanRun\">\n" +
+    "<log-viewer ng-if=\"selectedTab.logs\" follow-affix-top=\"390\" object=\"replicaSet\" context=\"projectContext\" options=\"logOptions\" empty=\"logEmpty\" run=\"logCanRun\">\n" +
     "<span ng-if=\"replicaSet | deploymentStatus\">\n" +
     "<label>Status:</label>\n" +
     "<status-icon status=\"replicaSet | deploymentStatus\"></status-icon>\n" +
@@ -7142,12 +7142,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<div ng-show=\"state=='logs'\">\n" +
     "<div class=\"log-view\" id=\"{{logViewerID}}\" ng-class=\"{'log-fixed-height': fixedHeight}\">\n" +
-    "<div ng-show=\"showScrollLinks\" id=\"{{logViewerID}}-affixedFollow\" class=\"log-scroll log-scroll-top\">\n" +
+    "<div id=\"{{logViewerID}}-affixedFollow\" class=\"log-scroll log-scroll-top\">\n" +
     "<a ng-if=\"loading\" href=\"\" ng-click=\"toggleAutoScroll()\">\n" +
     "<span ng-if=\"!autoScrollActive\">Follow</span>\n" +
-    "<span ng-if=\"autoScrollActive\">Stop following</span>\n" +
+    "<span ng-if=\"autoScrollActive\">Stop Following</span>\n" +
     "</a>\n" +
-    "<a ng-if=\"!loading\" href=\"\" ng-click=\"onScrollBottom()\">\n" +
+    "<a ng-if=\"!loading\" href=\"\" ng-show=\"showScrollLinks\" ng-click=\"onScrollBottom()\">\n" +
     "Go to End\n" +
     "</a>\n" +
     "</div>\n" +


### PR DESCRIPTION
* Follow logs as soon as the tab is selected.
* Always show follow log links for live logs. This lets you follow or
  stop following without having to wait for the log to go past the
  bottom of the visible page. (The go to top and go to end links will
  still be hidden unless the log is taller than the visible page.)
* Fix issue with affix-bottom being set on the follow log link, causing
  the link to sometimes appear at the bottom of the page.
* Fix references to unused `$scope.autoScroll` variable. It has since
  been renamed `$scope.autoScrollActive`.
* Fix issue where scrollbars appear even if the log doesn't fill the page.

Fixes #1061

@stevekuznetsov fyi