### PR TITLE
Turn off capitalization and autocorrect for some inputs

### DIFF
--- a/app/views/directives/deploy-image.html
+++ b/app/views/directives/deploy-image.html
@@ -38,7 +38,10 @@
                  select-on-focus
                  ng-disabled="mode !== 'dockerImage'"
                  placeholder="Image name or pull spec"
-                 class="form-control">
+                 class="form-control"
+                 autocorrect="off"
+                 autocapitalize="off"
+                 spellcheck="false">
           <span class="input-group-btn">
             <button class="btn btn-default"
                     type="submit"

--- a/app/views/directives/events.html
+++ b/app/views/directives/events.html
@@ -11,7 +11,10 @@
                  placeholder="Filter by keyword"
                  class="form-control"
                  id="events-filter"
-                 ng-model="filter.text">
+                 ng-model="filter.text"
+                 autocorrect="off"
+                 autocapitalize="off"
+                 spellcheck="false">
           <button
               type="button"
               class="clear"

--- a/app/views/membership.html
+++ b/app/views/membership.html
@@ -177,7 +177,10 @@
                         type="text"
                         class="form-control input-name"
                         placeholder="Name"
-                        ng-model="newBinding.name">
+                        ng-model="newBinding.name"
+                        autocorrect="off"
+                        autocapitalize="off"
+                        spellcheck="false">
                       <div
                         ng-if="newBinding.kind === 'ServiceAccount'"
                         class="service-account-namespace hidden-sm hidden-md hidden-lg"

--- a/app/views/monitoring.html
+++ b/app/views/monitoring.html
@@ -25,12 +25,15 @@
                 <form role="form" class="search-pf has-button">
                   <div class="form-group filter-controls has-clear">
                     <div class="search-pf-input-group">
-                      <label for="events-filter" class="sr-only">Filter by name</label>
+                      <label for="name-filter" class="sr-only">Filter by name</label>
                       <input type="search"
                           placeholder="Filter by name"
                           class="form-control"
-                          id="events-filter"
-                          ng-model="filters.text">
+                          id="name-filter"
+                          ng-model="filters.text"
+                          autocorrect="off"
+                          autocapitalize="off"
+                          spellcheck="false">
                       <button
                           type="button"
                           class="clear"

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6508,7 +6508,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"form-group\">\n" +
     "<label for=\"imageName\" class=\"sr-only\">Image name or pull spec</label>\n" +
     "<div class=\"input-group\">\n" +
-    "<input type=\"search\" id=\"imageName\" ng-model=\"imageName\" required select-on-focus ng-disabled=\"mode !== 'dockerImage'\" placeholder=\"Image name or pull spec\" class=\"form-control\">\n" +
+    "<input type=\"search\" id=\"imageName\" ng-model=\"imageName\" required select-on-focus ng-disabled=\"mode !== 'dockerImage'\" placeholder=\"Image name or pull spec\" class=\"form-control\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\">\n" +
     "<span class=\"input-group-btn\">\n" +
     "<button class=\"btn btn-default\" type=\"submit\" ng-disabled=\"!imageName\" ng-click=\"findImage()\">\n" +
     "<i class=\"fa fa-search\" aria-hidden=\"true\"></i>\n" +
@@ -7110,7 +7110,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"form-group filter-controls has-clear\">\n" +
     "<div class=\"search-pf-input-group\">\n" +
     "<label for=\"events-filter\" class=\"sr-only\">Filter</label>\n" +
-    "<input type=\"search\" placeholder=\"Filter by keyword\" class=\"form-control\" id=\"events-filter\" ng-model=\"filter.text\">\n" +
+    "<input type=\"search\" placeholder=\"Filter by keyword\" class=\"form-control\" id=\"events-filter\" ng-model=\"filter.text\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\">\n" +
     "<button type=\"button\" class=\"clear\" aria-hidden=\"true\" ng-if=\"filter.text\" ng-click=\"filter.text = ''\">\n" +
     "<span class=\"pficon pficon-close\"></span>\n" +
     "</button>\n" +
@@ -10325,7 +10325,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<label ng-attr-for=\"newBindingName\" class=\"sr-only\">\n" +
     "Name\n" +
     "</label>\n" +
-    "<input type=\"text\" class=\"form-control input-name\" placeholder=\"Name\" ng-model=\"newBinding.name\">\n" +
+    "<input type=\"text\" class=\"form-control input-name\" placeholder=\"Name\" ng-model=\"newBinding.name\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\">\n" +
     "<div ng-if=\"newBinding.kind === 'ServiceAccount'\" class=\"service-account-namespace hidden-sm hidden-md hidden-lg\" aria-hidden=\"true\">\n" +
     "<ui-select ng-model=\"newBinding.namespace\" theme=\"bootstrap\" search-enabled=\"true\" title=\"Select a project\" class=\"select-role\">\n" +
     "<ui-select-match placeholder=\"Select a project\">\n" +
@@ -10769,8 +10769,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<form role=\"form\" class=\"search-pf has-button\">\n" +
     "<div class=\"form-group filter-controls has-clear\">\n" +
     "<div class=\"search-pf-input-group\">\n" +
-    "<label for=\"events-filter\" class=\"sr-only\">Filter by name</label>\n" +
-    "<input type=\"search\" placeholder=\"Filter by name\" class=\"form-control\" id=\"events-filter\" ng-model=\"filters.text\">\n" +
+    "<label for=\"name-filter\" class=\"sr-only\">Filter by name</label>\n" +
+    "<input type=\"search\" placeholder=\"Filter by name\" class=\"form-control\" id=\"name-filter\" ng-model=\"filters.text\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\">\n" +
     "<button type=\"button\" class=\"clear\" aria-hidden=\"true\" ng-if=\"filters.text\" ng-click=\"filters.text = ''\">\n" +
     "<span class=\"pficon pficon-close\"></span>\n" +
     "</button>\n" +


### PR DESCRIPTION
Disable capitalization, autocorrect, and spell checking for mobile users on the following inputs:

* Image name field for Add to Project -> Deploy Image
* Keyword filter in the events directive
* Name field when editing membership
* Name filter on monitoring page