### PR TITLE
Fix membership addRoleToUser() fn, check namespace w/subject

### DIFF
--- a/app/scripts/controllers/membership.js
+++ b/app/scripts/controllers/membership.js
@@ -337,7 +337,7 @@ angular
               // infer this, but isn't clear at the moment.  Will fast-follow PR if
               // a good solution is found.
               var rolebindingToUpdate = _.find($scope.roleBindings, {roleRef: {name: role.metadata.name}});
-              if(rolebindingToUpdate && _.some(rolebindingToUpdate.subjects, {name: subjectName})) {
+              if(rolebindingToUpdate && _.some(rolebindingToUpdate.subjects, subject)) {
                 showAlert('rolebindingUpdate', 'info', messages.update.subject.exists({
                   roleName: role.metadata.name,
                   subjectName: subjectName

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5519,9 +5519,7 @@ roleRef:{
 name:c.metadata.name
 }
 });
-g && _.some(g.subjects, {
-name:a
-}) ? u("rolebindingUpdate", "info", t.update.subject.exists({
+g && _.some(g.subjects, f) ? u("rolebindingUpdate", "info", t.update.subject.exists({
 roleName:c.metadata.name,
 subjectName:a
 })) :g ? z(g, f, e) :y(c, f, e);


### PR DESCRIPTION
Fix bugzilla #1420247

Will now allow you to add roles to service accounts with the same name that exist in different projects, oversight from last update.

@jwforres @spadgett 