### PR TITLE
Use `metadata.name` as secondary sort for projects

### DIFF
--- a/app/scripts/controllers/projects.js
+++ b/app/scripts/controllers/projects.js
@@ -60,9 +60,10 @@ angular.module('openshiftConsole')
       var primarySortOrder = $scope.sortConfig.isAscending ? 'asc' : 'desc';
       switch (sortID) {
       case 'metadata.annotations["openshift.io/display-name"]':
-        // Sort by display name, falling back to project name if no display name.
+        // Sort by display name. Use `metadata.name` as a secondary sort when
+        // projects have the same display name.
         sortedProjects = _.sortByOrder(projects,
-                                       [ displayNameLower ],
+                                       [ displayNameLower, 'metadata.name' ],
                                        [ primarySortOrder ]);
         break;
       case 'metadata.annotations["openshift.io/requester"]':

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -435,6 +435,14 @@ angular.module('openshiftConsole')
       itemsArray.sort(function(left, right) {
         var leftName = displayNameFilter(left) || '';
         var rightName = displayNameFilter(right) || '';
+
+        // Fall back to sorting by `metadata.name` if the display names are the
+        // same so that the sort is stable.
+        if (leftName === rightName) {
+          leftName = _.get(left, 'metadata.name', '');
+          rightName = _.get(right, 'metadata.name', '');
+        }
+
         return leftName.localeCompare(rightName);
       });
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4184,7 +4184,7 @@ return s(a).toLowerCase();
 }, d = a.sortConfig.isAscending ? "asc" :"desc";
 switch (b) {
 case 'metadata.annotations["openshift.io/display-name"]':
-m = _.sortByOrder(l, [ c ], [ d ]);
+m = _.sortByOrder(l, [ c, "metadata.name" ], [ d ]);
 break;
 
 case 'metadata.annotations["openshift.io/requester"]':
@@ -13503,7 +13503,7 @@ return function(c) {
 var d = b(c);
 return d.sort(function(b, c) {
 var d = a(b) || "", e = a(c) || "";
-return d.localeCompare(e);
+return d === e && (d = _.get(b, "metadata.name", ""), e = _.get(c, "metadata.name", "")), d.localeCompare(e);
 }), d;
 };
 } ]).filter("isPodStuck", function() {


### PR DESCRIPTION
Update the projects page and `orderByDisplayName` filter to use
`metadata.name` as a secondary sort when projects have the same display
name.

Fixes #915