### PR TITLE
Remove unnecessary gutter-top style from routes table

### DIFF
--- a/app/views/browse/routes.html
+++ b/app/views/browse/routes.html
@@ -30,7 +30,7 @@
         <div class="container-fluid">
           <alerts alerts="alerts"></alerts>
           <div class="row">
-            <div class="col-md-12 gutter-top">
+            <div class="col-md-12">
               <table class="table table-bordered table-hover table-mobile">
                 <thead>
                   <tr>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3737,7 +3737,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-fluid\">\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
-    "<div class=\"col-md-12 gutter-top\">\n" +
+    "<div class=\"col-md-12\">\n" +
     "<table class=\"table table-bordered table-hover table-mobile\">\n" +
     "<thead>\n" +
     "<tr>\n" +


### PR DESCRIPTION
`middle-header` already has a bottom margin, so the style is not needed. This makes the routes table consistent with others like services, deployments, and builds.