### PR TITLE
Let users paste certificate values

### DIFF
--- a/app/scripts/directives/oscFileInput.js
+++ b/app/scripts/directives/oscFileInput.js
@@ -8,8 +8,7 @@ angular.module('openshiftConsole')
         model: "=",
         required: "=",
         disabled: "=ngDisabled",
-        // Show the file contents below the file input.
-        showValues: "=",
+        showTextArea: '=',
         helpText: "@?",
         dropZoneId: "@?"
       },
@@ -24,7 +23,7 @@ angular.module('openshiftConsole')
         var dropMessageSelector = "#" + scope.dropMessageID,
             highlightDropZone = false,
             showDropZone = false,
-            inputFileField = element.find('input[type=file]')[0];
+            inputFileField = element.find('input[type=file]');
 
         setTimeout(addDropZoneListeners);
 
@@ -68,11 +67,11 @@ angular.module('openshiftConsole')
         scope.cleanInputValues = function() {
           scope.model = '';
           scope.fileName = '';
-          inputFileField.value = "";
+          inputFileField[0].value = "";
         };
 
-        element.change(function() {
-          addFile(inputFileField.files[0]);
+        inputFileField.change(function() {
+          addFile(inputFileField[0].files[0]);
         });
 
         // Add listeners for the dropZone element

--- a/app/styles/_forms.less
+++ b/app/styles/_forms.less
@@ -61,3 +61,9 @@
     }
   }
 }
+
+.osc-file-input textarea {
+  font-family: @font-family-monospace;
+  // Use the same spacing as `help-block` so the textarea is evenly spaced under the help text.
+  margin: 5px 0;
+}

--- a/app/views/directives/create-secret.html
+++ b/app/views/directives/create-secret.html
@@ -112,7 +112,6 @@
           model="newSecret.data.cacert"
           drop-zone-id="cacert"
           help-text="Upload your ca.crt file."
-          show-values="false"
           required="true"></osc-file-input>
         <div ui-ace="{
           mode: 'txt',
@@ -134,8 +133,7 @@
           id="private-key-file-input"
           model="newSecret.data.privateKey"
           drop-zone-id="private-key"
-          help-text="Upload your private SSH key file."
-          show-values="false"></osc-file-input>
+          help-text="Upload your private SSH key file."></osc-file-input>
         <div ui-ace="{
           theme: 'eclipse',
           rendererOptions: {
@@ -166,7 +164,6 @@
           model="newSecret.data.gitconfig"
           drop-zone-id="gitconfig"
           help-text="Upload your .gitconfig or  file."
-          show-values="false"
           required="true"></osc-file-input>
         <div ui-ace="{
           mode: 'ini',
@@ -271,7 +268,6 @@
           model="newSecret.data.dockerConfig"
           drop-zone-id="docker-config"
           help-text="Upload a .dockercfg or .docker/config.json file"
-          show-values="false"
           required="true"></osc-file-input>
         <div ui-ace="{
           mode: 'json',

--- a/app/views/directives/edit-config-map.html
+++ b/app/views/directives/edit-config-map.html
@@ -91,8 +91,7 @@
         <osc-file-input
           model="item.value"
           drop-zone-id="drop-zone-{{$id}}"
-          help-text="Enter a value for the config map entry or use the contents of a file."
-          show-values="false"></osc-file-input>
+          help-text="Enter a value for the config map entry or use the contents of a file."></osc-file-input>
         <div ui-ace="{
           theme: 'eclipse',
           rendererOptions: {

--- a/app/views/directives/from-file.html
+++ b/app/views/directives/from-file.html
@@ -11,8 +11,7 @@
           model="editorContent"
           drop-zone-id="from-file"
           help-text="Upload file by dragging & dropping, selecting it, or pasting from the clipboard."
-          ng-disabled="false"
-          show-values="false"></osc-file-input>
+          ng-disabled="false"></osc-file-input>
         <div ui-ace="{
           mode: 'yaml',
           theme: 'eclipse',

--- a/app/views/directives/osc-file-input.html
+++ b/app/views/directives/osc-file-input.html
@@ -1,38 +1,40 @@
-<div ng-attr-id="{{dropMessageID}}" class="drag-and-drop-zone">
-  <p>Drop file here</p>
-</div>
-<div class="input-group">
-  <input
-      type="text"
-      class="form-control"
-      ng-model="fileName"
-      readonly
-      ng-show="supportsFileUpload"
-      ng-disabled="disabled"
-      ng-attr-aria-describedby="{{helpText ? helpID : undefined}}">
-  <span class="input-group-btn">
-    <span class="btn btn-default btn-file" ng-show="supportsFileUpload" ng-attr-disabled="{{ disabled || undefined }}">
-      Browse&hellip;
-      <input type="file" ng-disabled="disabled" class="form-control">
+<div class="osc-file-input">
+  <div ng-attr-id="{{dropMessageID}}" class="drag-and-drop-zone">
+    <p>Drop file here</p>
+  </div>
+  <div class="input-group">
+    <input
+        type="text"
+        class="form-control"
+        ng-model="fileName"
+        readonly
+        ng-show="supportsFileUpload"
+        ng-disabled="disabled"
+        ng-attr-aria-describedby="{{helpText ? helpID : undefined}}">
+    <span class="input-group-btn">
+      <span class="btn btn-default btn-file" ng-show="supportsFileUpload" ng-attr-disabled="{{ disabled || undefined }}">
+        Browse&hellip;
+        <input type="file" ng-disabled="disabled" class="form-control">
+      </span>
     </span>
-  </span>
-</div>
-<textarea class="form-control"
-    rows="8"
-    ng-hide="supportsFileUpload"
-    ng-model="model"
-    ng-required="required"
-    ng-disabled="disabled"
-    ng-attr-aria-describedby="{{helpText ? helpID : undefined}}">
-</textarea>
-<div ng-if="helpText">
-  <span ng-attr-id="{{helpID}}" class="help-block">{{::helpText}}</span>
-</div>
-<div class="has-error" ng-show="uploadError">
-  <span class="help-block">There was an error reading the file. Please copy the file content into the text area.</span>
-</div>
+  </div>
+  <div ng-if="helpText">
+    <span ng-attr-id="{{helpID}}" class="help-block">{{::helpText}}</span>
+  </div>
+  <div class="has-error" ng-show="uploadError">
+    <span class="help-block">There was an error reading the file. Please copy the file content into the text area.</span>
+  </div>
+  <textarea class="form-control"
+      rows="5"
+      ng-show="showTextArea || !supportsFileUpload"
+      ng-model="model"
+      ng-required="required"
+      ng-disabled="disabled"
+      autocorrect="off"
+      autocapitalize="off"
+      spellcheck="false"
+      ng-attr-aria-describedby="{{helpText ? helpID : undefined}}">
+  </textarea>
 
-<div ng-if="model && showValues && supportsFileUpload">
-  <pre ng-if="model && showValues && supportsFileUpload" class="clipped scroll">{{model}}</pre>
+  <a href="" ng-show="(model || fileName) && !disabled" ng-click="cleanInputValues()">Clear Value</a>
 </div>
-<a href="" ng-show="model || fileName" class="clear-btn" ng-click="cleanInputValues()">Clear Value</a>

--- a/app/views/directives/osc-routing.html
+++ b/app/views/directives/osc-routing.html
@@ -113,10 +113,6 @@
       </osc-routing-service>
     </div>
 
-    <div ng-if="alternateServiceOptions.length && !route.alternateServices.length" class="form-group">
-      <a href="" ng-click="addAlternateService()">Split traffic across multiple services</a>
-    </div>
-
     <!-- Target Port -->
     <div ng-if="route.portOptions.length" class="form-group">
       <label for="routeTargetPort">Target Port</label>
@@ -133,9 +129,23 @@
       </div>
     </div>
 
+
     <!-- Alternate Services for A/B Traffic -->
-    <div ng-if="route.alternateServices.length">
+    <div ng-if="alternateServiceOptions.length">
       <h3>Alternate Services</h3>
+      <div class="form-group">
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" ng-model="options.alternateServices" aria-describedby="secure-route-help">
+            Split traffic across multiple services
+          </label>
+          <div class="help-block">
+            Routes can direct traffic to multiple services for A/B testing. Each service has a weight
+            controlling how much traffic it gets.
+          </div>
+        </div>
+      </div>
+
       <div ng-repeat="alternate in route.alternateServices" class="form-group">
         <osc-routing-service model="alternate"
                              services="alternateServiceOptions"
@@ -162,12 +172,12 @@
         <div class="weight-slider-values">
           <div>
             <span class="service-name">{{route.to.service.metadata.name}}</span>
-            <span class="weight-percentage">{{weightAsPercentage(route.to.weight)}}</span>
+            <span class="weight-percentage">{{weightAsPercentage(route.to.weight, true)}}</span>
           </div>
           <div>
-            <span class="weight-percentage hidden-xs">{{weightAsPercentage(route.alternateServices[0].weight)}}</span>
+            <span class="weight-percentage hidden-xs">{{weightAsPercentage(route.alternateServices[0].weight, true)}}</span>
             <span class="service-name">{{route.alternateServices[0].service.metadata.name}}</span>
-            <span class="weight-percentage visible-xs-inline">{{weightAsPercentage(route.alternateServices[0].weight)}}</span>
+            <span class="weight-percentage visible-xs-inline">{{weightAsPercentage(route.alternateServices[0].weight, true)}}</span>
           </div>
         </div>
         <label class="sr-only" for="weight-slider">Service {{route.to.service.metadata.name}} Weight</label>
@@ -195,9 +205,10 @@
       </div>
     </div>
 
+    <h3>Security</h3>
     <div class="checkbox">
       <label>
-        <input type="checkbox" ng-model="secureRoute" aria-describedby="secure-route-help">
+        <input type="checkbox" ng-model="options.secureRoute" aria-describedby="secure-route-help">
         Secure route
       </label>
       <div class="help-block" id="secure-route-help">
@@ -205,7 +216,7 @@
       </div>
     </div>
 
-    <div ng-show="secureRoute">
+    <div ng-show="options.secureRoute">
       <!-- TLS Termination -->
       <div class="form-group">
         <label for="tlsTermination">TLS Termination</label>
@@ -238,11 +249,9 @@
 
       <!-- Key and Certificates -->
       <h3>Certificates</h3>
-      <div>
-        <span class="help-block">
-          TLS certificates for edge and re-encrypt termination. If not
-          specified, the router's default certificate is used.
-        </span>
+      <div class="help-block">
+        TLS certificates for edge and re-encrypt termination. If not specified, the router's default
+        certificate is used.
       </div>
       <div ng-if="showCertificatesNotUsedWarning" class="has-warning">
         <span class="help-block">
@@ -255,7 +264,7 @@
           </span>
         </span>
       </div>
-      <fieldset>
+      <fieldset class="mar-top-md">
         <div>
           <div class="form-group" id="certificate-file">
             <label>Certificate</label>
@@ -300,8 +309,8 @@
                  not already showing the generic certificate warning above. -->
             <div ng-if="route.tls.destinationCACertificate && route.tls.termination !== 'reencrypt' && !showCertificatesNotUsedWarning" class="has-warning">
               <span class="help-block">
-                The destination CA certificate will not be used. Destination CA
-                certificates are only used for re-encrypt termination.
+                The destination CA certificate will be removed from the route.
+                Destination CA certificates are only used for re-encrypt termination.
               </span>
             </div>
           </div>

--- a/app/views/directives/osc-routing.html
+++ b/app/views/directives/osc-routing.html
@@ -262,8 +262,8 @@
             <osc-file-input
               model="route.tls.certificate"
               drop-zone-id="certificate-file"
-              show-values="true"
-              help-text="The PEM format certificate. Upload file by dragging & dropping, or selecting it."
+              show-text-area="true"
+              help-text="The PEM format certificate. Upload file by dragging & dropping, selecting it, or pasting from the clipbard."
               ng-disabled="disableCertificateInputs()">
             </osc-file-input>
           </div>
@@ -272,8 +272,8 @@
             <osc-file-input
               model="route.tls.key"
               drop-zone-id="private-key-file"
-              show-values="true"
-              help-text="The PEM format key. Upload file by dragging & dropping, or selecting it."
+              show-text-area="true"
+              help-text="The PEM format key. Upload file by dragging & dropping, selecting it, or pasting from the clipboard."
               ng-disabled="disableCertificateInputs()">
           </osc-file-input>
           </div>
@@ -282,8 +282,8 @@
             <osc-file-input
               model="route.tls.caCertificate"
               drop-zone-id="ca-certificate-file"
-              show-values="true"
-              help-text="The PEM format CA certificate. Upload file by dragging & dropping, or selecting it."
+              show-text-area="true"
+              help-text="The PEM format CA certificate. Upload file by dragging & dropping, selecting it, or pasting from the clipboard."
               ng-disabled="disableCertificateInputs()">
             </osc-file-input>
           </div>
@@ -291,9 +291,9 @@
             <label>Destination CA Certificate</label>
             <osc-file-input
                 model="route.tls.destinationCACertificate"
-                show-values="true"
+                show-text-area="true"
                 drop-zone-id="dest-ca-certificate-file"
-                help-text="The PEM format CA certificate to validate the endpoint certificate for re-encrypt termination. Upload file by dragging & dropping, or selecting it."
+                help-text="The PEM format CA certificate to validate the endpoint certificate for re-encrypt termination. Upload file by dragging & dropping, selecting it, or pasting from the clipboard."
                 ng-disabled="route.tls.termination !== 'reencrypt'">
             </osc-file-input>
             <!-- Show a warning if the value won't be used, but only if we're

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -9658,7 +9658,7 @@ scope:{
 model:"=",
 required:"=",
 disabled:"=ngDisabled",
-showValues:"=",
+showTextArea:"=",
 helpText:"@?",
 dropZoneId:"@?"
 },
@@ -9715,7 +9715,7 @@ c.find(".drag-and-drop-zone").removeClass("show-drag-and-drop-zone highlight-dra
 }
 var g = _.uniqueId("osc-file-input-");
 b.dropMessageID = g + "-drop-message", b.helpID = g + "-help", b.supportsFileUpload = window.File && window.FileReader && window.FileList && window.Blob, b.uploadError = !1;
-var h = "#" + b.dropMessageID, i = !1, j = !1, k = c.find("input[type=file]")[0];
+var h = "#" + b.dropMessageID, i = !1, j = !1, k = c.find("input[type=file]");
 setTimeout(d), $(document).on("drop." + g, function() {
 return f(), c.find(".drag-and-drop-zone").trigger("putDropZoneFront", !1), !1;
 }), $(document).on("dragenter." + g, function() {
@@ -9727,9 +9727,9 @@ return j = !1, _.delay(function() {
 j || c.find(".drag-and-drop-zone").removeClass("show-drag-and-drop-zone");
 }, 200), !1;
 }), b.cleanInputValues = function() {
-b.model = "", b.fileName = "", k.value = "";
-}, c.change(function() {
-e(k.files[0]);
+b.model = "", b.fileName = "", k[0].value = "";
+}, k.change(function() {
+e(k[0].files[0]);
 }), b.$on("$destroy", function() {
 $(h).off(), $(document).off("drop." + g).off("dragenter." + g).off("dragover." + g).off("dragleave." + g);
 });

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -9905,11 +9905,14 @@ routingDisabled:"=",
 hostReadOnly:"="
 },
 templateUrl:"views/directives/osc-routing.html",
-controller:[ "$scope", function(a) {
-a.disableCertificateInputs = function() {
-var b = _.get(a, "route.tls.termination");
-return !b || "passthrough" === b;
-}, a.insecureTrafficOptions = [ {
+link:function(b, c, d, e) {
+b.form = e, b.controls = {}, b.options = {
+secureRoute:!1,
+alternateServices:!1
+}, b.disableWildcards = a.DISABLE_WILDCARD_ROUTES, b.disableCertificateInputs = function() {
+var a = _.get(b, "route.tls.termination");
+return !a || "passthrough" === a;
+}, b.insecureTrafficOptions = [ {
 value:"",
 label:"None"
 }, {
@@ -9918,10 +9921,7 @@ label:"Allow"
 }, {
 value:"Redirect",
 label:"Redirect"
-} ];
-} ],
-link:function(b, c, d, e) {
-b.form = e, b.controls = {}, b.disableWildcards = a.DISABLE_WILDCARD_ROUTES, b.disableWildcards ? b.hostnamePattern = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/ :b.hostnamePattern = /^(\*(\.[a-z0-9]([-a-z0-9]*[a-z0-9]))+|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$/;
+} ], _.has(b, "route.tls.insecureEdgeTerminationPolicy") || _.set(b, "route.tls.insecureEdgeTerminationPolicy", ""), b.disableWildcards ? b.hostnamePattern = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/ :b.hostnamePattern = /^(\*(\.[a-z0-9]([-a-z0-9]*[a-z0-9]))+|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$/;
 var f = function(a) {
 a && (b.unnamedServicePort = 1 === a.spec.ports.length && !a.spec.ports[0].name, a.spec.ports.length && !b.unnamedServicePort ? b.route.portOptions = _.map(a.spec.ports, function(a) {
 return {
@@ -9937,21 +9937,22 @@ return a === b;
 }), b.$watch("route.alternateServices", function(a) {
 b.duplicateServices = _(a).map("service").filter(function(a, b, c) {
 return _.includes(c, a, b + 1);
-}).value(), e.$setValidity("duplicateServices", !b.duplicateServices.length);
+}).value(), e.$setValidity("duplicateServices", !b.duplicateServices.length), b.options.alternateServices = !_.isEmpty(a);
 }, !0);
 var g = function() {
 return !!b.route.tls && ((!b.route.tls.termination || "passthrough" === b.route.tls.termination) && (b.route.tls.certificate || b.route.tls.key || b.route.tls.caCertificate || b.route.tls.destinationCACertificate));
 };
 b.$watch("route.tls.termination", function() {
-b.secureRoute = !!_.get(b, "route.tls.termination"), b.showCertificatesNotUsedWarning = g();
+b.options.secureRoute = !!_.get(b, "route.tls.termination"), b.showCertificatesNotUsedWarning = g();
 });
 var h;
-b.$watch("secureRoute", function(a, c) {
+b.$watch("options.secureRoute", function(a, c) {
 if (a !== c) {
-a && !_.get(b, "route.tls.insecureEdgeTerminationPolicy") && _.set(b, "route.tls.insecureEdgeTerminationPolicy", b.insecureTrafficOptions[0]);
 var d = _.get(b, "route.tls.termination");
-!b.securetRoute && d && (h = d, delete b.route.tls.termination), b.secureRoute && !d && _.set(b, "route.tls.termination", h || "edge");
+!b.securetRoute && d && (h = d, delete b.route.tls.termination), b.options.secureRoute && !d && _.set(b, "route.tls.termination", h || "edge");
 }
+}), b.$watch("options.alternateServices", function(a, c) {
+a !== c && (a || (b.route.alternateServices = []), a && _.isEmpty(b.route.alternateServices) && b.addAlternateService());
 }), b.addAlternateService = function() {
 b.route.alternateServices = b.route.alternateServices || [];
 var a = _.find(b.services, function(a) {
@@ -9959,20 +9960,24 @@ return a !== b.route.to.service && !_.some(b.route.alternateServices, {
 service:a
 });
 });
-b.route.alternateServices.push({
+_.has(b, "route.to.weight") || _.set(b, "route.to.weight", 1), b.route.alternateServices.push({
 service:a,
 weight:1
-}), _.has(b, "route.to.weight") || _.set(b, "route.to.weight", 1);
-}, b.weightAsPercentage = function(a) {
+});
+}, b.weightAsPercentage = function(a, c) {
 a = a || 0;
-var c = _.get(b, "route.to.weight", 0);
+var d = _.get(b, "route.to.weight", 0);
 if (_.each(b.route.alternateServices, function(a) {
-c += _.get(a, "weight", 0);
-}), !c) return "";
-var d = a / c * 100;
-return d3.round(d, 1) + "%";
-}, b.$watch("controls.rangeSlider", function(a, c) {
-a !== c && (a = parseInt(a, 10), _.set(b, "route.to.weight", a), _.set(b, "route.alternateServices[0].weight", 100 - a));
+d += _.get(a, "weight", 0);
+}), !d) return "";
+var e = a / d * 100;
+return c ? d3.round(e, 1) + "%" :e;
+};
+var i = !1;
+b.$watch("route.alternateServices.length", function(a) {
+0 === a && _.has(b, "route.to.weight") && delete b.route.to.weight, 1 === a && (i = !0, b.controls.rangeSlider = b.weightAsPercentage(b.route.to.weight));
+}), b.$watch("controls.rangeSlider", function(a, c) {
+return i ? void (i = !1) :void (a !== c && (a = parseInt(a, 10), _.set(b, "route.to.weight", a), _.set(b, "route.alternateServices[0].weight", 100 - a)));
 });
 }
 };

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5905,7 +5905,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"form-group\" ng-if=\"add.cacert\" id=\"cacert\">\n" +
     "<label class=\"required\" for=\"cacert\">CA Certificate File</label>\n" +
-    "<osc-file-input id=\"cacert-file-input\" model=\"newSecret.data.cacert\" drop-zone-id=\"cacert\" help-text=\"Upload your ca.crt file.\" show-values=\"false\" required=\"true\"></osc-file-input>\n" +
+    "<osc-file-input id=\"cacert-file-input\" model=\"newSecret.data.cacert\" drop-zone-id=\"cacert\" help-text=\"Upload your ca.crt file.\" required=\"true\"></osc-file-input>\n" +
     "<div ui-ace=\"{\n" +
     "          mode: 'txt',\n" +
     "          theme: 'eclipse',\n" +
@@ -5919,7 +5919,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"newSecret.authType === 'kubernetes.io/ssh-auth'\">\n" +
     "<div class=\"form-group\" id=\"private-key\">\n" +
     "<label for=\"privateKey\" class=\"required\">SSH Private Key</label>\n" +
-    "<osc-file-input id=\"private-key-file-input\" model=\"newSecret.data.privateKey\" drop-zone-id=\"private-key\" help-text=\"Upload your private SSH key file.\" show-values=\"false\"></osc-file-input>\n" +
+    "<osc-file-input id=\"private-key-file-input\" model=\"newSecret.data.privateKey\" drop-zone-id=\"private-key\" help-text=\"Upload your private SSH key file.\"></osc-file-input>\n" +
     "<div ui-ace=\"{\n" +
     "          theme: 'eclipse',\n" +
     "          rendererOptions: {\n" +
@@ -5943,7 +5943,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"form-group\" ng-if=\"add.gitconfig\" id=\"gitconfig\">\n" +
     "<label class=\"required\" for=\"gitconfig\">Git Configuration File</label>\n" +
-    "<osc-file-input id=\"gitconfig-file-input\" model=\"newSecret.data.gitconfig\" drop-zone-id=\"gitconfig\" help-text=\"Upload your .gitconfig or  file.\" show-values=\"false\" required=\"true\"></osc-file-input>\n" +
+    "<osc-file-input id=\"gitconfig-file-input\" model=\"newSecret.data.gitconfig\" drop-zone-id=\"gitconfig\" help-text=\"Upload your .gitconfig or  file.\" required=\"true\"></osc-file-input>\n" +
     "<div ui-ace=\"{\n" +
     "          mode: 'ini',\n" +
     "          theme: 'eclipse',\n" +
@@ -6006,7 +6006,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"newSecret.authType === 'kubernetes.io/dockerconfigjson'\">\n" +
     "<div class=\"form-group\" id=\"docker-config\">\n" +
     "<label for=\"dockerConfig\" class=\"required\">Configuration File</label>\n" +
-    "<osc-file-input id=\"dockercfg-file-input\" model=\"newSecret.data.dockerConfig\" drop-zone-id=\"docker-config\" help-text=\"Upload a .dockercfg or .docker/config.json file\" show-values=\"false\" required=\"true\"></osc-file-input>\n" +
+    "<osc-file-input id=\"dockercfg-file-input\" model=\"newSecret.data.dockerConfig\" drop-zone-id=\"docker-config\" help-text=\"Upload a .dockercfg or .docker/config.json file\" required=\"true\"></osc-file-input>\n" +
     "<div ui-ace=\"{\n" +
     "          mode: 'json',\n" +
     "          theme: 'eclipse',\n" +
@@ -6398,7 +6398,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"form-group\" ng-attr-id=\"drop-zone-{{$id}}\">\n" +
     "<label ng-attr-for=\"name-{{$id}}\">Value</label>\n" +
-    "<osc-file-input model=\"item.value\" drop-zone-id=\"drop-zone-{{$id}}\" help-text=\"Enter a value for the config map entry or use the contents of a file.\" show-values=\"false\"></osc-file-input>\n" +
+    "<osc-file-input model=\"item.value\" drop-zone-id=\"drop-zone-{{$id}}\" help-text=\"Enter a value for the config map entry or use the contents of a file.\"></osc-file-input>\n" +
     "<div ui-ace=\"{\n" +
     "          theme: 'eclipse',\n" +
     "          rendererOptions: {\n" +
@@ -6790,7 +6790,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"col-sm-12 pod-bottom-xl\">\n" +
     "<form name=\"form\">\n" +
     "<div class=\"form-group\" id=\"from-file\">\n" +
-    "<osc-file-input model=\"editorContent\" drop-zone-id=\"from-file\" help-text=\"Upload file by dragging & dropping, selecting it, or pasting from the clipboard.\" ng-disabled=\"false\" show-values=\"false\"></osc-file-input>\n" +
+    "<osc-file-input model=\"editorContent\" drop-zone-id=\"from-file\" help-text=\"Upload file by dragging & dropping, selecting it, or pasting from the clipboard.\" ng-disabled=\"false\"></osc-file-input>\n" +
     "<div ui-ace=\"{\n" +
     "          mode: 'yaml',\n" +
     "          theme: 'eclipse',\n" +
@@ -7308,6 +7308,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/directives/osc-file-input.html',
+    "<div class=\"osc-file-input\">\n" +
     "<div ng-attr-id=\"{{dropMessageID}}\" class=\"drag-and-drop-zone\">\n" +
     "<p>Drop file here</p>\n" +
     "</div>\n" +
@@ -7320,18 +7321,16 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</span>\n" +
     "</div>\n" +
-    "<textarea class=\"form-control\" rows=\"8\" ng-hide=\"supportsFileUpload\" ng-model=\"model\" ng-required=\"required\" ng-disabled=\"disabled\" ng-attr-aria-describedby=\"{{helpText ? helpID : undefined}}\">\n" +
-    "</textarea>\n" +
     "<div ng-if=\"helpText\">\n" +
     "<span ng-attr-id=\"{{helpID}}\" class=\"help-block\">{{::helpText}}</span>\n" +
     "</div>\n" +
     "<div class=\"has-error\" ng-show=\"uploadError\">\n" +
     "<span class=\"help-block\">There was an error reading the file. Please copy the file content into the text area.</span>\n" +
     "</div>\n" +
-    "<div ng-if=\"model && showValues && supportsFileUpload\">\n" +
-    "<pre ng-if=\"model && showValues && supportsFileUpload\" class=\"clipped scroll\">{{model}}</pre>\n" +
-    "</div>\n" +
-    "<a href=\"\" ng-show=\"model || fileName\" class=\"clear-btn\" ng-click=\"cleanInputValues()\">Clear Value</a>"
+    "<textarea class=\"form-control\" rows=\"5\" ng-show=\"showTextArea || !supportsFileUpload\" ng-model=\"model\" ng-required=\"required\" ng-disabled=\"disabled\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" ng-attr-aria-describedby=\"{{helpText ? helpID : undefined}}\">\n" +
+    "  </textarea>\n" +
+    "<a href=\"\" ng-show=\"(model || fileName) && !disabled\" ng-click=\"cleanInputValues()\">Clear Value</a>\n" +
+    "</div>"
   );
 
 
@@ -7855,22 +7854,22 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div>\n" +
     "<div class=\"form-group\" id=\"certificate-file\">\n" +
     "<label>Certificate</label>\n" +
-    "<osc-file-input model=\"route.tls.certificate\" drop-zone-id=\"certificate-file\" show-values=\"true\" help-text=\"The PEM format certificate. Upload file by dragging & dropping, or selecting it.\" ng-disabled=\"disableCertificateInputs()\">\n" +
+    "<osc-file-input model=\"route.tls.certificate\" drop-zone-id=\"certificate-file\" show-text-area=\"true\" help-text=\"The PEM format certificate. Upload file by dragging & dropping, selecting it, or pasting from the clipbard.\" ng-disabled=\"disableCertificateInputs()\">\n" +
     "</osc-file-input>\n" +
     "</div>\n" +
     "<div class=\"form-group\" id=\"private-key-file\">\n" +
     "<label>Private Key</label>\n" +
-    "<osc-file-input model=\"route.tls.key\" drop-zone-id=\"private-key-file\" show-values=\"true\" help-text=\"The PEM format key. Upload file by dragging & dropping, or selecting it.\" ng-disabled=\"disableCertificateInputs()\">\n" +
+    "<osc-file-input model=\"route.tls.key\" drop-zone-id=\"private-key-file\" show-text-area=\"true\" help-text=\"The PEM format key. Upload file by dragging & dropping, selecting it, or pasting from the clipboard.\" ng-disabled=\"disableCertificateInputs()\">\n" +
     "</osc-file-input>\n" +
     "</div>\n" +
     "<div class=\"form-group\" id=\"ca-certificate-file\">\n" +
     "<label>CA Certificate</label>\n" +
-    "<osc-file-input model=\"route.tls.caCertificate\" drop-zone-id=\"ca-certificate-file\" show-values=\"true\" help-text=\"The PEM format CA certificate. Upload file by dragging & dropping, or selecting it.\" ng-disabled=\"disableCertificateInputs()\">\n" +
+    "<osc-file-input model=\"route.tls.caCertificate\" drop-zone-id=\"ca-certificate-file\" show-text-area=\"true\" help-text=\"The PEM format CA certificate. Upload file by dragging & dropping, selecting it, or pasting from the clipboard.\" ng-disabled=\"disableCertificateInputs()\">\n" +
     "</osc-file-input>\n" +
     "</div>\n" +
     "<div class=\"form-group\" id=\"dest-ca-certificate-file\">\n" +
     "<label>Destination CA Certificate</label>\n" +
-    "<osc-file-input model=\"route.tls.destinationCACertificate\" show-values=\"true\" drop-zone-id=\"dest-ca-certificate-file\" help-text=\"The PEM format CA certificate to validate the endpoint certificate for re-encrypt termination. Upload file by dragging & dropping, or selecting it.\" ng-disabled=\"route.tls.termination !== 'reencrypt'\">\n" +
+    "<osc-file-input model=\"route.tls.destinationCACertificate\" show-text-area=\"true\" drop-zone-id=\"dest-ca-certificate-file\" help-text=\"The PEM format CA certificate to validate the endpoint certificate for re-encrypt termination. Upload file by dragging & dropping, selecting it, or pasting from the clipboard.\" ng-disabled=\"route.tls.termination !== 'reencrypt'\">\n" +
     "</osc-file-input>\n" +
     "\n" +
     "<div ng-if=\"route.tls.destinationCACertificate && route.tls.termination !== 'reencrypt' && !showCertificatesNotUsedWarning\" class=\"has-warning\">\n" +

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7728,9 +7728,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<osc-routing-service model=\"route.to\" services=\"services\" show-weight=\"route.alternateServices.length > 1 || (controls.hideSlider && route.alternateServices.length)\">\n" +
     "</osc-routing-service>\n" +
     "</div>\n" +
-    "<div ng-if=\"alternateServiceOptions.length && !route.alternateServices.length\" class=\"form-group\">\n" +
-    "<a href=\"\" ng-click=\"addAlternateService()\">Split traffic across multiple services</a>\n" +
-    "</div>\n" +
     "\n" +
     "<div ng-if=\"route.portOptions.length\" class=\"form-group\">\n" +
     "<label for=\"routeTargetPort\">Target Port</label>\n" +
@@ -7747,8 +7744,19 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "\n" +
-    "<div ng-if=\"route.alternateServices.length\">\n" +
+    "<div ng-if=\"alternateServiceOptions.length\">\n" +
     "<h3>Alternate Services</h3>\n" +
+    "<div class=\"form-group\">\n" +
+    "<div class=\"checkbox\">\n" +
+    "<label>\n" +
+    "<input type=\"checkbox\" ng-model=\"options.alternateServices\" aria-describedby=\"secure-route-help\">\n" +
+    "Split traffic across multiple services\n" +
+    "</label>\n" +
+    "<div class=\"help-block\">\n" +
+    "Routes can direct traffic to multiple services for A/B testing. Each service has a weight controlling how much traffic it gets.\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
     "<div ng-repeat=\"alternate in route.alternateServices\" class=\"form-group\">\n" +
     "<osc-routing-service model=\"alternate\" services=\"alternateServiceOptions\" is-alternate=\"true\" show-weight=\"route.alternateServices.length > 1 || controls.hideSlider\">\n" +
     "</osc-routing-service>\n" +
@@ -7771,12 +7779,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"weight-slider-values\">\n" +
     "<div>\n" +
     "<span class=\"service-name\">{{route.to.service.metadata.name}}</span>\n" +
-    "<span class=\"weight-percentage\">{{weightAsPercentage(route.to.weight)}}</span>\n" +
+    "<span class=\"weight-percentage\">{{weightAsPercentage(route.to.weight, true)}}</span>\n" +
     "</div>\n" +
     "<div>\n" +
-    "<span class=\"weight-percentage hidden-xs\">{{weightAsPercentage(route.alternateServices[0].weight)}}</span>\n" +
+    "<span class=\"weight-percentage hidden-xs\">{{weightAsPercentage(route.alternateServices[0].weight, true)}}</span>\n" +
     "<span class=\"service-name\">{{route.alternateServices[0].service.metadata.name}}</span>\n" +
-    "<span class=\"weight-percentage visible-xs-inline\">{{weightAsPercentage(route.alternateServices[0].weight)}}</span>\n" +
+    "<span class=\"weight-percentage visible-xs-inline\">{{weightAsPercentage(route.alternateServices[0].weight, true)}}</span>\n" +
     "</div>\n" +
     "</div>\n" +
     "<label class=\"sr-only\" for=\"weight-slider\">Service {{route.to.service.metadata.name}} Weight</label>\n" +
@@ -7794,16 +7802,17 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
+    "<h3>Security</h3>\n" +
     "<div class=\"checkbox\">\n" +
     "<label>\n" +
-    "<input type=\"checkbox\" ng-model=\"secureRoute\" aria-describedby=\"secure-route-help\">\n" +
+    "<input type=\"checkbox\" ng-model=\"options.secureRoute\" aria-describedby=\"secure-route-help\">\n" +
     "Secure route\n" +
     "</label>\n" +
     "<div class=\"help-block\" id=\"secure-route-help\">\n" +
     "Routes can be secured using several TLS termination types for serving certificates.\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-show=\"secureRoute\">\n" +
+    "<div ng-show=\"options.secureRoute\">\n" +
     "\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"tlsTermination\">TLS Termination</label>\n" +
@@ -7834,10 +7843,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "\n" +
     "<h3>Certificates</h3>\n" +
-    "<div>\n" +
-    "<span class=\"help-block\">\n" +
+    "<div class=\"help-block\">\n" +
     "TLS certificates for edge and re-encrypt termination. If not specified, the router's default certificate is used.\n" +
-    "</span>\n" +
     "</div>\n" +
     "<div ng-if=\"showCertificatesNotUsedWarning\" class=\"has-warning\">\n" +
     "<span class=\"help-block\">\n" +
@@ -7850,7 +7857,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</span>\n" +
     "</div>\n" +
-    "<fieldset>\n" +
+    "<fieldset class=\"mar-top-md\">\n" +
     "<div>\n" +
     "<div class=\"form-group\" id=\"certificate-file\">\n" +
     "<label>Certificate</label>\n" +
@@ -7874,7 +7881,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<div ng-if=\"route.tls.destinationCACertificate && route.tls.termination !== 'reencrypt' && !showCertificatesNotUsedWarning\" class=\"has-warning\">\n" +
     "<span class=\"help-block\">\n" +
-    "The destination CA certificate will not be used. Destination CA certificates are only used for re-encrypt termination.\n" +
+    "The destination CA certificate will be removed from the route. Destination CA certificates are only used for re-encrypt termination.\n" +
     "</span>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3595,6 +3595,7 @@ to{transform:rotate(359deg)}
 @media (min-width:768px){.weight-slider-values{-webkit-flex-direction:row;-moz-flex-direction:row;-ms-flex-direction:row;flex-direction:row;justify-content:space-between}
 .weight-slider-values .weight-percentage{margin-right:5px}
 }
+.osc-file-input textarea{font-family:Menlo,Monaco,Consolas,monospace;margin:5px 0}
 .card-pf{box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09)}
 .card-pf .image-icon,.card-pf .template-icon{font-size:28px;line-height:1;margin-right:15px;opacity:.38}
 .card-pf-badge{color:#999;font-size:11px;text-transform:uppercase}


### PR DESCRIPTION
When creating or editing a route, let users paste in the certificate values if they need to. Previously you could only upload from a file.

Fixes #964

<img width="737" alt="screen shot 2016-12-22 at 9 32 33 am" src="https://cloud.githubusercontent.com/assets/1167259/21428939/91302214-c82a-11e6-8bb9-dd7a04ee2e75.png">
