### PR TITLE
Include conditional style to set spacing for ui-select

### DIFF
--- a/app/views/browse/pod.html
+++ b/app/views/browse/pod.html
@@ -89,7 +89,8 @@
                       context="projectContext"
                       options="logOptions"
                       empty="logEmpty"
-                      run="logCanRun">
+                      run="logCanRun"
+                      ng-class="{'log-viewer-select': pod.spec.containers.length > 1}">
 
                       <span class="container-details">
                         <label for="selectLogContainer">Container:</label>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3320,7 +3320,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</uib-tab>\n" +
     "<uib-tab active=\"selectedTab.logs\" ng-if=\"'pods/log' | canI : 'get'\">\n" +
     "<uib-tab-heading>Logs</uib-tab-heading>\n" +
-    "<log-viewer ng-if=\"selectedTab.logs\" follow-affix-top=\"390\" object=\"pod\" context=\"projectContext\" options=\"logOptions\" empty=\"logEmpty\" run=\"logCanRun\">\n" +
+    "<log-viewer ng-if=\"selectedTab.logs\" follow-affix-top=\"390\" object=\"pod\" context=\"projectContext\" options=\"logOptions\" empty=\"logEmpty\" run=\"logCanRun\" ng-class=\"{'log-viewer-select': pod.spec.containers.length > 1}\">\n" +
     "<span class=\"container-details\">\n" +
     "<label for=\"selectLogContainer\">Container:</label>\n" +
     "<span ng-if=\"pod.spec.containers.length === 1\">\n" +


### PR DESCRIPTION
This is also used on the monitoring page to set spacing beneath the select if it exists. 

Fixes https://github.com/openshift/origin-web-console/issues/1309

<img width="615" alt="screen shot 2017-03-01 at 11 21 29 am" src="https://cloud.githubusercontent.com/assets/1874151/23469842/cddc8fe4-fe72-11e6-86fe-acfb59f49606.png">
