### PR TITLE
Change needed to allow multiple labels to display inline, but also truncate if parent width dictates

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -1159,14 +1159,14 @@ pre.clipped {
   margin-right: 5px;
   // A bit more space below the actions button.
   margin-top: 3px;
-  width: 100%; // needed to enable truncation within table
+  max-width: 100%; // needed to enable truncation within table, but still allow inline display if room is available
   &:before {
     content: ' ';
     white-space: normal;
   }
   .label-pair {
     margin-bottom: 2px;
-    width: 100%; // needed to enable truncation within table
+    max-width: 100%; // needed to enable truncation within table, but still allow inline display if room is available
   .label {
     // prevent short label-key or label-value from being truncated less than 4 characters
     min-width: 50px;

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4106,9 +4106,9 @@ status-icon .spinner.spinner-inline{margin-left:.153846em;margin-right:.153846em
 .last-status status-icon .spinner.spinner-inline{margin-left:4px;margin-right:4px}
 pre.clipped{display:inline-block;margin-top:10px;max-width:100%}
 pre.clipped.scroll{max-height:150px;overflow:auto;width:100%}
-.k8s-label{margin-right:5px;margin-top:3px;width:100%}
+.k8s-label{margin-right:5px;margin-top:3px;max-width:100%}
 .k8s-label:before{content:' ';white-space:normal}
-.k8s-label .label-pair{margin-bottom:2px;width:100%}
+.k8s-label .label-pair{margin-bottom:2px;max-width:100%}
 .k8s-label .label-pair .label{min-width:50px}
 .k8s-label .label-pair .label:first-child{border-radius:2px 0 0 2px}
 .k8s-label .label-pair .label:last-child{border-radius:0 2px 2px 0}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin-web-console/issues/1297

<img width="376" alt="screen shot 2017-02-24 at 2 36 56 pm" src="https://cloud.githubusercontent.com/assets/1874151/23319326/1137e3d8-faa4-11e6-8581-c920d2b06027.png">
<img width="653" alt="screen shot 2017-02-24 at 2 36 39 pm 2" src="https://cloud.githubusercontent.com/assets/1874151/23319325/11371796-faa4-11e6-8ba4-2851632b7123.png">
<img width="848" alt="screen shot 2017-02-24 at 2 36 16 pm" src="https://cloud.githubusercontent.com/assets/1874151/23319344/21a4a224-faa4-11e6-8708-33cfa5423ca3.png">
<img width="416" alt="screen shot 2017-02-24 at 2 34 07 pm" src="https://cloud.githubusercontent.com/assets/1874151/23319342/21a0a6ec-faa4-11e6-8d52-4afa81745f46.png">
<img width="606" alt="screen shot 2017-02-24 at 2 33 54 pm" src="https://cloud.githubusercontent.com/assets/1874151/23319343/21a27472-faa4-11e6-86a6-6ef512f4cf7a.png">

