### PR TITLE
Escaping <> chars when included in display name within ui-select drop…

### DIFF
--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -120,16 +120,29 @@ angular.module('openshiftConsole')
       });
       return nameCount;
     }
-    return function (resource, projects){
+    function escapeLessThanGreaterThan(str) {
+      return str.
+        replace(/</g, '&lt;').
+        replace(/>/g, '&gt;');
+    }
+    return function (resource, projects, escape){
       if (!resource) {
         return '';
       }
       var displayName = displayNameFilter(resource);
       var name = resource.metadata.name;
       if (displayName !== name && countNames(projects)[displayName] > 1 ){
-        return displayName + ' (' + name + ')';
+        if (!!escape) {
+          return escapeLessThanGreaterThan(displayName) + ' (' + name + ')';
+        } else {
+          return displayName + ' (' + name + ')';
+        }
       }
-      return displayName;
+      if (!!escape) {
+        return escapeLessThanGreaterThan(displayName);
+      } else {
+        return displayName;
+      }
     };
   })
   .filter('searchProjects', function(annotationNameFilter) {

--- a/app/views/create-from-url.html
+++ b/app/views/create-from-url.html
@@ -28,7 +28,7 @@
                           {{$select.selected | uniqueDisplayName : projects}}
                         </ui-select-match>
                         <ui-select-choices repeat="project in projects | searchProjects : $select.search">
-                          <div ng-bind-html="project | uniqueDisplayName : projects | highlight : $select.search"></div>
+                          <div ng-bind-html="project | uniqueDisplayName : projects : true | highlight : $select.search"></div>
                         </ui-select-choices>
                       </ui-select>
                     </div>
@@ -41,7 +41,7 @@
                               {{$select.selected | uniqueDisplayName : projects}}
                             </ui-select-match>
                             <ui-select-choices repeat="project in projects | searchProjects : $select.search">
-                              <div ng-bind-html="project | uniqueDisplayName : projects | highlight : $select.search"></div>
+                              <div ng-bind-html="project | uniqueDisplayName : projects : true | highlight : $select.search"></div>
                             </ui-select-choices>
                           </ui-select>
                           <div class="button-group mar-bottom-lg mar-top-lg">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -13431,10 +13431,13 @@ var e = a(b);
 c[e] = (c[e] || 0) + 1;
 }), c;
 }
-return function(c, d) {
-if (!c) return "";
-var e = a(c), f = c.metadata.name;
-return e !== f && b(d)[e] > 1 ? e + " (" + f + ")" :e;
+function c(a) {
+return a.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+return function(d, e, f) {
+if (!d) return "";
+var g = a(d), h = d.metadata.name;
+return g !== h && b(e)[g] > 1 ? f ? c(g) + " (" + h + ")" :g + " (" + h + ")" :f ? c(g) :g;
 };
 } ]).filter("searchProjects", [ "annotationNameFilter", function(a) {
 return function(b, c) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4463,7 +4463,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "{{$select.selected | uniqueDisplayName : projects}}\n" +
     "</ui-select-match>\n" +
     "<ui-select-choices repeat=\"project in projects | searchProjects : $select.search\">\n" +
-    "<div ng-bind-html=\"project | uniqueDisplayName : projects | highlight : $select.search\"></div>\n" +
+    "<div ng-bind-html=\"project | uniqueDisplayName : projects : true | highlight : $select.search\"></div>\n" +
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
     "</div>\n" +
@@ -4476,7 +4476,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "{{$select.selected | uniqueDisplayName : projects}}\n" +
     "</ui-select-match>\n" +
     "<ui-select-choices repeat=\"project in projects | searchProjects : $select.search\">\n" +
-    "<div ng-bind-html=\"project | uniqueDisplayName : projects | highlight : $select.search\"></div>\n" +
+    "<div ng-bind-html=\"project | uniqueDisplayName : projects : true | highlight : $select.search\"></div>\n" +
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
     "<div class=\"button-group mar-bottom-lg mar-top-lg\">\n" +


### PR DESCRIPTION
…down

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1414195

Note:  this breaks search highlighting when the search query includes < or > since < and &amp;lt; and > and &amp;gt; are not the same.  This seems like the lesser of two evils since the inclusion of < or > in ui-select dropdowns is [a limitation of ui-select itself](https://github.com/angular-ui/ui-select/issues/846#issuecomment-226226811).

Before:

<img width="753" alt="screen shot 2017-01-18 at 2 31 14 pm" src="https://cloud.githubusercontent.com/assets/895728/22079713/cdc5b098-dd8a-11e6-88e5-696fa4339400.PNG">

After:

<img width="745" alt="screen shot 2017-01-18 at 2 28 32 pm" src="https://cloud.githubusercontent.com/assets/895728/22079618/84adda70-dd8a-11e6-87d8-eea5cd753358.PNG">

Search highlighting ok as < or > not included in search query:
<img width="740" alt="screen shot 2017-01-18 at 2 28 43 pm" src="https://cloud.githubusercontent.com/assets/895728/22079617/84ae6378-dd8a-11e6-8b78-27043b3aa425.PNG">

Search highlighting broken as < included in search query:
<img width="739" alt="screen shot 2017-01-18 at 2 28 51 pm" src="https://cloud.githubusercontent.com/assets/895728/22079616/84a8294a-dd8a-11e6-84ab-128cd90a5431.PNG">

@jwforres or @spadgett, PTAL.
