### PR TITLE
Only show quota alerts at bottom of page

### DIFF
--- a/app/scripts/controllers/create/createFromImage.js
+++ b/app/scripts/controllers/create/createFromImage.js
@@ -59,6 +59,7 @@ angular.module("openshiftConsole")
       }
     ];
     $scope.alerts = {};
+    $scope.quotaAlerts = {};
 
     var appLabel = {name: 'app', value: ''};
 
@@ -317,7 +318,7 @@ angular.module("openshiftConsole")
           var errorAlerts = _.filter(quotaAlerts, {type: 'error'});
           if ($scope.nameTaken || errorAlerts.length) {
             $scope.disableInputs = false;
-            $scope.alerts = quotaAlerts;
+            $scope.quotaAlerts = quotaAlerts;
           }
           else if (quotaAlerts.length) {
              launchConfirmationDialog(quotaAlerts);

--- a/app/scripts/controllers/newfromtemplate.js
+++ b/app/scripts/controllers/newfromtemplate.js
@@ -43,7 +43,7 @@ angular.module('openshiftConsole')
 
     $scope.emptyMessage = "Loading...";
     $scope.alerts = {};
-    $scope.alertsTop = {};
+    $scope.quotaAlerts = {};
     $scope.projectName = $routeParams.project;
     $scope.projectPromise = $.Deferred();
     $scope.labels = [];
@@ -85,7 +85,7 @@ angular.module('openshiftConsole')
         return JSON.parse($routeParams.templateParamsMap);
       }
       catch (e) {
-        $scope.alertsTop.invalidTemplateParams = {
+        $scope.alerts.invalidTemplateParams = {
           type: "error",
           message: "The templateParamsMap is not valid JSON. " + e
         };
@@ -311,7 +311,7 @@ angular.module('openshiftConsole')
           var errorAlerts = _.filter(quotaAlerts, {type: 'error'});
           if (errorAlerts.length) {
             $scope.disableInputs = false;
-            $scope.alerts = quotaAlerts;
+            $scope.quotaAlerts = quotaAlerts;
           }
           else if (quotaAlerts.length) {
              launchConfirmationDialog(quotaAlerts);

--- a/app/views/create/fromimage.html
+++ b/app/views/create/fromimage.html
@@ -16,6 +16,7 @@
                   {{ emptyMessage }}
                 </div>
                 <div class="osc-form" ng-show="imageStream">
+                  <alerts alerts="alerts"></alerts>
                   <div class="row">
                     <div class="col-md-2 icon hidden-sm hidden-xs">
                       <custom-icon resource="imageStream" kind="image" tag="imageTag"></custom-icon>
@@ -405,7 +406,7 @@
                             <a href="" ng-click="advancedOptions = !advancedOptions" role="button">advanced options</a>
                             for source, routes, builds, and deployments.
                           </div>
-                          <alerts alerts="alerts"></alerts>
+                          <alerts alerts="quotaAlerts"></alerts>
                           <div class="buttons gutter-bottom" ng-class="{'gutter-top': !alerts.length}">
                             <!-- unable to use form.valid.  need to fix validators in labels and key values directive -->
                             <button type="submit"

--- a/app/views/newfromtemplate.html
+++ b/app/views/newfromtemplate.html
@@ -16,7 +16,7 @@
                   {{ emptyMessage }}
                 </div>
                 <div class="osc-form" ng-show="template">
-                  <alerts alerts="alertsTop" hide-close-button="true"></alerts>
+                  <alerts alerts="alerts"></alerts>
                   <div class="row">
                     <div class="col-md-2 icon hidden-sm hidden-xs">
                       <custom-icon resource="template" kind="template"></custom-icon>
@@ -51,7 +51,7 @@
                               can-toggle="false"
                               help-text="Each label is applied to each created resource.">
                           </label-editor>
-                          <alerts alerts="alerts"></alerts>
+                          <alerts alerts="quotaAlerts"></alerts>
                           <div class="buttons gutter-top-bottom">
                             <button class="btn btn-primary btn-lg" ng-click="createFromTemplate()" ng-disabled="templateForm.$invalid || disableInputs">Create</button>
                             <a class="btn btn-default btn-lg" href="{{projectName | projectOverviewURL}}">Cancel</a>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7776,7 +7776,7 @@ title:"Catalog",
 link:"project/" + a.projectName + "/create?tab=fromCatalog"
 }, {
 title:d.displayName || y
-} ], a.alerts = {};
+} ], a.alerts = {}, a.quotaAlerts = {};
 var z = {
 name:"app",
 value:""
@@ -7928,7 +7928,7 @@ b.result.then(D);
 var c = b.quotaAlerts || [], d = _.filter(c, {
 type:"error"
 });
-a.nameTaken || d.length ? (a.disableInputs = !1, a.alerts = c) :c.length ? (E(c), a.disableInputs = !1) :D();
+a.nameTaken || d.length ? (a.disableInputs = !1, a.quotaAlerts = c) :c.length ? (E(c), a.disableInputs = !1) :D();
 };
 a.projectDisplayName = function() {
 return w(this.project) || this.projectName;
@@ -8007,7 +8007,7 @@ d.unwatchAll(r);
 } ]), angular.module("openshiftConsole").controller("NewFromTemplateController", [ "$scope", "$http", "$routeParams", "DataService", "ProcessedTemplateService", "AlertMessageService", "ProjectsService", "QuotaService", "$q", "$location", "TaskList", "$parse", "Navigate", "$filter", "$uibModal", "imageObjectRefFilter", "failureObjectNameFilter", "CachedTemplateService", "keyValueEditorUtils", "Constants", function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) {
 var u = c.template, v = c.namespace || "";
 if (!u) return void m.toErrorPage("Cannot create from template: a template name was not specified.");
-a.emptyMessage = "Loading...", a.alerts = {}, a.alertsTop = {}, a.projectName = c.project, a.projectPromise = $.Deferred(), a.labels = [], a.systemLabels = [], a.breadcrumbs = [ {
+a.emptyMessage = "Loading...", a.alerts = {}, a.quotaAlerts = {}, a.projectName = c.project, a.projectPromise = $.Deferred(), a.labels = [], a.systemLabels = [], a.breadcrumbs = [ {
 title:a.projectName,
 link:"project/" + a.projectName
 }, {
@@ -8025,7 +8025,7 @@ var w = n("displayName"), x = n("humanize"), y = l("spec.template.spec.container
 try {
 return JSON.parse(c.templateParamsMap);
 } catch (b) {
-a.alertsTop.invalidTemplateParams = {
+a.alerts.invalidTemplateParams = {
 type:"error",
 message:"The templateParamsMap is not valid JSON. " + b
 };
@@ -8185,7 +8185,7 @@ b.result.then(J);
 var c = b.quotaAlerts || [], d = _.filter(c, {
 type:"error"
 });
-d.length ? (a.disableInputs = !1, a.alerts = c) :c.length ? (K(c), a.disableInputs = !1) :J();
+d.length ? (a.disableInputs = !1, a.quotaAlerts = c) :c.length ? (K(c), a.disableInputs = !1) :J();
 };
 a.createFromTemplate = function() {
 a.disableInputs = !0;

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4762,6 +4762,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "{{ emptyMessage }}\n" +
     "</div>\n" +
     "<div class=\"osc-form\" ng-show=\"imageStream\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-2 icon hidden-sm hidden-xs\">\n" +
     "<custom-icon resource=\"imageStream\" kind=\"image\" tag=\"imageTag\"></custom-icon>\n" +
@@ -4998,7 +4999,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a href=\"\" ng-click=\"advancedOptions = !advancedOptions\" role=\"button\">advanced options</a>\n" +
     "for source, routes, builds, and deployments.\n" +
     "</div>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
+    "<alerts alerts=\"quotaAlerts\"></alerts>\n" +
     "<div class=\"buttons gutter-bottom\" ng-class=\"{'gutter-top': !alerts.length}\">\n" +
     "\n" +
     "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-disabled=\"form.$invalid || nameTaken || cpuProblems.length || memoryProblems.length || disableInputs\">Create</button>\n" +
@@ -10459,7 +10460,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "{{ emptyMessage }}\n" +
     "</div>\n" +
     "<div class=\"osc-form\" ng-show=\"template\">\n" +
-    "<alerts alerts=\"alertsTop\" hide-close-button=\"true\"></alerts>\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-2 icon hidden-sm hidden-xs\">\n" +
     "<custom-icon resource=\"template\" kind=\"template\"></custom-icon>\n" +
@@ -10489,7 +10490,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<template-options parameters=\"template.parameters\" expand=\"true\" can-toggle=\"false\"></template-options>\n" +
     "<label-editor labels=\"labels\" system-labels=\"systemLabels\" expand=\"true\" can-toggle=\"false\" help-text=\"Each label is applied to each created resource.\">\n" +
     "</label-editor>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
+    "<alerts alerts=\"quotaAlerts\"></alerts>\n" +
     "<div class=\"buttons gutter-top-bottom\">\n" +
     "<button class=\"btn btn-primary btn-lg\" ng-click=\"createFromTemplate()\" ng-disabled=\"templateForm.$invalid || disableInputs\">Create</button>\n" +
     "<a class=\"btn btn-default btn-lg\" href=\"{{projectName | projectOverviewURL}}\">Cancel</a>\n" +


### PR DESCRIPTION
Use a separate alerts directive just for quota warnings, which appears at the bottom of the page. Other alerts should appear at the top.

Fixes #1084