### PR TITLE
Let users specify insecureEdgeTerminationPolicy for other termination types

### DIFF
--- a/app/scripts/controllers/edit/route.js
+++ b/app/scripts/controllers/edit/route.js
@@ -125,10 +125,6 @@ angular.module('openshiftConsole')
 
           if (_.get($scope, 'routing.tls.termination')) {
             updated.spec.tls = $scope.routing.tls;
-            if (updated.spec.tls.termination !== 'edge') {
-              // insecureEdgeTerminationPolicy only applies to edge routes.
-              delete updated.spec.tls.insecureEdgeTerminationPolicy;
-            }
 
             if (updated.spec.tls.termination === 'passthrough') {
               delete updated.spec.path;

--- a/app/scripts/directives/oscRouting.js
+++ b/app/scripts/directives/oscRouting.js
@@ -69,6 +69,14 @@ angular.module("openshiftConsole")
           _.set(scope, 'route.tls.insecureEdgeTerminationPolicy', '');
         }
 
+        var validateInsecureTerminationPolicy = function() {
+          var insecureTrafficValid = _.get(scope, 'route.tls.termination') !== 'passthrough' ||
+                                     _.get(scope, 'route.tls.insecureEdgeTerminationPolicy') !== 'Allow';
+          scope.routeForm.insecureTraffic.$setValidity('passthrough', insecureTrafficValid);
+        };
+        scope.$watchGroup([ 'route.tls.termination', 'route.tls.insecureEdgeTerminationPolicy' ],
+                          validateInsecureTerminationPolicy);
+
         scope.nameValidation = DNS1123_SUBDOMAIN_VALIDATION;
 
         // Use different patterns for validating hostnames if wildcard subdomains are supported.

--- a/app/scripts/services/applicationGenerator.js
+++ b/app/scripts/services/applicationGenerator.js
@@ -157,10 +157,11 @@ angular.module("openshiftConsole")
           termination: tls.termination
         };
 
+        if (tls.insecureEdgeTerminationPolicy) {
+          route.spec.tls.insecureEdgeTerminationPolicy = tls.insecureEdgeTerminationPolicy;
+        }
+
         if (tls.termination !== 'passthrough') {
-          if (tls.termination === 'edge' && tls.insecureEdgeTerminationPolicy) {
-            route.spec.tls.insecureEdgeTerminationPolicy = tls.insecureEdgeTerminationPolicy;
-          }
           if (tls.certificate) {
             route.spec.tls.certificate = tls.certificate;
           }

--- a/app/views/browse/route.html
+++ b/app/views/browse/route.html
@@ -147,8 +147,8 @@
                   <dl class="dl-horizontal left" ng-if="route.spec.tls">
                     <dt>Termination Type:</dt>
                     <dd>{{route.spec.tls.termination | humanizeTLSTermination}}</dd>
-                    <dt ng-if-start="route.spec.tls.termination === 'edge'">Insecure Traffic:</dt>
-                    <dd ng-if-end>{{route.spec.tls.insecureEdgeTerminationPolicy || 'None'}}</dd>
+                    <dt>Insecure Traffic:</dt>
+                    <dd>{{route.spec.tls.insecureEdgeTerminationPolicy || 'None'}}</dd>
                     <dt>Certificate:</dt>
                     <dd>
                       <span ng-show="route.spec.tls.certificate && !reveal.certificate">

--- a/app/views/directives/osc-routing.html
+++ b/app/views/directives/osc-routing.html
@@ -247,15 +247,28 @@
       <!-- Insecure Edge Termination Policy -->
       <div class="form-group">
         <label for="insecureTraffic">Insecure Traffic</label>
-        <ui-select ng-model="route.tls.insecureEdgeTerminationPolicy" ng-disabled="route.tls.termination !== 'edge'" input-id="insecureTraffic" aria-describedby="route-insecure-policy-help" search-enabled="false">
+        <!-- Since we can't give the ui-select field a name, create a hidden input for Angular form validation. -->
+        <input type="hidden" name="insecureTraffic">
+        <ui-select ng-model="route.tls.insecureEdgeTerminationPolicy"
+            name="insecureTraffic"
+            input-id="insecureTraffic"
+            aria-describedby="route-insecure-policy-help"
+            search-enabled="false">
           <ui-select-match>{{$select.selected.label}}</ui-select-match>
-          <ui-select-choices repeat="option.value as option in insecureTrafficOptions">
+          <ui-select-choices
+              repeat="option.value as option in insecureTrafficOptions"
+              ui-disable-choice="route.tls.termination === 'passthrough' && option.value === 'Allow'">
             {{option.label}}
           </ui-select-choices>
         </ui-select>
         <div>
           <span id="route-insecure-policy-help" class="help-block">
-            Policy for traffic on insecure schemes like HTTP for edge termination.
+            Policy for traffic on insecure schemes like HTTP.
+          </span>
+        </div>
+        <div ng-if="routeForm.insecureTraffic.$error.passthrough" class="has-warning">
+          <span class="help-block">
+            Passthrough routes can't use the insecure traffic policy <var>Allow</var>.
           </span>
         </div>
       </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1814,7 +1814,7 @@ targetPort:a.routing.targetPort
 var f = a.routing.tls;
 return f && f.termination && (d.spec.tls = {
 termination:f.termination
-}, "passthrough" !== f.termination && ("edge" === f.termination && f.insecureEdgeTerminationPolicy && (d.spec.tls.insecureEdgeTerminationPolicy = f.insecureEdgeTerminationPolicy), f.certificate && (d.spec.tls.certificate = f.certificate), f.key && (d.spec.tls.key = f.key), f.caCertificate && (d.spec.tls.caCertificate = f.caCertificate), f.destinationCACertificate && "reencrypt" === f.termination && (d.spec.tls.destinationCACertificate = f.destinationCACertificate))), d;
+}, f.insecureEdgeTerminationPolicy && (d.spec.tls.insecureEdgeTerminationPolicy = f.insecureEdgeTerminationPolicy), "passthrough" !== f.termination && (f.certificate && (d.spec.tls.certificate = f.certificate), f.key && (d.spec.tls.key = f.key), f.caCertificate && (d.spec.tls.caCertificate = f.caCertificate), f.destinationCACertificate && "reencrypt" === f.termination && (d.spec.tls.destinationCACertificate = f.destinationCACertificate))), d;
 }, f._generateDeploymentConfig = function(a, b, c) {
 var d = [];
 angular.forEach(a.deploymentConfig.envVars, function(a, b) {
@@ -7893,7 +7893,7 @@ _.set(a, "spec.to.name", b);
 var c = _.get(d, "routing.to.weight");
 isNaN(c) || _.set(a, "spec.to.weight", c), a.spec.path = d.routing.path;
 var e = d.routing.targetPort;
-e ? _.set(a, "spec.port.targetPort", e) :delete a.spec.port, _.get(d, "routing.tls.termination") ? (a.spec.tls = d.routing.tls, "edge" !== a.spec.tls.termination && delete a.spec.tls.insecureEdgeTerminationPolicy, "passthrough" === a.spec.tls.termination && (delete a.spec.path, delete a.spec.tls.certificate, delete a.spec.tls.key, delete a.spec.tls.caCertificate), "reencrypt" !== a.spec.tls.termination && delete a.spec.tls.destinationCACertificate) :delete a.spec.tls;
+e ? _.set(a, "spec.port.targetPort", e) :delete a.spec.port, _.get(d, "routing.tls.termination") ? (a.spec.tls = d.routing.tls, "passthrough" === a.spec.tls.termination && (delete a.spec.path, delete a.spec.tls.certificate, delete a.spec.tls.key, delete a.spec.tls.caCertificate), "reencrypt" !== a.spec.tls.termination && delete a.spec.tls.destinationCACertificate) :delete a.spec.tls;
 var f = _.get(d, "routing.alternateServices", []);
 return _.isEmpty(f) ? delete a.spec.alternateBackends :a.spec.alternateBackends = _.map(f, function(a) {
 return {
@@ -10225,8 +10225,13 @@ label:"Allow"
 }, {
 value:"Redirect",
 label:"Redirect"
-} ], _.has(c, "route.tls.insecureEdgeTerminationPolicy") || _.set(c, "route.tls.insecureEdgeTerminationPolicy", ""), c.nameValidation = b, c.disableWildcards ? c.hostnamePattern = b.pattern :c.hostnamePattern = /^(\*(\.[a-z0-9]([-a-z0-9]*[a-z0-9]))+|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$/, c.hostnameMaxLength = b.maxlength;
-var g = function(a) {
+} ], _.has(c, "route.tls.insecureEdgeTerminationPolicy") || _.set(c, "route.tls.insecureEdgeTerminationPolicy", "");
+var g = function() {
+var a = "passthrough" !== _.get(c, "route.tls.termination") || "Allow" !== _.get(c, "route.tls.insecureEdgeTerminationPolicy");
+c.routeForm.insecureTraffic.$setValidity("passthrough", a);
+};
+c.$watchGroup([ "route.tls.termination", "route.tls.insecureEdgeTerminationPolicy" ], g), c.nameValidation = b, c.disableWildcards ? c.hostnamePattern = b.pattern :c.hostnamePattern = /^(\*(\.[a-z0-9]([-a-z0-9]*[a-z0-9]))+|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$/, c.hostnameMaxLength = b.maxlength;
+var h = function(a) {
 a && (c.unnamedServicePort = 1 === a.spec.ports.length && !a.spec.ports[0].name, a.spec.ports.length && !c.unnamedServicePort ? c.route.portOptions = _.map(a.spec.ports, function(a) {
 return {
 port:a.name,
@@ -10235,7 +10240,7 @@ label:a.port + " → " + a.targetPort + " (" + a.protocol + ")"
 }) :c.route.portOptions = []);
 };
 c.services && !c.route.service && (c.route.service = _.find(c.services)), c.$watch("route.to.service", function(a, b) {
-g(a), a === b && c.route.targetPort || (c.route.targetPort = _.get(c, "route.portOptions[0].port")), c.services && (c.alternateServiceOptions = _.reject(c.services, function(b) {
+h(a), a === b && c.route.targetPort || (c.route.targetPort = _.get(c, "route.portOptions[0].port")), c.services && (c.alternateServiceOptions = _.reject(c.services, function(b) {
 return a === b;
 }));
 }), c.$watch("route.alternateServices", function(a) {
@@ -10243,17 +10248,17 @@ c.duplicateServices = _(a).map("service").filter(function(a, b, c) {
 return _.includes(c, a, b + 1);
 }).value(), f.$setValidity("duplicateServices", !c.duplicateServices.length), c.options.alternateServices = !_.isEmpty(a);
 }, !0);
-var h = function() {
+var i = function() {
 return !!c.route.tls && ((!c.route.tls.termination || "passthrough" === c.route.tls.termination) && (c.route.tls.certificate || c.route.tls.key || c.route.tls.caCertificate || c.route.tls.destinationCACertificate));
 };
 c.$watch("route.tls.termination", function() {
-c.options.secureRoute = !!_.get(c, "route.tls.termination"), c.showCertificatesNotUsedWarning = h();
+c.options.secureRoute = !!_.get(c, "route.tls.termination"), c.showCertificatesNotUsedWarning = i();
 });
-var i;
+var j;
 c.$watch("options.secureRoute", function(a, b) {
 if (a !== b) {
 var d = _.get(c, "route.tls.termination");
-!c.securetRoute && d && (i = d, delete c.route.tls.termination), c.options.secureRoute && !d && _.set(c, "route.tls.termination", i || "edge");
+!c.securetRoute && d && (j = d, delete c.route.tls.termination), c.options.secureRoute && !d && _.set(c, "route.tls.termination", j || "edge");
 }
 }), c.$watch("options.alternateServices", function(a, b) {
 a !== b && (a || (c.route.alternateServices = []), a && _.isEmpty(c.route.alternateServices) && c.addAlternateService());
@@ -10277,11 +10282,11 @@ d += _.get(a, "weight", 0);
 var e = a / d * 100;
 return b ? d3.round(e, 1) + "%" :e;
 };
-var j = !1;
+var k = !1;
 c.$watch("route.alternateServices.length", function(a) {
-0 === a && _.has(c, "route.to.weight") && delete c.route.to.weight, 1 === a && (j = !0, c.controls.rangeSlider = c.weightAsPercentage(c.route.to.weight));
+0 === a && _.has(c, "route.to.weight") && delete c.route.to.weight, 1 === a && (k = !0, c.controls.rangeSlider = c.weightAsPercentage(c.route.to.weight));
 }), c.$watch("controls.rangeSlider", function(a, b) {
-return j ? void (j = !1) :void (a !== b && (a = parseInt(a, 10), _.set(c, "route.to.weight", a), _.set(c, "route.alternateServices[0].weight", 100 - a)));
+return k ? void (k = !1) :void (a !== b && (a = parseInt(a, 10), _.set(c, "route.to.weight", a), _.set(c, "route.alternateServices[0].weight", 100 - a)));
 });
 }
 };

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3730,8 +3730,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dl class=\"dl-horizontal left\" ng-if=\"route.spec.tls\">\n" +
     "<dt>Termination Type:</dt>\n" +
     "<dd>{{route.spec.tls.termination | humanizeTLSTermination}}</dd>\n" +
-    "<dt ng-if-start=\"route.spec.tls.termination === 'edge'\">Insecure Traffic:</dt>\n" +
-    "<dd ng-if-end>{{route.spec.tls.insecureEdgeTerminationPolicy || 'None'}}</dd>\n" +
+    "<dt>Insecure Traffic:</dt>\n" +
+    "<dd>{{route.spec.tls.insecureEdgeTerminationPolicy || 'None'}}</dd>\n" +
     "<dt>Certificate:</dt>\n" +
     "<dd>\n" +
     "<span ng-show=\"route.spec.tls.certificate && !reveal.certificate\">\n" +
@@ -8297,15 +8297,22 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"insecureTraffic\">Insecure Traffic</label>\n" +
-    "<ui-select ng-model=\"route.tls.insecureEdgeTerminationPolicy\" ng-disabled=\"route.tls.termination !== 'edge'\" input-id=\"insecureTraffic\" aria-describedby=\"route-insecure-policy-help\" search-enabled=\"false\">\n" +
+    "\n" +
+    "<input type=\"hidden\" name=\"insecureTraffic\">\n" +
+    "<ui-select ng-model=\"route.tls.insecureEdgeTerminationPolicy\" name=\"insecureTraffic\" input-id=\"insecureTraffic\" aria-describedby=\"route-insecure-policy-help\" search-enabled=\"false\">\n" +
     "<ui-select-match>{{$select.selected.label}}</ui-select-match>\n" +
-    "<ui-select-choices repeat=\"option.value as option in insecureTrafficOptions\">\n" +
+    "<ui-select-choices repeat=\"option.value as option in insecureTrafficOptions\" ui-disable-choice=\"route.tls.termination === 'passthrough' && option.value === 'Allow'\">\n" +
     "{{option.label}}\n" +
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
     "<div>\n" +
     "<span id=\"route-insecure-policy-help\" class=\"help-block\">\n" +
-    "Policy for traffic on insecure schemes like HTTP for edge termination.\n" +
+    "Policy for traffic on insecure schemes like HTTP.\n" +
+    "</span>\n" +
+    "</div>\n" +
+    "<div ng-if=\"routeForm.insecureTraffic.$error.passthrough\" class=\"has-warning\">\n" +
+    "<span class=\"help-block\">\n" +
+    "Passthrough routes can't use the insecure traffic policy <var>Allow</var>.\n" +
     "</span>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
Previously we only let users specify the insecureEdgeTerminationPolicy for edge-terminated routes. Allow it for any termination type. The value `Allow` should be disabled for passthrough routes, however.

cc @smarterclayton 