### PR TITLE
Remove emptyMessage var if its not changing

### DIFF
--- a/app/scripts/controllers/create/createFromImage.js
+++ b/app/scripts/controllers/create/createFromImage.js
@@ -86,7 +86,6 @@ angular.module("openshiftConsole")
         }
         function initAndValidate(scope){
 
-          scope.emptyMessage = "Loading...";
           scope.name = $routeParams.name;
           scope.imageName = imageName;
           scope.imageTag = $routeParams.imageTag;

--- a/app/scripts/controllers/create/nextSteps.js
+++ b/app/scripts/controllers/create/nextSteps.js
@@ -13,7 +13,6 @@ angular.module("openshiftConsole")
     var displayNameFilter = $filter('displayName');
     var watches = [];
 
-    $scope.emptyMessage = "Loading...";
     $scope.alerts = [];
     $scope.loginBaseUrl = DataService.openshiftAPIBaseUrl();
     $scope.buildConfigs = {};

--- a/app/scripts/controllers/deployment.js
+++ b/app/scripts/controllers/deployment.js
@@ -38,7 +38,6 @@ angular.module('openshiftConsole')
         title: $routeParams.deployment
       }
     ];
-    $scope.emptyMessage = "Loading...";
     $scope.healthCheckURL = Navigate.healthCheckURL($routeParams.project,
                                                     "Deployment",
                                                     $routeParams.deployment,

--- a/app/scripts/controllers/image.js
+++ b/app/scripts/controllers/image.js
@@ -37,8 +37,6 @@ angular.module('openshiftConsole')
       }
     ];
 
-    $scope.emptyMessage = "Loading...";
-
     var watches = [];
 
     var fetchImageStreamTag = _.debounce(function(tagData, context) {
@@ -84,7 +82,6 @@ angular.module('openshiftConsole')
 
     var imageStreamResolved = function(imageStream, context, action) {
       populateWithImageStream(imageStream, context);
-      $scope.emptyMessage = "";
       if (action === "DELETED") {
         $scope.alerts["deleted"] = {
           type: "warning",

--- a/app/scripts/controllers/membership.js
+++ b/app/scripts/controllers/membership.js
@@ -161,7 +161,6 @@ angular
         projectName: projectName,
         alerts: {},
         forms: {},
-        emptyMessage: 'Loading...',
         subjectKinds: subjectKinds,
         newBinding: {
           role: '',

--- a/app/scripts/controllers/newfromtemplate.js
+++ b/app/scripts/controllers/newfromtemplate.js
@@ -41,7 +41,6 @@ angular.module('openshiftConsole')
       return;
     }
 
-    $scope.emptyMessage = "Loading...";
     $scope.alerts = {};
     $scope.quotaAlerts = {};
     $scope.projectName = $routeParams.project;

--- a/app/scripts/controllers/replicaSet.js
+++ b/app/scripts/controllers/replicaSet.js
@@ -480,7 +480,6 @@ angular.module('openshiftConsole')
 
         watches.push(DataService.watch($scope.resource, context, function(replicaSets, action, replicaSet) {
           $scope.replicaSets = replicaSets.by("metadata.name");
-          $scope.emptyMessage = "No deployments to show";
           if (kind === 'ReplicationController') {
             $scope.deploymentsByDeploymentConfig = DeploymentsService.associateDeploymentsToDeploymentConfig($scope.replicaSets);
           }

--- a/app/scripts/controllers/secret.js
+++ b/app/scripts/controllers/secret.js
@@ -16,7 +16,6 @@ angular.module('openshiftConsole')
     };
 
     $scope.alerts = $scope.alerts || {};
-    $scope.emptyMessage = "Loading...";
 
     $scope.breadcrumbs = [
       {

--- a/app/scripts/controllers/statefulSet.js
+++ b/app/scripts/controllers/statefulSet.js
@@ -23,8 +23,6 @@ angular
       namespace: $routeParams.project
     });
 
-    $scope.emptyMessage = "Loading...";
-
     var updateEnvVars = function(statefulSet) {
       // Return a copy so that we don't alter the original object, which is
       // cached by DataService. Normalizing would otherwise modify the original.

--- a/app/scripts/controllers/statefulSets.js
+++ b/app/scripts/controllers/statefulSets.js
@@ -5,7 +5,6 @@ angular.module('openshiftConsole')
     $scope.projectName = $routeParams.project;
     $scope.alerts = $scope.alerts || {};
     $scope.labelSuggestions = {};
-    $scope.emptyMessage = "Loading...";
 
     // get and clear any alerts
     AlertMessageService.getAlerts().forEach(function(alert) {

--- a/app/scripts/directives/resources.js
+++ b/app/scripts/directives/resources.js
@@ -182,8 +182,6 @@ angular.module('openshiftConsole')
         services: '=',
         portsByRoute: '=',
         showNodePorts: '=?',
-        // Optional empty message to display when there are no pods.
-        emptyMessage: '=?',
         // Alternative header text to display in the 'Name' column.
         customNameHeader: '=?',
       },

--- a/app/views/browse/routes.html
+++ b/app/views/browse/routes.html
@@ -49,7 +49,7 @@
                   </tr>
                 </thead>
                 <tbody ng-if="(routes | hashSize) == 0">
-                  <tr><td colspan="5"><em>{{emptyMessage || 'No routes to show'}}</em></td></tr>
+                  <tr><td colspan="5"><em>{{emptyMessage}}</em></td></tr>
                 </tbody>
                 <tbody ng-if="(routes | hashSize) > 0">
                   <tr ng-repeat="route in routes | orderObjectsByDate : true">

--- a/app/views/create/fromimage.html
+++ b/app/views/create/fromimage.html
@@ -12,8 +12,8 @@
             <div class="row">
               <div class="col-md-12">
                 <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
-                <div ng-if="imageStream">
-                  {{ emptyMessage }}
+                <div ng-hide="imageStream">
+                  Loading...
                 </div>
                 <div class="osc-form" ng-if="imageStream">
                   <alerts alerts="alerts"></alerts>

--- a/app/views/directives/traffic-table.html
+++ b/app/views/directives/traffic-table.html
@@ -12,7 +12,7 @@
     </tr>
   </thead>
   <tbody ng-if="(portsByRoute | hashSize) == 0">
-    <tr><td colspan="7"><em>{{emptyMessage || 'No routes or ports to show'}}</em></td></tr>
+    <tr><td colspan="7"><em>No routes or ports to show</em></td></tr>
   </tbody>
   <tbody ng-if="(portsByRoute | hashSize) > 0">
     <tr ng-repeat-start="(routeName,ports) in portsByRoute" style="display: none;"></tr>

--- a/app/views/newfromtemplate.html
+++ b/app/views/newfromtemplate.html
@@ -13,7 +13,7 @@
               <div class="col-md-12">
                 <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
                 <div ng-hide="template">
-                  {{ emptyMessage }}
+                  Loading...
                 </div>
                 <div class="osc-form" ng-show="template">
                   <alerts alerts="alerts"></alerts>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5558,7 +5558,6 @@ selectedTab:A,
 projectName:o,
 alerts:{},
 forms:{},
-emptyMessage:"Loading...",
 subjectKinds:B,
 newBinding:{
 role:"",
@@ -6036,7 +6035,7 @@ title:b.imagestream,
 link:"project/" + b.project + "/browse/images/" + b.imagestream
 }, {
 title:":" + b.tag
-} ], a.emptyMessage = "Loading...";
+} ];
 var i = [], j = _.debounce(function(d, f) {
 var h = b.imagestream + ":" + b.tag;
 c.get("imagestreamtags", h, f).then(function(b) {
@@ -6049,7 +6048,7 @@ details:"Reason: " + e("getErrorDetails")(b)
 };
 });
 }, 200), k = function(b, c, d) {
-h(b, c), a.emptyMessage = "", "DELETED" === d && (a.alerts.deleted = {
+h(b, c), "DELETED" === d && (a.alerts.deleted = {
 type:"warning",
 message:"This image stream has been deleted."
 });
@@ -6194,7 +6193,7 @@ title:"Deployments",
 link:"project/" + c.project + "/browse/deployments"
 }, {
 title:c.deployment
-} ], a.emptyMessage = "Loading...", a.healthCheckURL = k.healthCheckURL(c.project, "Deployment", c.deployment, "extensions"), d.getAlerts().forEach(function(b) {
+} ], a.healthCheckURL = k.healthCheckURL(c.project, "Deployment", c.deployment, "extensions"), d.getAlerts().forEach(function(b) {
 a.alerts[b.name] = b.data;
 }), d.clearAlerts();
 var p = !1, q = function(b, c) {
@@ -6727,7 +6726,7 @@ kind:s,
 namespace:c.project
 });
 }), x.push(g.watch(a.resource, i, function(c, d, e) {
-a.replicaSets = c.by("metadata.name"), a.emptyMessage = "No deployments to show", "ReplicationController" === s && (a.deploymentsByDeploymentConfig = h.associateDeploymentsToDeploymentConfig(a.replicaSets));
+a.replicaSets = c.by("metadata.name"), "ReplicationController" === s && (a.deploymentsByDeploymentConfig = h.associateDeploymentsToDeploymentConfig(a.replicaSets));
 var f, g;
 e && (f = u(e, "deploymentConfig"), g = e.metadata.name), a.deploymentConfigDeploymentsInProgress = a.deploymentConfigDeploymentsInProgress || {}, d ? "ADDED" === d || "MODIFIED" === d && b("deploymentIsInProgress")(e) ? (a.deploymentConfigDeploymentsInProgress[f] = a.deploymentConfigDeploymentsInProgress[f] || {}, a.deploymentConfigDeploymentsInProgress[f][g] = e) :"MODIFIED" === d && a.deploymentConfigDeploymentsInProgress[f] && delete a.deploymentConfigDeploymentsInProgress[f][g] :a.deploymentConfigDeploymentsInProgress = h.associateRunningDeploymentToDeploymentConfig(a.deploymentsByDeploymentConfig), e ? "DELETED" !== d && (e.causes = b("deploymentCauses")(e)) :angular.forEach(a.replicaSets, function(a) {
 a.causes = b("deploymentCauses")(a);
@@ -6794,7 +6793,7 @@ g.unwatchAll(x);
 });
 }));
 } ]), angular.module("openshiftConsole").controller("StatefulSetsController", [ "$scope", "$routeParams", "AlertMessageService", "DataService", "ProjectsService", "LabelFilter", "LabelsService", function(a, b, c, d, e, f, g) {
-a.projectName = b.project, a.alerts = a.alerts || {}, a.labelSuggestions = {}, a.emptyMessage = "Loading...", c.getAlerts().forEach(function(b) {
+a.projectName = b.project, a.alerts = a.alerts || {}, a.labelSuggestions = {}, c.getAlerts().forEach(function(b) {
 a.alerts[b.name] = b.data;
 }), c.clearAlerts();
 var h = [];
@@ -6831,7 +6830,7 @@ b.projectName = c.project, b.statefulSetName = c.statefulset, b.forms = {}, b.al
 name:b.statefulSetName,
 kind:"StatefulSet",
 namespace:c.project
-}), b.emptyMessage = "Loading...";
+});
 var j = function(a) {
 return g.copyAndNormalize(a);
 };
@@ -6963,7 +6962,7 @@ b.secretsByType = f.groupSecretsByType(a), b.loaded = !0;
 } ]), angular.module("openshiftConsole").controller("SecretController", [ "$routeParams", "$filter", "$scope", "AlertMessageService", "DataService", "ProjectsService", "SecretsService", function(a, b, c, d, e, f, g) {
 c.projectName = a.project, c.secretName = a.secret, c.view = {
 showSecret:!1
-}, c.alerts = c.alerts || {}, c.emptyMessage = "Loading...", c.breadcrumbs = [ {
+}, c.alerts = c.alerts || {}, c.breadcrumbs = [ {
 title:"Secrets",
 link:"project/" + a.project + "/browse/secrets"
 }, {
@@ -8338,7 +8337,7 @@ details:c
 };
 g.get(d.project).then(_.spread(function(e, g) {
 function q(b) {
-b.emptyMessage = "Loading...", b.name = d.name, b.imageName = y, b.imageTag = d.imageTag, b.namespace = d.namespace, b.buildConfig = {
+b.name = d.name, b.imageName = y, b.imageTag = d.imageTag, b.namespace = d.namespace, b.buildConfig = {
 buildOnSourceChange:!0,
 buildOnImageChange:!0,
 buildOnConfigChange:!0,
@@ -8517,7 +8516,7 @@ f.then(j, j).then(J, J);
 }));
 } ]), angular.module("openshiftConsole").controller("NextStepsController", [ "$scope", "$http", "$routeParams", "DataService", "$q", "$location", "ProcessedTemplateService", "TaskList", "$parse", "Navigate", "Logger", "$filter", "imageObjectRefFilter", "failureObjectNameFilter", "ProjectsService", function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) {
 var p = (l("displayName"), []);
-a.emptyMessage = "Loading...", a.alerts = [], a.loginBaseUrl = d.openshiftAPIBaseUrl(), a.buildConfigs = {}, a.showParamsTable = !1, a.projectName = c.project, a.fromSampleRepo = c.fromSample, a.breadcrumbs = [ {
+a.alerts = [], a.loginBaseUrl = d.openshiftAPIBaseUrl(), a.buildConfigs = {}, a.showParamsTable = !1, a.projectName = c.project, a.fromSampleRepo = c.fromSample, a.breadcrumbs = [ {
 title:a.projectName,
 link:"project/" + a.projectName
 }, {
@@ -8566,7 +8565,7 @@ d.unwatchAll(p);
 } ]), angular.module("openshiftConsole").controller("NewFromTemplateController", [ "$scope", "$http", "$routeParams", "DataService", "ProcessedTemplateService", "AlertMessageService", "ProjectsService", "QuotaService", "$q", "$location", "TaskList", "$parse", "Navigate", "$filter", "$uibModal", "imageObjectRefFilter", "failureObjectNameFilter", "CachedTemplateService", "keyValueEditorUtils", "Constants", function(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) {
 var u = c.template, v = c.namespace || "";
 if (!u) return void m.toErrorPage("Cannot create from template: a template name was not specified.");
-a.emptyMessage = "Loading...", a.alerts = {}, a.quotaAlerts = {}, a.projectName = c.project, a.projectPromise = $.Deferred(), a.labels = [], a.systemLabels = [], a.breadcrumbs = [ {
+a.alerts = {}, a.quotaAlerts = {}, a.projectName = c.project, a.projectPromise = $.Deferred(), a.labels = [], a.systemLabels = [], a.breadcrumbs = [ {
 title:a.projectName,
 link:"project/" + a.projectName
 }, {
@@ -10999,7 +10998,6 @@ routes:"=",
 services:"=",
 portsByRoute:"=",
 showNodePorts:"=?",
-emptyMessage:"=?",
 customNameHeader:"=?"
 },
 templateUrl:"views/directives/traffic-table.html"

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3779,7 +3779,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</tr>\n" +
     "</thead>\n" +
     "<tbody ng-if=\"(routes | hashSize) == 0\">\n" +
-    "<tr><td colspan=\"5\"><em>{{emptyMessage || 'No routes to show'}}</em></td></tr>\n" +
+    "<tr><td colspan=\"5\"><em>{{emptyMessage}}</em></td></tr>\n" +
     "</tbody>\n" +
     "<tbody ng-if=\"(routes | hashSize) > 0\">\n" +
     "<tr ng-repeat=\"route in routes | orderObjectsByDate : true\">\n" +
@@ -5025,8 +5025,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
-    "<div ng-if=\"imageStream\">\n" +
-    "{{ emptyMessage }}\n" +
+    "<div ng-hide=\"imageStream\">\n" +
+    "Loading...\n" +
     "</div>\n" +
     "<div class=\"osc-form\" ng-if=\"imageStream\">\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
@@ -8870,7 +8870,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</tr>\n" +
     "</thead>\n" +
     "<tbody ng-if=\"(portsByRoute | hashSize) == 0\">\n" +
-    "<tr><td colspan=\"7\"><em>{{emptyMessage || 'No routes or ports to show'}}</em></td></tr>\n" +
+    "<tr><td colspan=\"7\"><em>No routes or ports to show</em></td></tr>\n" +
     "</tbody>\n" +
     "<tbody ng-if=\"(portsByRoute | hashSize) > 0\">\n" +
     "<tr ng-repeat-start=\"(routeName,ports) in portsByRoute\" style=\"display: none\"></tr>\n" +
@@ -11142,7 +11142,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"col-md-12\">\n" +
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<div ng-hide=\"template\">\n" +
-    "{{ emptyMessage }}\n" +
+    "Loading...\n" +
     "</div>\n" +
     "<div class=\"osc-form\" ng-show=\"template\">\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +


### PR DESCRIPTION
Found out that there are place in the code where we use `emptyMessage` var as part of the scope, where we just set it to "No $resource to show" and thats it. So I've got rid of that and use the scoped `loaded` variable to check if the resources are loaded since we do it on most parts of the code.
Other option would be to get rid even of the `loaded` var and check only the resource variable, which wont be set by default in the controller... eg:
```
<div ng-if="!services">Loading...</div>
<div class="row" ng-if="services">
     <tbody ng-if="(services | hashSize) == 0">
         <tr><td colspan="4"><em>No image streams to show</em></td></tr>
     </tbody>
     <tbody ng-if="(imageStreams | hashSize) > 0">
```

Also removed `emptyMessage` var on places we didn't even used that variable in views.

Will add `dist` after review


@spadgett PTAL

Closes https://github.com/openshift/origin-web-console/issues/1182