### PR TITLE
Bug 1427084 - Fix problem showing project usage for cluster quota

### DIFF
--- a/app/scripts/controllers/quota.js
+++ b/app/scripts/controllers/quota.js
@@ -111,10 +111,10 @@ angular.module('openshiftConsole')
           $scope.clusterQuotas = _.sortBy(quotas.by("metadata.name"), "metadata.name");
           $scope.orderedTypesByClusterQuota = orderTypes($scope.clusterQuotas);
           $scope.namespaceUsageByClusterQuota = {};
-          _.each($scope.clusterQuotas, function(quota, quotaName) {
+          _.each($scope.clusterQuotas, function(quota) {
             if (quota.status) {
               var namespaceUsage = _.find(quota.status.namespaces, { namespace: $routeParams.project });
-              $scope.namespaceUsageByClusterQuota[quotaName] = namespaceUsage.status;
+              $scope.namespaceUsageByClusterQuota[quota.metadata.name] = namespaceUsage.status;
             }
           });
           Logger.log("cluster quotas", $scope.clusterQuotas);

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5268,12 +5268,12 @@ e.get(b.project).then(_.spread(function(a, e) {
 c.project = a, d.list("resourcequotas", e, function(a) {
 c.quotas = _.sortBy(a.by("metadata.name"), "metadata.name"), c.orderedTypesByQuota = k(c.quotas), f.log("quotas", c.quotas);
 }), d.list("appliedclusterresourcequotas", e, function(a) {
-c.clusterQuotas = _.sortBy(a.by("metadata.name"), "metadata.name"), c.orderedTypesByClusterQuota = k(c.clusterQuotas), c.namespaceUsageByClusterQuota = {}, _.each(c.clusterQuotas, function(a, d) {
+c.clusterQuotas = _.sortBy(a.by("metadata.name"), "metadata.name"), c.orderedTypesByClusterQuota = k(c.clusterQuotas), c.namespaceUsageByClusterQuota = {}, _.each(c.clusterQuotas, function(a) {
 if (a.status) {
-var e = _.find(a.status.namespaces, {
+var d = _.find(a.status.namespaces, {
 namespace:b.project
 });
-c.namespaceUsageByClusterQuota[d] = e.status;
+c.namespaceUsageByClusterQuota[a.metadata.name] = d.status;
 }
 }), f.log("cluster quotas", c.clusterQuotas);
 }), d.list("limitranges", e, function(a) {


### PR DESCRIPTION
Since we switched from a `clusterQuotas` map to a `clusterQuotas` array
for sorting, we incorrectly keyed the `namespaceUsageByClusterQuota` map
by array index instead of namespace. This prevented the project usage
for a cluster quota from displaying.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1427084

@benjaminapetersen ptal
@jwforres fyi