### PR TITLE
Don't disable overview start pipeline button when pipeline running

### DIFF
--- a/app/views/overview/_dc.html
+++ b/app/views/overview/_dc.html
@@ -57,11 +57,7 @@
             <a ng-href="{{pipeline | navigateResourceURL}}">{{pipeline.metadata.name}}</a>.
           </p>
           <div ng-if="('buildconfigs/instantiate' | canI : 'create')">
-            <!-- Disable the button if a pipeline is running. -->
-            <button
-                class="btn btn-primary"
-                ng-click="startPipeline(pipeline)"
-                ng-disabled="incompletePipelinesByDC[deploymentConfig.metadata.name].length">
+            <button class="btn btn-primary" ng-click="startPipeline(pipeline)">
               Start Pipeline
             </button>
           </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -10734,8 +10734,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a ng-href=\"{{pipeline | navigateResourceURL}}\">{{pipeline.metadata.name}}</a>.\n" +
     "</p>\n" +
     "<div ng-if=\"('buildconfigs/instantiate' | canI : 'create')\">\n" +
-    "\n" +
-    "<button class=\"btn btn-primary\" ng-click=\"startPipeline(pipeline)\" ng-disabled=\"incompletePipelinesByDC[deploymentConfig.metadata.name].length\">\n" +
+    "<button class=\"btn btn-primary\" ng-click=\"startPipeline(pipeline)\">\n" +
     "Start Pipeline\n" +
     "</button>\n" +
     "</div>\n" +


### PR DESCRIPTION
We made this change to the build config page when `runPolicy` was added, but not here.