### PR TITLE
Lock bootstrap-switch to version 3.3.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -45,7 +45,8 @@
     "js-yaml": "3.6.1",
     "angular-moment": "1.0.0",
     "angular-utf8-base64": "0.0.5",
-    "file-saver": "1.3.3"
+    "file-saver": "1.3.3",
+    "bootstrap-switch": "3.3.3"
   },
   "devDependencies": {
     "angular-mocks": "1.5.11",


### PR DESCRIPTION
Avoids jQuery conflicts with bootstrap-switch 3.3.4.

Fixes #1301

@jwforres Opinion on this change? It might be right to remove the dependency altogether, but this works around the bower conflict.