### PR TITLE
Include vendor prefixes required for consistent styling of placeholder text

### DIFF
--- a/app/styles/_forms.less
+++ b/app/styles/_forms.less
@@ -95,3 +95,12 @@
   margin-left: 0;
   margin-right: 10px;
 }
+
+// Add vendor prefixes for placeholder text, since they where removed from PatternFly
+// https://github.com/patternfly/patternfly/issues/597
+.placeholder(@color: @input-color-placeholder) {
+  &:-moz-placeholder            { color: @color; font-style: italic; } // Firefox 4-18
+  &::-moz-placeholder           { color: @color; font-style: italic; opacity: 1; } // Firefox 19+
+  &:-ms-input-placeholder       { color: @color; font-style: italic; } // Internet Explorer 10+
+  &::-webkit-input-placeholder  { color: @color; font-style: italic; } // Safari and Chrome
+}

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -689,10 +689,11 @@ input[type=checkbox]:focus,input[type=radio]:focus,input[type=file]:focus{outlin
 output{padding-top:3px}
 .form-control{width:100%;height:27px;padding:2px 6px;background-color:#fff;border:1px solid #bbb;border-radius:1px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.075);box-shadow:inset 0 1px 1px rgba(0,0,0,.075);-webkit-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;-o-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s}
 .form-control:focus{border-color:#0088ce;outline:0;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(0,136,206,.6);box-shadow:inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(0,136,206,.6)}
-.form-control::-moz-placeholder{color:#999;opacity:1}
-.form-control:-ms-input-placeholder{color:#999}
-.form-control::-webkit-input-placeholder{color:#999}
+.form-control:-ms-input-placeholder{color:#999;font-style:italic}
+.form-control::-webkit-input-placeholder{color:#999;font-style:italic}
 .form-control::placeholder{color:#999;font-style:italic}
+.form-control:-moz-placeholder{color:#999;font-style:italic}
+.form-control::-moz-placeholder{color:#999;font-style:italic;opacity:1}
 .has-success .checkbox,.has-success .checkbox-inline,.has-success .control-label,.has-success .form-control-feedback,.has-success .help-block,.has-success .radio,.has-success .radio-inline,.has-success.checkbox label,.has-success.checkbox-inline label,.has-success.radio label,.has-success.radio-inline label{color:#3c763d}
 .form-control::-ms-expand{border:0;background-color:transparent}
 .form-control[disabled],.form-control[readonly],fieldset[disabled] .form-control{background-color:#f5f5f5;opacity:1}


### PR DESCRIPTION
Was removed from patternfly

fixes https://github.com/openshift/origin-web-console/issues/1259