### PR TITLE
[enterprise-3.5] Bug 1425728 - Fix cancel from add config files page

### DIFF
--- a/app/scripts/controllers/addConfigVolume.js
+++ b/app/scripts/controllers/addConfigVolume.js
@@ -63,9 +63,6 @@ angular.module('openshiftConsole')
       includeProject: true
     });
 
-    // Return URL for creating secrets.
-    $scope.returnURL = $location.url();
-
     var humanizeKind = $filter('humanizeKind');
     $scope.groupByKind = function(object) {
       return humanizeKind(object.kind);

--- a/app/scripts/controllers/createSecret.js
+++ b/app/scripts/controllers/createSecret.js
@@ -43,7 +43,7 @@ angular.module('openshiftConsole')
         return;
       }
 
-      Navigate.toResourceList('secrets', $scope.projectName);
+      $window.history.back();
     };
 
     ProjectsService

--- a/app/views/add-config-volume.html
+++ b/app/views/add-config-volume.html
@@ -61,7 +61,7 @@
                             </span>
                             <span ng-if="'secrets' | canI : 'create'">
                               <span ng-if="'configmaps' | canI : 'create'" class="action-divider" aria-hidden="true">|</span>
-                              <a ng-href="project/{{project.metadata.name}}/create-secret?then={{returnURL | encodeURIComponent}}">Create Secret</a>
+                              <a ng-href="project/{{project.metadata.name}}/create-secret">Create Secret</a>
                             </span>
                           </div>
                           <div class="help-block">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -6780,7 +6780,7 @@ link:"project/" + d.projectName + "/browse/secrets"
 title:"Create Secret"
 } ];
 var l = function() {
-return c.then ? void b.url(c.then) :void j.toResourceList("secrets", d.projectName);
+return c.then ? void b.url(c.then) :void e.history.back();
 };
 k.get(c.project).then(_.spread(function(b, e) {
 return d.project = b, d.context = e, d.breadcrumbs[0].title = a("displayName")(b), h.canI("secrets", "create", c.project) ? (d.postCreateAction = function(a, b) {
@@ -8939,7 +8939,7 @@ kind:c.kind,
 namespace:c.project,
 subpage:"Add Config Files",
 includeProject:!0
-}), d.returnURL = b.url();
+});
 var p = a("humanizeKind");
 d.groupByKind = function(a) {
 return p(a.kind);

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1061,7 +1061,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "<span ng-if=\"'secrets' | canI : 'create'\">\n" +
     "<span ng-if=\"'configmaps' | canI : 'create'\" class=\"action-divider\" aria-hidden=\"true\">|</span>\n" +
-    "<a ng-href=\"project/{{project.metadata.name}}/create-secret?then={{returnURL | encodeURIComponent}}\">Create Secret</a>\n" +
+    "<a ng-href=\"project/{{project.metadata.name}}/create-secret\">Create Secret</a>\n" +
     "</span>\n" +
     "</div>\n" +
     "<div class=\"help-block\">\n" +


### PR DESCRIPTION
If you click create secret, then cancel out both forms, you go back to the create secret page. Use `$window.history.back()` instead of a `then` parameter from the create secret page to prevent this.

https://bugzilla.redhat.com/show_bug.cgi?id=1425728