### PR TITLE
Fix missing "Create Source Secret" link

### DIFF
--- a/app/views/create/fromimage.html
+++ b/app/views/create/fromimage.html
@@ -12,10 +12,10 @@
             <div class="row">
               <div class="col-md-12">
                 <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
-                <div ng-hide="imageStream">
+                <div ng-if="imageStream">
                   {{ emptyMessage }}
                 </div>
-                <div class="osc-form" ng-show="imageStream">
+                <div class="osc-form" ng-if="imageStream">
                   <alerts alerts="alerts"></alerts>
                   <div class="row">
                     <div class="col-md-2 icon hidden-sm hidden-xs">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5099,10 +5099,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
-    "<div ng-hide=\"imageStream\">\n" +
+    "<div ng-if=\"imageStream\">\n" +
     "{{ emptyMessage }}\n" +
     "</div>\n" +
-    "<div class=\"osc-form\" ng-show=\"imageStream\">\n" +
+    "<div class=\"osc-form\" ng-if=\"imageStream\">\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-2 icon hidden-sm hidden-xs\">\n" +


### PR DESCRIPTION
Make sure the project has loaded before the `canI` check is evaluated when creating from source.

Fixes #1279