### PR TITLE
Fix dangling "none" on statefulset template

### DIFF
--- a/app/views/browse/stateful-set.html
+++ b/app/views/browse/stateful-set.html
@@ -106,9 +106,6 @@
                         detailed="true">
                       </pod-template>
 
-                      <p ng-if="!statefulSet.spec.volumeClaimTemplates.length">
-                        none
-                      </p>
                       <volume-claim-templates
                           templates="statefulSet.spec.volumeClaimTemplates"
                           namespace="project.metadata.name">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4111,9 +4111,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<h3>Template</h3>\n" +
     "<pod-template pod-template=\"statefulSet.spec.template\" detailed=\"true\">\n" +
     "</pod-template>\n" +
-    "<p ng-if=\"!statefulSet.spec.volumeClaimTemplates.length\">\n" +
-    "none\n" +
-    "</p>\n" +
     "<volume-claim-templates templates=\"statefulSet.spec.volumeClaimTemplates\" namespace=\"project.metadata.name\">\n" +
     "</volume-claim-templates>\n" +
     "</div>\n" +


### PR DESCRIPTION
Just noticed this, after shifting around the location of the volume claim templates.

Without a volume claim template there is a dangling "none":
![screen shot 2017-01-19 at 10 17 05 am](https://cloud.githubusercontent.com/assets/280512/22112416/d0742dd2-de30-11e6-9f13-becd28b0335c.png)

Fix will eliminate:
![screen shot 2017-01-19 at 10 17 46 am](https://cloud.githubusercontent.com/assets/280512/22112417/d0770a7a-de30-11e6-9ca9-b7ab334d730b.png)

What it looks like with a volume claim template, for reference:

![screen shot 2017-01-19 at 10 20 58 am](https://cloud.githubusercontent.com/assets/280512/22112614/91bb699c-de31-11e6-8523-a395ebb2edf7.png)

@jwforres 