### PR TITLE
Addition of truncate class to tile headers and when no deployments have started

### DIFF
--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -299,6 +299,8 @@
       .flex-wrap(@wrap: wrap);
       .flex-direction(@direction: column);
       overview-service {
+        // default width needed to enable truncation on elements within
+        width: 100%;
         &:nth-child(n+3) {
           margin-top: @service-group-vertical-margin;
         }
@@ -380,8 +382,10 @@
     .service-name {
       .h3();
       font-weight: @overview-font-weight;
-      margin-top: 3px;
-      margin-bottom: 3px;
+      // minimum line-height to prevent descender clipping since they use truncate
+      line-height: 1.2;
+      margin-top: 2px;
+      margin-bottom: 2px;
       .pficon {
         margin-right: 7px;
         vertical-align: -2px;
@@ -398,8 +402,10 @@
     .rc-header {
       .text-muted();
       padding: 5px 10px;
-      // Prevent the content from overlapping the deployment shield
-      margin-right: @shield-width-lg;
+      &.rc-header-shield {
+        // Prevent the content from overlapping the deployment shield
+        margin-right: @shield-width-lg;
+      }
     }
     image-names {
       // truncate long image names
@@ -570,7 +576,6 @@
     width: 50%;
   }
   .no-child-services-message, .no-deployments-message {
-    .text-center();
     .text-muted();
     .well();
     margin-bottom: 0;
@@ -589,7 +594,7 @@
     }
   }
   .no-deployments-message {
-    .flex(@columns: 1 0 0%); // the parent overview-service is where width with flex-basis is set.
+    width: 100%;
   }
   .no-child-services-message {
     display: none;
@@ -597,15 +602,19 @@
       .flex-display(@display: flex);
       .flex(@columns: 1 0 0%);
       .flex-direction(@direction: column);
+      height: 100%;
     }
   }
   .empty-tile {
-    padding: 50px;
+    .text-center();
+    padding: 50px 20px;
+    .word-break();
   }
   .empty-dc {
     .text-center();
     .text-muted();
-    padding: 0 50px 70px;
+    padding: 0 20px 70px;
+    .word-break();
   }
   @media (min-width: @screen-md-min) {
     .overview-services.single-alternate-service {

--- a/app/views/overview/_dc.html
+++ b/app/views/overview/_dc.html
@@ -1,8 +1,8 @@
 <div class="overview-tile" ng-class="{ 'deployment-in-progress': inProgressDeployment }">
   <ng-include src="'views/overview/_service-header.html'"></ng-include>
   <div class="overview-tile-header">
-    <div class="rc-header">
-      <div>
+    <div class="rc-header" ng-class="{ 'rc-header-shield' : activeReplicationController}">
+      <div class="truncate">
         Deployment Config
         <a ng-href="{{deploymentConfig | navigateResourceURL}}">{{deploymentConfig.metadata.name}}</a>
         <small class="overview-timestamp" ng-if="activeReplicationController && !inProgressDeployment">
@@ -43,8 +43,7 @@
         A new deployment will start automatically when
         <span ng-if="imageChangeTriggers.length === 1">
           an image is available for
-          <a ng-href="{{urlForImageChangeTrigger(imageChangeTriggers[0], deploymentConfig)}}">
-            {{imageChangeTriggers[0].imageChangeParams.from | imageObjectRef : deploymentConfig.metadata.namespace}}</a>.
+          <a ng-href="{{urlForImageChangeTrigger(imageChangeTriggers[0], deploymentConfig)}}">{{imageChangeTriggers[0].imageChangeParams.from | imageObjectRef : deploymentConfig.metadata.namespace}}</a>.
         </span>
         <span ng-if="imageChangeParams.length > 1">
           one of the images for this deployment config changes.
@@ -63,11 +62,8 @@
           </div>
         </div>
         <div ng-if="!pipelinesForDC[deploymentConfig.metadata.name].length">
-          <p>
-            No deployments have started for
-            <a ng-href="{{deploymentConfig | navigateResourceURL}}">{{deploymentConfig.metadata.name}}</a>.
-          </p>
-
+            <p>No deployments have started for
+            <a ng-href="{{deploymentConfig | navigateResourceURL}}">{{deploymentConfig.metadata.name}}</a>.</p>
           <button ng-if="'deploymentconfigs' | canI : 'update'" class="btn btn-primary" ng-click="startDeployment(deploymentConfig)">
             Start Deployment
           </button>

--- a/app/views/overview/_deployment.html
+++ b/app/views/overview/_deployment.html
@@ -1,8 +1,8 @@
 <div class="overview-tile" ng-class="{ 'deployment-in-progress': inProgressDeployment }">
   <ng-include src="'views/overview/_service-header.html'"></ng-include>
   <div class="overview-tile-header">
-    <div class="rc-header">
-      <div>
+    <div class="rc-header" ng-class="{ 'rc-header-shield' : latestReplicaSet && latestRevision && !inProgressDeployment}">
+      <div class="truncate">
         Deployment
         <a ng-href="{{deployment | navigateResourceURL}}">{{deploymentName}}</a>
         <small class="overview-timestamp" ng-if="latestReplicaSet">

--- a/app/views/overview/_pod.html
+++ b/app/views/overview/_pod.html
@@ -1,7 +1,7 @@
 <div class="overview-tile" ng-if="pod.kind === 'Pod'">
   <ng-include src="'views/overview/_service-header.html'"></ng-include>
   <div class="rc-header"> <!-- TODO may want different treatment for a pod-name? -->
-    <div>
+    <div class="truncate">
       Pod
       <a ng-href="{{pod | navigateResourceURL}}">{{pod.metadata.name}}</a>
       <small class="overview-timestamp">

--- a/app/views/overview/_service-group.html
+++ b/app/views/overview/_service-group.html
@@ -67,14 +67,13 @@
               ng-repeat="service in childServices">
           </overview-service>
 
-          <div flex column ng-if="alternateServices.length === 0 && childServices.length === 0 && service" class="no-child-services-block">
+          <div column ng-if="alternateServices.length === 0 && childServices.length === 0 && service" class="no-child-services-block">
             <div class="no-child-services-message">
               <div class="empty-tile">
                 <h2>No grouped services.</h2>
-                <p>
-                  No services are grouped with <a ng-href="{{service | navigateResourceURL}}">{{service.metadata.name}}</a>.
-                  <span ng-if="(services | hashSize) > 1 && ('services' | canI : 'update')">Add a service to group them together.</span>
-                </p>
+                  <p>No services are grouped with <a ng-href="{{service | navigateResourceURL}}">{{service.metadata.name}}</a>.
+                    <span ng-if="(services | hashSize) > 1 && ('services' | canI : 'update')">Add a service to group them together.</span>
+                  </p>
                 <div ng-if="(services | hashSize) > 1 && ('services' | canI : 'update')">
                   <button class="btn btn-primary" ng-click="linkService()">
                     Group Service

--- a/app/views/overview/_service-header.html
+++ b/app/views/overview/_service-header.html
@@ -1,5 +1,5 @@
 <div row class="service-title" ng-if="service">
-  <div class="service-name">
+  <div class="service-name truncate">
     <span class="pficon pficon-service" aria-hidden="true" title="Service"></span>
     <span class="sr-only">Service</span>
     <a ng-href="{{service | navigateResourceURL}}">{{service.metadata.name}}</a>

--- a/app/views/overview/_service.html
+++ b/app/views/overview/_service.html
@@ -1,11 +1,10 @@
 <div ng-if="!tileCount" class="no-deployments-block">
-  <div column class="no-deployments-message">
+  <div column class="no-deployments-message overview-tile">
     <ng-include src="'views/overview/_service-header.html'"></ng-include>
     <div class="empty-tile">
       <h2>No deployments or pods.</h2>
       <p>
-        Service
-        <a ng-href="{{service | navigateResourceURL}}">{{service.metadata.name}}</a>
+        Service <a ng-href="{{service | navigateResourceURL}}">{{service.metadata.name}}</a>
         does not route to any deployments or pods.
       </p>
     </div>

--- a/app/views/overview/_set.html
+++ b/app/views/overview/_set.html
@@ -2,7 +2,7 @@
   <ng-include src="'views/overview/_service-header.html'"></ng-include>
   <div class="overview-tile-header">
     <div class="rc-header">
-      <div>
+      <div class="truncate">
         {{set.kind | humanizeKind : true}}
         <a ng-href="{{set | navigateResourceURL}}">{{set.metadata.name}}</a>
         <small class="overview-timestamp">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -11374,8 +11374,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"overview-tile\" ng-class=\"{ 'deployment-in-progress': inProgressDeployment }\">\n" +
     "<ng-include src=\"'views/overview/_service-header.html'\"></ng-include>\n" +
     "<div class=\"overview-tile-header\">\n" +
-    "<div class=\"rc-header\">\n" +
-    "<div>\n" +
+    "<div class=\"rc-header\" ng-class=\"{ 'rc-header-shield' : activeReplicationController}\">\n" +
+    "<div class=\"truncate\">\n" +
     "Deployment Config\n" +
     "<a ng-href=\"{{deploymentConfig | navigateResourceURL}}\">{{deploymentConfig.metadata.name}}</a>\n" +
     "<small class=\"overview-timestamp\" ng-if=\"activeReplicationController && !inProgressDeployment\">\n" +
@@ -11413,8 +11413,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "A new deployment will start automatically when\n" +
     "<span ng-if=\"imageChangeTriggers.length === 1\">\n" +
     "an image is available for\n" +
-    "<a ng-href=\"{{urlForImageChangeTrigger(imageChangeTriggers[0], deploymentConfig)}}\">\n" +
-    "{{imageChangeTriggers[0].imageChangeParams.from | imageObjectRef : deploymentConfig.metadata.namespace}}</a>.\n" +
+    "<a ng-href=\"{{urlForImageChangeTrigger(imageChangeTriggers[0], deploymentConfig)}}\">{{imageChangeTriggers[0].imageChangeParams.from | imageObjectRef : deploymentConfig.metadata.namespace}}</a>.\n" +
     "</span>\n" +
     "<span ng-if=\"imageChangeParams.length > 1\">\n" +
     "one of the images for this deployment config changes.\n" +
@@ -11433,10 +11432,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"!pipelinesForDC[deploymentConfig.metadata.name].length\">\n" +
-    "<p>\n" +
-    "No deployments have started for\n" +
-    "<a ng-href=\"{{deploymentConfig | navigateResourceURL}}\">{{deploymentConfig.metadata.name}}</a>.\n" +
-    "</p>\n" +
+    "<p>No deployments have started for\n" +
+    "<a ng-href=\"{{deploymentConfig | navigateResourceURL}}\">{{deploymentConfig.metadata.name}}</a>.</p>\n" +
     "<button ng-if=\"'deploymentconfigs' | canI : 'update'\" class=\"btn btn-primary\" ng-click=\"startDeployment(deploymentConfig)\">\n" +
     "Start Deployment\n" +
     "</button>\n" +
@@ -11505,8 +11502,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"overview-tile\" ng-class=\"{ 'deployment-in-progress': inProgressDeployment }\">\n" +
     "<ng-include src=\"'views/overview/_service-header.html'\"></ng-include>\n" +
     "<div class=\"overview-tile-header\">\n" +
-    "<div class=\"rc-header\">\n" +
-    "<div>\n" +
+    "<div class=\"rc-header\" ng-class=\"{ 'rc-header-shield' : latestReplicaSet && latestRevision && !inProgressDeployment}\">\n" +
+    "<div class=\"truncate\">\n" +
     "Deployment\n" +
     "<a ng-href=\"{{deployment | navigateResourceURL}}\">{{deploymentName}}</a>\n" +
     "<small class=\"overview-timestamp\" ng-if=\"latestReplicaSet\">\n" +
@@ -11576,7 +11573,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"overview-tile\" ng-if=\"pod.kind === 'Pod'\">\n" +
     "<ng-include src=\"'views/overview/_service-header.html'\"></ng-include>\n" +
     "<div class=\"rc-header\"> \n" +
-    "<div>\n" +
+    "<div class=\"truncate\">\n" +
     "Pod\n" +
     "<a ng-href=\"{{pod | navigateResourceURL}}\">{{pod.metadata.name}}</a>\n" +
     "<small class=\"overview-timestamp\">\n" +
@@ -11661,12 +11658,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</overview-service>\n" +
     "<overview-service ng-init=\"isChild = true\" ng-repeat=\"service in childServices\">\n" +
     "</overview-service>\n" +
-    "<div flex column ng-if=\"alternateServices.length === 0 && childServices.length === 0 && service\" class=\"no-child-services-block\">\n" +
+    "<div column ng-if=\"alternateServices.length === 0 && childServices.length === 0 && service\" class=\"no-child-services-block\">\n" +
     "<div class=\"no-child-services-message\">\n" +
     "<div class=\"empty-tile\">\n" +
     "<h2>No grouped services.</h2>\n" +
-    "<p>\n" +
-    "No services are grouped with <a ng-href=\"{{service | navigateResourceURL}}\">{{service.metadata.name}}</a>.\n" +
+    "<p>No services are grouped with <a ng-href=\"{{service | navigateResourceURL}}\">{{service.metadata.name}}</a>.\n" +
     "<span ng-if=\"(services | hashSize) > 1 && ('services' | canI : 'update')\">Add a service to group them together.</span>\n" +
     "</p>\n" +
     "<div ng-if=\"(services | hashSize) > 1 && ('services' | canI : 'update')\">\n" +
@@ -11686,7 +11682,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/overview/_service-header.html',
     "<div row class=\"service-title\" ng-if=\"service\">\n" +
-    "<div class=\"service-name\">\n" +
+    "<div class=\"service-name truncate\">\n" +
     "<span class=\"pficon pficon-service\" aria-hidden=\"true\" title=\"Service\"></span>\n" +
     "<span class=\"sr-only\">Service</span>\n" +
     "<a ng-href=\"{{service | navigateResourceURL}}\">{{service.metadata.name}}</a>\n" +
@@ -11714,13 +11710,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/overview/_service.html',
     "<div ng-if=\"!tileCount\" class=\"no-deployments-block\">\n" +
-    "<div column class=\"no-deployments-message\">\n" +
+    "<div column class=\"no-deployments-message overview-tile\">\n" +
     "<ng-include src=\"'views/overview/_service-header.html'\"></ng-include>\n" +
     "<div class=\"empty-tile\">\n" +
     "<h2>No deployments or pods.</h2>\n" +
     "<p>\n" +
-    "Service\n" +
-    "<a ng-href=\"{{service | navigateResourceURL}}\">{{service.metadata.name}}</a>\n" +
+    "Service <a ng-href=\"{{service | navigateResourceURL}}\">{{service.metadata.name}}</a>\n" +
     "does not route to any deployments or pods.\n" +
     "</p>\n" +
     "</div>\n" +
@@ -11767,7 +11762,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<ng-include src=\"'views/overview/_service-header.html'\"></ng-include>\n" +
     "<div class=\"overview-tile-header\">\n" +
     "<div class=\"rc-header\">\n" +
-    "<div>\n" +
+    "<div class=\"truncate\">\n" +
     "{{set.kind | humanizeKind : true}}\n" +
     "<a ng-href=\"{{set | navigateResourceURL}}\">{{set.metadata.name}}</a>\n" +
     "<small class=\"overview-timestamp\">\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4513,7 +4513,7 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview .unserviced-row .no-service:nth-child(even){padding-left:3px}
 .overview .unserviced-row .no-service:nth-child(even):before{left:3px}
 }
-.overview .unserviced-row .no-service .overview-tile-wrapper{width:100%}
+.overview .service-group-body .overview-services overview-service,.overview .unserviced-row .no-service .overview-tile-wrapper{width:100%}
 .overview .service-group-header{cursor:pointer;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-justify-content:space-between;-moz-justify-content:space-between;justify-content:space-between;padding:7px}
 .overview .service-group-header .route-title{font-weight:300;line-height:1.4;margin:0 0 0 6px}
 .overview .service-group-header .route-title:only-child{margin:0}
@@ -4554,12 +4554,13 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview .component-label{color:#9c9c9c;font-size:11px;padding:0 10px 4px 0;text-transform:uppercase}
 .overview .build-pipeline{margin-top:-1px}
 .overview .service-title{color:#9c9c9c;-webkit-align-items:center;-moz-align-items:center;align-items:center;-webkit-justify-content:space-between;-moz-justify-content:space-between;justify-content:space-between;padding:5px 10px}
-.overview .service-title .service-name{font-family:inherit;line-height:1.1;color:inherit;font-size:16px;font-weight:300;margin-top:3px;margin-bottom:3px}
+.overview .service-title .service-name{font-family:inherit;color:inherit;font-size:16px;font-weight:300;line-height:1.2;margin-top:2px;margin-bottom:2px}
 .overview .service-title .service-name .small,.overview .service-title .service-name small{font-weight:400;line-height:1;color:#9c9c9c;font-size:65%}
 .overview .service-title .service-name .pficon{margin-right:7px;vertical-align:-2px}
 .overview .overview-tile{border-left:1px solid #d6d6d6;width:100%}
 .overview .overview-tile .overview-tile-header{color:#9c9c9c;position:relative}
-.overview .overview-tile .rc-header{color:#9c9c9c;padding:5px 10px;margin-right:50px}
+.overview .overview-tile .rc-header{color:#9c9c9c;padding:5px 10px}
+.overview .overview-tile .rc-header.rc-header-shield{margin-right:50px}
 .overview .overview-tile image-names{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .overview .no-deployments-block,.overview .shield .shield-number{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex}
 .overview .overview-tile .overview-tile-body{-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;padding:10px;position:relative}
@@ -4568,6 +4569,7 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview .overview-tile .overview-tile-body{-webkit-flex-direction:row;-moz-flex-direction:row;-ms-flex-direction:row;flex-direction:row;-webkit-justify-content:space-between;-moz-justify-content:space-between;justify-content:space-between}
 }
 .overview .overview-tile.deployment-in-progress{overflow:hidden}
+.overview .empty-dc,.overview .empty-tile{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0;text-align:center}
 .overview .overview-tile .overview-donut,.overview .overview-tile .overview-metrics{-webkit-align-items:center;-moz-align-items:center;align-items:center}
 @media (min-width:1200px){.overview .overview-tile .overview-metrics .metrics-sparkline{width:60%}
 }
@@ -4606,17 +4608,17 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 }
 .overview .no-deployments-block{display:flex;height:100%;width:100%}
 .overview .no-child-services-block{padding-left:3px;width:50%}
-.overview .no-child-services-message,.overview .no-deployments-message{text-align:center;color:#9c9c9c;min-height:20px;background-color:#f5f5f5;border:1px solid #e3e3e3;border-radius:1px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.05);box-shadow:inset 0 1px 1px rgba(0,0,0,.05);margin-bottom:0;padding:0}
+.overview .no-deployments-block .progress .progress-bar,.overview .no-deployments-message,.overview .overview-tile .progress .progress-bar{width:100%}
+.overview .no-child-services-message,.overview .no-deployments-message{color:#9c9c9c;min-height:20px;background-color:#f5f5f5;border:1px solid #e3e3e3;border-radius:1px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.05);box-shadow:inset 0 1px 1px rgba(0,0,0,.05);margin-bottom:0;padding:0}
 .overview .no-child-services-message blockquote,.overview .no-deployments-message blockquote{border-color:#ddd;border-color:rgba(0,0,0,.15)}
 .overview .no-child-services-message h1:first-child,.overview .no-child-services-message h2:first-child,.overview .no-child-services-message h3:first-child,.overview .no-child-services-message h4:first-child,.overview .no-child-services-message h5:first-child,.overview .no-deployments-message h1:first-child,.overview .no-deployments-message h2:first-child,.overview .no-deployments-message h3:first-child,.overview .no-deployments-message h4:first-child,.overview .no-deployments-message h5:first-child{margin:5px 0 15px}
 .overview .no-child-services-message h2:first-child,.overview .no-deployments-message h2:first-child{margin-top:15px}
-.overview .no-deployments-message{-webkit-flex:1 0 0%;-moz-flex:1 0 0%;-ms-flex:1 0 0%;flex:1 0 0%}
 .overview .no-child-services-message{display:none}
 @media (min-width:750px){.overview .no-child-services-message h2,.overview .no-deployments-message h2{margin-top:0}
-.overview .no-child-services-message{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex:1 0 0%;-moz-flex:1 0 0%;-ms-flex:1 0 0%;flex:1 0 0%;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column}
+.overview .no-child-services-message{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex:1 0 0%;-moz-flex:1 0 0%;-ms-flex:1 0 0%;flex:1 0 0%;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;height:100%}
 }
-.overview .empty-tile{padding:50px}
-.overview .empty-dc{text-align:center;color:#9c9c9c;padding:0 50px 70px}
+.overview .empty-tile{padding:50px 20px}
+.overview .empty-dc{color:#9c9c9c;padding:0 20px 70px}
 @media (min-width:992px){.overview .overview-services.single-alternate-service .alternate-service .no-deployments-block .service-title,.overview .overview-services.single-alternate-service .alternate-service .overview-tile .service-title,.overview .overview-services.single-alternate-service overview-service:nth-child(even){padding-left:0}
 .overview .overview-services.single-alternate-service .primary-service .no-deployments-block,.overview .overview-services.single-alternate-service .primary-service .overview-tile{border-right:0}
 .overview .overview-services.single-alternate-service .primary-service .no-deployments-block .service-title,.overview .overview-services.single-alternate-service .primary-service .overview-tile .service-title,.overview .overview-services.single-alternate-service overview-service:nth-child(odd){padding-right:0}
@@ -4628,7 +4630,6 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 }
 .overview .no-deployments-block .traffic-label,.overview .overview-tile .traffic-label{display:inline-block}
 .overview .no-deployments-block .progress,.overview .overview-tile .progress{background-color:inherit;border:0;box-shadow:none;display:inline-block;margin:0 0 0 5px;min-width:2em;vertical-align:-3px}
-.overview .no-deployments-block .progress .progress-bar,.overview .overview-tile .progress .progress-bar{width:100%}
 @media (min-width:1200px){.overview .no-deployments-block .progress,.overview .overview-tile .progress{width:250px}
 }
 .overview .standalone-service-row{-webkit-justify-content:space-between;-moz-justify-content:space-between;justify-content:space-between}


### PR DESCRIPTION
Include ng-class to selectively apply margin-right for tiles that have rc shield & number
Tested in FF, Chrome, Safari, IE

Fixes https://github.com/openshift/origin-web-console/issues/1175

<img width="636" alt="screen shot 2017-01-27 at 3 07 00 pm" src="https://cloud.githubusercontent.com/assets/1874151/22386771/8c51efdc-e4a6-11e6-90c1-c622d1d3e584.png">

