### PR TITLE
Removal of legacy css rule causing clipping of pod donut arrows.

### DIFF
--- a/app/styles/_components.less
+++ b/app/styles/_components.less
@@ -309,7 +309,6 @@ code.command {
 
 .deployment-donut {
   justify-content: center;
-  min-width: 200px;
   .scaling-controls {
     justify-content: center;
     font-size: 24px;

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3711,7 +3711,7 @@ code.command{display:inline-block;line-height:1.3;margin-right:2px}
 .pod-donut .c3-defocused{opacity:.5!important}
 .pod-donut .c3-tooltip-container{top:-27px!important;left:50%!important;transform:translateX(-50%);white-space:nowrap}
 .pod-donut path.c3-arc-Empty{stroke:#d1d1d1;cursor:inherit!important}
-.deployment-donut{justify-content:center;min-width:200px}
+.deployment-donut{justify-content:center}
 .deployment-donut .scaling-controls{justify-content:center;font-size:24px}
 .deployment-donut .scaling-controls a{color:#bbb}
 .deployment-donut .scaling-controls a:active,.deployment-donut .scaling-controls a:hover{color:#72767b;text-decoration:none}


### PR DESCRIPTION
There is a min-width,  that is not needed, on `.deployment-donut` inherited from some [legacy code](url) that was originally associated with `.overview-pods`. Removing it tests fine on Chrome, FF, IE, Safari

Fixes https://github.com/openshift/origin-web-console/issues/1091


![200donutissue](https://cloud.githubusercontent.com/assets/1874151/21903337/792c6bba-d8cd-11e6-8b66-4926d0d5a175.gif)

![200donutissueie](https://cloud.githubusercontent.com/assets/1874151/21903336/792b75a2-d8cd-11e6-95aa-7895909c6cc0.gif)
