### PR TITLE
Display custom metrics for pods if they are available.

### DIFF
--- a/app/scripts/constants.js
+++ b/app/scripts/constants.js
@@ -64,6 +64,9 @@ window.OPENSHIFT_CONSTANTS = {
 
   // true indicates that deployment metrics should be disabled on the web console overview
   DISABLE_OVERVIEW_METRICS: false,
+ 
+  // true indicates that custom metrics should be disabled when viewing pod metrics
+  DISABLE_CUSTOM_METRICS: false,
 
   // true indicates that none of the routers support wildcard subdomains and
   // removes the option from the route creation form.

--- a/app/scripts/directives/podMetrics.js
+++ b/app/scripts/directives/podMetrics.js
@@ -95,6 +95,41 @@ angular.module('openshiftConsole')
           });
         }
 
+        if (!window.OPENSHIFT_CONSTANTS.DISABLE_CUSTOM_METRICS) {
+          // Load any custom metrics onto the page
+          MetricsService.getCustomMetrics(scope.pod).then(
+            function(response) {
+              angular.forEach(response, function(metric) {
+
+                // set the label to the description if specified
+                var label = metric.description || metric.name;
+              
+                // get the unit value if specified
+                var unit =  metric.unit || "";
+
+                scope.metrics.push({
+                  label: label,
+                  units: unit,
+                  chartPrefix: "custom-" + _.uniqueId('custom-metric-'),
+                  chartType: "spline",
+
+                  datasets: [
+                    {
+                      id: "custom/" + metric.name,
+                      label: label,
+                      type: metric.type,
+                      data: []
+                    },
+                  ]
+                });
+
+              });
+              // update the page with the new charts.
+              update();
+            }
+          );
+        }
+
         // Set to true when any data has been loaded (or failed to load).
         scope.loaded = false;
         scope.noData = true;
@@ -260,6 +295,7 @@ angular.module('openshiftConsole')
           var lastPoint;
           var config = {
             metric: dataset.id,
+            type: dataset.type,
             bucketDuration: getBucketDuration()
           };
 


### PR DESCRIPTION
The Hawkular OpenShift Agent is capable of gathering a few custom metrics from pods which are deployed.

This PR will allow these pods to be displayed under the pod's metric page