### PR TITLE
Correct the position of the log viewer "Go to End" button by …

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -50,14 +50,7 @@
     }
   }
 }
-@media (min-width: @screen-md-min) {
-  .console-os {
-    .middle .container-fluid {
-      margin-left: 10px;
-      margin-right: 10px;
-    }
-  }
-}
+
 
 // Firefox-specific hack for preventing fieldset content causing the container to expand
 // see: https://stackoverflow.com/questions/17408815/fieldset-resizes-wrong-appears-to-have-unremovable-min-width-min-content/17863685#17863685

--- a/app/styles/_log.less
+++ b/app/styles/_log.less
@@ -118,7 +118,10 @@
   // this is toggled in JS
   .log-scroll-top.affix.target-logger-node {
     position: fixed;
-    right: 45px;
+    right: @log-scroll-top-offset;
+    @media (min-width: @screen-md-min) {
+      right: @log-scroll-top-offset-lg;
+    }
     top: 60px !important;
   }
 

--- a/app/styles/_substructure.less
+++ b/app/styles/_substructure.less
@@ -228,6 +228,11 @@ html,body {
 
 @media (min-width: @screen-md-min) {
   .console-os {
+    .middle .container-fluid {
+      // At wide view increase the space between middle container and sidebar-left/right, by setting its padding to 30px instead of the bootstrap 20px default
+      padding-left: @middle-content-container-padding-lg;
+      padding-right: @middle-content-container-padding-lg;
+    }
     .sidebar-right {
       .flex(@columns: 0 0 @sidebar-right-width-md);
       .right-section {

--- a/app/styles/_variables.less
+++ b/app/styles/_variables.less
@@ -42,9 +42,13 @@
 @link-hover-color-bright: lighten(@link-color, 13%);
 @list-view-expanded-bg: #f5f5f5;
 @log-bg-color: #101214;
+@log-scroll-top-offset: (@scrollbar-width + @middle-content-container-padding);
+@log-scroll-top-offset-lg: (@scrollbar-width + @middle-content-container-padding-lg);
 // The log viewer needs to be udpated if this value changes.  It accounts for
 // bottom margin when resizing the log in JavaScript.
 @middle-content-bottom-margin: @grid-gutter-width;
+@middle-content-container-padding: floor((@grid-gutter-width / 2)); // 20px bootstrap default
+@middle-content-container-padding-lg: (@middle-content-container-padding + 10px);
 @navbar-header-offset: 2px;
 @navbar-os-header-height-desktop: 60px;
 @navbar-os-header-height-mobile: 46px;
@@ -104,7 +108,7 @@
 @scrollbar-track: rgba(0,0,0,.03);
 @scrollbar-track-inverse: @sidebar-os-border-color;
 @scrollbar-track-inverse-alt: rgba(255,255,255,.1);
-@scrollbar-width: 14px;
+@scrollbar-width: 15px;
 @scrollbar-width-log-viewer: 17px;
 @status-bg-color: #E6ECF1;
 @status-border-color: #BFCEDB;

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3744,8 +3744,6 @@ body{padding-right:0px!important}
 .ios .nav-tabs li.active>a:before{content:''}
 .console-os .wrap>.container{margin-top:35px;margin-bottom:80px}
 .console-os .wrap>.container h1{margin:10px 0 20px}
-@media (min-width:992px){.console-os .middle .container-fluid{margin-left:10px;margin-right:10px}
-}
 @-moz-document url-prefix(){.console-os fieldset{display:table-cell}
 }
 .separator{border-top:1px solid rgba(0,0,0,.15)}
@@ -4756,7 +4754,7 @@ td.visible-print,th.visible-print{display:table-cell!important}
 .hidden-print{display:none!important}
 }
 ::-webkit-scrollbar-corner{background:0 0}
-::-webkit-scrollbar{height:10px;overflow:visible;width:14px}
+::-webkit-scrollbar{height:10px;overflow:visible;width:15px}
 ::-webkit-scrollbar-thumb{background-color:rgba(0,0,0,.08);background-clip:padding-box;border:solid transparent;border-width:1px;min-height:28px;max-height:60px;padding:100px 0 0;-webkit-box-shadow:inset 1px 1px 0 rgba(0,0,0,.1),inset 0 -1px 0 rgba(0,0,0,.07);box-shadow:inset 1px 1px 0 rgba(0,0,0,.1),inset 0 -1px 0 rgba(0,0,0,.07)}
 ::-webkit-scrollbar-thumb:active,::-webkit-scrollbar-thumb:hover{background-color:rgba(0,0,0,.18)}
 ::-webkit-scrollbar-track{background-clip:padding-box;background-color:rgba(0,0,0,.03)}
@@ -4929,7 +4927,8 @@ body,html{margin:0;padding:0}
 .right-section .right-container .right-header{-webkit-flex:0 0 auto;-moz-flex:0 0 auto;-ms-flex:0 0 auto;flex:0 0 auto;width:100%}
 .right-section .right-container .right-content{-webkit-flex:1 1 auto;-moz-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;position:relative;overflow-x:hidden;overflow-y:auto;width:100%}
 }
-@media (min-width:992px){.console-os .sidebar-right{-webkit-flex:0 0 310px;-moz-flex:0 0 310px;-ms-flex:0 0 310px;flex:0 0 310px}
+@media (min-width:992px){.console-os .middle .container-fluid{padding-left:30px;padding-right:30px}
+.console-os .sidebar-right{-webkit-flex:0 0 310px;-moz-flex:0 0 310px;-ms-flex:0 0 310px;flex:0 0 310px}
 .console-os .sidebar-right .right-section{width:310px}
 }
 @media (min-width:1200px){.console-os .sidebar-left{-webkit-flex:0 0 145px;-moz-flex:0 0 145px;-ms-flex:0 0 145px;flex:0 0 145px}
@@ -5163,7 +5162,9 @@ a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;borde
 .log-view .log-scroll-top{position:absolute;right:0;border-right-width:0;border-top:0}
 .log-view .log-scroll-top.affix-top{position:absolute;right:0;top:0}
 .log-view .log-scroll-top.affix{position:fixed;right:20px;top:0}
-.log-view .log-scroll-top.affix.target-logger-node{position:fixed;right:45px;top:60px!important}
+.log-view .log-scroll-top.affix.target-logger-node{position:fixed;right:35px;top:60px!important}
+@media (min-width:992px){.log-view .log-scroll-top.affix.target-logger-node{right:45px}
+}
 .log-view .log-scroll-bottom{position:absolute;border-bottom:0;border-right-width:0;bottom:0;right:0}
 .log-view .log-view-output{font-size:11px;padding:40px 0}
 @media (min-width:768px){.log-view .log-view-output{font-size:12px}
@@ -5180,7 +5181,7 @@ a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;borde
 .ellipsis-loader{position:absolute;bottom:10px;margin-left:auto;margin-right:auto;left:0;right:0}
 .log-end-msg{font-size:12px;color:#72767b;position:absolute;bottom:5px;left:10px}
 .chromeless .log-scroll-top.affix{right:0px}
-.chromeless .log-scroll-top.affix.target-logger-node{right:14px}
+.chromeless .log-scroll-top.affix.target-logger-node{right:15px}
 .log-link-external a{margin-left:20px;margin-right:10px;white-space:nowrap}
 .log-link-external i{font-size:10px;margin-left:5px}
 .log-line{color:#d1d1d1}


### PR DESCRIPTION
adjusting its' right alignment to match middle container-fluid edge. At >992 width the middle container margin is wider so the button position needs to adjust.
- added variables to calc positioning
- scrollbar width increased 1px so button edge doesn't overhang in Firefox
- moved related classes to _substructure.less from _core.less

Fixes https://github.com/openshift/origin-web-console/issues/1162

<img width="694" alt="screen shot 2017-01-24 at 1 52 42 pm" src="https://cloud.githubusercontent.com/assets/1874151/22262165/ce3991ea-e23d-11e6-978d-a6b66d04d1a9.png">
<img width="687" alt="screen shot 2017-01-24 at 1 50 34 pm" src="https://cloud.githubusercontent.com/assets/1874151/22262166/ce3b0110-e23d-11e6-9440-eff948c5d927.png">
<img width="673" alt="screen shot 2017-01-24 at 1 49 50 pm" src="https://cloud.githubusercontent.com/assets/1874151/22262164/ce3999e2-e23d-11e6-890a-3365cffc09c4.png">

<b>Monitoring</b>
<img width="568" alt="screen shot 2017-01-24 at 1 31 19 pm" src="https://cloud.githubusercontent.com/assets/1874151/22262163/ce39762e-e23d-11e6-8c0b-f3a7c88bc779.png">

<b>Chromeless view</b>
<img width="262" alt="screen shot 2017-01-24 at 1 34 27 pm" src="https://cloud.githubusercontent.com/assets/1874151/22262167/ce417b30-e23d-11e6-8444-1d210ff6fbb8.png">
