### PR TITLE
Refresh membership page when removing 'admin' role from current user

### DIFF
--- a/app/scripts/services/authorization.js
+++ b/app/scripts/services/authorization.js
@@ -2,7 +2,7 @@
 
 angular.module("openshiftConsole")
   .factory("AuthorizationService", function($q, $cacheFactory, Logger, $interval, APIService, DataService){
-    
+
     var currentProject = null;
     var cachedRulesByProject = $cacheFactory('rulesCache', {
           number: 10
@@ -34,7 +34,7 @@ angular.module("openshiftConsole")
     // Check if resource name meets one of following conditions, since those resources can't be create/update via `Add to project` page:
     //  - 'projectrequests'
     //  - subresource that contains '/', eg: 'builds/source', 'builds/logs', ...
-    //  - resource is in REVIEW_RESOURCES list 
+    //  - resource is in REVIEW_RESOURCES list
     var checkResource = function(resource) {
       if (resource === "projectrequests" || _.contains(resource, "/") || _.contains(REVIEW_RESOURCES, resource)) {
         return false;
@@ -52,12 +52,13 @@ angular.module("openshiftConsole")
       });
     };
 
-    var getProjectRules = function(projectName) {
+    // forceRefresh is a boolean to bust the cache & request new perms
+    var getProjectRules = function(projectName, forceRefresh) {
       var deferred = $q.defer();
       currentProject = projectName;
       var projectRules = cachedRulesByProject.get(projectName);
       var rulesResource = "selfsubjectrulesreviews";
-      if (!projectRules || projectRules.forceRefresh) {
+      if (!projectRules || projectRules.forceRefresh || forceRefresh) {
         // Check if APIserver contains 'selfsubjectrulesreviews' resource. If not switch to permissive mode.
         if (APIService.apiInfo(rulesResource)) {
           Logger.log("AuthorizationService, loading user rules for " + projectName + " project");
@@ -127,7 +128,7 @@ angular.module("openshiftConsole")
              _canI(rules, verb, '*',     '*'       ) ||
              _canI(rules, verb, r.group, '*'       ) ||
              _canI(rules, verb, '*',     r.resource);
-    }; 
+    };
 
     var canIAddToProject = function(projectName) {
       if (permissiveMode) {

--- a/app/scripts/services/membership/roleBindings.js
+++ b/app/scripts/services/membership/roleBindings.js
@@ -96,8 +96,14 @@ angular
           cleanBinding(binding);
           binding.subjects = _.reject(binding.subjects, {name: subjectName});
           return binding.subjects.length ?
-                  DataService.update('rolebindings', binding.metadata.name, binding, context):
-                  DataService.delete('rolebindings', binding.metadata.name, context);
+                  DataService.update('rolebindings', binding.metadata.name, binding, context) :
+                  DataService.delete('rolebindings', binding.metadata.name, context)
+                  // For a delete, resp is simply a 201 or less useful object.
+                  // Instead, this intercepts the response & returns the binding object
+                  // with the empty .subjects[] list. 
+                  .then(function() {
+                    return binding;
+                  });
         }));
     };
 

--- a/app/views/membership.html
+++ b/app/views/membership.html
@@ -10,7 +10,7 @@
               <a
                 class="pull-right btn btn-default"
                 href=""
-                ng-if="'rolebindings' | canI : 'update'"
+                ng-if="canUpdateRolebindings"
                 ng-click="toggleEditMode()">
                 <span ng-if="!(mode.edit)">Edit Membership</span>
                 <span ng-if="mode.edit">Done Editing</span>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -9630,7 +9630,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-fluid\">\n" +
     "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
     "<h1>\n" +
-    "<a class=\"pull-right btn btn-default\" href=\"\" ng-if=\"'rolebindings' | canI : 'update'\" ng-click=\"toggleEditMode()\">\n" +
+    "<a class=\"pull-right btn btn-default\" href=\"\" ng-if=\"canUpdateRolebindings\" ng-click=\"toggleEditMode()\">\n" +
     "<span ng-if=\"!(mode.edit)\">Edit Membership</span>\n" +
     "<span ng-if=\"mode.edit\">Done Editing</span>\n" +
     "</a>\n" +


### PR DESCRIPTION
Fixes #1103 

- Adds a forceRefresh flag to `AuthorizationService.getProjectRules` to allow busting the rules cache
- Ensures the edit mode is tested after every update
- Falls back to manually updating a roleBindings if the list on roleBindings fails (which it will if the user removes `admin` from self)

@spadgett 