### PR TITLE
Correcting word-break-all comment

### DIFF
--- a/app/styles/_mixins.less
+++ b/app/styles/_mixins.less
@@ -69,7 +69,7 @@
 // This class will break normal words in awkward places.  Therefore:
 // - DO use for shas or other long identifiers that are arbitrary
 // - DO NOT use in any other case such as paragraph text, descriptions, titles, project names, etc.
-//   opt for 'word-break' below
+//   opt for 'word-break' above
 .word-break-all {
     word-break: break-all;  // firefox, IE
     word-break: break-word; // non-standard for webkit


### PR DESCRIPTION
A silly PR, but I noticed this and figure it out to be fixed

@spadgett, PTAL