### PR TITLE
Show advanced source options when used by "Try It"

### DIFF
--- a/app/scripts/controllers/create/createFromImage.js
+++ b/app/scripts/controllers/create/createFromImage.js
@@ -133,6 +133,11 @@ angular.module("openshiftConsole")
             scope.buildConfig.sourceUrl = annotations.sampleRepo || "";
             scope.buildConfig.gitRef = annotations.sampleRef || "";
             scope.buildConfig.contextDir = annotations.sampleContextDir || "";
+            if (annotations.sampleRef || annotations.sampleContextDir) {
+              // Show the advanced source options (without exapnding all
+              // advanced options) if the sample repo uses it.
+              scope.advancedSourceOptions = true;
+            }
           };
 
           scope.usingSampleRepo = function() {

--- a/app/views/create/fromimage.html
+++ b/app/views/create/fromimage.html
@@ -71,8 +71,9 @@
                           </div>
                           <div class="row">
                             <div ng-class="{
-                              'col-md-8': advancedOptions,
-                              'col-lg-12': !advancedOptions}">
+                              'col-md-8': advancedOptions || advancedSourceOptions,
+                              'col-lg-12': !advancedOptions && !advancedSourceOptions
+                            }">
                               <div class="form-group">
                                 <label for="sourceUrl" class="required">Git Repository URL</label>
                                 <div ng-class="{
@@ -107,7 +108,7 @@
                               </div>
                             </div>
 
-                            <div class="col-md-4" ng-if="advancedOptions">
+                            <div class="col-md-4" ng-if="advancedOptions || advancedSourceOptions">
                               <div class="form-group">
                                 <label for="gitref">Git Reference</label>
                                 <div>
@@ -126,23 +127,23 @@
                             </div>
                           </div>
 
-                          <div ng-if="advancedOptions">
-                            <div class="form-group">
-                              <label for="contextdir">Context Dir</label>
-                              <div>
-                                <input
-                                  id="contextdir"
-                                  ng-model="buildConfig.contextDir"
-                                  type="text"
-                                  placeholder="/"
-                                  autocorrect="off"
-                                  autocapitalize="off"
-                                  spellcheck="false"
-                                  class="form-control">
-                              </div>
-                              <div class="help-block">Optional subdirectory for the application source code, used as the context directory for the build.</div>
+                          <div ng-if="advancedOptions || advancedSourceOptions" class="form-group">
+                            <label for="contextdir">Context Dir</label>
+                            <div>
+                              <input
+                                id="contextdir"
+                                ng-model="buildConfig.contextDir"
+                                type="text"
+                                placeholder="/"
+                                autocorrect="off"
+                                autocapitalize="off"
+                                spellcheck="false"
+                                class="form-control">
                             </div>
+                            <div class="help-block">Optional subdirectory for the application source code, used as the context directory for the build.</div>
+                          </div>
 
+                          <div ng-if="advancedOptions">
                             <div class="form-group">
                               <osc-secrets model="buildConfig.secrets.gitSecret"
                                           namespace="projectName"

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7806,7 +7806,7 @@ value:!0
 resources:{}
 }, b.cpuRequestCalculated = j.isRequestCalculated("cpu", e), b.cpuLimitCalculated = j.isLimitCalculated("cpu", e), b.memoryRequestCalculated = j.isRequestCalculated("memory", e), b.fillSampleRepo = function() {
 var a;
-(b.image || b.image.metadata || b.image.metadata.annotations) && (a = b.image.metadata.annotations, b.buildConfig.sourceUrl = a.sampleRepo || "", b.buildConfig.gitRef = a.sampleRef || "", b.buildConfig.contextDir = a.sampleContextDir || "");
+(b.image || b.image.metadata || b.image.metadata.annotations) && (a = b.image.metadata.annotations, b.buildConfig.sourceUrl = a.sampleRepo || "", b.buildConfig.gitRef = a.sampleRef || "", b.buildConfig.contextDir = a.sampleContextDir || "", (a.sampleRef || a.sampleContextDir) && (b.advancedSourceOptions = !0));
 }, b.usingSampleRepo = function() {
 return b.buildConfig.sourceUrl === _.get(b, "image.metadata.annotations.sampleRepo");
 }, k.isAvailable().then(function(b) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4799,8 +4799,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"row\">\n" +
     "<div ng-class=\"{\n" +
-    "                              'col-md-8': advancedOptions,\n" +
-    "                              'col-lg-12': !advancedOptions}\">\n" +
+    "                              'col-md-8': advancedOptions || advancedSourceOptions,\n" +
+    "                              'col-lg-12': !advancedOptions && !advancedSourceOptions\n" +
+    "                            }\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"sourceUrl\" class=\"required\">Git Repository URL</label>\n" +
     "<div ng-class=\"{\n" +
@@ -4822,7 +4823,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"col-md-4\" ng-if=\"advancedOptions\">\n" +
+    "<div class=\"col-md-4\" ng-if=\"advancedOptions || advancedSourceOptions\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"gitref\">Git Reference</label>\n" +
     "<div>\n" +
@@ -4832,14 +4833,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-if=\"advancedOptions\">\n" +
-    "<div class=\"form-group\">\n" +
+    "<div ng-if=\"advancedOptions || advancedSourceOptions\" class=\"form-group\">\n" +
     "<label for=\"contextdir\">Context Dir</label>\n" +
     "<div>\n" +
     "<input id=\"contextdir\" ng-model=\"buildConfig.contextDir\" type=\"text\" placeholder=\"/\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" class=\"form-control\">\n" +
     "</div>\n" +
     "<div class=\"help-block\">Optional subdirectory for the application source code, used as the context directory for the build.</div>\n" +
     "</div>\n" +
+    "<div ng-if=\"advancedOptions\">\n" +
     "<div class=\"form-group\">\n" +
     "<osc-secrets model=\"buildConfig.secrets.gitSecret\" namespace=\"projectName\" display-type=\"source\" type=\"source\" service-account-to-link=\"builder\" secrets-by-type=\"secretsByType\" alerts=\"alerts\" allow-multiple-secrets=\"false\">\n" +
     "</osc-secrets>\n" +


### PR DESCRIPTION
If the "Try It" link fills in advanced source options like git ref or context dir, show those fields (without expanding all advanced options).

Fixes https://github.com/openshift/origin/issues/9297