### PR TITLE
Resolving IE11 bug where descenders in project names clipped

### DIFF
--- a/app/styles/_projects.less
+++ b/app/styles/_projects.less
@@ -71,8 +71,8 @@
     }
     a {
       display: block;
+      line-height: normal;
       overflow: hidden;
-      line-height: initial;
       text-overflow: ellipsis;
     }
   }

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5216,7 +5216,7 @@ a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;borde
 }
 .project-name-item.list-group-item-heading .h1{margin-bottom:0;margin-top:0}
 .project-name-item.list-group-item-heading .h1 [data-toggle=tooltip]{cursor:help;margin-left:5px}
-.project-name-item.list-group-item-heading .h1 a{display:block;overflow:hidden;line-height:initial;text-overflow:ellipsis}
+.project-name-item.list-group-item-heading .h1 a{display:block;line-height:normal;overflow:hidden;text-overflow:ellipsis}
 .project-name-item.list-group-item-heading p{margin-bottom:0;margin-top:5px}
 .projects-bar{display:flex;flex-direction:column}
 @media (min-width:650px){.projects-bar{flex-direction:row;justify-content:space-between}


### PR DESCRIPTION
Before:

![screen shot 2017-01-04 at 9 22 16 am](https://cloud.githubusercontent.com/assets/895728/21645282/67331bd0-d25f-11e6-90da-13a9de1d3a74.PNG)

After:

![screen shot 2017-01-04 at 9 16 02 am](https://cloud.githubusercontent.com/assets/895728/21645291/6d440084-d25f-11e6-8a9c-fb53bc088d29.PNG)

@jwforres or @spadgett, PTAL