### PR TITLE
Don't show full editor for one-line post-commit scripts

### DIFF
--- a/app/views/directives/build-hooks.html
+++ b/app/views/directives/build-hooks.html
@@ -2,7 +2,7 @@
   Use `dl-horizontal left` style unless there's a script.
   Otherwise use the default `dl` style because it looks strange with the block editor.
 -->
-<dl ng-class="{ 'dl-horizontal left': !build.spec.postCommit.script }">
+<dl ng-class="{ 'dl-horizontal left': !build.spec.postCommit.script || !(build.spec.postCommit.script | isMultiline)}">
   <dt ng-if-start="build.spec.postCommit.command">Command:</dt>
   <dd ng-if-end>
     <code class="command">
@@ -17,7 +17,16 @@
   </dd>
   <dt ng-if-start="build.spec.postCommit.script">Script:</dt>
   <dd ng-if-end>
+    <code ng-if="!(build.spec.postCommit.script | isMultiline)" class="command">
+      <truncate-long-text
+          content="build.spec.postCommit.script"
+          limit="80"
+          expandable="true"
+          use-word-boundary="false">
+      </truncate-long-text>
+    </code>
     <div
+      ng-if="build.spec.postCommit.script | isMultiline"
       ui-ace="{
         mode: 'sh',
         theme: 'eclipse',

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6058,7 +6058,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/directives/build-hooks.html',
-    " <dl ng-class=\"{ 'dl-horizontal left': !build.spec.postCommit.script }\">\n" +
+    " <dl ng-class=\"{ 'dl-horizontal left': !build.spec.postCommit.script || !(build.spec.postCommit.script | isMultiline)}\">\n" +
     "<dt ng-if-start=\"build.spec.postCommit.command\">Command:</dt>\n" +
     "<dd ng-if-end>\n" +
     "<code class=\"command\">\n" +
@@ -6068,7 +6068,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</dd>\n" +
     "<dt ng-if-start=\"build.spec.postCommit.script\">Script:</dt>\n" +
     "<dd ng-if-end>\n" +
-    "<div ui-ace=\"{\n" +
+    "<code ng-if=\"!(build.spec.postCommit.script | isMultiline)\" class=\"command\">\n" +
+    "<truncate-long-text content=\"build.spec.postCommit.script\" limit=\"80\" expandable=\"true\" use-word-boundary=\"false\">\n" +
+    "</truncate-long-text>\n" +
+    "</code>\n" +
+    "<div ng-if=\"build.spec.postCommit.script | isMultiline\" ui-ace=\"{\n" +
     "        mode: 'sh',\n" +
     "        theme: 'eclipse',\n" +
     "        rendererOptions: {\n" +


### PR DESCRIPTION
Doesn't change the build config editor, only the browse page.