### PR TITLE
Introduction of a horizontal scroll mixin that displays left and right dropshadow as visual cue.

### DIFF
--- a/app/styles/_forms.less
+++ b/app/styles/_forms.less
@@ -9,6 +9,7 @@
 }
 
 .copy-to-clipboard-multiline {
+  display: block;
   position: relative;
   width: 100%;
   a {

--- a/app/styles/_scroll-shadows-horizontal.less
+++ b/app/styles/_scroll-shadows-horizontal.less
@@ -1,0 +1,36 @@
+// Horizontal scroll drop shadows
+// Adds drop shadows to left and right edges that display when scrollable content is hidden
+// Test cases http://codepen.io/sg00dwin/pen/GWWRLR/
+@scroll-shadows-horizontal-bg:         rgba(255,255,255,1);
+@bg-color:                             @scroll-shadows-horizontal-bg;
+
+.scroll-shadows-horizontal(@bg-color: @scroll-shadows-horizontal-bg) {
+  background:
+    radial-gradient(ellipse at left, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0) 75%) 0 center, // left shadow
+    radial-gradient(ellipse at right, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0) 75%) 100% center, // right shadow
+    @bg-color;
+  background-size:
+    10px 100%,
+    10px 100%;
+  background-attachment:
+    scroll,
+    scroll;
+  background-repeat: no-repeat;
+	// make horizontally scrollable
+	overflow-x: auto;
+  min-height: .01%;
+
+	// White gradient to hide the scroll shadows when at the farthermost scroll positions
+	// change these gradients from white to your background colour if it differs
+  // background-images must be on a different element than the scroll-shadows-horizontal
+	> .scroll-shadows-cover {
+		  overflow: auto;
+			background-image:
+			linear-gradient(to left, rgba(255, 255, 255, .0) 0%, rgba(255, 255, 255, 1) 100%), // left shadow cover
+			linear-gradient(to right, rgba(255, 255, 255, .0) 0%,rgba(255, 255, 255, 1) 100%);  // right shadow cover
+			background-repeat: no-repeat;
+			background-size: 50px 100%, 50px 100%;
+			background-position:  0 center, 100% center;
+			background-attachment: local, local;
+	}
+}

--- a/app/styles/_tables.less
+++ b/app/styles/_tables.less
@@ -108,13 +108,13 @@
         }
       }
     }
-    &.table-bordered-columns > {
-      tbody, thead {
-        > tr > {
-          td, th {
-            border-left: 1px solid @table-border-color;
-            border-right: 1px solid @table-border-color;
-          }
+  }
+  &.table-bordered-columns > {
+    tbody, thead {
+      > tr > {
+        td, th {
+          border-left: 1px solid @table-border-color;
+          border-right: 1px solid @table-border-color;
         }
       }
     }
@@ -215,24 +215,31 @@
   }
 }
 
+// for testing
+.middle { background-color: #def3ff}
 .table-responsive {
   margin-bottom: @line-height-computed;
-  @media(max-width: @screen-xs-max) {
-    .table.table-bordered {
-      > tbody, > thead {
-        > tr {
-          &:first-child {
-            > td, > th {
-              border-top: 0;
-            }
-          }
+  .scroll-shadows-horizontal();
+    .table {
+      // custom background color can be set on scroll-shadows-horizontal() otherwise it will be white
+      background-color: transparent;
+      margin-bottom: 0;
+    }
+  .table.table-bordered {
+    border: 0;
+    > tbody, > thead {
+      > tr {
+        &:first-child {
           > td, > th {
-            &:first-child {
-              border-left: 0;
-            }
-            &:last-child {
-              border-right: 0;
-            }
+            border-top: 0;
+          }
+        }
+        > td, > th {
+          &:first-child {
+            border-left: 0;
+          }
+          &:last-child {
+            border-right: 0;
           }
         }
       }

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -28,6 +28,7 @@
 @import "_project-menu.less";
 @import "_responsive-utilities.less";
 @import "_scrollbars.less";
+@import "_scroll-shadows-horizontal.less";
 @import "_select.less";
 @import "_secrets.less";
 @import "_sidebar.less";

--- a/app/views/directives/annotations.html
+++ b/app/views/directives/annotations.html
@@ -3,22 +3,24 @@
   <a href="" ng-click="toggleAnnotations()" ng-if="expandAnnotations">Hide Annotations</a>
 </p>
 <div ng-if="expandAnnotations">
-  <div ng-if="annotations" class="table-responsive">
-    <table class="table table-bordered table-bordered-columns key-value-table">
-      <tbody>
-        <tr ng-repeat="(annotationKey, annotationValue) in annotations">
-          <td class="key">{{annotationKey}}</td>
-          <td class="value">
-            <truncate-long-text
+  <div ng-if="annotations" class="table-responsive scroll-shadows-horizontal">
+    <div class="scroll-shadows-cover">
+      <table class="table table-bordered table-bordered-columns key-value-table">
+        <tbody>
+          <tr ng-repeat="(annotationKey, annotationValue) in annotations">
+            <td class="key">{{annotationKey}}</td>
+            <td class="value">
+              <truncate-long-text
                 content="annotationValue | prettifyJSON"
                 limit="500"
                 newlineLimit="20"
                 expandable="true">
-            </truncate-long-text>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+              </truncate-long-text>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
   <p ng-if="!annotations" class="mar-bottom-xl">
     There are no annotations on this resource.

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -1,6 +1,7 @@
 div.code,pre,textarea{overflow:auto}
 .text-left,caption,th{text-align:left}
-.bootstrap-select.btn-group .dropdown-menu li a,.datepicker table{-ms-user-select:none;-webkit-user-select:none;-moz-user-select:none}
+.btn,.datepicker table{-webkit-user-select:none}
+.navbar-fixed-bottom .navbar-collapse,.navbar-fixed-top .navbar-collapse,.pre-scrollable{max-height:340px}
 .c3 svg,html{-webkit-tap-highlight-color:transparent}
 .list-view-pf-top-align .list-view-pf-actions,.list-view-pf-top-align .list-view-pf-checkbox{align-self:flex-start}
 @font-face{font-family:"Open Sans";font-style:normal;font-weight:300;src:url(../styles/fonts/OpenSans-Light-webfont.eot);src:local("Open Sans Light"),local("OpenSans-Light"),url(../styles/fonts/OpenSans-Light-webfont.eot?#iefix) format("embedded-opentype"),url(../styles/fonts/OpenSans-Light-webfont.woff2) format("woff2"),url(../styles/fonts/OpenSans-Light-webfont.woff) format("woff"),url(../styles/fonts/OpenSans-Light-webfont.ttf) format("truetype"),url(../styles/fonts/OpenSans-Light-webfont.svg#OpenSans) format("svg")}
@@ -425,7 +426,7 @@ div.code,pre{padding:10px;margin:0 0 10.5px;font-size:12px;line-height:1.6666666
 pre code,table{background-color:transparent}
 pre code{padding:0;font-size:inherit;color:inherit;white-space:pre-wrap;border-radius:0}
 .container,.container-fluid{padding-left:20px;padding-right:20px}
-.pre-scrollable{max-height:340px;overflow-y:scroll}
+.pre-scrollable{overflow-y:scroll}
 @media (min-width:768px){.container{width:760px}
 }
 @media (min-width:992px){.container{width:980px}
@@ -766,7 +767,7 @@ select[multiple].input-lg,textarea.input-lg{height:auto}
 @media (min-width:768px){.form-horizontal .form-group-lg .control-label{padding-top:7px;font-size:15px}
 .form-horizontal .form-group-sm .control-label{padding-top:3px;font-size:11px}
 }
-.btn{display:inline-block;margin-bottom:0;font-weight:600;text-align:center;vertical-align:middle;touch-action:manipulation;cursor:pointer;border:1px solid transparent;white-space:nowrap;padding:2px 6px;font-size:13px;line-height:1.66666667;border-radius:1px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+.btn{display:inline-block;margin-bottom:0;font-weight:600;text-align:center;vertical-align:middle;touch-action:manipulation;cursor:pointer;border:1px solid transparent;white-space:nowrap;padding:2px 6px;font-size:13px;line-height:1.66666667;border-radius:1px;-moz-user-select:none;-ms-user-select:none;user-select:none}
 .btn.active.focus,.btn.active:focus,.btn.focus,.btn:active.focus,.btn:active:focus,.btn:focus{outline:dotted thin!important;outline:-webkit-focus-ring-color auto 5px!important;outline-offset:-2px!important}
 .btn.focus,.btn:focus,.btn:hover{color:#4d5258;text-decoration:none}
 .btn.active,.btn:active{outline:0;-webkit-box-shadow:inset 0 3px 5px rgba(0,0,0,.125);box-shadow:inset 0 3px 5px rgba(0,0,0,.125)}
@@ -952,7 +953,6 @@ select[multiple].input-group-sm>.form-control,select[multiple].input-group-sm>.i
 .navbar-fixed-bottom .navbar-collapse,.navbar-fixed-top .navbar-collapse,.navbar-static-top .navbar-collapse{padding-left:0;padding-right:0}
 }
 .embed-responsive,.modal,.modal-open,.progress{overflow:hidden}
-.navbar-fixed-bottom .navbar-collapse,.navbar-fixed-top .navbar-collapse{max-height:340px}
 @media (max-device-width:480px) and (orientation:landscape){.navbar-fixed-bottom .navbar-collapse,.navbar-fixed-top .navbar-collapse{max-height:200px}
 }
 .container-fluid>.navbar-collapse,.container-fluid>.navbar-header,.container>.navbar-collapse,.container>.navbar-header{margin-right:-20px;margin-left:-20px}
@@ -2319,7 +2319,7 @@ td>.progress:first-child:last-child{margin-bottom:0;margin-top:3px}
 .datepicker-dropdown.datepicker-orient-bottom:after{top:-6px}
 .datepicker-dropdown.datepicker-orient-top:before{bottom:-7px;border-bottom:0;border-top:7px solid #bbb}
 .datepicker-dropdown.datepicker-orient-top:after{bottom:-6px;border-bottom:0;border-top:6px solid #fff}
-.datepicker table{margin:0;-webkit-touch-callout:none;-khtml-user-select:none;user-select:none}
+.datepicker table{margin:0;-webkit-touch-callout:none;-khtml-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
 .datepicker table tr td,.datepicker table tr th{text-align:center;width:30px;height:30px;border:none}
 .datepicker table tr td.new,.datepicker table tr td.old{color:#9c9c9c}
 .datepicker table tr td.day:hover,.datepicker table tr td.focused{background:#f1f1f1;cursor:pointer}
@@ -2425,8 +2425,7 @@ select.bs-select-hidden,select.selectpicker{display:none!important}
 .bootstrap-select.btn-group .dropdown-menu.inner{position:static;float:none;border:0;padding:0;margin:0;border-radius:0;box-shadow:none}
 .bootstrap-select.btn-group .dropdown-menu li{position:relative}
 .bootstrap-select.btn-group .dropdown-menu li.active small{color:#fff}
-.bootstrap-select.btn-group .dropdown-menu li a{cursor:pointer;user-select:none}
-.bootstrap-switch,.c3 text{-webkit-user-select:none;-moz-user-select:none}
+.bootstrap-select.btn-group .dropdown-menu li a{cursor:pointer;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
 .bootstrap-select.btn-group .dropdown-menu li a.opt{position:relative;padding-left:2.25em}
 .bootstrap-select.btn-group .dropdown-menu li a span.check-mark{display:none}
 .bootstrap-select.btn-group .dropdown-menu li a span.text{display:inline-block}
@@ -2453,9 +2452,9 @@ select.bs-select-hidden,select.selectpicker{display:none!important}
 .bs-donebutton .btn-group button{width:100%}
 .bs-searchbox+.bs-actionsbox{padding:0 8px 4px}
 .bs-searchbox .form-control{margin-bottom:0;width:100%;float:none}
-.bootstrap-switch{display:inline-block;direction:ltr;cursor:pointer;border-radius:1px;border:1px solid #bbb;position:relative;text-align:left;overflow:hidden;line-height:8px;z-index:0;-ms-user-select:none;user-select:none;vertical-align:middle;-webkit-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;-o-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s}
+.bootstrap-switch{display:inline-block;direction:ltr;cursor:pointer;border-radius:1px;border:1px solid #bbb;position:relative;text-align:left;overflow:hidden;line-height:8px;z-index:0;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;vertical-align:middle;-webkit-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;-o-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s}
 .bootstrap-switch .bootstrap-switch-container{display:inline-block;top:0;border-radius:1px;-webkit-transform:translate3d(0,0,0);transform:translate3d(0,0,0)}
-.bootstrap-switch .bootstrap-switch-handle-off,.bootstrap-switch .bootstrap-switch-handle-on,.bootstrap-switch .bootstrap-switch-label{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;cursor:pointer;display:inline-block!important;height:100%;padding:2px 6px;font-size:13px;line-height:21px}
+.bootstrap-switch .bootstrap-switch-handle-off,.bootstrap-switch .bootstrap-switch-handle-on,.bootstrap-switch .bootstrap-switch-label{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;cursor:pointer;display:table-cell;vertical-align:middle;padding:2px 6px;font-size:13px;line-height:21px}
 .ie9.layout-pf-alt-fixed .nav-pf-vertical-alt,.ie9.layout-pf-fixed .nav-pf-secondary-nav,.ie9.layout-pf-fixed .nav-pf-tertiary-nav,.ie9.layout-pf-fixed .nav-pf-vertical,.list-group-item-header{box-sizing:content-box}
 .bootstrap-switch .bootstrap-switch-handle-off,.bootstrap-switch .bootstrap-switch-handle-on{text-align:center;z-index:1}
 .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-primary,.bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-primary{color:#fff;background:#0088ce}
@@ -2465,9 +2464,10 @@ select.bs-select-hidden,select.selectpicker{display:none!important}
 .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-danger,.bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-danger{color:#fff;background:#a30000}
 .bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-default,.bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-default{color:#000}
 .bootstrap-switch .bootstrap-switch-label{text-align:center;margin-top:-1px;margin-bottom:-1px;color:#4d5258}
+.bootstrap-switch span::before{content:"\200b"}
 .bootstrap-switch .bootstrap-switch-handle-on{border-bottom-left-radius:0px;border-top-left-radius:0px}
 .bootstrap-switch .bootstrap-switch-handle-off{border-bottom-right-radius:0px;border-top-right-radius:0px}
-.bootstrap-switch input[type=radio],.bootstrap-switch input[type=checkbox]{position:absolute!important;top:0;left:0;margin:0;z-index:-1;opacity:0;filter:alpha(opacity=0)}
+.bootstrap-switch input[type=radio],.bootstrap-switch input[type=checkbox]{position:absolute!important;top:0;left:0;margin:0;z-index:-1;opacity:0;filter:alpha(opacity=0);visibility:hidden}
 .bootstrap-switch.bootstrap-switch-mini .bootstrap-switch-handle-off,.bootstrap-switch.bootstrap-switch-mini .bootstrap-switch-handle-on,.bootstrap-switch.bootstrap-switch-mini .bootstrap-switch-label{padding:1px 5px;font-size:11px;line-height:1.5}
 .bootstrap-switch.bootstrap-switch-small .bootstrap-switch-handle-off,.bootstrap-switch.bootstrap-switch-small .bootstrap-switch-handle-on,.bootstrap-switch.bootstrap-switch-small .bootstrap-switch-label{padding:2px 6px;font-size:11px;line-height:1.5}
 .bootstrap-switch.bootstrap-switch-large .bootstrap-switch-handle-off,.bootstrap-switch.bootstrap-switch-large .bootstrap-switch-handle-on,.bootstrap-switch.bootstrap-switch-large .bootstrap-switch-label{padding:2px 10px;font-size:15px;line-height:1.3333333}
@@ -2487,7 +2487,7 @@ select.bs-select-hidden,select.selectpicker{display:none!important}
 .bootstrap-touchspin .input-group-btn-vertical i{position:absolute;font-weight:400}
 .c3 svg{font:10px sans-serif}
 .c3 line,.c3 path{fill:none;stroke:#000}
-.c3 text{user-select:none}
+.c3 text{-webkit-user-select:none;-moz-user-select:none;user-select:none}
 .c3-bars path,.c3-event-rect,.c3-legend-item-tile,.c3-xgrid-focus,.c3-ygrid{shape-rendering:crispEdges}
 .c3-chart-arc text{fill:#fff;font-size:13px}
 .c3-grid text{fill:#aaa}
@@ -3673,7 +3673,7 @@ table.dataTable th:active{outline:0}
 .static-form-value-large{font-family:inherit;font-weight:500;line-height:1.1;color:inherit;margin-bottom:10.5px;font-size:16px;margin-top:3px}
 .static-form-value-large .small,.static-form-value-large small{font-weight:400;line-height:1;color:#9c9c9c;font-size:65%}
 .copy-to-clipboard input.form-control:read-only{background-color:#fff;color:#363636}
-.copy-to-clipboard-multiline{position:relative;width:100%}
+.copy-to-clipboard-multiline{display:block;position:relative;width:100%}
 .copy-to-clipboard-multiline a{box-shadow:none;position:absolute;right:0;top:0}
 .copy-to-clipboard-multiline pre{background-color:#fff;max-width:100%;overflow-x:auto}
 .input-group-addon.wildcard-prefix{padding-left:10px}
@@ -4896,7 +4896,7 @@ td.visible-print,th.visible-print{display:table-cell!important}
 .osc-secrets-form .advanced-secrets .secret-row .destination-dir,.osc-secrets-form .advanced-secrets .secret-row .secret-name{width:50%;display:inline-block}
 .osc-secrets-form .advanced-secrets .secret-row .destination-dir{padding-left:5px}
 dl.secret-data{overflow:hidden}
-dl.secret-data pre{margin-bottom:0}
+dl.secret-data pre{margin-bottom:0;background:linear-gradient(to left,rgba(255,255,255,.25) 0%,#fff 100%) 0 center,linear-gradient(to right,rgba(255,255,255,.25) 0%,#fff 100%) 100% center,radial-gradient(ellipse at left,rgba(0,0,0,.25) 0%,rgba(0,0,0,0) 75%) 0 center,radial-gradient(ellipse at right,rgba(0,0,0,.25) 0%,rgba(0,0,0,0) 75%) 100% center,#fff;background-size:50px 100%,50px 100%,10px 100%,10px 100%;background-attachment:local,local,scroll,scroll;background-repeat:no-repeat;border:1px solid #d1d1d1}
 .create-secret-form .help-block,dl.secret-data dd{margin-bottom:10px}
 dl.secret-data dd{overflow-x:auto}
 .events-sidebar .right-content .event .event-details,.events-sidebar .right-content .event .event-details .event-message,.events-sidebar .right-content .event .event-details .event-object,.events-sidebar .right-content .event .event-details .event-reason{overflow:hidden;white-space:nowrap;text-overflow:ellipsis}
@@ -5077,7 +5077,7 @@ body,html{margin:0;padding:0}
 .key-value-table>tbody>tr>td.value .truncated-content{white-space:pre}
 .table{background-color:#fff}
 .table.table-bordered>tbody>tr td,.table.table-bordered>tbody>tr th,.table.table-bordered>thead>tr td,.table.table-bordered>thead>tr th{border-left:0;border-right:0;padding-bottom:8px;padding-top:8px;vertical-align:middle}
-.table-filter-wrapper,.table.table-bordered.table-bordered-columns tbody>tr td,.table.table-bordered.table-bordered-columns tbody>tr th,.table.table-bordered.table-bordered-columns thead>tr td,.table.table-bordered.table-bordered-columns thead>tr th{border-left:1px solid #d1d1d1;border-right:1px solid #d1d1d1}
+.table-filter-wrapper,.table.table-bordered-columns tbody>tr td,.table.table-bordered-columns tbody>tr th,.table.table-bordered-columns thead>tr td,.table.table-bordered-columns thead>tr th{border-left:1px solid #d1d1d1;border-right:1px solid #d1d1d1}
 .table.table-layout-fixed{table-layout:fixed}
 .table.table-layout-fixed td{overflow-wrap:break-word}
 .table>tbody+tbody{border-top-width:1px}
@@ -5097,11 +5097,13 @@ body,html{margin:0;padding:0}
 .table-mobile>tbody>tr>td{border:none;border-bottom:1px solid #dedede;min-height:37.67px;padding-left:35%;position:relative}
 .table-mobile>tbody>tr>td:last-child{border-bottom:none}
 .table-mobile>tbody>tr>td:before{content:attr(data-title);position:absolute;top:8px;left:6px;width:35%;padding-right:10px;white-space:nowrap}
+}
+.table-responsive{margin-bottom:21px;background:linear-gradient(to left,rgba(255,255,255,.25) 0%,#fff 100%) 0 center,linear-gradient(to right,rgba(255,255,255,.25) 0%,#fff 100%) 100% center,radial-gradient(ellipse at left,rgba(0,0,0,.25) 0%,rgba(0,0,0,0) 75%) 0 center,radial-gradient(ellipse at right,rgba(0,0,0,.25) 0%,rgba(0,0,0,0) 75%) 100% center,#fff;background-size:50px 100%,50px 100%,10px 100%,10px 100%;background-attachment:local,local,scroll,scroll;background-repeat:no-repeat;border:1px solid #d1d1d1}
+.table-responsive .table{background-color:transparent}
+.table-responsive .table.table-bordered{border:0}
 .table-responsive .table.table-bordered>tbody>tr:first-child>td,.table-responsive .table.table-bordered>tbody>tr:first-child>th,.table-responsive .table.table-bordered>thead>tr:first-child>td,.table-responsive .table.table-bordered>thead>tr:first-child>th{border-top:0}
 .table-responsive .table.table-bordered>tbody>tr>td:first-child,.table-responsive .table.table-bordered>tbody>tr>th:first-child,.table-responsive .table.table-bordered>thead>tr>td:first-child,.table-responsive .table.table-bordered>thead>tr>th:first-child{border-left:0}
 .table-responsive .table.table-bordered>tbody>tr>td:last-child,.table-responsive .table.table-bordered>tbody>tr>th:last-child,.table-responsive .table.table-bordered>thead>tr>td:last-child,.table-responsive .table.table-bordered>thead>tr>th:last-child{border-right:0}
-}
-.table-responsive{margin-bottom:21px}
 .table>tbody>tr.disabled>td,.table>tbody>tr.disabled>th,.table>tbody>tr>td.disabled,.table>tbody>tr>th.disabled,.table>tfoot>tr.disabled>td,.table>tfoot>tr.disabled>th,.table>tfoot>tr>td.disabled,.table>tfoot>tr>th.disabled,.table>thead>tr.disabled>td,.table>thead>tr.disabled>th,.table>thead>tr>td.disabled,.table>thead>tr>th.disabled{background-color:#f5f5f5}
 .table-hover>tbody>tr.disabled:hover>td,.table-hover>tbody>tr.disabled:hover>th,.table-hover>tbody>tr:hover>.disabled,.table-hover>tbody>tr>td.disabled:hover,.table-hover>tbody>tr>th.disabled:hover{background-color:#e8e8e8}
 td[role=presentation].arrow:after{content:"\2193"}


### PR DESCRIPTION
Current usage on `.table-responsive` and multi line secrets with `pre`
Can be added to other elements as needed.

Fixes https://github.com/openshift/origin-web-console/issues/1237

![screen shot 2017-03-03 at 10 43 15 am](https://cloud.githubusercontent.com/assets/1874151/23571065/26947818-0035-11e7-8666-299110af8820.png)

![screen shot 2017-03-03 at 5 19 33 pm](https://cloud.githubusercontent.com/assets/1874151/23571160/a6ace86e-0035-11e7-8dea-9847801712cc.png)


![screen shot 2017-03-03 at 1 13 43 pm](https://cloud.githubusercontent.com/assets/1874151/23571059/1fdaf38a-0035-11e7-9536-5df2f7e9ebf3.png)

![screen shot 2017-03-03 at 10 44 27 am](https://cloud.githubusercontent.com/assets/1874151/23571110/6e2e0fe0-0035-11e7-96f0-ddfe93d08842.png)




