### PR TITLE
Fix bug searching builders with tags that reference other tags

### DIFF
--- a/app/scripts/directives/catalog/catalogImage.js
+++ b/app/scripts/directives/catalog/catalogImage.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('openshiftConsole')
-  .directive('catalogImage', function($filter) {
+  .directive('catalogImage', function($filter, CatalogService) {
     return {
       restrict: 'E',
       // Replace the catalog-template element so that the tiles are all equal height as flexbox items.
@@ -23,10 +23,7 @@ angular.module('openshiftConsole')
         var tagTags = {};
         _.each(specTags, function(tag) {
           tagTags[tag.name] = imageStreamTagTags($scope.imageStream, tag.name);
-          if (tag.from &&
-              tag.from.kind === 'ImageStreamTag' &&
-              tag.from.name.indexOf(':') === -1 &&
-             !tag.from.namespace) {
+          if (CatalogService.referencesSameImageStream(tag)) {
             referenceTags[tag.name] = true;
             $scope.referencedBy[tag.from.name] = $scope.referencedBy[tag.from.name] || [];
             $scope.referencedBy[tag.from.name].push(tag.name);


### PR DESCRIPTION
If builder `nodejs:latest` tracks `nodejs:4` and a search term matches only the `nodejs:latest` description, the version select appears empty in the add to project catalog.

Fix this by only matching search terms in the nodejs:4 description (but still match searches for "latest").

Fixes #1242