### PR TITLE
Add note for storage class used on PVC grid

### DIFF
--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -98,6 +98,11 @@ angular.module('openshiftConsole')
              annotationFilter(resource, 'kubernetes.io/description');
     };
   })
+  .filter('storageClass', function(annotationFilter) {
+     return function(pvc) {
+       return annotationFilter(pvc, 'volume.beta.kubernetes.io/storage-class');
+     };
+  })
   .filter('displayName', function(annotationFilter) {
     // annotationOnly - if true, don't fall back to using metadata.name when
     //                  there's no displayName annotation

--- a/app/views/storage.html
+++ b/app/views/storage.html
@@ -55,7 +55,9 @@
                 </tbody>
                 <tbody ng-if="(pvcs | hashSize) > 0">
                   <tr ng-repeat="pvc in pvcs | orderObjectsByDate : true">
-                    <td data-title="Name"><a ng-href="{{pvc | navigateResourceURL}}">{{pvc.metadata.name}}</a></td>
+                    <td data-title="Name"><a ng-href="{{pvc | navigateResourceURL}}">{{pvc.metadata.name}}</a>
+                      <span ng-if="pvc | storageClass" class="text-muted"> using storage class {{pvc | storageClass}}</span>
+                    </td>
                     <td data-title="Status">
                       <status-icon status="pvc.status.phase" disable-animation></status-icon>
                       {{pvc.status.phase}}

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -13785,6 +13785,10 @@ return null;
 return function(b) {
 return a(b, "openshift.io/description") || a(b, "kubernetes.io/description");
 };
+} ]).filter("storageClass", [ "annotationFilter", function(a) {
+return function(b) {
+return a(b, "volume.beta.kubernetes.io/storage-class");
+};
 } ]).filter("displayName", [ "annotationFilter", function(a) {
 return function(b, c) {
 var d = a(b, "displayName");

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -13096,7 +13096,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</tbody>\n" +
     "<tbody ng-if=\"(pvcs | hashSize) > 0\">\n" +
     "<tr ng-repeat=\"pvc in pvcs | orderObjectsByDate : true\">\n" +
-    "<td data-title=\"Name\"><a ng-href=\"{{pvc | navigateResourceURL}}\">{{pvc.metadata.name}}</a></td>\n" +
+    "<td data-title=\"Name\"><a ng-href=\"{{pvc | navigateResourceURL}}\">{{pvc.metadata.name}}</a>\n" +
+    "<span ng-if=\"pvc | storageClass\" class=\"text-muted\"> using storage class {{pvc | storageClass}}</span>\n" +
+    "</td>\n" +
     "<td data-title=\"Status\">\n" +
     "<status-icon status=\"pvc.status.phase\" disable-animation></status-icon>\n" +
     "{{pvc.status.phase}}\n" +


### PR DESCRIPTION
We have a request to show which provisioner was used to create a claim.  I have added a muted note next to the PVC name when a storage class was assigned.