### PR TITLE
Bug  1421097 - Fix problems with secret links on build config page

### DIFF
--- a/app/scripts/directives/oscSourceSecrets.js
+++ b/app/scripts/directives/oscSourceSecrets.js
@@ -21,9 +21,9 @@ angular.module("openshiftConsole")
           var lastSecret = _.last($scope.pickedSecrets);
           switch ($scope.strategyType) {
           case 'Custom':
-            return lastSecret.secretSource.name;
+            return _.get(lastSecret, 'secretSource.name');
           default:
-            return lastSecret.secret.name;
+            return _.get(lastSecret, 'secret.name');
           }
         };
 

--- a/app/views/edit/build-config.html
+++ b/app/views/edit/build-config.html
@@ -347,8 +347,10 @@
                           </div>
                         </div>
 
-                        <div class="form-group" ng-if="strategyType !== 'JenkinsPipeline'">
-                          <!-- Use ng-show instead of ng-if so the form is still marked invalid if a hidden field has errors. -->
+                        <!-- Wait for project to load since the directive uses `canI` checks that need it. -->
+                        <div class="form-group" ng-if="project && strategyType !== 'JenkinsPipeline'">
+                          <!-- Use ng-show instead of ng-if when checking `view.advancedOptions` so
+                               the form is still marked invalid if a hidden field has errors. -->
                           <div ng-show="view.advancedOptions">
                             <osc-secrets model="secrets.picked.pullSecret"
                                         namespace="projectName"
@@ -401,19 +403,21 @@
                             </div>
                           </div>
 
-                          <!-- Use ng-show instead of ng-if so the form is still marked invalid if a hidden field has errors. -->
-                          <div class="form-group" ng-show="view.advancedOptions">
-                            <osc-secrets model="secrets.picked.pushSecret"
-                                        namespace="projectName"
-                                        display-type="push"
-                                        type="image"
-                                        disable-input="imageOptions.to.type==='None'"
-                                        service-account-to-link="builder"
-                                        secrets-by-type="secrets.secretsByType"
-                                        alerts="alerts">
-                            </osc-secrets>
+                          <!-- Wait for project to load since the directive uses `canI` checks that need it. -->
+                          <div ng-if="project">
+                            <!-- Use ng-show instead of ng-if so the form is still marked invalid if a hidden field has errors. -->
+                            <div class="form-group" ng-show="view.advancedOptions">
+                              <osc-secrets model="secrets.picked.pushSecret"
+                                          namespace="projectName"
+                                          display-type="push"
+                                          type="image"
+                                          disable-input="imageOptions.to.type==='None'"
+                                          service-account-to-link="builder"
+                                          secrets-by-type="secrets.secretsByType"
+                                          alerts="alerts">
+                              </osc-secrets>
+                            </div>
                           </div>
-
                         </div>
                       </dl>
                     </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10783,10 +10783,10 @@ b.canAddSourceSecret = function() {
 var a = _.last(b.pickedSecrets);
 switch (b.strategyType) {
 case "Custom":
-return a.secretSource.name;
+return _.get(a, "secretSource.name");
 
 default:
-return a.secret.name;
+return _.get(a, "secret.name");
 }
 }, b.setLastSecretsName = function(a) {
 var c = _.last(b.pickedSecrets);

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -9271,7 +9271,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"form-group\" ng-if=\"strategyType !== 'JenkinsPipeline'\">\n" +
+    "\n" +
+    "<div class=\"form-group\" ng-if=\"project && strategyType !== 'JenkinsPipeline'\">\n" +
     "\n" +
     "<div ng-show=\"view.advancedOptions\">\n" +
     "<osc-secrets model=\"secrets.picked.pullSecret\" namespace=\"projectName\" display-type=\"pull\" type=\"image\" secrets-by-type=\"secrets.secretsByType\" service-account-to-link=\"builder\" alerts=\"alerts\">\n" +
@@ -9306,9 +9307,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "\n" +
+    "<div ng-if=\"project\">\n" +
+    "\n" +
     "<div class=\"form-group\" ng-show=\"view.advancedOptions\">\n" +
     "<osc-secrets model=\"secrets.picked.pushSecret\" namespace=\"projectName\" display-type=\"push\" type=\"image\" disable-input=\"imageOptions.to.type==='None'\" service-account-to-link=\"builder\" secrets-by-type=\"secrets.secretsByType\" alerts=\"alerts\">\n" +
     "</osc-secrets>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</dl>\n" +


### PR DESCRIPTION
* Fix missing "Create Secret" link if the page is accessed directly by URL
* Fix runtime error in `canAddSourceSecret`

https://bugzilla.redhat.com/show_bug.cgi?id=1421097