### PR TITLE
Don't link to image stream tags that haven't synced yet

### DIFF
--- a/app/views/browse/imagestream.html
+++ b/app/views/browse/imagestream.html
@@ -68,7 +68,10 @@
                 </tbody>
                 <tbody ng-if="(tagsByName | hashSize) > 0">
                   <tr ng-repeat="tag in tagsByName | orderBy : 'name'">
-                    <td data-title="Tag"><a href="{{imageStream | navigateResourceURL}}/{{tag.name}}">{{tag.name}}</a></td>
+                    <td data-title="Tag">
+                      <a ng-if="tag.status" ng-href="{{imageStream | navigateResourceURL}}/{{tag.name}}">{{tag.name}}</a>
+                      <span ng-if="!tag.status">{{tag.name}}</span>
+                    </td>
                     <td data-title="From">
                       <!-- this value can get long when its an ImageStreamImage. Use max width and class truncate to elide some
                            of the SHA1 for long values. They can still be copied even when elided. -->

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3171,7 +3171,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</tbody>\n" +
     "<tbody ng-if=\"(tagsByName | hashSize) > 0\">\n" +
     "<tr ng-repeat=\"tag in tagsByName | orderBy : 'name'\">\n" +
-    "<td data-title=\"Tag\"><a href=\"{{imageStream | navigateResourceURL}}/{{tag.name}}\">{{tag.name}}</a></td>\n" +
+    "<td data-title=\"Tag\">\n" +
+    "<a ng-if=\"tag.status\" ng-href=\"{{imageStream | navigateResourceURL}}/{{tag.name}}\">{{tag.name}}</a>\n" +
+    "<span ng-if=\"!tag.status\">{{tag.name}}</span>\n" +
+    "</td>\n" +
     "<td data-title=\"From\">\n" +
     "\n" +
     "<span ng-if=\"!tag.spec.from\"><em>pushed</em></span>\n" +


### PR DESCRIPTION
Don't link to image stream tags that haven't synced or had an error syncing. The page will give a not found error.

Fixes #1199