### PR TITLE
Bug 1411258, Bug 1411266 - Fix editing existing commands

### DIFF
--- a/app/scripts/directives/editCommand.js
+++ b/app/scripts/directives/editCommand.js
@@ -35,15 +35,16 @@ angular.module('openshiftConsole')
         }, true);
 
         scope.$watch('input.args', function(newValue, oldValue) {
-          if (newValue === oldValue) {
-            return;
-          }
           if (argsChanged) {
             argsChanged = false;
             return;
           }
-          inputChanged = true;
 
+          if (newValue === oldValue) {
+            return;
+          }
+
+          inputChanged = true;
           scope.args = _.map(scope.input.args, function(arg) {
             return arg.value;
           });

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12513,12 +12513,9 @@ multiline:e(a)
 };
 }), c = !0));
 }, !0), b.$watch("input.args", function(a, e) {
-if (a !== e) {
-if (c) return void (c = !1);
-d = !0, b.args = _.map(b.input.args, function(a) {
+return c ? void (c = !1) :void (a !== e && (d = !0, b.args = _.map(b.input.args, function(a) {
 return a.value;
-}), b.form.command.$setDirty();
-}
+}), b.form.command.$setDirty()));
 }, !0), b.addArg = function() {
 b.nextArg && (b.input.args = b.input.args || [], b.input.args.push({
 value:b.nextArg,


### PR DESCRIPTION
The first edit made when editing an existing command is ignored. The
`argsChanged` value is not properly reset on the first `input.args` watch
callback, so changes are not saved unless there is a second edit.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1411258
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1411266