### PR TITLE
Fix bug 1426118, ignore namespace except for service account

### DIFF
--- a/app/scripts/controllers/membership.js
+++ b/app/scripts/controllers/membership.js
@@ -327,9 +327,11 @@ angular
             addRoleTo:function(subjectName, subjectKind, role, subjectNamespace) {
               var subject = {
                 name: subjectName,
-                kind: subjectKind,
-                namespace: subjectNamespace
+                kind: subjectKind
               };
+              if(subjectKind === 'ServiceAccount') {
+                subject.namespace = subjectNamespace;
+              }
               // TODO (bpeterse): future. Role/ClusterRole roleRef disambiguation
               // Edge case a user creates a local Role with same name as ClusterRole,
               // roleRef doesn't necessarily contain namespace. There may be a way to

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5669,9 +5669,10 @@ httpErr:a("getErrorDetails")(b)
 addRoleTo:function(a, b, c, e) {
 var f = {
 name:a,
-kind:b,
-namespace:e
-}, g = _.find(d.roleBindings, {
+kind:b
+};
+"ServiceAccount" === b && (f.namespace = e);
+var g = _.find(d.roleBindings, {
 roleRef:{
 name:c.metadata.name
 }


### PR DESCRIPTION
Fix bug #1426118

@jwforres @spadgett 

Ignoring the namespace for everything but `ServiceAccount` clears up this problem.