### PR TITLE
Making placement of actions menu consistent across pages

### DIFF
--- a/app/styles/_typography.less
+++ b/app/styles/_typography.less
@@ -35,13 +35,18 @@
   }
 }
 
-h1 small.meta,
-.build-config-summary .meta,
-.deployment-config-summary .meta {
-  font-size: 12px;
-  @media (max-width: @screen-xs-min) {
-    display: block;
-    margin-top: 5px;
+h1 {
+  &.contains-actions {
+    .word-break();
+  }
+  small.meta,
+  .build-config-summary .meta,
+  .deployment-config-summary .meta {
+    font-size: 12px;
+    @media (max-width: @screen-xs-min) {
+      display: block;
+      margin-top: 5px;
+    }
   }
 }
 

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -7,14 +7,7 @@
           <div class="container-fluid">
             <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
             <alerts alerts="alerts"></alerts>
-            <h1>
-              {{buildConfigName}}
-              <span class="pficon pficon-warning-triangle-o"
-                    ng-if="buildConfigPaused || buildConfigDeleted"
-                    aria-hidden="true"
-                    data-toggle="tooltip"
-                    data-original-title="{{buildConfigDeleted ? 'This build configuration no longer exists' : 'Building from build configuration ' + buildConfig.metadata.name + ' has been paused.'}}">
-              </span>
+            <h1 class="contains-actions">
               <div class="pull-right dropdown" ng-if="buildConfig" ng-hide="!('buildConfigs' | canIDoAny)">
                 <!-- Primary Actions -->
                 <button
@@ -64,6 +57,12 @@
                   </li>
                 </ul>
               </div>
+              {{buildConfigName}}
+              <span class="pficon pficon-warning-triangle-o"
+                    aria-hidden="true"
+                    data-toggle="tooltip"
+                    data-original-title="{{buildConfigDeleted ? 'This build configuration no longer exists' : 'Building from build configuration ' + buildConfig.metadata.name + ' has been paused.'}}">
+              </span>
               <small class="meta" ng-if="buildConfig">created <span am-time-ago="buildConfig.metadata.creationTimestamp"></span></small>
             </h1>
             <labels labels="buildConfig.metadata.labels" clickable="true" kind="builds" title-kind="build configs" project-name="{{buildConfig.metadata.namespace}}" limit="3"></labels>

--- a/app/views/browse/build.html
+++ b/app/views/browse/build.html
@@ -10,15 +10,7 @@
             <alerts alerts="alerts"></alerts>
             <div ng-if="!loaded" class="mar-top-xl">Loading...</div>
             <div ng-if="build">
-              <h1>
-                {{build.metadata.name}}
-                <span class="pficon pficon-warning-triangle-o"
-                      ng-if="buildConfigPaused || buildConfigDeleted"
-                      aria-hidden="true"
-                      data-toggle="tooltip"
-                      data-original-title="{{buildConfigDeleted ? 'The build configuration for this build no longer exists.' : 'Building from build configuration ' + buildConfig.metadata.name + ' has been paused.'}}">
-                </span>
-                <small class="meta">created <span am-time-ago="build.metadata.creationTimestamp"></span></small>
+              <h1 class="contains-actions">
                 <div class="pull-right dropdown" ng-hide="!('builds' | canIDoAny)">
                   <!-- Primary Actions -->
                   <button class="btn btn-default hidden-xs"
@@ -78,6 +70,14 @@
                     </li>
                   </ul>
                 </div>
+                {{build.metadata.name}}
+                <span class="pficon pficon-warning-triangle-o"
+                      ng-if="buildConfigPaused || buildConfigDeleted"
+                      aria-hidden="true"
+                      data-toggle="tooltip"
+                      data-original-title="{{buildConfigDeleted ? 'The build configuration for this build no longer exists.' : 'Building from build configuration ' + buildConfig.metadata.name + ' has been paused.'}}">
+                </span>
+                <small class="meta">created <span am-time-ago="build.metadata.creationTimestamp"></span></small>
               </h1>
               <labels ng-if="buildConfigName" labels="build.metadata.labels" clickable="true" kind="builds" title-kind="builds for build config {{buildConfigName}}" project-name="{{build.metadata.namespace}}" limit="3" navigate-url="project/{{build.metadata.namespace}}/browse/builds/{{buildConfigName}}"></labels>
               <labels ng-if="!buildConfigName" labels="build.metadata.labels" limit="3"></labels>

--- a/app/views/browse/config-map.html
+++ b/app/views/browse/config-map.html
@@ -13,7 +13,7 @@
             <p>{{error | getErrorDetails}}</p>
           </div>
           <div ng-if="loaded && !error">
-            <h1>
+            <h1 class="contains-actions">
               <div class="pull-right dropdown" ng-if="'configmaps' | canIDoAny">
                 <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
                   Actions

--- a/app/views/browse/deployment-config.html
+++ b/app/views/browse/deployment-config.html
@@ -9,9 +9,7 @@
             <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
             <alerts alerts="alerts"></alerts>
             <div>
-              <h1>
-                {{deploymentConfigName}}
-
+              <h1 class="contains-actions">
                 <div class="pull-right dropdown" ng-if="deploymentConfig" ng-hide="!('deploymentConfigs' | canIDoAny)">
                   <!-- Primary Actions -->
                   <button
@@ -84,6 +82,7 @@
                     </li>
                   </ul>
                 </div>
+                {{deploymentConfigName}}
                 <!-- <span ng-if="deploymentConfig.status.details.message" class="pficon pficon-warning-triangle-o" style="cursor: help;" data-toggle="popover" data-trigger="hover" dynamic-content="{{deploymentConfig.status.details.message}}"></span> -->
                 <small class="meta" ng-if="deploymentConfig">created <span am-time-ago="deploymentConfig.metadata.creationTimestamp"></span></small>
               </h1>

--- a/app/views/browse/deployment.html
+++ b/app/views/browse/deployment.html
@@ -9,8 +9,7 @@
           <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
           <alerts alerts="alerts"></alerts>
           <div>
-            <h1>
-              {{name}}
+            <h1 class="contains-actions">
               <div class="pull-right dropdown" ng-if="deployment" ng-hide="!('deployments' | canIDoAny)">
                 <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
                   Actions
@@ -64,6 +63,7 @@
                   </li>
                 </ul>
               </div>
+              {{name}}
               <small class="meta" ng-if="deployment">created <span am-time-ago="deployment.metadata.creationTimestamp"></span></small>
             </h1>
             <labels labels="deployment.metadata.labels" clickable="true" kind="deployments" project-name="{{deployment.metadata.namespace}}" limit="3"></labels>

--- a/app/views/browse/imagestream.html
+++ b/app/views/browse/imagestream.html
@@ -10,8 +10,7 @@
           <alerts alerts="alerts"></alerts>
           <div ng-if="!imageStream" class="mar-top-xl">Loading...</div>
           <div ng-if="imageStream">
-            <h1>
-              {{imageStream.metadata.name}}
+            <h1 class="contains-actions">
               <div class="pull-right dropdown" ng-hide="!('imageStreams' | canIDoAny)">
                 <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
                   Actions
@@ -34,6 +33,7 @@
                   </li>
                 </ul>
               </div>
+              {{imageStream.metadata.name}}
               <small class="meta">created <span am-time-ago="imageStream.metadata.creationTimestamp"></span></small>
             </h1>
             <labels labels="imageStream.metadata.labels" clickable="true" kind="images" project-name="{{imageStream.metadata.namespace}}" limit="3"></labels>

--- a/app/views/browse/persistent-volume-claim.html
+++ b/app/views/browse/persistent-volume-claim.html
@@ -10,15 +10,7 @@
           <alerts alerts="alerts"></alerts>
           <div ng-if="!loaded">Loading...</div>
           <div ng-if="pvc">
-            <h1>
-              {{pvc.metadata.name}}
-              <small class="meta" ng-if="!pvc.spec.volumeName">
-                  <span ng-if="pvc.spec.resources.requests['storage']">
-                    waiting for {{pvc.spec.resources.requests['storage'] | usageWithUnits: 'storage'}} allocation,
-                  </span>
-                  <span ng-if="!pvc.spec.resources.requests['storage']">waiting for allocation,</span>
-              </small>
-              <small class="meta">created <span am-time-ago="pvc.metadata.creationTimestamp"></span></small>
+            <h1 class="contains-actions">
               <div class="pull-right dropdown" ng-hide="!('persistentVolumeClaims' | canIDoAny)">
                 <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
                   Actions
@@ -42,6 +34,14 @@
                   </li>
                 </ul>
               </div>
+              {{pvc.metadata.name}}
+              <small class="meta" ng-if="!pvc.spec.volumeName">
+                  <span ng-if="pvc.spec.resources.requests['storage']">
+                    waiting for {{pvc.spec.resources.requests['storage'] | usageWithUnits: 'storage'}} allocation,
+                  </span>
+                  <span ng-if="!pvc.spec.resources.requests['storage']">waiting for allocation,</span>
+              </small>
+              <small class="meta">created <span am-time-ago="pvc.metadata.creationTimestamp"></span></small>
             </h1>
             <labels labels="pvc.metadata.labels" clickable="true" kind="storage" project-name="{{pvc.metadata.namespace}}" limit="3"></labels>
           </div><!-- /deployment -->

--- a/app/views/browse/pod.html
+++ b/app/views/browse/pod.html
@@ -10,9 +10,7 @@
             <alerts alerts="alerts"></alerts>
             <div ng-if="!loaded" class="mar-top-xl">Loading...</div>
             <div ng-if="pod">
-              <h1>
-                {{pod.metadata.name}}
-
+              <h1 class="contains-actions">
                 <div class="pull-right dropdown" ng-hide="!('pods' | canIDoAny)">
                   <button type="button" class="dropdown-toggle actions-dropdown-btn btn btn-default hidden-xs" data-toggle="dropdown">
                     Actions
@@ -39,6 +37,7 @@
                     </li>
                   </ul>
                 </div>
+                {{pod.metadata.name}}
                 <span ng-if="pod | isTroubledPod">
                   <pod-warnings pod="pod"></pod-warnings>
                 </span>

--- a/app/views/browse/replica-set.html
+++ b/app/views/browse/replica-set.html
@@ -10,7 +10,14 @@
             <alerts alerts="alerts"></alerts>
             <div ng-if="!loaded" class="mar-top-md">Loading...</div>
             <div ng-if="replicaSet">
-              <h1>
+              <h1 class="contains-actions">
+                <!-- Actions -->
+                <ng-include ng-if="kind === 'ReplicaSet'"
+                  src=" 'views/browse/_replica-set-actions.html' ">
+                </ng-include>
+                <ng-include ng-if="kind === 'ReplicationController'"
+                  src=" 'views/browse/_replication-controller-actions.html' ">
+                </ng-include>
                 {{replicaSet.metadata.name}}
                 <span
                   ng-if="deploymentConfigMissing"
@@ -23,14 +30,6 @@
                 </span>
                 <span ng-if="deploymentConfigMissing" class="sr-only">Warning: The deployment's deployment config is missing.</span>
                 <small class="meta">created <span am-time-ago="replicaSet.metadata.creationTimestamp"></span></small>
-
-                <!-- Actions -->
-                <ng-include ng-if="kind === 'ReplicaSet'"
-                            src=" 'views/browse/_replica-set-actions.html' ">
-                </ng-include>
-                <ng-include ng-if="kind === 'ReplicationController'"
-                            src=" 'views/browse/_replication-controller-actions.html' ">
-                </ng-include>
               </h1>
               <labels ng-if="deploymentConfigName" labels="replicaSet.metadata.labels" clickable="true" kind="deployments" title-kind="deployments for deployment config {{deploymentConfigName}}" project-name="{{replicaSet.metadata.namespace}}" limit="3" navigate-url="{{replicaSet | configURLForResource}}"></labels>
               <labels ng-if="!deploymentConfigName" labels="replicaSet.metadata.labels" clickable="true" kind="deployments" project-name="{{replicaSet.metadata.namespace}}" limit="3"></labels>

--- a/app/views/browse/route.html
+++ b/app/views/browse/route.html
@@ -10,13 +10,7 @@
           <alerts alerts="alerts"></alerts>
           <div ng-if="!loaded" class="mar-top-xl">Loading...</div>
           <div ng-if="route">
-            <h1>
-              {{route.metadata.name}}
-              <route-warnings ng-if="route.spec.to.kind !== 'Service' || services"
-                              route="route"
-                              service="services[route.spec.to.name]">
-              </route-warnings>
-              <small class="meta">created <span am-time-ago="route.metadata.creationTimestamp"></span></small>
+            <h1 class="contains-actions">
               <div class="pull-right dropdown" ng-hide="!('routes' | canIDoAny)">
                 <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
                   Actions
@@ -42,6 +36,12 @@
                   </li>
                 </ul>
               </div>
+              {{route.metadata.name}}
+              <route-warnings ng-if="route.spec.to.kind !== 'Service' || services"
+                              route="route"
+                              service="services[route.spec.to.name]">
+              </route-warnings>
+              <small class="meta">created <span am-time-ago="route.metadata.creationTimestamp"></span></small>
             </h1>
             <labels labels="route.metadata.labels" clickable="true" kind="routes" project-name="{{route.metadata.namespace}}" limit="3"></labels>
           </div>

--- a/app/views/browse/secret.html
+++ b/app/views/browse/secret.html
@@ -9,7 +9,7 @@
           <alerts alerts="alerts"></alerts>
           <div ng-if="!loaded" class="mar-top-xl">Loading...</div>
           <div ng-if="loaded">
-            <h1>
+            <h1 class="contains-actions">
               <div class="pull-right dropdown" ng-hide="!('secrets' | canIDoAny)">
                 <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
                   Actions

--- a/app/views/browse/service.html
+++ b/app/views/browse/service.html
@@ -10,8 +10,7 @@
           <alerts alerts="alerts"></alerts>
           <div ng-if="!loaded" class="mar-top-xl">Loading...</div>
           <div ng-if="service">
-            <h1>
-              {{service.metadata.name}}
+            <h1 class="contains-actions">
               <div class="pull-right dropdown" ng-hide="!('services' | canIDoAny)">
                 <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
                   Actions
@@ -38,6 +37,7 @@
                   </li>
                 </ul>
               </div>
+              {{service.metadata.name}}
               <small class="meta">created <span am-time-ago="service.metadata.creationTimestamp"></span></small>
             </h1>
             <labels labels="service.metadata.labels" clickable="true" kind="services" project-name="{{service.metadata.namespace}}" limit="3"></labels>

--- a/app/views/settings.html
+++ b/app/views/settings.html
@@ -8,8 +8,7 @@
           <div class="container-fluid">
             <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
             <alerts alerts="alerts"></alerts>
-            <h1>
-              Project Settings
+            <h1 class="contains-actions">
               <div class="pull-right dropdown" ng-hide="!project || !('projects' | canIDoAny)">
                 <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
                   Actions
@@ -40,6 +39,7 @@
                   </li>
                 </ul>
               </div>
+              Project Settings
             </h1>
           </div>
         </div><!-- /middle-header-->

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1759,10 +1759,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-fluid\">\n" +
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
-    "<h1>\n" +
-    "{{buildConfigName}}\n" +
-    "<span class=\"pficon pficon-warning-triangle-o\" ng-if=\"buildConfigPaused || buildConfigDeleted\" aria-hidden=\"true\" data-toggle=\"tooltip\" data-original-title=\"{{buildConfigDeleted ? 'This build configuration no longer exists' : 'Building from build configuration ' + buildConfig.metadata.name + ' has been paused.'}}\">\n" +
-    "</span>\n" +
+    "<h1 class=\"contains-actions\">\n" +
     "<div class=\"pull-right dropdown\" ng-if=\"buildConfig\" ng-hide=\"!('buildConfigs' | canIDoAny)\">\n" +
     "\n" +
     "<button class=\"btn btn-default hidden-xs\" ng-if=\"'buildconfigs/instantiate' | canI : 'create'\" ng-click=\"startBuild()\">\n" +
@@ -1802,6 +1799,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</li>\n" +
     "</ul>\n" +
     "</div>\n" +
+    "{{buildConfigName}}\n" +
+    "<span class=\"pficon pficon-warning-triangle-o\" aria-hidden=\"true\" data-toggle=\"tooltip\" data-original-title=\"{{buildConfigDeleted ? 'This build configuration no longer exists' : 'Building from build configuration ' + buildConfig.metadata.name + ' has been paused.'}}\">\n" +
+    "</span>\n" +
     "<small class=\"meta\" ng-if=\"buildConfig\">created <span am-time-ago=\"buildConfig.metadata.creationTimestamp\"></span></small>\n" +
     "</h1>\n" +
     "<labels labels=\"buildConfig.metadata.labels\" clickable=\"true\" kind=\"builds\" title-kind=\"build configs\" project-name=\"{{buildConfig.metadata.namespace}}\" limit=\"3\"></labels>\n" +
@@ -2186,11 +2186,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!loaded\" class=\"mar-top-xl\">Loading...</div>\n" +
     "<div ng-if=\"build\">\n" +
-    "<h1>\n" +
-    "{{build.metadata.name}}\n" +
-    "<span class=\"pficon pficon-warning-triangle-o\" ng-if=\"buildConfigPaused || buildConfigDeleted\" aria-hidden=\"true\" data-toggle=\"tooltip\" data-original-title=\"{{buildConfigDeleted ? 'The build configuration for this build no longer exists.' : 'Building from build configuration ' + buildConfig.metadata.name + ' has been paused.'}}\">\n" +
-    "</span>\n" +
-    "<small class=\"meta\">created <span am-time-ago=\"build.metadata.creationTimestamp\"></span></small>\n" +
+    "<h1 class=\"contains-actions\">\n" +
     "<div class=\"pull-right dropdown\" ng-hide=\"!('builds' | canIDoAny)\">\n" +
     "\n" +
     "<button class=\"btn btn-default hidden-xs\" ng-click=\"cancelBuild()\" ng-if=\"!build.metadata.deletionTimestamp && (build | isIncompleteBuild) && ('builds' | canI : 'update')\">Cancel Build</button>\n" +
@@ -2228,6 +2224,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</li>\n" +
     "</ul>\n" +
     "</div>\n" +
+    "{{build.metadata.name}}\n" +
+    "<span class=\"pficon pficon-warning-triangle-o\" ng-if=\"buildConfigPaused || buildConfigDeleted\" aria-hidden=\"true\" data-toggle=\"tooltip\" data-original-title=\"{{buildConfigDeleted ? 'The build configuration for this build no longer exists.' : 'Building from build configuration ' + buildConfig.metadata.name + ' has been paused.'}}\">\n" +
+    "</span>\n" +
+    "<small class=\"meta\">created <span am-time-ago=\"build.metadata.creationTimestamp\"></span></small>\n" +
     "</h1>\n" +
     "<labels ng-if=\"buildConfigName\" labels=\"build.metadata.labels\" clickable=\"true\" kind=\"builds\" title-kind=\"builds for build config {{buildConfigName}}\" project-name=\"{{build.metadata.namespace}}\" limit=\"3\" navigate-url=\"project/{{build.metadata.namespace}}/browse/builds/{{buildConfigName}}\"></labels>\n" +
     "<labels ng-if=\"!buildConfigName\" labels=\"build.metadata.labels\" limit=\"3\"></labels>\n" +
@@ -2299,7 +2299,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p>{{error | getErrorDetails}}</p>\n" +
     "</div>\n" +
     "<div ng-if=\"loaded && !error\">\n" +
-    "<h1>\n" +
+    "<h1 class=\"contains-actions\">\n" +
     "<div class=\"pull-right dropdown\" ng-if=\"'configmaps' | canIDoAny\">\n" +
     "<button type=\"button\" class=\"dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs\" data-toggle=\"dropdown\">\n" +
     "Actions\n" +
@@ -2440,8 +2440,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div>\n" +
-    "<h1>\n" +
-    "{{deploymentConfigName}}\n" +
+    "<h1 class=\"contains-actions\">\n" +
     "<div class=\"pull-right dropdown\" ng-if=\"deploymentConfig\" ng-hide=\"!('deploymentConfigs' | canIDoAny)\">\n" +
     "\n" +
     "<button ng-if=\"'deploymentconfigs' | canI : 'update'\" class=\"btn btn-default hidden-xs\" ng-click=\"startLatestDeployment()\" ng-disabled=\"!canDeploy()\">\n" +
@@ -2494,6 +2493,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</li>\n" +
     "</ul>\n" +
     "</div>\n" +
+    "{{deploymentConfigName}}\n" +
     "\n" +
     "<small class=\"meta\" ng-if=\"deploymentConfig\">created <span am-time-ago=\"deploymentConfig.metadata.creationTimestamp\"></span></small>\n" +
     "</h1>\n" +
@@ -2753,8 +2753,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div>\n" +
-    "<h1>\n" +
-    "{{name}}\n" +
+    "<h1 class=\"contains-actions\">\n" +
     "<div class=\"pull-right dropdown\" ng-if=\"deployment\" ng-hide=\"!('deployments' | canIDoAny)\">\n" +
     "<button type=\"button\" class=\"dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs\" data-toggle=\"dropdown\">\n" +
     "Actions\n" +
@@ -2796,6 +2795,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</li>\n" +
     "</ul>\n" +
     "</div>\n" +
+    "{{name}}\n" +
     "<small class=\"meta\" ng-if=\"deployment\">created <span am-time-ago=\"deployment.metadata.creationTimestamp\"></span></small>\n" +
     "</h1>\n" +
     "<labels labels=\"deployment.metadata.labels\" clickable=\"true\" kind=\"deployments\" project-name=\"{{deployment.metadata.namespace}}\" limit=\"3\"></labels>\n" +
@@ -3037,8 +3037,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!imageStream\" class=\"mar-top-xl\">Loading...</div>\n" +
     "<div ng-if=\"imageStream\">\n" +
-    "<h1>\n" +
-    "{{imageStream.metadata.name}}\n" +
+    "<h1 class=\"contains-actions\">\n" +
     "<div class=\"pull-right dropdown\" ng-hide=\"!('imageStreams' | canIDoAny)\">\n" +
     "<button type=\"button\" class=\"dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs\" data-toggle=\"dropdown\">\n" +
     "Actions\n" +
@@ -3055,6 +3054,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</li>\n" +
     "</ul>\n" +
     "</div>\n" +
+    "{{imageStream.metadata.name}}\n" +
     "<small class=\"meta\">created <span am-time-ago=\"imageStream.metadata.creationTimestamp\"></span></small>\n" +
     "</h1>\n" +
     "<labels labels=\"imageStream.metadata.labels\" clickable=\"true\" kind=\"images\" project-name=\"{{imageStream.metadata.namespace}}\" limit=\"3\"></labels>\n" +
@@ -3178,15 +3178,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!loaded\">Loading...</div>\n" +
     "<div ng-if=\"pvc\">\n" +
-    "<h1>\n" +
-    "{{pvc.metadata.name}}\n" +
-    "<small class=\"meta\" ng-if=\"!pvc.spec.volumeName\">\n" +
-    "<span ng-if=\"pvc.spec.resources.requests['storage']\">\n" +
-    "waiting for {{pvc.spec.resources.requests['storage'] | usageWithUnits: 'storage'}} allocation,\n" +
-    "</span>\n" +
-    "<span ng-if=\"!pvc.spec.resources.requests['storage']\">waiting for allocation,</span>\n" +
-    "</small>\n" +
-    "<small class=\"meta\">created <span am-time-ago=\"pvc.metadata.creationTimestamp\"></span></small>\n" +
+    "<h1 class=\"contains-actions\">\n" +
     "<div class=\"pull-right dropdown\" ng-hide=\"!('persistentVolumeClaims' | canIDoAny)\">\n" +
     "<button type=\"button\" class=\"dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs\" data-toggle=\"dropdown\">\n" +
     "Actions\n" +
@@ -3203,6 +3195,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</li>\n" +
     "</ul>\n" +
     "</div>\n" +
+    "{{pvc.metadata.name}}\n" +
+    "<small class=\"meta\" ng-if=\"!pvc.spec.volumeName\">\n" +
+    "<span ng-if=\"pvc.spec.resources.requests['storage']\">\n" +
+    "waiting for {{pvc.spec.resources.requests['storage'] | usageWithUnits: 'storage'}} allocation,\n" +
+    "</span>\n" +
+    "<span ng-if=\"!pvc.spec.resources.requests['storage']\">waiting for allocation,</span>\n" +
+    "</small>\n" +
+    "<small class=\"meta\">created <span am-time-ago=\"pvc.metadata.creationTimestamp\"></span></small>\n" +
     "</h1>\n" +
     "<labels labels=\"pvc.metadata.labels\" clickable=\"true\" kind=\"storage\" project-name=\"{{pvc.metadata.namespace}}\" limit=\"3\"></labels>\n" +
     "</div>\n" +
@@ -3260,8 +3260,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!loaded\" class=\"mar-top-xl\">Loading...</div>\n" +
     "<div ng-if=\"pod\">\n" +
-    "<h1>\n" +
-    "{{pod.metadata.name}}\n" +
+    "<h1 class=\"contains-actions\">\n" +
     "<div class=\"pull-right dropdown\" ng-hide=\"!('pods' | canIDoAny)\">\n" +
     "<button type=\"button\" class=\"dropdown-toggle actions-dropdown-btn btn btn-default hidden-xs\" data-toggle=\"dropdown\">\n" +
     "Actions\n" +
@@ -3281,6 +3280,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</li>\n" +
     "</ul>\n" +
     "</div>\n" +
+    "{{pod.metadata.name}}\n" +
     "<span ng-if=\"pod | isTroubledPod\">\n" +
     "<pod-warnings pod=\"pod\"></pod-warnings>\n" +
     "</span>\n" +
@@ -3417,17 +3417,17 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!loaded\" class=\"mar-top-md\">Loading...</div>\n" +
     "<div ng-if=\"replicaSet\">\n" +
-    "<h1>\n" +
-    "{{replicaSet.metadata.name}}\n" +
-    "<span ng-if=\"deploymentConfigMissing\" class=\"pficon pficon-warning-triangle-o\" style=\"cursor: help; vertical-align: middle\" data-toggle=\"tooltip\" data-trigger=\"hover\" title=\"The deployment's deployment config is missing.\" aria-hidden=\"true\">\n" +
-    "</span>\n" +
-    "<span ng-if=\"deploymentConfigMissing\" class=\"sr-only\">Warning: The deployment's deployment config is missing.</span>\n" +
-    "<small class=\"meta\">created <span am-time-ago=\"replicaSet.metadata.creationTimestamp\"></span></small>\n" +
+    "<h1 class=\"contains-actions\">\n" +
     "\n" +
     "<ng-include ng-if=\"kind === 'ReplicaSet'\" src=\" 'views/browse/_replica-set-actions.html' \">\n" +
     "</ng-include>\n" +
     "<ng-include ng-if=\"kind === 'ReplicationController'\" src=\" 'views/browse/_replication-controller-actions.html' \">\n" +
     "</ng-include>\n" +
+    "{{replicaSet.metadata.name}}\n" +
+    "<span ng-if=\"deploymentConfigMissing\" class=\"pficon pficon-warning-triangle-o\" style=\"cursor: help; vertical-align: middle\" data-toggle=\"tooltip\" data-trigger=\"hover\" title=\"The deployment's deployment config is missing.\" aria-hidden=\"true\">\n" +
+    "</span>\n" +
+    "<span ng-if=\"deploymentConfigMissing\" class=\"sr-only\">Warning: The deployment's deployment config is missing.</span>\n" +
+    "<small class=\"meta\">created <span am-time-ago=\"replicaSet.metadata.creationTimestamp\"></span></small>\n" +
     "</h1>\n" +
     "<labels ng-if=\"deploymentConfigName\" labels=\"replicaSet.metadata.labels\" clickable=\"true\" kind=\"deployments\" title-kind=\"deployments for deployment config {{deploymentConfigName}}\" project-name=\"{{replicaSet.metadata.namespace}}\" limit=\"3\" navigate-url=\"{{replicaSet | configURLForResource}}\"></labels>\n" +
     "<labels ng-if=\"!deploymentConfigName\" labels=\"replicaSet.metadata.labels\" clickable=\"true\" kind=\"deployments\" project-name=\"{{replicaSet.metadata.namespace}}\" limit=\"3\"></labels>\n" +
@@ -3519,11 +3519,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!loaded\" class=\"mar-top-xl\">Loading...</div>\n" +
     "<div ng-if=\"route\">\n" +
-    "<h1>\n" +
-    "{{route.metadata.name}}\n" +
-    "<route-warnings ng-if=\"route.spec.to.kind !== 'Service' || services\" route=\"route\" service=\"services[route.spec.to.name]\">\n" +
-    "</route-warnings>\n" +
-    "<small class=\"meta\">created <span am-time-ago=\"route.metadata.creationTimestamp\"></span></small>\n" +
+    "<h1 class=\"contains-actions\">\n" +
     "<div class=\"pull-right dropdown\" ng-hide=\"!('routes' | canIDoAny)\">\n" +
     "<button type=\"button\" class=\"dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs\" data-toggle=\"dropdown\">\n" +
     "Actions\n" +
@@ -3543,6 +3539,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</li>\n" +
     "</ul>\n" +
     "</div>\n" +
+    "{{route.metadata.name}}\n" +
+    "<route-warnings ng-if=\"route.spec.to.kind !== 'Service' || services\" route=\"route\" service=\"services[route.spec.to.name]\">\n" +
+    "</route-warnings>\n" +
+    "<small class=\"meta\">created <span am-time-ago=\"route.metadata.creationTimestamp\"></span></small>\n" +
     "</h1>\n" +
     "<labels labels=\"route.metadata.labels\" clickable=\"true\" kind=\"routes\" project-name=\"{{route.metadata.namespace}}\" limit=\"3\"></labels>\n" +
     "</div>\n" +
@@ -3815,7 +3815,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!loaded\" class=\"mar-top-xl\">Loading...</div>\n" +
     "<div ng-if=\"loaded\">\n" +
-    "<h1>\n" +
+    "<h1 class=\"contains-actions\">\n" +
     "<div class=\"pull-right dropdown\" ng-hide=\"!('secrets' | canIDoAny)\">\n" +
     "<button type=\"button\" class=\"dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs\" data-toggle=\"dropdown\">\n" +
     "Actions\n" +
@@ -3894,8 +3894,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!loaded\" class=\"mar-top-xl\">Loading...</div>\n" +
     "<div ng-if=\"service\">\n" +
-    "<h1>\n" +
-    "{{service.metadata.name}}\n" +
+    "<h1 class=\"contains-actions\">\n" +
     "<div class=\"pull-right dropdown\" ng-hide=\"!('services' | canIDoAny)\">\n" +
     "<button type=\"button\" class=\"dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs\" data-toggle=\"dropdown\">\n" +
     "Actions\n" +
@@ -3915,6 +3914,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</li>\n" +
     "</ul>\n" +
     "</div>\n" +
+    "{{service.metadata.name}}\n" +
     "<small class=\"meta\">created <span am-time-ago=\"service.metadata.creationTimestamp\"></span></small>\n" +
     "</h1>\n" +
     "<labels labels=\"service.metadata.labels\" clickable=\"true\" kind=\"services\" project-name=\"{{service.metadata.namespace}}\" limit=\"3\"></labels>\n" +
@@ -12147,8 +12147,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-fluid\">\n" +
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
-    "<h1>\n" +
-    "Project Settings\n" +
+    "<h1 class=\"contains-actions\">\n" +
     "<div class=\"pull-right dropdown\" ng-hide=\"!project || !('projects' | canIDoAny)\">\n" +
     "<button type=\"button\" class=\"dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs\" data-toggle=\"dropdown\">\n" +
     "Actions\n" +
@@ -12165,6 +12164,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</li>\n" +
     "</ul>\n" +
     "</div>\n" +
+    "Project Settings\n" +
     "</h1>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3561,7 +3561,7 @@ to{transform:rotate(359deg)}
 .key-value-editor .key-value-editor-header,.key-value-editor .key-value-editor-input{float:left;padding-right:5px;width:50%}
 .word-break{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .word-break-all{word-break:break-all;word-break:break-word;overflow-wrap:break-word}
-.events-table td,.modal-resource-action h1,.resource-description,.row-cards-pf-flex .card-pf-body p{word-break:break-word;word-wrap:break-word}
+.events-table td,.modal-resource-action h1,.resource-description,.row-cards-pf-flex .card-pf-body p{word-wrap:break-word;word-break:break-word}
 .pre-wrap{white-space:pre-wrap}
 .visible-xlg-inline-block{display:none!important}
 @media (max-width:767px){.td-long-string{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
@@ -4983,6 +4983,7 @@ td[role=presentation].arrow:after{content:"\2193"}
 .key-value-table>tbody>tr>td.value .truncated-content{white-space:pre}
 .table-word-break-all td{word-break:break-all;word-break:break-word;overflow-wrap:break-word}
 .table-word-break-all td.word-break-normal{word-break:normal;overflow-wrap:normal}
+.log-line-text,h1.contains-actions{word-wrap:break-word;word-break:break-word}
 .table>tbody>tr.disabled>td,.table>tbody>tr.disabled>th,.table>tbody>tr>td.disabled,.table>tbody>tr>th.disabled,.table>tfoot>tr.disabled>td,.table>tfoot>tr.disabled>th,.table>tfoot>tr>td.disabled,.table>tfoot>tr>th.disabled,.table>thead>tr.disabled>td,.table>thead>tr.disabled>th,.table>thead>tr>td.disabled,.table>thead>tr>th.disabled{background-color:#f5f5f5}
 .table-hover>tbody>tr.disabled:hover>td,.table-hover>tbody>tr.disabled:hover>th,.table-hover>tbody>tr:hover>.disabled,.table-hover>tbody>tr>td.disabled:hover,.table-hover>tbody>tr>th.disabled:hover{background-color:#e8e8e8}
 .tile{background:#fff;padding:20px;margin-bottom:20px;word-wrap:break-word;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;overflow-x:hidden}
@@ -5022,8 +5023,9 @@ kubernetes-topology-graph{height:700px}
 .console-os .section-header{border-color:#e4e4e4;padding-left:20px;padding-right:20px;border-bottom:none;padding-bottom:10px;margin:20px -20px 0}
 .action-inline,.learn-more-inline{margin-left:5px;font-size:11px}
 .console-os .section-header .actions{margin-top:0}
-.build-config-summary .meta,.deployment-config-summary .meta,h1 small.meta{font-size:12px}
-@media (max-width:480px){.build-config-summary .meta,.deployment-config-summary .meta,h1 small.meta{display:block;margin-top:5px}
+h1.contains-actions{overflow-wrap:break-word;min-width:0}
+h1 .build-config-summary .meta,h1 .deployment-config-summary .meta,h1 small.meta{font-size:12px}
+@media (max-width:480px){h1 .build-config-summary .meta,h1 .deployment-config-summary .meta,h1 small.meta{display:block;margin-top:5px}
 }
 .learn-more-block{display:block;font-size:11px;font-weight:400}
 .learn-more-inline{display:inline;font-weight:400}
@@ -5180,7 +5182,7 @@ a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;borde
 .log-line:hover{background-color:#22262b;color:#ededed}
 .log-line-number:before{content:attr(data-line-number)}
 .log-line-number{-ms-user-select:none;border-right:1px #272b30 solid;padding-right:10px;vertical-align:top;white-space:nowrap;width:60px;color:#72767b}
-.log-line-text{padding:0 10px;white-space:pre-wrap;width:100%;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
+.log-line-text{padding:0 10px;white-space:pre-wrap;width:100%;overflow-wrap:break-word;min-width:0}
 .log-line-text::-moz-selection{color:#101214;background:#e5e5e5}
 .table-log-pods{background-color:#fff;border:1px solid #D1D1D1}
 .table-log-pods>tbody+tbody{border-top-width:1px}


### PR DESCRIPTION
And adding word-wrap() to the h1 so that long, unbroken strings don’t
cause the layout to break.

Fixes #1112

<img width="338" alt="screen shot 2017-01-17 at 4 07 09 pm" src="https://cloud.githubusercontent.com/assets/895728/22039932/258524ec-dccf-11e6-88fc-15b3fdecc562.PNG">
<img width="338" alt="screen shot 2017-01-17 at 4 07 51 pm" src="https://cloud.githubusercontent.com/assets/895728/22039933/258e42ca-dccf-11e6-94fd-f565973b9d10.PNG">

@jwforres or @spadgett, PTAL