### PR TITLE
Fix sample pipeline button

### DIFF
--- a/app/scripts/controllers/pipelines.js
+++ b/app/scripts/controllers/pipelines.js
@@ -119,8 +119,8 @@ angular.module('openshiftConsole')
             var sampleName = Constants.SAMPLE_PIPELINE_TEMPLATE.name;
             var sampleNamespace = Constants.SAMPLE_PIPELINE_TEMPLATE.namespace;
             DataService.get("templates", sampleName, {namespace: sampleNamespace}, {errorNotification: false}).then(
-              function() {
-                $scope.createSampleURL = Navigate.fromTemplateURL($scope.projectName, sampleName, sampleNamespace);
+              function(template) {
+                $scope.createSampleURL = Navigate.createFromTemplateURL(template, $scope.projectName);
               });
           }
           update();

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5623,8 +5623,8 @@ h.get("templates", b, {
 namespace:f
 }, {
 errorNotification:!1
-}).then(function() {
-c.createSampleURL = e.fromTemplateURL(c.projectName, b, f);
+}).then(function(a) {
+c.createSampleURL = e.createFromTemplateURL(a, c.projectName);
 });
 }
 p();


### PR DESCRIPTION
We were calling a removed Navigate service API to get the template URL, which caused a runtime error.

Fixes #1247