### PR TITLE
Bug 1415083 - Make build hook fields required for selected type

### DIFF
--- a/app/views/edit/build-config.html
+++ b/app/views/edit/build-config.html
@@ -547,7 +547,7 @@
                         </div>
                       </div>
 
-                      <div ng-show="view.hasHooks">
+                      <div ng-if="view.hasHooks">
                         <div class="form-group">
                           <h4>Hook Types</h4>
                           <ui-select
@@ -561,7 +561,7 @@
                         </div>
 
                         <fieldset>
-                          <div ng-show="buildHookSelection.type.id === 'script' || buildHookSelection.type.id === 'scriptArgs'">
+                          <div ng-if="buildHookSelection.type.id === 'script' || buildHookSelection.type.id === 'scriptArgs'">
                             <h4>Script</h4>
                             <div
                               ui-ace="{
@@ -573,22 +573,25 @@
                                 }
                               }"
                               ng-model="updatedBuildConfig.spec.postCommit.script"
+                              required
                               class="ace-bordered ace-inline mar-top-md">
                             </div>
                           </div>
 
-                          <div ng-show="buildHookSelection.type.id === 'command' || buildHookSelection.type.id === 'commandArgs'">
+                          <div ng-if="buildHookSelection.type.id === 'command' || buildHookSelection.type.id === 'commandArgs'">
                             <h4>Command</h4>
                             <edit-command
-                              args="updatedBuildConfig.spec.postCommit.command">
+                              args="updatedBuildConfig.spec.postCommit.command"
+                              is-required="true">
                             </edit-command>
                           </div>
 
-                          <div ng-show="buildHookSelection.type.id === 'args' || buildHookSelection.type.id === 'commandArgs' || buildHookSelection.type.id === 'scriptArgs' ">
+                          <div ng-if="buildHookSelection.type.id === 'args' || buildHookSelection.type.id === 'commandArgs' || buildHookSelection.type.id === 'scriptArgs' ">
                             <h4>Arguments</h4>
                             <edit-command
                               args="updatedBuildConfig.spec.postCommit.args"
-                              type="argument">
+                              type="argument"
+                              is-required="true">
                             </edit-command>
                           </div>
                         </fieldset>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -9235,7 +9235,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Build hooks allow you to run commands at the end of the build to verify the image.\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-show=\"view.hasHooks\">\n" +
+    "<div ng-if=\"view.hasHooks\">\n" +
     "<div class=\"form-group\">\n" +
     "<h4>Hook Types</h4>\n" +
     "<ui-select ng-model=\"buildHookSelection.type\" title=\"Choose a type of build hook\">\n" +
@@ -9246,7 +9246,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</ui-select>\n" +
     "</div>\n" +
     "<fieldset>\n" +
-    "<div ng-show=\"buildHookSelection.type.id === 'script' || buildHookSelection.type.id === 'scriptArgs'\">\n" +
+    "<div ng-if=\"buildHookSelection.type.id === 'script' || buildHookSelection.type.id === 'scriptArgs'\">\n" +
     "<h4>Script</h4>\n" +
     "<div ui-ace=\"{\n" +
     "                                mode: 'sh',\n" +
@@ -9255,17 +9255,17 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "                                  fadeFoldWidgets: true,\n" +
     "                                  showPrintMargin: false\n" +
     "                                }\n" +
-    "                              }\" ng-model=\"updatedBuildConfig.spec.postCommit.script\" class=\"ace-bordered ace-inline mar-top-md\">\n" +
+    "                              }\" ng-model=\"updatedBuildConfig.spec.postCommit.script\" required class=\"ace-bordered ace-inline mar-top-md\">\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-show=\"buildHookSelection.type.id === 'command' || buildHookSelection.type.id === 'commandArgs'\">\n" +
+    "<div ng-if=\"buildHookSelection.type.id === 'command' || buildHookSelection.type.id === 'commandArgs'\">\n" +
     "<h4>Command</h4>\n" +
-    "<edit-command args=\"updatedBuildConfig.spec.postCommit.command\">\n" +
+    "<edit-command args=\"updatedBuildConfig.spec.postCommit.command\" is-required=\"true\">\n" +
     "</edit-command>\n" +
     "</div>\n" +
-    "<div ng-show=\"buildHookSelection.type.id === 'args' || buildHookSelection.type.id === 'commandArgs' || buildHookSelection.type.id === 'scriptArgs' \">\n" +
+    "<div ng-if=\"buildHookSelection.type.id === 'args' || buildHookSelection.type.id === 'commandArgs' || buildHookSelection.type.id === 'scriptArgs' \">\n" +
     "<h4>Arguments</h4>\n" +
-    "<edit-command args=\"updatedBuildConfig.spec.postCommit.args\" type=\"argument\">\n" +
+    "<edit-command args=\"updatedBuildConfig.spec.postCommit.args\" type=\"argument\" is-required=\"true\">\n" +
     "</edit-command>\n" +
     "</div>\n" +
     "</fieldset>\n" +


### PR DESCRIPTION
Make the post-commit hook inputs required when the type is selected in
the build hook type dropdown. Hooks can be removed by unchecking the
"Run build hooks" checkbox.

https://bugzilla.redhat.com/show_bug.cgi?id=1415083