### PR TITLE
[enterprise-3.5] Bug 1427289 - Fix log updates when switching containers

### DIFF
--- a/app/scripts/directives/logViewer.js
+++ b/app/scripts/directives/logViewer.js
@@ -7,6 +7,7 @@ angular.module('openshiftConsole')
     '$timeout',
     '$window',
     '$filter',
+    '$q',
     'AuthService',
     'APIService',
     'APIDiscovery',
@@ -19,6 +20,7 @@ angular.module('openshiftConsole')
              $timeout,
              $window,
              $filter,
+             $q,
              AuthService,
              APIService,
              APIDiscovery,
@@ -264,9 +266,15 @@ angular.module('openshiftConsole')
             // since the user can (potentially) swap between multiple containers
             var streamer;
             var stopStreaming = function(keepContent) {
+              var deferred = $q.defer();
               if (streamer) {
+                streamer.onClose(function() {
+                  deferred.resolve();
+                });
                 streamer.stop();
-                streamer = null;
+              } else {
+                // Resolve immediately if no active stream.
+                deferred.resolve();
               }
 
               if (!keepContent) {
@@ -275,118 +283,120 @@ angular.module('openshiftConsole')
                 cachedLogNode && (cachedLogNode.innerHTML = '');
                 buffer = document.createDocumentFragment();
               }
+
+              return deferred.promise;
             };
 
             var streamLogs = function() {
               // Stop any active streamer.
-              stopStreaming();
-
-              if(!$scope.run) {
-                return;
-              }
-
-              angular.extend($scope, {
-                loading: true,
-                autoScrollActive: true,
-                limitReached: false,
-                showScrollLinks: false
-              });
-
-              var options = angular.extend({
-                follow: true,
-                tailLines: 5000,
-                // Limit log size to 10 MiB. Note: This can't be more than 500 MiB,
-                // otherwise save log will break because we'll exceed the max Blob
-                // size for some browsers.
-                // https://github.com/eligrey/FileSaver.js#supported-browsers
-                limitBytes: 10 * 1024 * 1024
-              }, $scope.options);
-
-              streamer = DataService.createStream(logSubresource, name, $scope.context, options);
-
-              var lastLineNumber = 0;
-              var addLine = function(text) {
-                lastLineNumber++;
-                // Append the line to the document fragment buffer.
-                buffer.appendChild(buildLogLineNode(lastLineNumber, text));
-                update();
-              };
-
-              streamer.onMessage(function(msg, raw, cumulativeBytes) {
-                // ensures the digest loop will catch the state change.
+              stopStreaming().then(function() {
                 $scope.$evalAsync(function() {
-                  $scope.empty = false;
-                  if($scope.state !== 'logs') {
-                    $scope.state = 'logs';
-                    // setTimeout so that the log content is visible to correctly calculate fill height.
-                    setTimeout(fillHeight);
+                  if(!$scope.run) {
+                    return;
                   }
-                });
 
-                // Completely empty messages (without even a newline character) should not add lines
-                if (!msg) {
-                  return;
-                }
-
-                if (options.limitBytes && cumulativeBytes >= options.limitBytes) {
-                  $scope.$evalAsync(function() {
-                    $scope.limitReached = true;
-                    $scope.loading = false;
-                  });
-                  stopStreaming(true);
-                }
-
-                addLine(msg);
-
-                // Warn the user if we might be showing a partial log.
-                if (!$scope.largeLog && lastLineNumber >= options.tailLines) {
-                  $scope.$evalAsync(function() {
-                    $scope.largeLog = true;
-                  });
-                }
-              });
-
-              streamer.onClose(function() {
-                streamer = null;
-                $scope.$evalAsync(function() {
-                  $scope.autoScrollActive = false;
-                  // - if no logs, they have already been archived.
-                  // - if emptyStateMessage has already been set, it means the onError
-                  //   callback has already fired.  onError message takes priority in severity.
-                  // - at present we are using the same error message in both onError and onClose
-                  //   because we dont have enough information to give the user something better.
-                  if((lastLineNumber === 0) && (!$scope.emptyStateMessage)) {
-                    $scope.state = 'empty';
-                    $scope.emptyStateMessage = 'The logs are no longer available or could not be loaded.';
-                  }
-                });
-
-                // Wrap in a timeout so that content displays before we remove the loading ellipses.
-                $timeout(function() {
-                  $scope.loading = false;
-                }, 100);
-              });
-
-              streamer.onError(function() {
-                streamer = null;
-                $scope.$evalAsync(function() {
                   angular.extend($scope, {
-                    loading: false,
-                    autoScrollActive: false
+                    loading: true,
+                    autoScrollActive: true,
+                    largeLog: false,
+                    limitReached: false,
+                    showScrollLinks: false,
+                    state: ''
                   });
-                  // if logs err before we get anything, will show an empty state message
-                  if(lastLineNumber === 0) {
-                    $scope.state = 'empty';
-                    $scope.emptyStateMessage = 'The logs are no longer available or could not be loaded.';
-                  } else {
-                    // if logs were running but something went wrong, will
-                    // show what we have & give option to retry
-                    $scope.errorWhileRunning = true;
-                  }
+
+                  var options = angular.extend({
+                    follow: true,
+                    tailLines: 5000,
+                    // Limit log size to 10 MiB. Note: This can't be more than 500 MiB,
+                    // otherwise save log will break because we'll exceed the max Blob
+                    // size for some browsers.
+                    // https://github.com/eligrey/FileSaver.js#supported-browsers
+                    limitBytes: 10 * 1024 * 1024
+                  }, $scope.options);
+
+                  streamer = DataService.createStream(logSubresource, name, $scope.context, options);
+
+                  var lastLineNumber = 0;
+                  var addLine = function(text) {
+                    lastLineNumber++;
+                    // Append the line to the document fragment buffer.
+                    buffer.appendChild(buildLogLineNode(lastLineNumber, text));
+                    update();
+                  };
+
+                  streamer.onMessage(function(msg, raw, cumulativeBytes) {
+                    // ensures the digest loop will catch the state change.
+                    $scope.$evalAsync(function() {
+                      $scope.empty = false;
+                      if($scope.state !== 'logs') {
+                        $scope.state = 'logs';
+                        // setTimeout so that the log content is visible to correctly calculate fill height.
+                        setTimeout(fillHeight);
+                      }
+                    });
+
+                    // Completely empty messages (without even a newline character) should not add lines
+                    if (!msg) {
+                      return;
+                    }
+
+                    if (options.limitBytes && cumulativeBytes >= options.limitBytes) {
+                      $scope.$evalAsync(function() {
+                        $scope.limitReached = true;
+                        $scope.loading = false;
+                      });
+                      stopStreaming(true);
+                    }
+
+                    addLine(msg);
+
+                    // Warn the user if we might be showing a partial log.
+                    if (!$scope.largeLog && lastLineNumber >= options.tailLines) {
+                      $scope.$evalAsync(function() {
+                        $scope.largeLog = true;
+                      });
+                    }
+                  });
+
+                  streamer.onClose(function() {
+                    streamer = null;
+                    $scope.$evalAsync(function() {
+                      $scope.loading = false;
+                      $scope.autoScrollActive = false;
+                      // - if no logs, they have already been archived.
+                      // - if emptyStateMessage has already been set, it means the onError
+                      //   callback has already fired.  onError message takes priority in severity.
+                      // - at present we are using the same error message in both onError and onClose
+                      //   because we dont have enough information to give the user something better.
+                      if((lastLineNumber === 0) && (!$scope.emptyStateMessage)) {
+                        $scope.state = 'empty';
+                        $scope.emptyStateMessage = 'The logs are no longer available or could not be loaded.';
+                      }
+                    });
+                  });
+
+                  streamer.onError(function() {
+                    streamer = null;
+                    $scope.$evalAsync(function() {
+                      angular.extend($scope, {
+                        loading: false,
+                        autoScrollActive: false
+                      });
+                      // if logs err before we get anything, will show an empty state message
+                      if(lastLineNumber === 0) {
+                        $scope.state = 'empty';
+                        $scope.emptyStateMessage = 'The logs are no longer available or could not be loaded.';
+                      } else {
+                        // if logs were running but something went wrong, will
+                        // show what we have & give option to retry
+                        $scope.errorWhileRunning = true;
+                      }
+                    });
+                  });
+
+                  streamer.start();
                 });
               });
-
-              streamer.start();
             };
 
             // Kibana archives -------------------------------------------------

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12081,11 +12081,11 @@ a.destroy();
 });
 }
 };
-} ]), angular.module("openshiftConsole").directive("logViewer", [ "$sce", "$timeout", "$window", "$filter", "AuthService", "APIService", "APIDiscovery", "DataService", "HTMLService", "ModalsService", "logLinks", "BREAKPOINTS", function(a, b, c, d, e, f, g, h, i, j, k, l) {
-var m = $(window), n = $('<tr class="log-line"><td class="log-line-number"></td><td class="log-line-text"></td></tr>').get(0), o = function(a, b) {
-var c = n.cloneNode(!0);
+} ]), angular.module("openshiftConsole").directive("logViewer", [ "$sce", "$timeout", "$window", "$filter", "$q", "AuthService", "APIService", "APIDiscovery", "DataService", "HTMLService", "ModalsService", "logLinks", "BREAKPOINTS", function(a, b, c, d, e, f, g, h, i, j, k, l, m) {
+var n = $(window), o = $('<tr class="log-line"><td class="log-line-number"></td><td class="log-line-text"></td></tr>').get(0), p = function(a, b) {
+var c = o.cloneNode(!0);
 c.firstChild.setAttribute("data-line-number", a);
-var d = ansi_up.escape_for_html(b), e = ansi_up.ansi_to_html(d), f = i.linkify(e, "_blank", !0);
+var d = ansi_up.escape_for_html(b), e = ansi_up.ansi_to_html(d), f = j.linkify(e, "_blank", !0);
 return c.lastChild.innerHTML = f, c;
 };
 return {
@@ -12104,140 +12104,147 @@ chromeless:"=?",
 empty:"=?",
 run:"=?"
 },
-controller:[ "$scope", function(i) {
-var j, n, p, q, r, s = document.documentElement;
-i.logViewerID = _.uniqueId("log-viewer"), i.empty = !0;
+controller:[ "$scope", function(b) {
+var j, k, o, q, r, s = document.documentElement;
+b.logViewerID = _.uniqueId("log-viewer"), b.empty = !0;
 var t, u;
-"ReplicationController" === i.object.kind ? (t = "deploymentconfigs/log", u = d("annotation")(i.object, "deploymentConfig")) :(t = f.kindToResource(i.object.kind) + "/log", u = i.object.metadata.name);
+"ReplicationController" === b.object.kind ? (t = "deploymentconfigs/log", u = d("annotation")(b.object, "deploymentConfig")) :(t = g.kindToResource(b.object.kind) + "/log", u = b.object.metadata.name);
 var v = function() {
-q = window.innerWidth < l.screenSmMin && !i.fixedHeight ? null :n;
+q = window.innerWidth < m.screenSmMin && !b.fixedHeight ? null :k;
 }, w = function() {
-i.$apply(function() {
+b.$apply(function() {
 var a = j.getBoundingClientRect();
-i.fixedHeight ? i.showScrollLinks = a && a.height > i.fixedHeight :i.showScrollLinks = a && (a.top < 0 || a.bottom > s.clientHeight);
+b.fixedHeight ? b.showScrollLinks = a && a.height > b.fixedHeight :b.showScrollLinks = a && (a.top < 0 || a.bottom > s.clientHeight);
 });
 }, x = !1, y = function() {
-x ? x = !1 :i.$evalAsync(function() {
-i.autoScrollActive = !1;
+x ? x = !1 :b.$evalAsync(function() {
+b.autoScrollActive = !1;
 });
 }, z = function() {
-p.off("scroll", y), m.off("scroll", y), window.innerWidth <= l.screenSmMin && !i.fixedHeight ? m.on("scroll", y) :p.on("scroll", y);
+o.off("scroll", y), n.off("scroll", y), window.innerWidth <= m.screenSmMin && !b.fixedHeight ? n.on("scroll", y) :o.on("scroll", y);
 }, A = function() {
-i.fixedHeight || (window.innerWidth < l.screenSmMin && !i.fixedHeight ? r.removeClass("target-logger-node").affix({
+b.fixedHeight || (window.innerWidth < m.screenSmMin && !b.fixedHeight ? r.removeClass("target-logger-node").affix({
 target:window,
 offset:{
-top:i.followAffixTop || 0
+top:b.followAffixTop || 0
 }
 }) :r.addClass("target-logger-node").affix({
-target:p,
+target:o,
 offset:{
-top:i.followAffixTop || 0
+top:b.followAffixTop || 0
 }
 }));
 }, B = function(a) {
-var b = $("#" + i.logViewerID + " .log-view-output"), c = b.offset().top;
-if (!(c < 0)) {
-var d = $(".ellipsis-pulser").outerHeight(!0), e = i.fixedHeight ? i.fixedHeight :Math.floor($(window).height() - c - d);
-i.chromeless || i.fixedHeight || (e -= 40), a ? b.animate({
-"min-height":e + "px"
-}, "fast") :b.css("min-height", e + "px"), i.fixedHeight && b.css("max-height", e);
+var c = $("#" + b.logViewerID + " .log-view-output"), d = c.offset().top;
+if (!(d < 0)) {
+var e = $(".ellipsis-pulser").outerHeight(!0), f = b.fixedHeight ? b.fixedHeight :Math.floor($(window).height() - d - e);
+b.chromeless || b.fixedHeight || (f -= 40), a ? c.animate({
+"min-height":f + "px"
+}, "fast") :c.css("min-height", f + "px"), b.fixedHeight && c.css("max-height", f);
 }
 }, C = _.debounce(function() {
 B(!0), v(), z(), w(), A(), y();
 }, 100);
-m.on("resize", C);
+n.on("resize", C);
 var D, E = function() {
-x = !0, k.scrollBottom(q);
+x = !0, l.scrollBottom(q);
 }, F = function() {
-i.autoScrollActive = !i.autoScrollActive, i.autoScrollActive && E();
+b.autoScrollActive = !b.autoScrollActive, b.autoScrollActive && E();
 }, G = document.createDocumentFragment(), H = _.debounce(function() {
-j.appendChild(G), G = document.createDocumentFragment(), i.autoScrollActive && E(), i.showScrollLinks || w();
+j.appendChild(G), G = document.createDocumentFragment(), b.autoScrollActive && E(), b.showScrollLinks || w();
 }, 100, {
 maxWait:300
 }), I = function(a) {
-D && (D.stop(), D = null), a || (H.cancel(), j && (j.innerHTML = ""), G = document.createDocumentFragment());
+var b = e.defer();
+return D ? (D.onClose(function() {
+b.resolve();
+}), D.stop()) :b.resolve(), a || (H.cancel(), j && (j.innerHTML = ""), G = document.createDocumentFragment()), b.promise;
 }, J = function() {
-if (I(), i.run) {
-angular.extend(i, {
+I().then(function() {
+b.$evalAsync(function() {
+if (b.run) {
+angular.extend(b, {
 loading:!0,
 autoScrollActive:!0,
+largeLog:!1,
 limitReached:!1,
-showScrollLinks:!1
+showScrollLinks:!1,
+state:""
 });
 var a = angular.extend({
 follow:!0,
 tailLines:5e3,
 limitBytes:10485760
-}, i.options);
-D = h.createStream(t, u, i.context, a);
+}, b.options);
+D = i.createStream(t, u, b.context, a);
 var c = 0, d = function(a) {
-c++, G.appendChild(o(c, a)), H();
+c++, G.appendChild(p(c, a)), H();
 };
-D.onMessage(function(b, e, f) {
-i.$evalAsync(function() {
-i.empty = !1, "logs" !== i.state && (i.state = "logs", setTimeout(B));
-}), b && (a.limitBytes && f >= a.limitBytes && (i.$evalAsync(function() {
-i.limitReached = !0, i.loading = !1;
-}), I(!0)), d(b), !i.largeLog && c >= a.tailLines && i.$evalAsync(function() {
-i.largeLog = !0;
+D.onMessage(function(e, f, g) {
+b.$evalAsync(function() {
+b.empty = !1, "logs" !== b.state && (b.state = "logs", setTimeout(B));
+}), e && (a.limitBytes && g >= a.limitBytes && (b.$evalAsync(function() {
+b.limitReached = !0, b.loading = !1;
+}), I(!0)), d(e), !b.largeLog && c >= a.tailLines && b.$evalAsync(function() {
+b.largeLog = !0;
 }));
 }), D.onClose(function() {
-D = null, i.$evalAsync(function() {
-i.autoScrollActive = !1, 0 !== c || i.emptyStateMessage || (i.state = "empty", i.emptyStateMessage = "The logs are no longer available or could not be loaded.");
-}), b(function() {
-i.loading = !1;
-}, 100);
+D = null, b.$evalAsync(function() {
+b.loading = !1, b.autoScrollActive = !1, 0 !== c || b.emptyStateMessage || (b.state = "empty", b.emptyStateMessage = "The logs are no longer available or could not be loaded.");
+});
 }), D.onError(function() {
-D = null, i.$evalAsync(function() {
-angular.extend(i, {
+D = null, b.$evalAsync(function() {
+angular.extend(b, {
 loading:!1,
 autoScrollActive:!1
-}), 0 === c ? (i.state = "empty", i.emptyStateMessage = "The logs are no longer available or could not be loaded.") :i.errorWhileRunning = !0;
+}), 0 === c ? (b.state = "empty", b.emptyStateMessage = "The logs are no longer available or could not be loaded.") :b.errorWhileRunning = !0;
 });
 }), D.start();
 }
+});
+});
 };
-return g.getLoggingURL().then(function(b) {
-var d = _.get(i.context, "project.metadata.name"), f = _.get(i.options, "container");
-d && f && u && b && (angular.extend(i, {
-kibanaAuthUrl:a.trustAsResourceUrl(URI(b).segment("auth").segment("token").normalizePathname().toString()),
-access_token:e.UserStore().getToken()
-}), i.$watchGroup([ "context.project.metadata.name", "options.container", "name" ], function() {
-angular.extend(i, {
-kibanaArchiveUrl:a.trustAsResourceUrl(k.archiveUri({
-namespace:i.context.project.metadata.name,
-namespaceUid:i.context.project.metadata.uid,
+return h.getLoggingURL().then(function(d) {
+var e = _.get(b.context, "project.metadata.name"), g = _.get(b.options, "container");
+e && g && u && d && (angular.extend(b, {
+kibanaAuthUrl:a.trustAsResourceUrl(URI(d).segment("auth").segment("token").normalizePathname().toString()),
+access_token:f.UserStore().getToken()
+}), b.$watchGroup([ "context.project.metadata.name", "options.container", "name" ], function() {
+angular.extend(b, {
+kibanaArchiveUrl:a.trustAsResourceUrl(l.archiveUri({
+namespace:b.context.project.metadata.name,
+namespaceUid:b.context.project.metadata.uid,
 podname:u,
-containername:i.options.container,
+containername:b.options.container,
 backlink:URI.encode(c.location.href)
 }))
 });
 }));
 }), this.cacheScrollableNode = function(a) {
-n = a, p = $(n);
+k = a, o = $(k);
 }, this.cacheLogNode = function(a) {
 j = a;
 }, this.cacheAffixable = function(a) {
 r = $(a);
 }, this.start = function() {
 v(), z(), A();
-}, angular.extend(i, {
+}, angular.extend(b, {
 ready:!0,
 loading:!0,
 autoScrollActive:!0,
 state:!1,
 onScrollBottom:function() {
-k.scrollBottom(q);
+l.scrollBottom(q);
 },
 onScrollTop:function() {
-i.autoScrollActive = !1, k.scrollTop(q);
+b.autoScrollActive = !1, l.scrollTop(q);
 },
 toggleAutoScroll:F,
-goChromeless:k.chromelessLink,
+goChromeless:l.chromelessLink,
 restartLogs:J
-}), i.$on("$destroy", function() {
-I(), m.off("resize", C), m.off("scroll", y), p.off("scroll", y);
-}), "deploymentconfigs/logs" !== t || u ? void i.$watchGroup([ "name", "options.container", "run" ], J) :(i.state = "empty", void (i.emptyStateMessage = "Logs are not available for this replication controller because it was not generated from a deployment configuration."));
+}), b.$on("$destroy", function() {
+I(), n.off("resize", C), n.off("scroll", y), o.off("scroll", y);
+}), "deploymentconfigs/logs" !== t || u ? void b.$watchGroup([ "name", "options.container", "run" ], J) :(b.state = "empty", void (b.emptyStateMessage = "Logs are not available for this replication controller because it was not generated from a deployment configuration."));
 } ],
 require:"logViewer",
 link:function(a, c, d, e) {
@@ -12251,7 +12258,7 @@ type:"text/plain;charset=utf-8"
 saveAs(e, d);
 };
 a.canSave = !!new Blob(), a.saveLog = function() {
-return a.largeLog ? void j.confirmSaveLog(a.object).then(f) :void f();
+return a.largeLog ? void k.confirmSaveLog(a.object).then(f) :void f();
 };
 }
 };


### PR DESCRIPTION
The `onClose` callback for log streamers happens asynchronously. Make
sure the `onClose` cleanup happens before we begin streaming the next
container log.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1427289