### PR TITLE
Let users reset "Don't Show Me Again" alerts

### DIFF
--- a/app/scripts/controllers/about.js
+++ b/app/scripts/controllers/about.js
@@ -7,13 +7,26 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('AboutController', function ($scope, AuthService, Constants) {
+  .controller('AboutController',
+              function($scope,
+                       AlertMessageService,
+                       AuthService,
+                       Constants) {
     AuthService.withUser();
-    
+
+    $scope.alerts = {};
     $scope.version = {
       master: {
         openshift: Constants.VERSION.openshift,
         kubernetes: Constants.VERSION.kubernetes,
       },
+    };
+
+    $scope.resetHiddenAlerts = function() {
+      AlertMessageService.resetHiddenAlerts();
+      $scope.alerts['hidden-alerts-reset'] = {
+        type: 'success',
+        message: '"Don\'t Show Me Again" alerts have been reset.'
+      };
     };
   });

--- a/app/scripts/services/alertMessage.js
+++ b/app/scripts/services/alertMessage.js
@@ -3,6 +3,9 @@
 angular.module("openshiftConsole")
   .service("AlertMessageService", function(){
     var alerts = [];
+    var isAlertKey = function(key) {
+      return _.startsWith(key, 'hide/alert/');
+    };
     var alertHiddenKey = function(alertID, namespace) {
       if (!namespace) {
         return 'hide/alert/' + alertID;
@@ -27,6 +30,23 @@ angular.module("openshiftConsole")
       permanentlyHideAlert: function(alertID, namespace) {
         var key = alertHiddenKey(alertID,namespace);
         localStorage.setItem(key, 'true');
+      },
+      resetHiddenAlerts: function() {
+        var i, key;
+        var alertKeys = [];
+
+        // Find the alert keys.
+        for (i = 0; i < localStorage.length; i++) {
+          key = localStorage.key(i);
+          if (isAlertKey(key)) {
+            alertKeys.push(key);
+          }
+        }
+
+        // Remove each alert key (outside the for loop so the indexes don't change and we miss items).
+        _.each(alertKeys, function(key) {
+          localStorage.removeItem(key);
+        });
       }
     };
   });

--- a/app/views/about.html
+++ b/app/views/about.html
@@ -17,6 +17,7 @@
                       <img src="images/openshift-logo.svg" />
                     </div>
                     <div class="col-md-9">
+                      <alerts alerts="alerts"></alerts>
                       <h1>Red Hat OpenShift <span class="about-reg">&reg;</span></h1>
                       <h2>About</h2>
                       <p><a target="_blank" href="https://openshift.com">OpenShift</a> is Red Hat's Platform-as-a-Service (PaaS) that allows developers to quickly develop, host, and scale applications in a cloud environment.</p>
@@ -34,6 +35,10 @@
                       <p>With the OpenShift command line interface (CLI), you can create applications and manage OpenShift projects from a terminal. To get started using the CLI, visit <a href="command-line">Command Line Tools</a>.
                       </p>
 
+                      <div class="small text-muted mar-top-xl">
+                        To see <var>Don't Show Me Again</var> messages that you've previously hidden, you can
+                        <a href="" ng-click="resetHiddenAlerts()" role="button">reset alerts</a>.
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2024,7 +2024,9 @@ message:b.invalidObjectKindOrVersion(c)
 }), g.promise;
 }, f;
 } ]), angular.module("openshiftConsole").service("AlertMessageService", function() {
-var a = [], b = function(a, b) {
+var a = [], b = function(a) {
+return _.startsWith(a, "hide/alert/");
+}, c = function(a, b) {
 return b ? "hide/alert/" + b + "/" + a :"hide/alert/" + a;
 };
 return {
@@ -2037,13 +2039,20 @@ return a;
 clearAlerts:function() {
 a = [];
 },
-isAlertPermanentlyHidden:function(a, c) {
-var d = b(a, c);
+isAlertPermanentlyHidden:function(a, b) {
+var d = c(a, b);
 return "true" === localStorage.getItem(d);
 },
-permanentlyHideAlert:function(a, c) {
-var d = b(a, c);
+permanentlyHideAlert:function(a, b) {
+var d = c(a, b);
 localStorage.setItem(d, "true");
+},
+resetHiddenAlerts:function() {
+var a, c, d = [];
+for (a = 0; a < localStorage.length; a++) c = localStorage.key(a), b(c) && d.push(c);
+_.each(d, function(a) {
+localStorage.removeItem(a);
+});
 }
 };
 }), angular.module("openshiftConsole").provider("RedirectLoginService", function() {
@@ -9084,12 +9093,17 @@ b.close("ok");
 a.ok = function() {
 b.close("ok");
 };
-} ]), angular.module("openshiftConsole").controller("AboutController", [ "$scope", "AuthService", "Constants", function(a, b, c) {
-b.withUser(), a.version = {
+} ]), angular.module("openshiftConsole").controller("AboutController", [ "$scope", "AlertMessageService", "AuthService", "Constants", function(a, b, c, d) {
+c.withUser(), a.alerts = {}, a.version = {
 master:{
-openshift:c.VERSION.openshift,
-kubernetes:c.VERSION.kubernetes
+openshift:d.VERSION.openshift,
+kubernetes:d.VERSION.kubernetes
 }
+}, a.resetHiddenAlerts = function() {
+b.resetHiddenAlerts(), a.alerts["hidden-alerts-reset"] = {
+type:"success",
+message:'"Don\'t Show Me Again" alerts have been reset.'
+};
 };
 } ]), angular.module("openshiftConsole").controller("CommandLineController", [ "$scope", "DataService", "AuthService", "Constants", function(a, b, c, d) {
 c.withUser(), a.cliDownloadURL = d.CLI, a.cliDownloadURLPresent = a.cliDownloadURL && !_.isEmpty(a.cliDownloadURL), a.loginBaseURL = b.openshiftAPIBaseUrl(), a.sessionToken = c.UserStore().getToken(), a.showSessionToken = !1, a.toggleShowSessionToken = function() {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -979,6 +979,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<img src=\"images/openshift-logo.svg\"/>\n" +
     "</div>\n" +
     "<div class=\"col-md-9\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<h1>Red Hat OpenShift <span class=\"about-reg\">&reg;</span></h1>\n" +
     "<h2>About</h2>\n" +
     "<p><a target=\"_blank\" href=\"https://openshift.com\">OpenShift</a> is Red Hat's Platform-as-a-Service (PaaS) that allows developers to quickly develop, host, and scale applications in a cloud environment.</p>\n" +
@@ -992,6 +993,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p>The <a target=\"_blank\" href=\"{{'welcome' | helpLink}}\">documentation</a> contains information and guides to help you learn about OpenShift and start exploring its features. From getting started with creating your first application, to trying out more advanced build and deployment techniques, it provides what you need to set up and manage your OpenShift environment as an application developer.</p>\n" +
     "<p>With the OpenShift command line interface (CLI), you can create applications and manage OpenShift projects from a terminal. To get started using the CLI, visit <a href=\"command-line\">Command Line Tools</a>.\n" +
     "</p>\n" +
+    "<div class=\"small text-muted mar-top-xl\">\n" +
+    "To see <var>Don't Show Me Again</var> messages that you've previously hidden, you can\n" +
+    "<a href=\"\" ng-click=\"resetHiddenAlerts()\" role=\"button\">reset alerts</a>.\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
Add a link to reset hidden alerts on the about page. Lets users reset alerts they might need to see again like those from #1194

Since this resets notifications for all projects and we don't have a settings page, I've added it to the about page. Open to other suggestions.

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/22480278/d56a7c8c-e7be-11e6-8f28-81e117a1de09.png)

cc @ajacobs21e @lizsurette @ncameronbritt