### PR TITLE
Redesigned Overview

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -208,10 +208,13 @@
         <script src="scripts/services/keyValueEditorProvider.js"></script>
         <script src="scripts/services/keyValueEditorUtils.js"></script>
         <script src="scripts/services/fullscreen.js"></script>
+        <script src="scripts/services/apps.js"></script>
+        <script src="scripts/services/resourceAlerts.js"></script>
         <script src="scripts/controllers/projects.js"></script>
         <script src="scripts/controllers/pods.js"></script>
         <script src="scripts/controllers/pod.js"></script>
         <script src="scripts/controllers/overview.js"></script>
+        <script src="scripts/controllers/newOverview.js"></script>
         <script src="scripts/controllers/topology.js"></script>
         <script src="scripts/controllers/quota.js"></script>
         <script src="scripts/controllers/monitoring.js"></script>
@@ -337,6 +340,9 @@
         <script src="scripts/directives/editCommand.js"></script>
         <script src="scripts/directives/buildPipeline.js"></script>
         <script src="scripts/directives/buildStatus.js"></script>
+        <script src="scripts/directives/routeServiceBarChart.js"></script>
+
+        <!-- Old Overview, TODO: remove -->
         <script src="scripts/directives/serviceGroupNotifications.js"></script>
         <script src="scripts/directives/overview/service.js"></script>
         <script src="scripts/directives/overview/serviceGroup.js"></script>
@@ -345,6 +351,17 @@
         <script src="scripts/directives/overview/dc.js"></script>
         <script src="scripts/directives/overview/deployment.js"></script>
         <script src="scripts/directives/overview/imageNames.js"></script>
+
+        <!-- New Overview -->
+        <script src="scripts/directives/buildCounts.js"></script>
+        <script src="scripts/directives/metricsSummary.js"></script>
+        <script src="scripts/directives/miniLog.js"></script>
+        <script src="scripts/directives/notificationIcon.js"></script>
+        <script src="scripts/directives/overview/builds.js"></script>
+        <script src="scripts/directives/overview/listRow.js"></script>
+        <script src="scripts/directives/overview/networking.js"></script>
+        <script src="scripts/directives/overview/pipelines.js"></script>
+
         <script src="scripts/directives/istagSelect.js"></script>
         <script src="scripts/directives/deployImage.js"></script>
         <script src="scripts/directives/selector.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -33,6 +33,23 @@ angular
     'openshiftCommon'
   ])
   .config(function ($routeProvider) {
+    var overviewRoute;
+    if (window.OPENSHIFT_CONSTANTS.HIDE_NEW_OVERVIEW ||
+        localStorage.getItem('hide-new-overview') === 'true') {
+      overviewRoute = {
+        templateUrl: 'views/overview.html',
+        controller: 'OverviewController'
+      };
+    } else {
+      // TODO Rename new overview controller / view when the old is removed
+      overviewRoute = {
+        templateUrl: 'views/new-overview.html',
+        controller: 'NewOverviewController',
+        controllerAs: 'overview',
+        reloadOnSearch: false
+      };
+    }
+
     $routeProvider
       .when('/', {
         templateUrl: 'views/projects.html',
@@ -47,15 +64,7 @@ angular
           return '/project/' + encodeURIComponent(params.project) + "/overview";
         }
       })
-      .when('/project/:project/overview', {
-        templateUrl: 'views/overview.html',
-        controller: 'OverviewController'
-      })
-      // Old overview, keep for now in case of emergency
-      // .when('/project/:project/overview', {
-      //   templateUrl: 'views/project.html',
-      //   controller: 'TopologyController'
-      // })
+      .when('/project/:project/overview', overviewRoute)
       .when('/project/:project/quota', {
         templateUrl: 'views/quota.html',
         controller: 'QuotaController'

--- a/app/scripts/controllers/newOverview.js
+++ b/app/scripts/controllers/newOverview.js
@@ -1,0 +1,1240 @@
+'use strict';
+
+// TODO: Rename file and controller when old overview is removed.
+angular.module('openshiftConsole').controller('NewOverviewController', [
+  '$scope',
+  '$filter',
+  '$routeParams',
+  'AlertMessageService',
+  'AppsService',
+  'BuildsService',
+  'Constants',
+  'DataService',
+  'DeploymentsService',
+  'HPAService',
+  'HTMLService',
+  'ImageStreamResolver',
+  'KeywordService',
+  'LabelFilter',
+  'LabelsService',
+  'Logger',
+  'MetricsService',
+  'Navigate',
+  'ProjectsService',
+  'ResourceAlertsService',
+  'RoutesService',
+  OverviewController
+]);
+
+function OverviewController($scope,
+                            $filter,
+                            $routeParams,
+                            AlertMessageService,
+                            AppsService,
+                            BuildsService,
+                            Constants,
+                            DataService,
+                            DeploymentsService,
+                            HPAService,
+                            HTMLService,
+                            ImageStreamResolver,
+                            KeywordService,
+                            LabelFilter,
+                            LabelsService,
+                            Logger,
+                            MetricsService,
+                            Navigate,
+                            ProjectsService,
+                            ResourceAlertsService,
+                            RoutesService) {
+  var overview = this;
+  var limitWatches = $filter('isIE')() || $filter('isEdge')();
+  var DEFAULT_POLL_INTERVAL = 60 * 1000; // milliseconds
+
+  $scope.projectName = $routeParams.project;
+
+  // Filters used by this controller.
+  var annotation = $filter('annotation');
+  var getBuildConfigName = $filter('buildConfigForBuild');
+  var deploymentIsInProgress = $filter('deploymentIsInProgress');
+  var getErrorDetails = $filter('getErrorDetails');
+  var imageObjectRef = $filter('imageObjectRef');
+  var isJenkinsPipelineStrategy = $filter('isJenkinsPipelineStrategy');
+  var isNewerResource = $filter('isNewerResource');
+  var label = $filter('label');
+  var getPodTemplate = $filter('podTemplate');
+
+  var imageStreams;
+  var labelSuggestions = {};
+  var pipelineLabelSuggestions = {};
+
+  // The most recent replication controller by deployment config name. This
+  // might not be the active deployment if failed or cancelled.
+  var mostRecentByDeploymentConfig = {};
+
+  // `overview.state` tracks common state that is shared with overview-list-row.
+  // This avoids having to pass the same values as attributes again and again
+  // for different types, but lets us update these maps in one place as needed
+  // from watch callbacks in the overview controller.
+  //
+  // NOTE: Do not change or remove properties without updating overview-list-row.
+  var state = overview.state = {
+    alerts: {},
+    builds: {},
+    clusterQuotas: {},
+    imageStreamImageRefByDockerReference: {},
+    imagesByDockerReference: {},
+    limitRanges: {},
+    limitWatches: limitWatches,
+    notificationsByObjectUID: {},
+    pipelinesByDeploymentConfig: {},
+    podsByOwnerUID: {},
+    quotas: {},
+    recentPipelinesByDeploymentConfig: {},
+    routesByService: {},
+    servicesByObjectUID: {},
+    // Set to true below when metrics are available.
+    showMetrics: false
+  };
+
+  AlertMessageService.getAlerts().forEach(function(alert) {
+    state.alerts[alert.name] = alert.data;
+  });
+  AlertMessageService.clearAlerts();
+
+  // Track the breakpoint ourselves so we can remove elements from the page,
+  // rather than hiding them using CSS. This avoids rendering charts more than
+  // once for the responsive layout, which switches to tabs at smaller screen
+  // widths.
+  overview.state.breakpoint = HTMLService.getBreakpoint();
+  var onResize = _.throttle(function() {
+    var breakpoint = HTMLService.getBreakpoint();
+    if (overview.state.breakpoint !== breakpoint) {
+      $scope.$evalAsync(function() {
+        overview.state.breakpoint = breakpoint;
+      });
+    }
+  }, 50);
+
+  $(window).on('resize.overview', onResize);
+
+  overview.showGetStarted = false;
+  overview.showLoading = true;
+
+  overview.filterByOptions = [{
+    id: 'name',
+    label: 'Name'
+  }, {
+    id: 'label',
+    label: 'Label'
+  }];
+  overview.filterBy = 'name';
+
+  overview.viewByOptions = [{
+    id: 'app',
+    label: 'Application'
+  }, {
+    id: 'resource',
+    label: 'Resource Type'
+  }, {
+    id: 'pipeline',
+    label: 'Pipeline'
+  }];
+
+  var getName = function(apiObject) {
+    return _.get(apiObject, 'metadata.name');
+  };
+
+  var getUID = function(apiObject) {
+    return _.get(apiObject, 'metadata.uid');
+  };
+
+  // The size of all visible top-level items.
+  var size = function() {
+    return _.size(overview.deploymentConfigs) +
+           _.size(overview.vanillaReplicationControllers) +
+           _.size(overview.deployments) +
+           _.size(overview.vanillaReplicaSets) +
+           _.size(overview.statefulSets) +
+           _.size(overview.monopods);
+  };
+
+  // The size of all visible top-level items after filtering.
+  var filteredSize = function() {
+    return _.size(overview.filteredDeploymentConfigs) +
+           _.size(overview.filteredReplicationControllers) +
+           _.size(overview.filteredDeployments) +
+           _.size(overview.filteredReplicaSets) +
+           _.size(overview.filteredStatefulSets) +
+           _.size(overview.filteredMonopods);
+  };
+
+  // Show the "Get Started" message if the project is empty.
+  var updateShowGetStarted = function() {
+    overview.size = size();
+    overview.filteredSize = filteredSize();
+
+    // Check if there is any data visible in the overview.
+    var projectEmpty = overview.size === 0;
+
+    // Check if we've loaded the top-level items we show on the overview.
+    var loaded = overview.deploymentConfigs &&
+                 overview.replicationControllers &&
+                 overview.deployments &&
+                 overview.replicaSets &&
+                 overview.statefulSets &&
+                 overview.pods;
+
+    state.expandAll = loaded && overview.size === 1;
+
+    overview.showGetStarted = loaded && projectEmpty;
+    overview.showLoading = !loaded && projectEmpty;
+
+    overview.everythingFiltered = !projectEmpty && !overview.filteredSize;
+  };
+
+  // Group a collection of resources by app label. Returns a map where the key
+  // is the app label value and the value is an array of objects, sorted by
+  // `metadata.name`.
+  var groupByApp = function(collection) {
+    return AppsService.groupByApp(collection, 'metadata.name');
+  };
+
+  var getBestRoute = function(routes) {
+    var bestRoute = null;
+    _.each(routes, function(candidate) {
+      if (!bestRoute) {
+        bestRoute = candidate;
+        return;
+      }
+
+      // Is candidate better than the current display route?
+      bestRoute = RoutesService.getPreferredDisplayRoute(bestRoute, candidate);
+    });
+
+    return bestRoute;
+  };
+
+  // Debounce so we're not reevaluating this too often.
+  var updateRoutesByApp = _.debounce(function() {
+    $scope.$evalAsync(function() {
+      overview.bestRouteByApp = {};
+
+      if (!overview.routes) {
+        return;
+      }
+
+      // Any of the following can have services that have routes.
+      var toCheck = [
+        overview.filteredDeploymentConfigsByApp,
+        overview.filteredReplicationControllersByApp,
+        overview.filteredDeploymentsByApp,
+        overview.filteredReplicaSetsByApp,
+        overview.filteredStatefulSetsByApp,
+        overview.filteredMonopodsByApp
+      ];
+
+      // Find the best route for each app.
+      _.each(overview.apps, function(app) {
+        // Create a map of routes, keyed by route name to avoid adding them twice.
+        var routesForApp = {};
+        _.each(toCheck, function(byApp) {
+          var apiObjects = _.get(byApp, app, []);
+          _.each(apiObjects, function(apiObject) {
+            var uid = getUID(apiObject);
+            var services = _.get(state, ['servicesByObjectUID', uid], []);
+            _.each(services, function(service) {
+              // Only need to get the first route, since they're already sorted by score.
+              var routes = _.get(state, ['routesByService', service.metadata.name], []);
+              _.assign(routesForApp, _.indexBy(routes, 'metadata.name'));
+            });
+          });
+        });
+
+        overview.bestRouteByApp[app] = getBestRoute(routesForApp);
+      });
+    });
+  }, 300, { maxWait: 1500 });
+
+  // Group each resource kind by app and update the list of app label values.
+  var updateApps = function() {
+    overview.filteredDeploymentConfigsByApp = groupByApp(overview.filteredDeploymentConfigs);
+    overview.filteredReplicationControllersByApp = groupByApp(overview.filteredReplicationControllers);
+    overview.filteredDeploymentsByApp = groupByApp(overview.filteredDeployments);
+    overview.filteredReplicaSetsByApp = groupByApp(overview.filteredReplicaSets);
+    overview.filteredStatefulSetsByApp = groupByApp(overview.filteredStatefulSets);
+    overview.filteredMonopodsByApp = groupByApp(overview.filteredMonopods);
+    overview.apps = _.union(_.keys(overview.filteredDeploymentConfigsByApp),
+                            _.keys(overview.filteredReplicationControllersByApp),
+                            _.keys(overview.filteredDeploymentsByApp),
+                            _.keys(overview.filteredReplicaSetsByApp),
+                            _.keys(overview.filteredStatefulSetsByApp),
+                            _.keys(overview.filteredMonopodsByApp));
+
+    AppsService.sortAppNames(overview.apps);
+    updateRoutesByApp();
+  };
+
+  var updatePipelineOtherResources = function() {
+    // Find deployment configs not associated with a pipeline.
+    var otherDeploymentConfigs = _.filter(overview.deploymentConfigs, function(deploymentConfig) {
+      var name = getName(deploymentConfig);
+      return _.isEmpty(state.pipelinesByDeploymentConfig[name]);
+    });
+    overview.deploymentConfigsNoPipeline = _.sortBy(otherDeploymentConfigs, 'metadata.name');
+    overview.pipelineViewHasOtherResources =
+      !_.isEmpty(overview.deploymentConfigsNoPipeline) ||
+      !_.isEmpty(overview.vanillaReplicationControllers) ||
+      !_.isEmpty(overview.deployments) ||
+      !_.isEmpty(overview.vanillaReplicaSets) ||
+      !_.isEmpty(overview.statefulSets) ||
+      !_.isEmpty(overview.monopods);
+  };
+
+  var updateFilterDisabledState = function() {
+    overview.disableFilter = overview.viewBy === 'pipeline' && _.isEmpty(overview.pipelineBuildConfigs);
+  };
+
+  var filterByLabel = function(items) {
+    return LabelFilter.getLabelSelector().select(items);
+  };
+
+  // Updated on viewBy changes to include the app label when appropriate.
+  var filterFields = ['metadata.name'];
+  var filterByName = function(items) {
+    return KeywordService.filterForKeywords(items, filterFields, state.filterKeywords);
+  };
+
+  var filterItems = function(items) {
+    switch (overview.filterBy) {
+    case 'label':
+      return filterByLabel(items);
+    case 'name':
+      return filterByName(items);
+    }
+
+    return items;
+  };
+
+  var isFilterActive = function() {
+    switch (overview.filterBy) {
+    case 'label':
+      return !LabelFilter.getLabelSelector().isEmpty();
+    case 'name':
+      return !_.isEmpty(state.filterKeywords);
+    }
+  };
+
+  var updateFilter = function() {
+    overview.filteredDeploymentConfigs = filterItems(overview.deploymentConfigs);
+    overview.filteredReplicationControllers = filterItems(overview.vanillaReplicationControllers);
+    overview.filteredDeployments = filterItems(overview.deployments);
+    overview.filteredReplicaSets = filterItems(overview.vanillaReplicaSets);
+    overview.filteredStatefulSets = filterItems(overview.statefulSets);
+    overview.filteredMonopods = filterItems(overview.monopods);
+    overview.filteredPipelineBuildConfigs = filterItems(overview.pipelineBuildConfigs);
+    overview.filterActive = isFilterActive();
+    updateApps();
+    updateShowGetStarted();
+  };
+
+  // Track view-by state in localStorage.
+  var viewByKey = $routeParams.project + '/overview/view-by';
+  overview.viewBy = localStorage.getItem(viewByKey) || 'app';
+  $scope.$watch(function() {
+    return overview.viewBy;
+  },function(value){
+    localStorage.setItem(viewByKey, value);
+    updateFilterDisabledState();
+    filterFields = overview.viewBy === 'app' ? ['metadata.name', 'metadata.labels.app'] : ['metadata.name'];
+    updateFilter();
+    if (overview.viewBy === 'pipeline') {
+      LabelFilter.setLabelSuggestions(pipelineLabelSuggestions);
+    } else {
+      LabelFilter.setLabelSuggestions(labelSuggestions);
+    }
+  });
+
+  if (!window.OPENSHIFT_CONSTANTS.DISABLE_OVERVIEW_METRICS) {
+    // Check if a metrics URL has been configured for overview metrics.
+    MetricsService.isAvailable(true).then(function(available) {
+      state.showMetrics = available;
+    });
+
+    // Show a page-level alert when we fail to connect to Hawkular metrics.
+    $scope.$on('metrics-connection-failed', function(e, data) {
+      var hidden = AlertMessageService.isAlertPermanentlyHidden('metrics-connection-failed');
+      if (hidden || state.alerts['metrics-connection-failed']) {
+        return;
+      }
+
+      state.alerts['metrics-connection-failed'] = {
+        type: 'warning',
+        message: 'An error occurred getting metrics.',
+        links: [{
+          href: data.url,
+          label: 'Open Metrics URL',
+          target: '_blank'
+        }, {
+          href: '',
+          label: "Don't Show Me Again",
+          onClick: function() {
+            // Hide the alert on future page loads.
+            AlertMessageService.permanentlyHideAlert('metrics-connection-failed');
+
+            // Return true close the existing alert.
+            return true;
+          }
+        }]
+      };
+    });
+  }
+
+  var isPod = function(apiObject) {
+    return apiObject && apiObject.kind === 'Pod';
+  };
+
+  var getPods = function(apiObject) {
+    var uid = getUID(apiObject);
+    if (!uid) {
+      return [];
+    }
+
+    if (isPod(apiObject)) {
+      return [apiObject];
+    }
+
+    return _.get(overview, ['state', 'podsByOwnerUID', uid], []);
+  };
+
+  var setNotifications = function(apiObject, notifications) {
+    var uid = getUID(apiObject);
+    state.notificationsByObjectUID[uid] = notifications || {};
+  };
+
+  var getNotifications = function(apiObject) {
+    var uid = getUID(apiObject);
+    if (!uid) {
+      return {};
+    }
+    return _.get(state, ['notificationsByObjectUID', uid], {});
+  };
+
+  // Set pod warnings for pods owned by `apiObject`, which can be a set like
+  // a replication controller or replica set, or just a pod itself.
+  //
+  // Updates `state.notificationsByObjectUID`
+  //   key: object UID
+  //   value: alerts object
+  var updatePodWarningsForObject = function(apiObject) {
+    var uid = getUID(apiObject);
+    if (!uid) {
+      return;
+    }
+
+    var pods = getPods(apiObject);
+    var notifications = ResourceAlertsService.getPodAlerts(pods, $routeParams.project);
+    setNotifications(apiObject, notifications);
+  };
+
+  // Updates pod warnings for a collection of API objects such as replication
+  // controllers or monopods.
+  var updatePodWarnings = function(apiObjects) {
+    _.each(apiObjects, updatePodWarningsForObject);
+  };
+
+  // Get the most recently-created replication controller for a deployment
+  // config. This might not be the active deployment if it was a failed or
+  // cancelled.
+  var getMostRecentReplicationController = function(deploymentConfig) {
+    var name = getName(deploymentConfig);
+    if (!name) {
+      return null;
+    }
+
+    return mostRecentByDeploymentConfig[name];
+  };
+
+  // Get the replication controllers that are displayed for a deployment
+  // config. This will return only the active replication controller unless a
+  // deployment is in progress.
+  var getVisibleReplicationControllers = function(deploymentConfig) {
+    var name = getName(deploymentConfig);
+    if (!name) {
+      return [];
+    }
+    return _.get(overview, ['replicationControllersByDeploymentConfig', name]);
+  };
+
+  // Get the "previous" replication controller (when a deployment is in
+  // progress and more than one is active). This is the donut that appears on
+  // the left when we show two. Returns null if there is no deployment in
+  // progress or the previous has been scaled down.
+  overview.getPreviousReplicationController = function(deploymentConfig) {
+    var replicationControllers = getVisibleReplicationControllers(deploymentConfig);
+    if (_.size(replicationControllers) < 2) {
+      return null;
+    }
+
+    // The array is sorted by age, most recent first. Return the second item.
+    return replicationControllers[1];
+  };
+
+  // Set warnings for a deployment config, including warnings for any active
+  // replication controllers and cancelled and failed deployments.
+  //
+  // Updates `state.notificationsByObjectUID`
+  //   key: object UID
+  //   value: alerts object
+  var updateDeploymentConfigWarnings = function(deploymentConfig) {
+    var notifications = {};
+
+    // Add any failed / canceled deployment notifications.
+    var mostRecent = getMostRecentReplicationController(deploymentConfig);
+    notifications = ResourceAlertsService.getDeploymentStatusAlerts(deploymentConfig, mostRecent);
+
+    // Roll up notifications like pod warnings for any visible replication controller.
+    var visibleReplicationControllers = getVisibleReplicationControllers(deploymentConfig);
+    _.each(visibleReplicationControllers, function(replicationController) {
+      var rcNotifications = getNotifications(replicationController);
+      _.assign(notifications, rcNotifications);
+    });
+
+    setNotifications(deploymentConfig, notifications);
+  };
+
+  // Update warnings for all deployment configs.
+  var updateAllDeploymentConfigWarnings = function() {
+    _.each(overview.deploymentConfigs, updateDeploymentConfigWarnings);
+  };
+
+  // Get the replica sets that are displayed for a deployment. This will return
+  // only the active replica set unless a deployment is in progress.
+  var getVisibleReplicaSets = function(deployment) {
+    var name = getName(deployment);
+    if (!name) {
+      return {};
+    }
+    return _.get(overview, ['replicaSetsByDeployment', name]);
+  };
+
+  // Set warnings for a Kubernetes deployment, including any active replica sets.
+  //
+  // Updates `state.notificationsByObjectUID`
+  //   key: object UID
+  //   value: alerts object
+  var updateDeploymentWarnings = function(deployment) {
+    var notifications = {};
+
+    // Roll up notifications like pod warnings for any visible replica set.
+    var visibleReplicaSets = getVisibleReplicaSets(deployment);
+    _.each(visibleReplicaSets, function(replicaSet) {
+      var replicaSetNotifications = getNotifications(replicaSet);
+      _.assign(notifications, replicaSetNotifications);
+    });
+
+    setNotifications(deployment, notifications);
+  };
+
+  // Update warnings for all Kubernetes deployments.
+  var updateAllDeploymentWarnings = function() {
+    _.each(overview.deployments, updateDeploymentWarnings);
+  };
+
+  // Update all pod warnings, indexing the errors by owner UID.
+  var updateAllPodWarnings = function() {
+    updatePodWarnings(overview.replicationControllers);
+    updatePodWarnings(overview.replicaSets);
+    updatePodWarnings(overview.statefulSets);
+    updatePodWarnings(overview.monopods);
+  };
+
+  // Update warnings for all kinds. Debounce so we're not reevaluating this too often.
+  var updateWarnings = _.debounce(function() {
+    $scope.$evalAsync(function() {
+      updateAllPodWarnings();
+      updateAllDeploymentConfigWarnings();
+      updateAllDeploymentWarnings();
+    });
+  }, 500);
+
+  // Update the label filter suggestions for a list of objects. This should
+  // only be called for filterable top-level items to avoid polluting the list.
+  var updateLabelSuggestions = function(objects) {
+    if (_.isEmpty(objects)) {
+      return;
+    }
+
+    LabelFilter.addLabelSuggestionsFromResources(objects, labelSuggestions);
+    if (overview.viewBy !== 'pipeline') {
+      LabelFilter.setLabelSuggestions(labelSuggestions);
+    }
+  };
+
+  // Update the label suggestions used when viewBy === 'pipeline'.
+  var updatePipelineLabelSuggestions = function(pipelineBuildConfigs) {
+    if (_.isEmpty(pipelineBuildConfigs)) {
+      return;
+    }
+
+    LabelFilter.addLabelSuggestionsFromResources(pipelineBuildConfigs, pipelineLabelSuggestions);
+    if (overview.viewBy === 'pipeline') {
+      LabelFilter.setLabelSuggestions(pipelineLabelSuggestions);
+    }
+  };
+
+  // Get all resources that own pods (replication controllers, replica sets,
+  // and stateful sets).
+  var getPodOwners = function() {
+    var replicationControllers = _.toArray(overview.replicationControllers);
+    var replicaSets = _.toArray(overview.replicaSets);
+    var statefulSets = _.toArray(overview.statefulSets);
+
+    return replicationControllers.concat(replicaSets, statefulSets);
+  };
+
+  // Filter out monopods we know we don't want to see.
+  var showMonopod = function(pod) {
+    // Hide pods in the succeeded and failed phases since these are run once
+    // pods that are done.
+    if (pod.status.phase === 'Succeeded' ||
+        pod.status.phase === 'Failed') {
+      // TODO: We may want to show pods for X amount of time after they have completed.
+      return false;
+    }
+
+    // Hide our deployer pods since it is obvious the deployment is happening
+    // when the new deployment appears.
+    if (label(pod, "openshift.io/deployer-pod-for.name")) {
+      return false;
+    }
+
+    // Hide our build pods since we are already showing details for currently
+    // running or recently run builds under the appropriate areas.
+    if (annotation(pod, "openshift.io/build.name")) {
+      return false;
+    }
+
+    // Hide Jenkins slave pods.
+    if (label(pod, "jenkins") === "slave") {
+      return false;
+    }
+
+    return true;
+  };
+
+  // Group all pods by owner, tracked in the `state.podsByOwnerUID` map.
+  var groupPods = function() {
+    // Make sure the pod owners have loaded before grouping the pods. Otherwise
+    // the pods themselves appear briefly in separate rows as the page loads.
+    if (!overview.pods || !overview.replicationControllers || !overview.replicaSets || !overview.statefulSets) {
+      return;
+    }
+
+    var podOwners = getPodOwners();
+    state.podsByOwnerUID = LabelsService.groupBySelector(overview.pods, podOwners, { key: 'metadata.uid' });
+    overview.monopods = _.filter(state.podsByOwnerUID[''], showMonopod);
+  };
+
+  // Determine if a replication controller is visible, either as part of a
+  // deployment config or a standalone replication controller.
+  var isReplicationControllerVisible = function(replicationController) {
+    if (_.get(replicationController, 'status.replicas')) {
+      return true;
+    }
+    var dcName = annotation(replicationController, 'deploymentConfig');
+    if (!dcName) {
+      return true;
+    }
+
+    return deploymentIsInProgress(replicationController);
+  };
+
+  // Get the deployment config name for a replication controller by reading the
+  // "openshift.io/deployment-config.name" annotation.
+  var getDeploymentConfigName = function(replicationController) {
+    return annotation(replicationController, 'deploymentConfig');
+  };
+
+  // Group replication controllers by deployment config and filter the visible
+  // replication controllers.
+  var groupReplicationControllers = function() {
+    if (!overview.deploymentConfigs || !overview.replicationControllers) {
+      return;
+    }
+
+    // "Vanilla" replication controllers are those not owned by a deployment config.
+    var vanillaReplicationControllers = [];
+    overview.replicationControllersByDeploymentConfig = {};
+    overview.currentByDeploymentConfig = {};
+    mostRecentByDeploymentConfig = {};
+
+    // Add the replication controllers to a temporary map until we have them all and can sort.
+    var rcByDC = {};
+    _.each(overview.replicationControllers, function(replicationController) {
+      var dcName = getDeploymentConfigName(replicationController) || '';
+      if (!dcName || (!overview.deploymentConfigs[dcName] && _.get(replicationController, 'status.replicas'))) {
+        vanillaReplicationControllers.push(replicationController);
+      }
+
+      // Keep track of  the most recent replication controller even if not
+      // visible to show failed/canceled deployment notifications.
+      var mostRecent = mostRecentByDeploymentConfig[dcName];
+      if (!mostRecent || isNewerResource(replicationController, mostRecent)) {
+        mostRecentByDeploymentConfig[dcName] = replicationController;
+      }
+
+      // Only track the visible replication controllers. This way we only sort
+      // and check warnings for things we're showing.
+      if (isReplicationControllerVisible(replicationController)) {
+        _.set(rcByDC, [dcName, replicationController.metadata.name], replicationController);
+      }
+    });
+
+    // Sort the visible replication controllers.
+    _.each(rcByDC, function(replicationControllers, dcName) {
+      var ordered = DeploymentsService.sortByDeploymentVersion(replicationControllers, true);
+      overview.replicationControllersByDeploymentConfig[dcName] = ordered;
+      // "Current" is considered the most recent visible replication
+      // controller, even if the deployment hasn't completed.
+      overview.currentByDeploymentConfig[dcName] = _.head(ordered);
+    });
+    overview.vanillaReplicationControllers = _.sortBy(vanillaReplicationControllers, 'metadata.name');
+
+    // Since the visible replication controllers for each deployment config
+    // have changed, update the deployment config warnings.
+    updateAllDeploymentConfigWarnings();
+  };
+
+  // Determine if a replica set is visible, either as part of a deployment or
+  // as a standalone replica set.
+  var isReplicaSetVisible = function(replicaSet, deployment) {
+    // If the replica set has pods, show it.
+    if (_.get(replicaSet, 'status.replicas')) {
+      return true;
+    }
+
+    var revision = DeploymentsService.getRevision(replicaSet);
+
+    // If not part of a deployment, always show the replica set.
+    if (!revision) {
+      return true;
+    }
+
+    // If the deployment has been deleted and the replica set has no replicas, hide it.
+    // Otherwise all old replica sets for a deleted deployment will be visible.
+    if (!deployment) {
+      return false;
+    }
+
+    // Show the replica set if it's the latest revision.
+    return DeploymentsService.getRevision(deployment) === revision;
+  };
+
+  // Group replica sets by deployment and filter the visible replica sets.
+  var groupReplicaSets = function() {
+    if (!overview.replicaSets || !overview.deployments) {
+      return;
+    }
+
+    overview.replicaSetsByDeployment = LabelsService.groupBySelector(overview.replicaSets, overview.deployments, { matchSelector: true });
+    overview.currentByDeployment = {};
+
+    // Sort the visible replica sets.
+    _.each(overview.replicaSetsByDeployment, function(replicaSets, deploymentName) {
+      if (!deploymentName) {
+        return;
+      }
+
+      var deployment = overview.deployments[deploymentName];
+      var visibleReplicaSets = _.filter(replicaSets, function(replicaSet) {
+        return isReplicaSetVisible(replicaSet, deployment);
+      });
+      var ordered = DeploymentsService.sortByRevision(visibleReplicaSets);
+      overview.replicaSetsByDeployment[deploymentName] = ordered;
+      overview.currentByDeployment[deploymentName] = _.head(ordered);
+    });
+    overview.vanillaReplicaSets = _.sortBy(overview.replicaSetsByDeployment[''], 'metadata.name');
+
+    // Since the visible replica sets for each deployment have changed, update
+    // the deployment warnings.
+    updateAllDeploymentWarnings();
+  };
+
+  // Find the services that direct traffic to each API object.
+  //
+  // Updates `state.servicesByObjectUID`
+  //   key: object UID
+  //   value: array of sorted services
+  var selectorsByService = {};
+  var updateServicesForObjects = function(apiObjects) {
+    if (!apiObjects || !overview.services) {
+      return;
+    }
+
+    _.each(apiObjects, function(apiObject) {
+      var services = [];
+      var uid = getUID(apiObject);
+      var podTemplate = getPodTemplate(apiObject);
+      _.each(selectorsByService, function(selector, serviceName) {
+        if (selector.matches(podTemplate)) {
+          services.push(overview.services[serviceName]);
+        }
+      });
+      state.servicesByObjectUID[uid] = _.sortBy(services, 'metadata.name');
+    });
+  };
+
+  // Update the list of services for all API objects.
+  //
+  // Updates `state.servicesByObjectUID`
+  //   key: object UID
+  //   value: array of sorted services
+  var groupServices = function() {
+    if (!overview.services) {
+      return;
+    }
+
+    selectorsByService = _.mapValues(overview.services, function(service) {
+      return new LabelSelector(service.spec.selector);
+    });
+
+    var toUpdate = [
+      overview.deploymentConfigs,
+      overview.vanillaReplicationControllers,
+      overview.deployments,
+      overview.vanillaReplicaSets,
+      overview.statefulSets,
+      overview.monopods
+    ];
+    _.each(toUpdate, updateServicesForObjects);
+  };
+
+  // Group routes by the services they route to (either as a primary service or
+  // alternate backend).
+  //
+  // Updates `state.routesByService`
+  //   key: service name
+  //   value: array of routes, sorted by RoutesService.sortRoutesByScore
+  var groupRoutes = function() {
+    var routesByService = RoutesService.groupByService(overview.routes, true);
+    state.routesByService = _.mapValues(routesByService, RoutesService.sortRoutesByScore);
+    updateRoutesByApp();
+  };
+
+  // Group HPAs by the object they scale.
+  //
+  // Updates `state.hpaByResource`
+  //   key: hpaByResource[kind][name]
+  //   value: array of HPA objects
+  var groupHPAs = function() {
+    state.hpaByResource = HPAService.groupHPAs(overview.horizontalPodAutoscalers);
+  };
+
+  // Adds a recent pipeline build to the following maps:
+  //
+  // `overview.recentPipelinesByBuildConfig``
+  //   key: build config name
+  //   value: array of pipeline builds
+  //
+  // `state.recentPipelinesByDeploymentConfig`
+  //   key: deployment config name
+  //   value: array of pipeline builds
+  var groupPipeline = function(build) {
+    var bcName = getBuildConfigName(build);
+    var buildConfig = overview.buildConfigs[bcName];
+    if (!buildConfig) {
+      return;
+    }
+
+    overview.recentPipelinesByBuildConfig[bcName] = overview.recentPipelinesByBuildConfig[bcName] || [];
+    overview.recentPipelinesByBuildConfig[bcName].push(build);
+
+    // Index running pipelines by DC name.
+    var dcNames = BuildsService.usesDeploymentConfigs(buildConfig);
+    _.each(dcNames, function(dcName) {
+      state.recentPipelinesByDeploymentConfig[dcName] = state.recentPipelinesByDeploymentConfig[dcName] || [];
+      state.recentPipelinesByDeploymentConfig[dcName].push(build);
+    });
+    updatePipelineOtherResources();
+  };
+
+  // Group build configs by their output image. This lets us match them to
+  // deployment config image change triggers.
+  var buildConfigsByOutputImage = {};
+  var groupBuildConfigsByOutputImage = function() {
+    buildConfigsByOutputImage = BuildsService.groupBuildConfigsByOutputImage(overview.buildConfigs);
+  };
+
+  var getBuildConfigsForObject = function(apiObject) {
+    var uid = getUID(apiObject);
+    if (!uid) {
+      return;
+    }
+
+    return _.get(state, ['buildConfigsByObjectUID', uid], []);
+  };
+
+  // Find all recent builds for `deploymentConfig` from each of `buildConfigs`.
+  //
+  // Updates `state.recentBuildsByDeploymentConfig`
+  //   key: deployment config name
+  //   value: array of builds, sorted in descending order by creation date
+  var updateRecentBuildsForDeploymentConfig = function(deploymentConfig) {
+    var builds = [];
+    var buildConfigs = getBuildConfigsForObject(deploymentConfig);
+    _.each(buildConfigs, function(buildConfig) {
+      var recentForConfig = _.get(state, ['recentBuildsByBuildConfig', buildConfig.metadata.name], []);
+      builds = builds.concat(recentForConfig);
+    });
+
+    // These builds are only used to show a count, so don't need to be sorted.
+    var dcName = getName(deploymentConfig);
+    _.set(state, ['recentBuildsByDeploymentConfig', dcName], builds);
+  };
+
+  var setBuildConfigsForObject = function(buildConfigs, apiObject) {
+    var uid = getUID(apiObject);
+    if (!uid) {
+      return;
+    }
+
+    _.set(state, ['buildConfigsByObjectUID', uid], buildConfigs);
+  };
+
+  // Find build configs that use the pipeline strategy and have a
+  // "pipeline.alpha.openshift.io/uses" annotation pointing to a deployment
+  // config.
+  //
+  // Updates `state.pipelinesByDeploymentConfig`
+  //   key: deployment config name
+  //   value: array of pipeline build configs
+  var groupPipelineBuildConfigsByDeploymentConfig = function() {
+    var pipelineBuildConfigs = [];
+    overview.deploymentConfigsByPipeline = {};
+    state.pipelinesByDeploymentConfig = {};
+    _.each(overview.buildConfigs, function(buildConfig) {
+      if (!isJenkinsPipelineStrategy(buildConfig)) {
+        return;
+      }
+
+      pipelineBuildConfigs.push(buildConfig);
+
+      // TODO: Handle other types.
+      // Preserve the order they appear in the annotation.
+      var dcNames = BuildsService.usesDeploymentConfigs(buildConfig);
+      var bcName = getName(buildConfig);
+      _.set(overview, ['deploymentConfigsByPipeline', bcName], dcNames);
+      _.each(dcNames, function(dcName) {
+        state.pipelinesByDeploymentConfig[dcName] = state.pipelinesByDeploymentConfig[dcName] || [];
+        state.pipelinesByDeploymentConfig[dcName].push(buildConfig);
+      });
+    });
+
+    overview.pipelineBuildConfigs = _.sortBy(pipelineBuildConfigs, 'metadata.name');
+    updatePipelineOtherResources();
+    updatePipelineLabelSuggestions(overview.pipelineBuildConfigs);
+    updateFilterDisabledState();
+  };
+
+  // Find build configs with an output image that matches the deployment config
+  // image change trigger.
+  //
+  // Updates `state.buildConfigsByObjectUID`
+  //   key: deployment config UID
+  //   value: array of build configs, sorted by name
+  var matchOutputImagesToImageChangeTriggers = function() {
+    state.buildConfigsByObjectUID = {};
+    _.each(overview.deploymentConfigs, function(deploymentConfig) {
+      var buildConfigs = [];
+      var triggers = _.get(deploymentConfig, 'spec.triggers');
+      _.each(triggers, function(trigger) {
+        var from = _.get(trigger, 'imageChangeParams.from');
+        if (!from) {
+          return;
+        }
+
+        var ref = imageObjectRef(from, deploymentConfig.metadata.namespace);
+        var buildConfigsForRef = buildConfigsByOutputImage[ref];
+        if (!_.isEmpty(buildConfigsForRef)) {
+          buildConfigs = buildConfigs.concat(buildConfigsForRef);
+        }
+      });
+
+      buildConfigs = _.sortBy(buildConfigs, 'metadata.name');
+      setBuildConfigsForObject(buildConfigs, deploymentConfig);
+      updateRecentBuildsForDeploymentConfig(deploymentConfig);
+    });
+  };
+
+  // Find the build configs that relate to each deployment config. Pipeline
+  // build configs are grouped using an annotation. Other build configs are
+  // grouping using output images matched against a deployment config image
+  // change trigger.
+  var groupBuildConfigsByDeploymentConfig = function() {
+    groupPipelineBuildConfigsByDeploymentConfig();
+    matchOutputImagesToImageChangeTriggers();
+  };
+
+  var groupRecentBuildsByDeploymentConfig = function() {
+    _.each(overview.deploymentConfigs, updateRecentBuildsForDeploymentConfig);
+  };
+
+  var groupBuilds = function() {
+    if(!state.builds || !overview.buildConfigs) {
+      return;
+    }
+
+    // Reset these maps.
+    overview.recentPipelinesByBuildConfig = {};
+    state.recentBuildsByBuildConfig = {};
+    state.recentPipelinesByDeploymentConfig = {};
+
+    var recentByConfig = {};
+    _.each(BuildsService.interestingBuilds(state.builds), function(build) {
+      var bcName = getBuildConfigName(build);
+      if(isJenkinsPipelineStrategy(build)) {
+        groupPipeline(build);
+      } else {
+        recentByConfig[bcName] = recentByConfig[bcName] || [];
+        recentByConfig[bcName].push(build);
+      }
+    });
+
+    overview.recentPipelinesByBuildConfig = _.mapValues(overview.recentPipelinesByBuildConfig, function(builds) {
+      return BuildsService.sortBuilds(builds, true);
+    });
+    state.recentPipelinesByDeploymentConfig = _.mapValues(state.recentPipelinesByDeploymentConfig, function(builds) {
+      return BuildsService.sortBuilds(builds, true);
+    });
+    state.recentBuildsByBuildConfig = _.mapValues(recentByConfig, function(builds) {
+      return BuildsService.sortBuilds(builds, true);
+    });
+
+    groupRecentBuildsByDeploymentConfig();
+  };
+
+  var updateQuotaWarnings = function() {
+    ResourceAlertsService.setGenericQuotaWarning(state.quotas,
+                                                 state.clusterQuotaData,
+                                                 $routeParams.project,
+                                                 state.alerts);
+  };
+
+  overview.clearFilter = function() {
+    LabelFilter.getLabelSelector().clearConjuncts();
+    overview.filterText = '';
+  };
+
+  $scope.$watch(function() {
+    return overview.filterText;
+  }, _.debounce(function(text, previous) {
+    if (text === previous) {
+      return;
+    }
+    state.filterKeywords = KeywordService.generateKeywords(text);
+    $scope.$evalAsync(updateFilter);
+  }, 50, { maxWait: 250 }));
+
+  $scope.$watch(function() {
+    return overview.filterBy;
+  }, function() {
+    // Clear any existing filter when switching filter types.
+    overview.clearFilter();
+    updateFilter();
+  });
+
+  LabelFilter.onActiveFiltersChanged(function() {
+    $scope.$evalAsync(updateFilter);
+  });
+
+  overview.startBuild = function(buildConfig) {
+    BuildsService
+      .startBuild(buildConfig.metadata.name, { namespace: buildConfig.metadata.namespace })
+      .then(_.noop, function(result) {
+        var buildType = isJenkinsPipelineStrategy(buildConfig) ? 'pipeline' : 'build';
+        state.alerts["start-build"] = {
+          type: "error",
+          message: "An error occurred while starting the " + buildType + ".",
+          details: getErrorDetails(result)
+        };
+      });
+  };
+
+  var watches = [];
+  ProjectsService.get($routeParams.project).then(_.spread(function(project, context) {
+    // Project must be set on `$scope` for the projects dropdown.
+    $scope.project = project;
+    state.context = context;
+
+    var updateReferencedImageStreams = function() {
+      if (!overview.pods) {
+        return;
+      }
+
+      ImageStreamResolver.fetchReferencedImageStreamImages(overview.pods,
+                                                           state.imagesByDockerReference,
+                                                           state.imageStreamImageRefByDockerReference,
+                                                           context);
+    };
+
+    watches.push(DataService.watch("pods", context, function(podsData) {
+      overview.pods = podsData.by("metadata.name");
+      groupPods();
+      updateReferencedImageStreams();
+      updateWarnings();
+      updateServicesForObjects(overview.monopods);
+      updatePodWarnings(overview.monopods);
+      updateLabelSuggestions(overview.monopods);
+      updateFilter();
+      Logger.log("pods (subscribe)", overview.pods);
+    }));
+
+    watches.push(DataService.watch("replicationcontrollers", context, function(rcData) {
+      overview.replicationControllers = rcData.by("metadata.name");
+      groupPods();
+      groupReplicationControllers();
+      updateServicesForObjects(overview.vanillaReplicationControllers);
+      updateServicesForObjects(overview.monopods);
+      updatePodWarnings(overview.vanillaReplicationControllers);
+      updateLabelSuggestions(overview.vanillaReplicationControllers);
+      updateFilter();
+      Logger.log("replicationcontrollers (subscribe)", overview.replicationControllers);
+    }));
+
+    watches.push(DataService.watch("deploymentconfigs", context, function(dcData) {
+      overview.deploymentConfigs = dcData.by("metadata.name");
+      groupReplicationControllers();
+      updateServicesForObjects(overview.deploymentConfigs);
+      // `overview.vanillaReplicationControllers` is not populated until
+      // deployment configs load. Make sure the services for these are updated
+      // if deployment configs load after replication controllers.
+      updateServicesForObjects(overview.vanillaReplicationControllers);
+      updateLabelSuggestions(overview.deploymentConfigs);
+      updateAllDeploymentWarnings();
+      groupBuildConfigsByDeploymentConfig();
+      groupRecentBuildsByDeploymentConfig();
+      updateFilter();
+      Logger.log("deploymentconfigs (subscribe)", overview.deploymentConfigs);
+    }));
+
+    watches.push(DataService.watch({
+      group: "extensions",
+      resource: "replicasets"
+    }, context, function(replicaSetData) {
+      overview.replicaSets = replicaSetData.by('metadata.name');
+      groupPods();
+      groupReplicaSets();
+      updateServicesForObjects(overview.vanillaReplicaSets);
+      updateServicesForObjects(overview.monopods);
+      updatePodWarnings(overview.vanillaReplicaSets);
+      updateLabelSuggestions(overview.vanillaReplicaSets);
+      updateFilter();
+      Logger.log("replicasets (subscribe)", overview.replicaSets);
+    }));
+
+    watches.push(DataService.watch({
+      group: "extensions",
+      resource: "deployments"
+    }, context, function(deploymentData) {
+      overview.deployments = deploymentData.by('metadata.name');
+      groupReplicaSets();
+      updateServicesForObjects(overview.deployments);
+      updateServicesForObjects(overview.vanillaReplicaSets);
+      updateLabelSuggestions(overview.deployments);
+      updateFilter();
+      Logger.log("deployments (subscribe)", overview.deployments);
+    }));
+
+    watches.push(DataService.watch("builds", context, function(buildData) {
+      state.builds = buildData.by("metadata.name");
+      groupBuilds();
+      Logger.log("builds (subscribe)", state.builds);
+    }));
+
+    watches.push(DataService.watch({
+      group: "apps",
+      resource: "statefulsets"
+    }, context, function(statefulSetData) {
+      overview.statefulSets = statefulSetData.by('metadata.name');
+      groupPods();
+      updateServicesForObjects(overview.statefulSets);
+      updateServicesForObjects(overview.monopods);
+      updatePodWarnings(overview.statefulSets);
+      updateLabelSuggestions(overview.statefulSets);
+      updateFilter();
+      Logger.log("statefulsets (subscribe)", overview.statefulSets);
+    }, {poll: limitWatches, pollInterval: DEFAULT_POLL_INTERVAL}));
+
+    watches.push(DataService.watch("services", context, function(serviceData) {
+      overview.services = serviceData.by("metadata.name");
+      groupServices();
+      Logger.log("services (subscribe)", overview.services);
+    }, {poll: limitWatches, pollInterval: DEFAULT_POLL_INTERVAL}));
+
+    watches.push(DataService.watch("routes", context, function(routesData) {
+      overview.routes = routesData.by("metadata.name");
+      groupRoutes();
+      Logger.log("routes (subscribe)", overview.routes);
+    }, {poll: limitWatches, pollInterval: DEFAULT_POLL_INTERVAL}));
+
+    watches.push(DataService.watch("buildConfigs", context, function(buildConfigData) {
+      overview.buildConfigs = buildConfigData.by("metadata.name");
+      groupBuildConfigsByOutputImage();
+      groupBuildConfigsByDeploymentConfig();
+      groupBuilds();
+      updateFilter();
+      Logger.log("buildconfigs (subscribe)", overview.buildConfigs);
+    }, {poll: limitWatches, pollInterval: DEFAULT_POLL_INTERVAL}));
+
+    watches.push(DataService.watch({
+      group: "extensions",
+      resource: "horizontalpodautoscalers"
+    }, context, function(hpaData) {
+      overview.horizontalPodAutoscalers = hpaData.by("metadata.name");
+      groupHPAs();
+      Logger.log("autoscalers (subscribe)", overview.horizontalPodAutoscalers);
+    }, {poll: limitWatches, pollInterval: DEFAULT_POLL_INTERVAL}));
+
+    watches.push(DataService.watch("imagestreams", context, function(imageStreamData) {
+      imageStreams = imageStreamData.by("metadata.name");
+      ImageStreamResolver.buildDockerRefMapForImageStreams(imageStreams,
+                                                           state.imageStreamImageRefByDockerReference);
+      updateReferencedImageStreams();
+      Logger.log("imagestreams (subscribe)", imageStreams);
+    }, {poll: limitWatches, pollInterval: DEFAULT_POLL_INTERVAL}));
+
+    // Always poll quotas instead of watching, its not worth the overhead of maintaining websocket connections
+    watches.push(DataService.watch('resourcequotas', context, function(quotaData) {
+      state.quotas = quotaData.by("metadata.name");
+      updateQuotaWarnings();
+    }, {poll: true, pollInterval: DEFAULT_POLL_INTERVAL}));
+
+    watches.push(DataService.watch('appliedclusterresourcequotas', context, function(clusterQuotaData) {
+      state.clusterQuotas = clusterQuotaData.by("metadata.name");
+      updateQuotaWarnings();
+    }, {poll: true, pollInterval: DEFAULT_POLL_INTERVAL}));
+
+    // List limit ranges in this project to determine if there is a default
+    // CPU request for autoscaling.
+    DataService.list("limitranges", context, function(response) {
+      state.limitRanges = response.by("metadata.name");
+    });
+
+    var samplePipelineTemplate = Constants.SAMPLE_PIPELINE_TEMPLATE;
+    if (samplePipelineTemplate) {
+      DataService.get("templates", samplePipelineTemplate.name, {
+        namespace: samplePipelineTemplate.namespace
+      }, {
+        errorNotification: false
+      }).then(function(template) {
+        overview.samplePipelineURL = Navigate.createFromTemplateURL(template, $scope.projectName);
+      });
+    }
+
+    $scope.$on('$destroy', function() {
+      DataService.unwatchAll(watches);
+      $(window).off('resize.overview', onResize);
+    });
+  }));
+}

--- a/app/scripts/directives/buildCounts.js
+++ b/app/scripts/directives/buildCounts.js
@@ -1,0 +1,41 @@
+'use strict';
+
+angular.module('openshiftConsole').component('buildCounts', {
+  controller: [
+    '$scope',
+    'BuildsService',
+    BuildCounts
+  ],
+  controllerAs: 'buildCounts',
+  bindings: {
+    builds: '<',
+    showRunningStage: '<',
+    label: '@'
+  },
+  templateUrl: 'views/overview/_build-counts.html'
+});
+
+function BuildCounts($scope, BuildsService) {
+  var buildCounts = this;
+
+  buildCounts.interestingPhases = ['New', 'Pending', 'Running', 'Failed', 'Error'];
+  var isInteresting = function(build) {
+    var phase = _.get(build, 'status.phase');
+    return _.includes(buildCounts.interestingPhases, phase);
+  };
+
+  buildCounts.$onChanges = _.debounce(function() {
+    $scope.$apply(function() {
+      var buildsByPhase = _.groupBy(buildCounts.builds, 'status.phase');
+      buildCounts.countByPhase = _.mapValues(buildsByPhase, _.size);
+      buildCounts.show = _.some(buildCounts.builds, isInteresting);
+      if (!buildCounts.showRunningStage || buildCounts.countByPhase.Running !== 1) {
+        buildCounts.currentStage = null;
+        return;
+      }
+
+      var runningBuild = _.head(buildsByPhase.Running);
+      buildCounts.currentStage = BuildsService.getCurrentStage(runningBuild);
+    });
+  }, 200);
+}

--- a/app/scripts/directives/buildPipeline.js
+++ b/app/scripts/directives/buildPipeline.js
@@ -6,7 +6,9 @@ angular.module('openshiftConsole')
       restrict: 'E',
       scope: {
         build: '=',
+        // TODO: Remove when the remove the previous overview.
         expandOnlyRunning: '=?',
+        collapsePending: '=?',
         buildConfigNameOnExpanded: '=?'
       },
       // To fill height as flexbox item.

--- a/app/scripts/directives/deploymentMetrics.js
+++ b/app/scripts/directives/deploymentMetrics.js
@@ -380,24 +380,26 @@ angular.module('openshiftConsole')
             return;
           }
 
-          // Show an alert if we've failed more than once.
-          // Use scope.$id in the alert ID so that it is unique on pages that
-          // use the directive multiple times like monitoring.
-          var alertID = 'metrics-failed-' + scope.uniqueID;
-          scope.alerts[alertID] = {
-            type: 'error',
-            message: 'An error occurred updating metrics.',
-            links: [{
-              href: '',
-              label: 'Retry',
-              onClick: function() {
-                delete scope.alerts[alertID];
-                // Reset failure count to 1 to trigger a retry.
-                failureCount = 1;
-                update();
-              }
-            }]
-          };
+          if (scope.alerts) {
+            // Show an alert if we've failed more than once.
+            // Use scope.$id in the alert ID so that it is unique on pages that
+            // use the directive multiple times like monitoring.
+            var alertID = 'metrics-failed-' + scope.uniqueID;
+            scope.alerts[alertID] = {
+              type: 'error',
+              message: 'An error occurred updating metrics.',
+              links: [{
+                href: '',
+                label: 'Retry',
+                onClick: function() {
+                  delete scope.alerts[alertID];
+                  // Reset failure count to 1 to trigger a retry.
+                  failureCount = 1;
+                  update();
+                }
+              }]
+            };
+          }
         }
 
         // Make sure there are no errors or missing data before updating.

--- a/app/scripts/directives/metricsSummary.js
+++ b/app/scripts/directives/metricsSummary.js
@@ -1,0 +1,179 @@
+'use strict';
+
+angular.module('openshiftConsole').component('metricsSummary', {
+  controller: [
+    '$interval',
+    'ConversionService',
+    'MetricsCharts',
+    'MetricsService',
+    MetricsSummary
+  ],
+  controllerAs: 'metricsSummary',
+  bindings: {
+    pods: '<',
+    // Take in the list of containers rather than reading from the pod spec
+    // in case pods is empty.
+    containers: '<',
+  },
+  templateUrl: 'views/overview/_metrics-summary.html'
+});
+
+function MetricsSummary($interval,
+                        ConversionService,
+                        MetricsCharts,
+                        MetricsService) {
+  var metricsSummary = this;
+
+  // Wait until the charts are in view before fetching metrics.
+  var paused = true;
+
+  // Track when we last requested metrics. When we scroll into view, this
+  // helps decide whether to update immediately or wait until the next
+  // interval tick.
+  var lastUpdated;
+
+  // TODO: Move to MetricsCharts ?
+  // Should we display the current usage as GiB when showing compact metrics?
+  var displayAsGiB = function(usageInMiB) {
+    return usageInMiB >= 1024;
+  };
+
+  metricsSummary.metrics = [{
+    label: 'Memory',
+    convert: ConversionService.bytesToMiB,
+    formatUsage: function(value) {
+      if (displayAsGiB(value)) {
+        value = value / 1024;
+      }
+      return MetricsCharts.formatUsage(value);
+    },
+    usageUnits: function(value) {
+      return displayAsGiB(value) ? 'GiB' : 'MiB';
+    },
+    datasets: [ 'memory/usage' ],
+    type: 'pod_container'
+  }, {
+    label: "CPU",
+    convert: ConversionService.millicoresToCores,
+    usageUnits: function() {
+      return 'cores';
+    },
+    formatUsage: function(value) {
+      if (value < 0.01) {
+        return "< 0.01";
+      }
+
+      return MetricsCharts.formatUsage(value);
+    },
+    datasets: [ 'cpu/usage_rate' ],
+    type: 'pod_container'
+  }, {
+    label: "Network",
+    units: "KiB/s",
+    convert: ConversionService.bytesToKiB,
+    formatUsage: function(value) {
+      if (value < 0.01) {
+        return "< 0.01";
+      }
+
+      return MetricsCharts.formatUsage(value);
+    },
+    usageUnits: function() {
+      return 'KiB/s';
+    },
+    datasets: [ 'network/tx_rate', 'network/rx_rate' ],
+    type: 'pod',
+  }];
+
+  var getConfig = function() {
+    var pod = _.find(metricsSummary.pods, 'metadata.namespace');
+    if (!pod) {
+      return null;
+    }
+
+    var config = {
+      pods: metricsSummary.pods,
+      containerName: _.head(pod.spec.containers).name,
+      namespace: pod.metadata.namespace,
+      start: '-1mn',
+      bucketDuration: '1mn'
+    };
+
+    return config;
+  };
+
+  var isNil = function(point) {
+    return point.value === null || point.value === undefined;
+  };
+
+  var calculateUsage = function(metric, data) {
+    var total = null;
+    var hasData = {};
+    _.each(metric.datasets, function(descriptor) {
+      _.each(data[descriptor], function(podData, podName) {
+        var point = _.last(podData);
+        if (isNil(point)) {
+          return;
+        }
+
+        hasData[podName] = true;
+        var value = metric.convert(point.value);
+        total = (total || 0) + value;
+      });
+    });
+
+    if (total === null) {
+      delete metric.currentUsage;
+    } else {
+      metric.currentUsage = total / _.size(hasData);
+    }
+  };
+
+  var processData = function(data) {
+    _.each(metricsSummary.metrics, function(metric) {
+      calculateUsage(metric, data);
+    });
+  };
+
+  var metricsFailed = function() {
+    metricsSummary.error = true;
+  };
+
+  var update = function() {
+    if (metricsSummary.error || paused) {
+      return;
+    }
+
+    var config = getConfig();
+    if (!config) {
+      return;
+    }
+
+    lastUpdated = Date.now();
+    MetricsService.getPodMetrics(config).then(processData, metricsFailed);
+  };
+
+  // Pause or resume metrics updates when the element scrolls into and
+  // out of view.
+  metricsSummary.updateInView = function(inview) {
+    paused = !inview;
+
+    // Update now if in view and it's been longer than updateInterval.
+    if (inview && (!lastUpdated || Date.now() > (lastUpdated + MetricsCharts.getDefaultUpdateInterval()))) {
+      update();
+    }
+  };
+
+  var intervalPromise;
+  metricsSummary.$onInit = function() {
+    intervalPromise = $interval(update, MetricsCharts.getDefaultUpdateInterval(), false);
+    update();
+  };
+
+  metricsSummary.$onDestroy = function() {
+    if (intervalPromise) {
+      $interval.cancel(intervalPromise);
+      intervalPromise = null;
+    }
+  };
+}

--- a/app/scripts/directives/miniLog.js
+++ b/app/scripts/directives/miniLog.js
@@ -1,0 +1,105 @@
+'use strict';
+
+angular.module('openshiftConsole').component('miniLog', {
+  controllerAs: 'miniLog',
+  controller: [
+    '$scope',
+    '$filter',
+    'APIService',
+    'DataService',
+    'HTMLService',
+    MiniLogController
+  ],
+  bindings: {
+    apiObject: '<',
+    numLines: '<',
+    context: '<'
+  },
+  templateUrl: 'views/overview/_mini-log.html'
+});
+
+function MiniLogController($scope,
+                           $filter,
+                           APIService,
+                           DataService,
+                           HTMLService) {
+  var miniLog = this;
+
+  var name, logSubresource, streamer;
+  var annotation = $filter('annotation');
+  var numLines = miniLog.numLines || 7;
+  var buffer = [];
+  miniLog.lines = [];
+
+  var update = _.throttle(function() {
+    $scope.$evalAsync(function() {
+      miniLog.lines = _.clone(buffer);
+    });
+  }, 200);
+
+  // Used as a "track by" ID in the view. Since we follow from the end, might
+  // not correspond to actual line numbers. Track by is necessary in case a
+  // line is repeated.
+  var lineNum = 0;
+  var onMessage = function(msg) {
+    if (!msg) {
+      return;
+    }
+
+    var escaped = ansi_up.escape_for_html(msg);
+    var html = ansi_up.ansi_to_html(escaped);
+    var linkifiedHTML = HTMLService.linkify(html, '_blank', true);
+
+    lineNum++;
+    buffer.push({
+      markup: linkifiedHTML,
+      id: lineNum
+    });
+
+    if (buffer.length > numLines) {
+      buffer = _.takeRight(buffer, numLines);
+    }
+
+    update();
+  };
+
+  var stopStreaming = function() {
+    if (!streamer) {
+      return;
+    }
+
+    streamer.stop();
+    streamer = null;
+  };
+
+  var startStreaming = function() {
+    var options = {
+      follow: true,
+      tailLines: numLines
+    };
+
+    streamer = DataService.createStream(logSubresource, name, miniLog.context, options);
+    streamer.start();
+    streamer.onMessage(onMessage);
+    streamer.onClose(function() {
+      streamer = null;
+    });
+  };
+
+  miniLog.$onInit = function() {
+    if (miniLog.apiObject.kind === "ReplicationController") {
+      logSubresource = "deploymentconfigs/log";
+      name = annotation(miniLog.apiObject, 'deploymentConfig');
+    }
+    else {
+      logSubresource = APIService.kindToResource(miniLog.apiObject.kind) + "/log";
+      name = miniLog.apiObject.metadata.name;
+    }
+
+    startStreaming();
+  };
+
+  miniLog.$onDestroy = function() {
+    stopStreaming();
+  };
+}

--- a/app/scripts/directives/notificationIcon.js
+++ b/app/scripts/directives/notificationIcon.js
@@ -1,0 +1,28 @@
+'use strict';
+
+angular.module('openshiftConsole').component('notificationIcon', {
+  controller: [
+    '$scope',
+    NotificationIcon
+  ],
+  controllerAs: 'notification',
+  bindings: {
+    alerts: '<'
+  },
+  templateUrl: 'views/overview/_notification-icon.html'
+});
+
+function NotificationIcon($scope) {
+  var notification = this;
+  notification.$onChanges = _.debounce(function() {
+    $scope.$apply(function() {
+      var byType = _.groupBy(notification.alerts, 'type');
+      notification.countByType = _.mapValues(byType, _.size);
+      notification.byType = _.mapValues(byType, function(alerts) {
+        return _.map(alerts, function(alert) {
+          return _.escape(alert.message);
+        }).join('<br>');
+      });
+    });
+  }, 200);
+}

--- a/app/scripts/directives/overview/builds.js
+++ b/app/scripts/directives/overview/builds.js
@@ -1,0 +1,52 @@
+'use strict';
+
+angular.module('openshiftConsole').component('overviewBuilds', {
+  controller: [
+    '$filter',
+    OverviewBuilds
+  ],
+  controllerAs: 'overviewBuilds',
+  bindings: {
+    buildConfigs: '<',
+    recentBuildsByBuildConfig: '<',
+    context: '<',
+    hideLog: '<'
+  },
+  templateUrl: 'views/overview/_builds.html'
+});
+
+function OverviewBuilds($filter) {
+  var canIViewLogs;
+  var canI = $filter('canI');
+
+  this.$onInit = function() {
+    canIViewLogs = canI('builds/log', 'get');
+  };
+
+  this.showLogs = function(build) {
+    if (this.hideLog) {
+      return false;
+    }
+
+    if (!canIViewLogs) {
+      return false;
+    }
+
+    if (!_.get(build, 'status.startTimestamp')) {
+      return false;
+    }
+
+    if (_.get(build, 'status.phase') !== 'Complete') {
+      return true;
+    }
+
+    // Has the build completed recently?
+    var completed = _.get(build, 'status.completionTimestamp');
+    if (!completed) {
+      return false;
+    }
+
+    var threeMinutesAgo = moment().subtract(3, 'm');
+    return moment(completed).isAfter(threeMinutesAgo);
+  };
+}

--- a/app/scripts/directives/overview/listRow.js
+++ b/app/scripts/directives/overview/listRow.js
@@ -1,0 +1,322 @@
+'use strict';
+
+angular.module('openshiftConsole').component('overviewListRow', {
+  controller: [
+    '$filter',
+    '$uibModal',
+    'APIService',
+    'BuildsService',
+    'DeploymentsService',
+    'Navigate',
+    OverviewListRow
+  ],
+  controllerAs: 'row',
+  bindings: {
+    apiObject: '<',
+    current: '<',
+    // Previous deployment (if a deployment is in progress)
+    previous: '<',
+    state: '<',
+    hidePipelines: '<'
+  },
+  templateUrl: 'views/overview/_list-row.html'
+});
+
+function OverviewListRow($filter,
+                         $uibModal,
+                         APIService,
+                         BuildsService,
+                         DeploymentsService,
+                         Navigate) {
+  var row = this;
+
+  var canI = $filter('canI');
+  var deploymentIsInProgress = $filter('deploymentIsInProgress');
+  var getErrorDetails = $filter('getErrorDetails');
+  var isJenkinsPipelineStrategy = $filter('isJenkinsPipelineStrategy');
+
+  var updateTriggers = function(apiObject) {
+    var triggers = _.get(apiObject, 'spec.triggers');
+    if (_.isEmpty(triggers)) {
+      return;
+    }
+
+    row.imageChangeTriggers = _.filter(triggers, function(trigger) {
+      return trigger.type === 'ImageChange' && _.get(trigger, 'imageChangeParams.automatic');
+    });
+  };
+
+  var updateCurrent = function(apiObject) {
+    if (!apiObject ||
+        row.current ||
+        apiObject.kind === 'DeploymentConfig' ||
+        apiObject.kind === 'Deployment') {
+      return;
+    }
+
+    // For anything that's not a deployment or deployment config, "current" is the object itself.
+    row.current = apiObject;
+  };
+
+  var updateAPIObject = function(apiObject) {
+    row.rgv = APIService.objectToResourceGroupVersion(apiObject);
+    updateCurrent(apiObject);
+    updateTriggers(apiObject);
+  };
+
+  row.$onChanges = function(changes) {
+    if (changes.apiObject) {
+      updateAPIObject(changes.apiObject.currentValue);
+    }
+  };
+
+  var getNotifications = function(object) {
+    var uid = _.get(object, 'metadata.uid');
+    if (!uid) {
+      return null;
+    }
+    return _.get(row, ['state', 'notificationsByObjectUID', uid]);
+  };
+
+  // Return the same empty array each time. Otherwise, digest loop errors occur.
+  var NO_HPA = [];
+  var getHPA = function(object) {
+    if (!row.state.hpaByResource) {
+      return null;
+    }
+
+    var kind = _.get(object, 'kind');
+    var name = _.get(object, 'metadata.name');
+
+    // TODO: Handle groups and subresources
+    // var groupVersion = APIService.parseGroupVersion(object.apiVersion) || {};
+    // var group = groupVersion.group || '';
+
+    return _.get(row.state.hpaByResource, [kind, name], NO_HPA);
+  };
+
+  var expandedKey = function(apiObject) {
+    var uid = _.get(apiObject, 'metadata.uid');
+    if (!uid) {
+      return null;
+    }
+
+    return 'overview/expand/' + uid;
+  };
+
+  row.toggleExpand = function(e, always) {
+    // Don't toggle if clicking on a link inside the row unless `always` is set.
+    if (!always && $(e.target).closest("a").length > 0) {
+      return;
+    }
+
+    var key = expandedKey(row.apiObject);
+    if (!key) {
+      return;
+    }
+
+    row.expanded = !row.expanded;
+    sessionStorage.setItem(key, row.expanded ? 'true' : 'false');
+  };
+
+  var setInitialExpandedState = function() {
+    var key = expandedKey(row.apiObject);
+    if (!key) {
+      row.expanded = false;
+      return;
+    }
+
+    var item = sessionStorage.getItem(key);
+    if (!item && row.state.expandAll) {
+      row.expanded = true;
+      return;
+    }
+
+    row.expanded = item === 'true';
+  };
+
+  row.$onInit = function() {
+    _.set(row, 'selectedTab.networking', true);
+    setInitialExpandedState();
+  };
+
+  row.$doCheck = function() {
+    // Update notifications.
+    row.notifications = getNotifications(row.apiObject);
+
+    // Update HPA.
+    row.hpa = getHPA(row.apiObject);
+    if (row.current && _.isEmpty(row.hpa)) {
+      row.hpa = getHPA(row.current);
+    }
+
+    // Update services and build configs.
+    var uid = _.get(row, 'apiObject.metadata.uid');
+    if (uid) {
+      row.services = _.get(row, ['state', 'servicesByObjectUID', uid]);
+      row.buildConfigs = _.get(row, ['state', 'buildConfigsByObjectUID', uid]);
+    }
+
+    var name;
+    var kind = _.get(row, 'apiObject.kind');
+    if (kind === 'DeploymentConfig') {
+      name = _.get(row, 'apiObject.metadata.name');
+      row.pipelines = _.get(row, ['state', 'pipelinesByDeploymentConfig', name]);
+      row.recentBuilds = _.get(row, ['state', 'recentBuildsByDeploymentConfig', name]);
+      row.recentPipelines = _.get(row, ['state', 'recentPipelinesByDeploymentConfig', name]);
+    }
+  };
+
+  row.getPods = function(owner) {
+    var uid = _.get(owner, 'metadata.uid');
+    return _.get(row, ['state', 'podsByOwnerUID', uid]);
+  };
+
+  row.firstPod = function(owner) {
+    var pods = row.getPods(owner);
+    // Use `_.find` to get the first item.
+    return _.find(pods);
+  };
+
+  row.isScalable = function() {
+    if (!_.isEmpty(row.hpa)) {
+      return false;
+    }
+
+    return !row.isDeploymentInProgress();
+  };
+
+  row.isDeploymentInProgress = function() {
+    if (row.current && row.previous) {
+      return true;
+    }
+
+    return deploymentIsInProgress(row.current);
+  };
+
+  row.canIDoAny = function() {
+    var kind = _.get(row, 'apiObject.kind');
+    switch (kind) {
+    case 'DeploymentConfig':
+      // Edit is displayed.
+      if (canI('deploymentconfigs', 'update')) {
+        return true;
+      }
+      // View logs is displayed.
+      if (row.current && canI('deploymentconfigs/log', 'get')) {
+        return true;
+      }
+      // Start pipeline or build is displayed.
+      if ((_.size(row.buildConfigs) === 1 || _.size(row.pipelines) === 1) &&
+           canI('buildconfigs/instantiate')) {
+        return true;
+      }
+
+      return false;
+
+    case 'Pod':
+      // View log is displayed.
+      if (canI('pods/log', 'get')) {
+        return true;
+      }
+      // Edit YAML is displayed.
+      if (canI('pods', 'update')) {
+        return true;
+      }
+
+      return false;
+
+    default:
+      // View log is displayed.
+      if (row.firstPod(row.current) && canI('pods/log', 'get')) {
+        return true;
+      }
+      // Edit YAML is displayed.
+      if (canI(row.rgv, 'update')) {
+        return true;
+      }
+
+      return false;
+    }
+  };
+
+  row.startBuild = function(buildConfig) {
+    BuildsService
+      .startBuild(buildConfig.metadata.name, { namespace: buildConfig.metadata.namespace })
+      .then(_.noop, function(result) {
+        var buildType = isJenkinsPipelineStrategy(buildConfig) ? 'pipeline' : 'build';
+        row.state.alerts["start-build"] = {
+          type: "error",
+          message: "An error occurred while starting the " + buildType + ".",
+          details: getErrorDetails(result)
+        };
+      });
+  };
+
+  row.startDeployment = function() {
+    DeploymentsService.startLatestDeployment(row.apiObject, {
+      namespace: row.apiObject.metadata.namespace
+    }, { alerts: row.state.alerts });
+  };
+
+  // TODO: Pulled from dc.js, but we should probably make the dialog generic and reuse for the deployment config page.
+  row.cancelDeployment = function() {
+    var replicationController = row.current;
+    if (!replicationController) {
+      return;
+    }
+
+    var rcName = replicationController.metadata.name;
+    var latestVersion = _.get(row, 'apiObject.status.latestVersion');
+    var modalInstance = $uibModal.open({
+      animation: true,
+      templateUrl: 'views/modals/confirm.html',
+      controller: 'ConfirmModalController',
+      resolve: {
+        modalConfig: function() {
+          return {
+            message: "Cancel deployment " + rcName + "?",
+            details: latestVersion ? ("This will attempt to stop the in-progress deployment and rollback to the previous deployment, #" + latestVersion + ". It may take some time to complete.") :
+                                      "This will attempt to stop the in-progress deployment and may take some time to complete.",
+            okButtonText: "Yes, cancel",
+            okButtonClass: "btn-danger",
+            cancelButtonText: "No, don't cancel"
+          };
+        }
+      }
+    });
+
+    modalInstance.result.then(function() {
+      if (replicationController.metadata.uid !== row.current.metadata.uid) {
+        row.state.alerts["cancel-deployment"] = {
+          type: "error",
+          message: "Deployment #" + latestVersion + " is no longer the latest."
+        };
+        return;
+      }
+
+      // Make sure we have the latest resource version of the replication controller.
+      replicationController = row.current;
+
+      // Make sure it's still running.
+      if (!deploymentIsInProgress(replicationController)) {
+        row.state.alerts["cancel-deployment"] = {
+          type: "error",
+          message: "Deployment " + rcName + " is no longer in progress."
+        };
+        return;
+      }
+
+      DeploymentsService.cancelRunningDeployment(replicationController, {
+        namespace: replicationController.metadata.namespace
+      }, { alerts: row.state.alerts });
+    });
+  };
+
+  row.urlForImageChangeTrigger = function(imageChangeTrigger) {
+    var imageStreamName = $filter('stripTag')(_.get(imageChangeTrigger, 'imageChangeParams.from.name'));
+    var deploymentConfigNamespace = _.get(row, 'apiObject.metadata.namespace');
+    var imageStreamNamespace = _.get(imageChangeTrigger, 'imageChangeParams.from.namespace', deploymentConfigNamespace);
+    return Navigate.resourceURL(imageStreamName, 'ImageStream', imageStreamNamespace);
+  };
+}

--- a/app/scripts/directives/overview/networking.js
+++ b/app/scripts/directives/overview/networking.js
@@ -1,0 +1,10 @@
+'use strict';
+
+angular.module('openshiftConsole').component('overviewNetworking', {
+  controllerAs: 'networking',
+  bindings: {
+    services: '<',
+    routesByService: '<'
+  },
+  templateUrl: 'views/overview/_networking.html'
+});

--- a/app/scripts/directives/overview/pipelines.js
+++ b/app/scripts/directives/overview/pipelines.js
@@ -1,0 +1,9 @@
+'use strict';
+
+angular.module('openshiftConsole').component('overviewPipelines', {
+  controllerAs: 'overviewPipelines',
+  bindings: {
+    recentPipelines: '<'
+  },
+  templateUrl: 'views/overview/_pipelines.html'
+});

--- a/app/scripts/directives/podDonut.js
+++ b/app/scripts/directives/podDonut.js
@@ -16,7 +16,8 @@ angular.module('openshiftConsole')
       scope: {
         pods: '=',
         desired: '=?',
-        idled: '=?'
+        idled: '=?',
+        mini: '=?'
       },
       templateUrl: 'views/directives/pod-donut.html',
       link: function($scope, element) {
@@ -28,6 +29,9 @@ angular.module('openshiftConsole')
         $scope.chartId = _.uniqueId('pods-donut-chart-');
 
         function updateCenterText() {
+          if ($scope.mini) {
+            return;
+          }
           var smallText;
           // Don't show failed pods like evicted pods in the donut.
           var pods = _.reject($scope.pods, { status: { phase: 'Failed' } });
@@ -55,11 +59,11 @@ angular.module('openshiftConsole')
             label: {
               show: false
             },
-            width: 10
+            width: $scope.mini ? 5 : 10
           },
           size: {
-            height: 150,
-            width: 150
+            height: $scope.mini ? 45 : 150,
+            width: $scope.mini ? 45 : 150
           },
           legend: {
             show: false
@@ -111,6 +115,15 @@ angular.module('openshiftConsole')
             }
           }
         };
+
+        if ($scope.mini) {
+          config.padding = {
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0
+          };
+        }
 
         function updateChart(countByPhase) {
           var data = {

--- a/app/scripts/directives/routeServiceBarChart.js
+++ b/app/scripts/directives/routeServiceBarChart.js
@@ -1,0 +1,67 @@
+'use strict';
+
+angular.module('openshiftConsole').component('routeServiceBarChart', {
+  controller: RouteServiceBarChart,
+  controllerAs: 'routeServices',
+  bindings: {
+    route: '<',
+    highlightService: '<'
+  },
+  templateUrl: 'views/directives/route-service-bar-chart.html'
+});
+
+function RouteServiceBarChart() {
+  var routeServices = this;
+
+  // Put the highlighted service at the top if set.
+  var compareWeights = function(left, right) {
+    if (left.name === routeServices.highlightService) {
+      return -1;
+    }
+
+    if (right.name === routeServices.highlightService) {
+      return 1;
+    }
+
+    // Fall back to comparing names if weights are equal.
+    if (right.weight === left.weight) {
+      return left.name.localeCompare(right.name);
+    }
+
+    return right.weight - left.weight;
+  };
+
+  var addBackend = function(backend) {
+    routeServices.total += backend.weight;
+    routeServices.max = Math.max(backend.weight, routeServices.max || 0);
+    routeServices.backends.push({
+      name: backend.name,
+      weight: backend.weight
+    });
+  };
+
+  routeServices.$onChanges = function() {
+    routeServices.backends = [];
+    routeServices.total = 0;
+    if (!routeServices.route) {
+      return;
+    }
+
+    addBackend(routeServices.route.spec.to);
+    var alternateBackends = _.get(routeServices, 'route.spec.alternateBackends', []);
+    _.each(alternateBackends, addBackend);
+
+    routeServices.backends.sort(compareWeights);
+  };
+
+  routeServices.getPercentage = function(backend) {
+    var total = routeServices.total || 100;
+    var percent = (backend.weight / total) * 100;
+    return _.round(percent)  + '%';
+  };
+
+  routeServices.barWidth = function(backend) {
+    var max = routeServices.max || 100;
+    return ((backend.weight / max) * 100) + '%';
+  };
+}

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -1322,6 +1322,19 @@ angular.module('openshiftConsole')
       return HPAService.convertRequestPercentToLimit(targetCPU, project);
     };
   })
+  .filter('podTemplate', function() {
+    return function(apiObject) {
+      if (!apiObject) {
+        return null;
+      }
+
+      if (apiObject.kind === 'Pod') {
+        return apiObject;
+      }
+
+      return _.get(apiObject, 'spec.template');
+    };
+  })
   .filter('hasHealthChecks', function() {
     return function(podTemplate) {
       // Returns true if every container has a readiness or liveness probe.
@@ -1488,5 +1501,11 @@ angular.module('openshiftConsole')
       }
 
       return false;
+    };
+  })
+  .filter('hasAlternateBackends', function() {
+    return function(route) {
+      var alternateBackends = _.get(route, 'spec.alternateBackends', []);
+      return !_.isEmpty(alternateBackends);
     };
   });

--- a/app/scripts/services/apps.js
+++ b/app/scripts/services/apps.js
@@ -1,0 +1,41 @@
+'use strict';
+
+angular.module("openshiftConsole")
+  .factory("AppsService", function() {
+    var appLabel = function(apiObject) {
+      return _.get(apiObject, 'metadata.labels.app', '');
+    };
+
+    // Place empty app labels last.
+    var compareAppNames = function(left, right) {
+      if (!left && !right) {
+        return 0;
+      }
+      if (!left) {
+        return 1;
+      }
+      if (!right) {
+        return -1;
+      }
+      return left.toLowerCase().localeCompare(right.toLowerCase());
+    };
+
+    return {
+      groupByApp: function(collection, sortBy) {
+        var byApp = _.groupBy(collection, appLabel);
+        if (sortBy) {
+          _.mapValues(byApp, function(items) {
+            return _.sortBy(items, sortBy);
+          });
+        }
+
+        return byApp;
+      },
+
+      // Sort an array of app names.
+      sortAppNames: function(appNames) {
+        appNames.sort(compareAppNames);
+      }
+    };
+  });
+

--- a/app/scripts/services/builds.js
+++ b/app/scripts/services/builds.js
@@ -53,6 +53,7 @@ angular.module("openshiftConsole")
       return true;
     };
 
+    // TODO: Generalize for other kinds since the annotation is generic.
     var usesDeploymentConfigs = function(buildConfig) {
       var uses = annotation(buildConfig, 'pipeline.alpha.openshift.io/uses');
       if (!uses) {
@@ -200,6 +201,98 @@ angular.module("openshiftConsole")
                     }));
     };
 
+    var imageObjectRef = $filter('imageObjectRef');
+    var groupBuildConfigsByOutputImage = function(buildConfigs) {
+      var buildConfigsByOutputImage = {};
+      _.each(buildConfigs, function(buildConfig) {
+        var outputImage = _.get(buildConfig, 'spec.output.to');
+        var ref = imageObjectRef(outputImage, buildConfig.metadata.namespace);
+        if (!ref) {
+          return;
+        }
+
+        buildConfigsByOutputImage[ref] = buildConfigsByOutputImage[ref] || [];
+        buildConfigsByOutputImage[ref].push(buildConfig);
+      });
+
+      return buildConfigsByOutputImage;
+    };
+
+    // Sort by date first, falling back to build number in case two builds
+    // have the same date.
+    var sortBuilds = function(builds, descending) {
+      var compareNumbers = function(left, right) {
+        var leftNumber = getBuildNumber(left);
+        var rightNumber = getBuildNumber(right);
+
+        // Fall back to names if no numbers.
+        var leftName, rightName;
+        if (!leftNumber && !rightNumber) {
+          leftName = _.get(left, 'metadata.name', '');
+          rightName = _.get(right, 'metadata.name', '');
+          if (descending) {
+            return rightName.localeCompare(leftName);
+          }
+          return leftName.localeCompare(rightName);
+        }
+
+        if (!leftNumber) {
+          return descending ? 1 : -1;
+        }
+
+        if (!rightNumber) {
+          return descending ? -1 : 1;
+        }
+
+        if (descending) {
+          return rightNumber - leftNumber;
+        }
+
+        return leftNumber - rightNumber;
+      };
+
+      var compareDates = function(left, right) {
+        var leftDate = _.get(left, 'metadata.creationTimestamp', '');
+        var rightDate = _.get(right, 'metadata.creationTimestamp', '');
+
+        // If the builds have identical dates, sort by number.
+        if (leftDate === rightDate) {
+          return compareNumbers(left, right);
+        }
+
+        // The date format can be sorted using straight string comparison.
+        // Example Date: 2016-02-02T21:53:07Z
+        if (descending) {
+          return rightDate.localeCompare(leftDate);
+        }
+
+        return leftDate.localeCompare(rightDate);
+      };
+
+      // Compare dates, falling back to build number, then name, if dates are the same.
+      return _.toArray(builds).sort(compareDates);
+    };
+
+    var getJenkinsStatus = function(pipelineBuild) {
+      var json = annotation(pipelineBuild, 'jenkinsStatus');
+      if (!json) {
+        return null;
+      }
+
+      try {
+        return JSON.parse(json);
+      } catch (e) {
+        Logger.error('Could not parse Jenkins status as JSON', json);
+        return null;
+      }
+    };
+
+    var getCurrentStage = function(pipelineBuild) {
+      var jenkinsStatus = getJenkinsStatus(pipelineBuild);
+      var stages = _.get(jenkinsStatus, 'stages', []);
+      return _.last(stages);
+    };
+
     return {
       startBuild: startBuild,
       cancelBuild: cancelBuild,
@@ -215,6 +308,10 @@ angular.module("openshiftConsole")
       incompleteBuilds: incompleteBuilds,
       completeBuilds: completeBuilds,
       lastCompleteByBuildConfig: lastCompleteByBuildConfig,
-      interestingBuilds: interestingBuilds
+      interestingBuilds: interestingBuilds,
+      groupBuildConfigsByOutputImage: groupBuildConfigsByOutputImage,
+      sortBuilds: sortBuilds,
+      getJenkinsStatus: getJenkinsStatus,
+      getCurrentStage: getCurrentStage
     };
   });

--- a/app/scripts/services/hpa.js
+++ b/app/scripts/services/hpa.js
@@ -193,11 +193,42 @@ angular.module("openshiftConsole")
       });
     };
 
+    // Group HPAs by the object they scale.
+    //
+    // Returns an hpaByResource map with
+    //   path:   hpaByResource[kind][name]
+    //   value:  array of HPA objects
+    var groupHPAs = function(horizontalPodAutoscalers) {
+      var hpaByResource = {};
+      _.each(horizontalPodAutoscalers, function(hpa) {
+        var name = hpa.spec.scaleRef.name, kind = hpa.spec.scaleRef.kind;
+        if (!name || !kind) {
+          return;
+        }
+
+        // TODO: Handle groups and subresources in hpa.spec.scaleRef
+        // var groupVersion = APIService.parseGroupVersion(hpa.spec.scaleRef.apiVersion) || {};
+        // var group = groupVersion.group || '';
+        // if (!_.has(hpaByResource, [group, kind, name])) {
+        //   _.set(hpaByResource, [group, kind, name], []);
+        // }
+        // hpaByResource[group][kind][name].push(hpa);
+
+        if (!_.has(hpaByResource, [kind, name])) {
+          _.set(hpaByResource, [kind, name], []);
+        }
+        hpaByResource[kind][name].push(hpa);
+      });
+
+      return hpaByResource;
+    };
+
     return {
       convertRequestPercentToLimit: convertRequestPercentToLimit,
       convertLimitPercentToRequest: convertLimitPercentToRequest,
       hasCPURequest: hasCPURequest,
       filterHPA: filterHPA,
-      getHPAWarnings: getHPAWarnings
+      getHPAWarnings: getHPAWarnings,
+      groupHPAs: groupHPAs
     };
   });

--- a/app/scripts/services/html.js
+++ b/app/scripts/services/html.js
@@ -1,8 +1,26 @@
 'use strict';
 
 angular.module("openshiftConsole")
-  .factory("HTMLService", function() {
+  .factory("HTMLService",
+           function(BREAKPOINTS) {
     return {
+      // Ge the breakpoint for the current screen width.
+      getBreakpoint: function() {
+        if (window.innerWidth < BREAKPOINTS.screenSmMin) {
+          return 'xs';
+        }
+
+        if (window.innerWidth < BREAKPOINTS.screenMdMin) {
+          return 'sm';
+        }
+
+        if (window.innerWidth < BREAKPOINTS.screenLgMin) {
+          return 'md';
+        }
+
+        return 'lg';
+      },
+
       // Based on https://github.com/drudru/ansi_up/blob/v1.3.0/ansi_up.js#L93-L97
       // and https://github.com/angular/angular.js/blob/v1.5.8/src/ngSanitize/filter/linky.js#L131-L132
       // The AngularJS `linky` regex will avoid matching special characters like `"` at

--- a/app/scripts/services/keyword.js
+++ b/app/scripts/services/keyword.js
@@ -23,7 +23,7 @@ angular.module("openshiftConsole")
 
     var filterForKeywords = function(objects, filterFields, keywords) {
       var filteredObjects = objects;
-      if (!keywords.length) {
+      if (_.isEmpty(keywords)) {
         return filteredObjects;
       }
 

--- a/app/scripts/services/navigate.js
+++ b/app/scripts/services/navigate.js
@@ -70,6 +70,10 @@ angular.module("openshiftConsole")
         return "project/" + encodeURIComponent(projectName) + "/overview";
       },
 
+      quotaURL: function(projectName) {
+        return "project/" + encodeURIComponent(projectName) + "/quota";
+      },
+
       createFromImageURL: function(imageStream, imageTag, projectName, queryParams) {
         var createURI = URI.expand("project/{project}/create/fromimage{?q*}", {
           project: projectName,

--- a/app/scripts/services/resourceAlerts.js
+++ b/app/scripts/services/resourceAlerts.js
@@ -1,0 +1,156 @@
+'use strict';
+
+angular.module("openshiftConsole")
+  .factory("ResourceAlertsService",
+           function($filter,
+                    AlertMessageService,
+                    Navigate,
+                    QuotaService) {
+    var annotation = $filter('annotation');
+    var deploymentStatus = $filter('deploymentStatus');
+    var getGroupedPodWarnings = $filter('groupedPodWarnings');
+
+    var getPodAlerts = function(pods, namespace) {
+      if (_.isEmpty(pods)) {
+        return {};
+      }
+
+      var alerts = {};
+      var groupedPodWarnings = getGroupedPodWarnings(pods);
+      _.each(groupedPodWarnings, function(podWarnings, groupID) {
+        var warning = _.head(podWarnings);
+        if (!warning) {
+          return;
+        }
+
+        var alertID = "pod_warning" + groupID;
+        var alert = {
+          type: warning.severity || 'warning',
+          message: warning.message
+        };
+
+        // Handle certain warnings specially.
+        switch (warning.reason) {
+          case "Looping":
+          case "NonZeroExit":
+            // Add a View Log link for crashing containers.
+            var podLink = Navigate.resourceURL(warning.pod, "Pod", namespace);
+            var logLink = URI(podLink).addSearch({ tab: "logs", container: warning.container }).toString();
+            alert.links = [{
+              href: logLink,
+              label: "View Log"
+            }];
+            break;
+
+          case "NonZeroExitTerminatingPod":
+            // Allow users to permanently dismiss the non-zero exit code message for terminating pods.
+            if (AlertMessageService.isAlertPermanentlyHidden(alertID, namespace)) {
+              return;
+            }
+
+            alert.links = [{
+              href: "",
+              label: "Don't Show Me Again",
+              onClick: function() {
+                // Hide the alert on future page loads.
+                AlertMessageService.permanentlyHideAlert(alertID, namespace);
+
+                // Return true close the existing alert.
+                return true;
+              }
+            }];
+            break;
+        }
+
+        alerts[alertID] = alert;
+      });
+
+      return alerts;
+    };
+
+    var setGenericQuotaWarning = function(quotas, clusterQuotas, projectName, alerts) {
+      var isHidden = AlertMessageService.isAlertPermanentlyHidden("overview-quota-limit-reached", projectName);
+      if (!isHidden && QuotaService.isAnyQuotaExceeded(quotas, clusterQuotas)) {
+        if (alerts['quotaExceeded']) {
+          // Don't recreate the alert or it will reset the temporary hidden state
+          return;
+        }
+
+        alerts['quotaExceeded'] = {
+          type: 'warning',
+          message: 'Quota limit has been reached.',
+          links: [{
+            href: Navigate.quotaURL(),
+            label: "View Quota"
+          },{
+            href: "",
+            label: "Don't Show Me Again",
+            onClick: function() {
+              // Hide the alert on future page loads.
+              AlertMessageService.permanentlyHideAlert("overview-quota-limit-reached", projectName);
+
+              // Return true close the existing alert.
+              return true;
+            }
+          }]
+        };
+      }
+      else {
+        delete alerts['quotaExceeded'];
+      }
+    };
+
+    var getDeploymentStatusAlerts = function(deploymentConfig, mostRecentRC) {
+      if (!deploymentConfig || !mostRecentRC) {
+        return {};
+      }
+
+      var alerts = {};
+      var dcName = _.get(deploymentConfig, 'metadata.name');
+
+      // Show messages about cancelled or failed deployments.
+      var logLink;
+      var status = deploymentStatus(mostRecentRC);
+      var version = annotation(mostRecentRC, 'deploymentVersion');
+      var displayName = version ? (dcName + ' #' + version) : mostRecentRC.metadata.name;
+      var rcLink = Navigate.resourceURL(mostRecentRC);
+      switch (status) {
+      case 'Cancelled':
+        alerts[mostRecentRC.metadata.uid + '-cancelled'] = {
+          type: 'info',
+          message: 'Deployment ' + displayName + ' was cancelled.',
+          // TODO: Add back start deployment link from previous overview (see serviceGroupNotifications.js)
+          links: [{
+            href: rcLink,
+            label: 'View Deployment'
+          }]
+        };
+        break;
+      case 'Failed':
+        logLink = URI(rcLink).addSearch({ tab: "logs" }).toString();
+        alerts[mostRecentRC.metadata.uid + '-failed'] = {
+          type: 'error',
+          message: 'Deployment ' + displayName + ' failed.',
+          reason: annotation(mostRecentRC, 'openshift.io/deployment.status-reason'),
+          links: [{
+            href: logLink,
+            label: 'View Log'
+          }, {
+            // Show all events since the event might not be on the replication controller itself.
+            href: 'project/' + mostRecentRC.metadata.namespace + '/browse/events',
+            label: 'View Events'
+          }]
+        };
+        break;
+      }
+
+      return alerts;
+    };
+
+    return {
+      getPodAlerts: getPodAlerts,
+      setGenericQuotaWarning: setGenericQuotaWarning,
+      getDeploymentStatusAlerts: getDeploymentStatusAlerts
+    };
+  });
+

--- a/app/styles/_components.less
+++ b/app/styles/_components.less
@@ -275,6 +275,14 @@ code.command {
 }
 
 .pod-donut {
+  &.mini {
+    display: inline-block;
+    margin: 0 0 0 -8px;
+    min-width: 45px;
+    min-height: 45px;
+    top: 3px;
+    vertical-align: middle;
+  }
   .c3-defocused {
     // Adjusting the default hover "opacity: .3" to be slightly darker
     // and prevent the "c3-Running" state from looking similar to "c3-Not-Ready" state
@@ -299,6 +307,11 @@ code.command {
     // hide tooltip text 'Empty'
     display:none;
   }
+}
+
+.donut-mini-text {
+  display: inline-block;
+  min-width: 50px;
 }
 
 .deployment-donut {

--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -339,7 +339,7 @@ mark {
   }
 }
 
-.metrics-compact {
+.overview .metrics-compact {
   margin-bottom: 10px;
   white-space : nowrap;
   @media (min-width: @screen-lg-min) {
@@ -401,6 +401,34 @@ mark {
 
 .quota-chart {
   margin: 0 20px;
+}
+
+.route-service-bar-chart {
+  .service-name,
+  .service-weight {
+    .small();
+    .text-muted();
+    display: inline-block;
+    vertical-align: middle;
+  }
+  .service-name {
+    .truncate();
+    width: 125px;
+  }
+  .service-weight {
+    margin-left: 5px;
+  }
+  .progress {
+    background: none;
+    box-shadow: none;
+    display: inline-block;
+    margin: 0;
+    width: 125px;
+    -webkit-box-shadow: none;
+    &:not(.highlight) .progress-bar {
+      background-color: @color-pf-black-300;
+    }
+  }
 }
 
 

--- a/app/styles/_list-pf.less
+++ b/app/styles/_list-pf.less
@@ -1,0 +1,51 @@
+//
+// PatternFly List
+// --------------------------------------------------
+
+.list-pf-actions {
+  .actions-dropdown-kebab {
+    font-size: 18px;
+    margin-right: -5px;
+  }
+  .dropdown {
+    // add dropdown-pf-kebab styles
+    .dropdown-kebab-pf;
+    .dropdown-menu.dropdown-menu-right {
+      right: -10px;
+    }
+  }
+}
+
+.list-pf-content {
+  flex-grow: 1;
+  .alert:first-child {
+    margin-top: 0;
+  }
+  .alert-wrapper:last-child {
+    margin-bottom: 20px;
+  }
+  .list-pf-chevron + & {
+    align-items: center;
+    display: flex;
+    .list-pf-details,
+    .list-pf-name {
+      flex-grow: 1;
+    }
+    .list-pf-details {
+      align-items: center;
+      display: flex;
+      width: 55%;
+    }
+    .list-pf-name {
+      width: 45%;
+    }
+  }
+}
+
+.list-pf-item:not(.active) .list-pf-chevron + .list-pf-content {
+  border-left-color: #dcdcdc;
+}
+
+.list-pf-name {
+  margin: 0;
+}

--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -1,3 +1,5 @@
+@list-pf-border-color: #dcdcdc;
+@list-pf-item-active-border-color: #bbb;
 @overview-border-light-gray: #ededed;
 @overview-border-gray: #d6d6d6;
 @overview-font-weight: 300;
@@ -12,6 +14,394 @@
 @tile-min-height:      256px;
 @tile-min-height-lg:   352px;
 
+
+// NEW OVERVIEW STYLES
+@mini-log-font-size: 11px;
+@mini-log-line-height: (@mini-log-font-size + 2);
+@mini-log-num-lines: 7;
+
+.build-count {
+  .builds,
+  .pipelines {
+    display: block;
+  }
+  .icon-count {
+    display: inline-block;
+    margin-right: 5px;
+    &, [data-toggle="tooltip"] {
+      cursor: help;
+    }
+  }
+  .running-stage {
+    .small();
+    .text-muted();
+  }
+}
+.builds-label {
+  margin-right: 5px;
+}
+.mini-log {
+  background-color: @color-pf-black-100;
+  border: 1px solid @color-pf-black-300;
+  color: @color-pf-black-700;
+  font-family: @font-family-monospace;
+  font-size: @mini-log-font-size;
+  margin-bottom: 5px;
+  margin-top: 5px;
+  padding: 5px;
+  .truncate();
+  .mini-log-content {
+    line-height: @mini-log-line-height;
+    min-height: (@mini-log-num-lines * @mini-log-line-height);
+    .mini-log-line {
+      white-space: pre;
+    }
+  }
+}
+.notification-icon-count {
+  display: inline-block;
+  margin: 0 5px 0 0;
+  [data-toggle="tooltip"] {
+    cursor: help;
+  }
+}
+
+.overview-new {
+  .app-heading {
+    display: flex;
+    justify-content: space-between;
+    // Stack the route at mobile. Use `max-width: @screen-sm-max` to set just
+    // the mobile styles. Otherwise we'd need to reset the default h3 margins
+    // at wider widths.
+    @media (max-width: @screen-sm-max) {
+      flex-direction: column;
+      justify-content: flex-start;
+      .overview-route {
+        .h4();
+        margin-top: -5px;
+        margin-bottom: 15px;
+      }
+    }
+  }
+  .build-pipeline {
+    border-color: @overview-border-gray;
+  }
+  .build-pipelines {
+    margin-top: 10px;
+    margin-bottom: 20px;
+  }
+  .c3-line {
+    stroke-width: 1px;
+  }
+  .component-label {
+    font-size: @component-label;
+    font-weight: 500;
+    padding: 0 0 4px 0;
+    .text-muted();
+    text-transform: uppercase;
+    .sublabel {
+      font-size: (@component-label - 1);
+      margin-left: 2px;
+      text-transform: none;
+    }
+  }
+  .data-toolbar-dropdown {
+    display: inline-block;
+  }
+  .data-toolbar-filter {
+    display: flex;
+    .label-filter,
+    .name-filter {
+      flex-grow: 1;
+    }
+    .label-filter,
+    .name-filter input {
+      // Avoid double border since the input is directly beside the filter select.
+      border-left: 0;
+    }
+    .label-filter .label-filter-key .selectize-input.not-full {
+      // FIXME: temp workaround for problem created by
+      // https://github.com/openshift/origin-web-console/pull/1216
+      width: auto;
+    }
+    .name-filter {
+      form,
+      input {
+        width: 100%;
+      }
+      input {
+        // Extra padding from the filter type combo
+        padding-left: 5px;
+      }
+    }
+    .ui-select-container {
+      width: 100px;
+    }
+    .ui-select-container .ui-select-match .btn,
+    .label-filter-add.btn {
+      box-shadow: none;
+      -webkit-box-shadow: none;
+    }
+  }
+  .data-toolbar-label {
+    margin-right: 7px;
+  }
+  // TODO: improve on this as it's pretty hacky
+  .deployment-connector-arrow {
+    display: inline-block;
+    font-size: 300%;
+    line-height: 1;
+    margin: 50px 0 0 10px;
+    text-align: center;
+    .text-muted();
+    @media (max-width: @screen-xs-max) {
+      margin: -3px auto 0 -4px;
+      transform: rotate(90deg);
+      width: 100%
+    }
+  }
+  .expanded-section {
+    margin-top: 20px;
+    > .row > [class^=col-] {
+      margin-bottom: 10px;
+    }
+    h3 {
+      line-height: 1.4;
+      margin-bottom: 5px;
+      margin-top: 0;
+      width: 100%; // IE
+      .word-break();
+    }
+    .section-title {
+      .h4();
+      border-bottom: 1px solid @list-pf-border-color;
+      padding-bottom: 10px;
+      &.no-border {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+    }
+  }
+  .filter-status {
+    margin-bottom: 5px;
+  }
+  h1, h2 {
+    // Don't clip descenders.
+    line-height: normal;
+    min-width: 130px; // prevent name from complete truncation at mobile
+    .truncate();
+  }
+  h2 {
+    margin-top: 0;
+    > .component-label {
+      padding-bottom: 0;
+    }
+  }
+  .list-pf {
+    border-bottom-color: @list-pf-border-color;
+    margin-bottom: 50px;
+  }
+  .list-pf-actions {
+    // if no actions-dropdown-kebab is present, still take up space
+    min-width: 19px;
+  }
+  .list-pf-details {
+    @media (min-width: @screen-sm-min) {
+      justify-content: flex-end;
+    }
+  }
+  .list-pf-expansion.in {
+    .deployment-donut > div[row] {
+      justify-content: center;
+    }
+    .empty-state-message {
+      margin-bottom: 30px;
+      margin-top: 20px;
+      // Avoid breaking long identifiers like image stream names in empty state message.
+      max-width: none;
+      padding: 0;
+      .text-center();
+      p {
+        .word-break();
+      }
+    }
+    .list-pf-content {
+      max-width: 100%;
+    }
+    .list-pf-container {
+      display: block; // so that .word-break() will work in IE
+    }
+    .pod-donut {
+      .text-center();
+    }
+  }
+  .list-pf-item {
+    border-top-color: @list-pf-border-color;
+    &.active {
+      border-top-color: @list-pf-item-active-border-color;
+    }
+    > .list-pf-container {
+      cursor: pointer;
+      > .list-pf-content {
+        @media (max-width: @screen-xs-max) {
+          align-items: stretch;
+          flex-direction: column;
+          width: 100%; // IE
+          .word-break();
+        }
+        @media (min-width: @screen-sm-min) {
+          // Prevent the row from shrinking slightly on expand.
+          min-height: 45px;
+          padding-right: 15px;
+        }
+      }
+      .toggle-expand-link {
+        color: inherit;
+      }
+    }
+  }
+  .list-pf-name {
+    display: flex;
+    flex-direction: column;
+    @media (max-width: @screen-sm-max) {
+      width: auto !important;
+    }
+    @media (min-width: @screen-md-min) {
+      align-items: center;
+      flex-direction: row;
+    }
+    h3 {
+      line-height: 1;
+      margin: 0 15px 0 0;
+      @media (min-width: @screen-md-min) {
+        width: 60%;
+      }
+      a {
+        .word-break();
+      }
+    }
+  }
+  .list-row-tabset {
+    margin-top: 20px;
+    @media (min-width: @screen-sm-min) {
+      margin-top: 0;
+    }
+    .nav-tabs > li.active > a .build-count {
+      color: #4d5258;
+    }
+  }
+  .list-view-pf-actions .actions-dropdown-kebab {
+    font-size: 18px;
+    // Give a bigger click target (fill `list-view-pf-actions` width)
+    width: 100%;
+  }
+  .loading-message {
+    margin-top: 20px;
+  }
+  .metrics-collapsed {
+    flex-grow: 1;
+    .text-center();
+  }
+  .metrics-summary {
+    display: inline-block;
+    .text-center();
+    + .metrics-summary {
+      margin-left: 20px;
+    }
+  }
+  .metrics-compact {
+    white-space : nowrap;
+    .metrics-sparkline {
+      border-bottom: 1px solid #ededed;
+      display: inline-block;
+      height: 28px;
+      max-width: 300px;
+      vertical-align: -6px;
+      width: calc(~"100% - 80px");
+    }
+    .metrics-usage {
+      display: inline-block;
+      margin-left: 10px;
+      max-width: 80px;
+    }
+    .usage-label {
+      // Make sure the labels align with the bottom of the chart.
+      line-height: 1;
+      margin-bottom: -1px;
+    }
+    .usage-value {
+      line-height: 1;
+      margin: 3px 0;
+    }
+  }
+  .middle .middle-container {
+    // FIXME: workaround issue where middle-container usage of flexbox causes content to not fill width
+    > div {
+      width: 100%;
+    }
+    .container-fluid {
+      padding-left: 20px;
+      padding-right: 20px;
+    }
+  }
+  .networking-section .row + .row:before {
+    content: '';
+    display: block;
+    border-top: 1px solid @list-pf-border-color;
+    margin: 0 20px 10px;
+  }
+  overview-list-row + overview-list-row .list-pf-item.active {
+    // avoid double borders when list-pf-item is open
+    margin-top: -1px;
+  }
+  .overview-route {
+    .word-break();
+  }
+  .overview-routes + .overview-routes {
+    .mar-top-md();
+  }
+  .overview-row-inline-actions {
+    .mar-left-md();
+  }
+  pod-donut[mini] {
+    align-items: center;
+    display: flex;
+  }
+  .status-icons {
+    margin-top: 5px;
+    @media (min-width: @screen-md-min) {
+      margin-right: 15px;
+      margin-top: 0;
+      width: 40%;
+    }
+  }
+  :not(.tab-pane) > overview-pipelines > .expanded-section {
+      margin-bottom: 30px;
+    }
+  .toolbar-container {
+    margin-top: 10px;
+    margin-bottom: 5px;
+  }
+  .triggers {
+    margin-bottom: 20px;
+  }
+  .usage-value {
+    font-size: 18px;
+    font-weight: 300;
+    line-height: 1;
+  }
+  .usage-label {
+    .small();
+    .text-muted();
+  }
+  .view-by-options {
+    align-items: center;
+    display: flex;
+    @media (max-width: @screen-xs-max) {
+      margin-top: 10px;
+    }
+  }
+}
 
 .overview {
   font-weight: @overview-font-weight;

--- a/app/styles/_tooltip.less
+++ b/app/styles/_tooltip.less
@@ -1,0 +1,7 @@
+//
+// Tooltips
+// --------------------------------------------------
+
+.tooltip-inner {
+  .word-break(); // so that long, unbroken strings don't overflow
+}

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -18,6 +18,7 @@
 @import "_data-toolbar.less";
 @import "_ellipsis.less";
 @import "_flexbox.less";
+@import "_list-pf.less";
 @import "_list-view.less";
 @import "_messages.less";
 @import "_navbar-alt.less";
@@ -35,6 +36,7 @@
 @import "_tables.less";
 @import "_tile.less";
 @import "_toast.less";
+@import "_tooltip.less";
 @import "_topology.less";
 @import "_typography.less";
 @import "_spacers.less";

--- a/app/views/_pod-template.html
+++ b/app/views/_pod-template.html
@@ -110,12 +110,17 @@
         </div>
         <div flex class="word-break">
           <span class="pod-template-key">Ports:</span>
-          <span ng-repeat="port in container.ports | orderBy: 'containerPort'">
+          <span ng-repeat="port in container.ports | orderBy: 'containerPort' | limitToOrAll : detailed ? undefined : 1">
             <span><span class="nowrap">{{port.containerPort}}/{{port.protocol}}</span>
               <span ng-if="port.name"> <span class="nowrap">({{port.name}})</span></span>
               <span ng-if="port.hostPort"> <span class="nowrap"><span class="port-icon">&#8594;</span> {{port.hostPort}}</span></span>
             </span>
             <span ng-if="!$last">, </span>
+          </span>
+          <span ng-if="!detailed && container.ports.length >= 2">
+            and {{container.ports.length - 1}}
+            <span ng-if="container.ports.length > 2">others</span>
+            <span ng-if="container.ports.length === 2">other</span>
           </span>
         </div>
       </div>

--- a/app/views/_project-page.html
+++ b/app/views/_project-page.html
@@ -2,7 +2,7 @@
   <div class="sidebar-left collapse navbar-collapse navbar-collapse-1">
     <sidebar></sidebar>
   </div>
-  <div id="container-main" class="middle">
+  <div id="container-main" class="middle" in-view-container>
     <div ng-transclude>
 
     </div>

--- a/app/views/directives/build-pipeline.html
+++ b/app/views/directives/build-pipeline.html
@@ -3,5 +3,9 @@
     <div class="animate-if" ng-if="build.status.phase === 'Running'" ng-include="'views/directives/_build-pipeline-expanded.html'"></div>
     <div class="animate-if" ng-if="build.status.phase !== 'Running'" ng-include="'views/directives/_build-pipeline-collapsed.html'"></div>
   </div>
-  <div ng-if="!expandOnlyRunning" ng-include="'views/directives/_build-pipeline-expanded.html'"></div>
+  <div ng-if="collapsePending">
+    <div ng-if="build.status.phase === 'New' || build.status.phase === 'Pending'" ng-include="'views/directives/_build-pipeline-collapsed.html'"></div>
+    <div ng-if="build.status.phase !== 'New' && build.status.phase !== 'Pending'" ng-include="'views/directives/_build-pipeline-expanded.html'"></div>
+  </div>
+  <div ng-if="!expandOnlyRunning && !collapsePending" ng-include="'views/directives/_build-pipeline-expanded.html'"></div>
 </div>

--- a/app/views/directives/metrics-compact.html
+++ b/app/views/directives/metrics-compact.html
@@ -1,4 +1,4 @@
-<div in-view="updateInView($inview)" in-view-options="{ debounce: 50 }">
+<div in-view="updateInView($inview)" in-view-options="{ throttle: 50 }">
   <div ng-repeat="metric in metrics" ng-if="!metric.compactCombineWith" class="metrics-compact">
     <div ng-attr-id="{{metric.chartID}}" class="metrics-sparkline"></div>
     <div class="metrics-usage">

--- a/app/views/directives/pod-donut.html
+++ b/app/views/directives/pod-donut.html
@@ -1,4 +1,16 @@
-<div ng-attr-id="{{chartId}}" class="pod-donut"></div>
+<div ng-attr-id="{{chartId}}" class="pod-donut" ng-class="{ mini: mini }"></div>
+
+<div ng-if="mini" class="donut-mini-text">
+  <span ng-if="!idled">
+    {{pods | hashSize}}
+    <span ng-if="(pods | hashSize) === 1">pod</span>
+    <span ng-if="(pods | hashSize) !== 1">pods</span>
+  </span>
+  <span ng-if="idled">
+    Idle
+  </span>
+</div>
+
 <!-- Include text values for screen readers -->
 <div class="sr-only">
   <div ng-if="(pods | hashSize) === 0">No pods.</div>

--- a/app/views/directives/route-service-bar-chart.html
+++ b/app/views/directives/route-service-bar-chart.html
@@ -1,0 +1,15 @@
+<div class="route-service-bar-chart">
+  <h5>Traffic Split</h5>
+  <div ng-repeat="backend in routeServices.backends">
+    <div class="service-name" title="{{backend.name}}">
+      {{backend.name}}
+    </div>
+    <div class="progress progress-xs"
+         ng-class="{ 'highlight': backend.name === routeServices.highlightService }">
+      <div class="progress-bar" ng-style="{ width: routeServices.barWidth(backend) }"></div>
+    </div>
+    <div class="service-weight">
+      {{routeServices.getPercentage(backend)}}
+    </div>
+  </div>
+</div>

--- a/app/views/edit/deployment-config.html
+++ b/app/views/edit/deployment-config.html
@@ -378,7 +378,7 @@
                         <button type="submit" class="btn btn-primary btn-lg" ng-disabled="form.$invalid || form.$pristine || disableInputs">
                           Save
                         </button>
-                        <a class="btn btn-default btn-lg" href="{{updatedDeploymentConfig | navigateResourceURL}}">
+                        <a class="btn btn-default btn-lg" back>
                           Cancel
                         </a>
                       </div>

--- a/app/views/new-overview.html
+++ b/app/views/new-overview.html
@@ -1,0 +1,364 @@
+<project-header class="top-header"></project-header>
+<project-page class="overview-new">
+  <div class="middle-section">
+    <div class="middle-container">
+      <!-- Empty states -->
+      <div ng-if="overview.showGetStarted">
+        <div class="container-fluid">
+          <tasks></tasks>
+          <alerts alerts="overview.state.alerts"></alerts>
+        </div>
+        <!-- Getting started -->
+        <div class="empty-state-message text-center">
+          <div ng-if="project.metadata.name | canIAddToProject">
+            <h2>Get started with your project.</h2>
+            <p class="gutter-top">
+              Use your source or an example repository to build an application
+              image, or add components like databases and message queues.
+            </p>
+            <p class="gutter-top">
+              <a ng-href="project/{{projectName}}/create" class="btn btn-lg btn-primary">
+                Add to Project
+              </a>
+            </p>
+          </div>
+          <div ng-if="!(project.metadata.name | canIAddToProject)">
+            <h2>Welcome to project {{projectName}}.</h2>
+            <ng-include src="'views/_request-access.html'"></ng-include>
+          </div>
+        </div>
+      </div>
+      <div ng-if="overview.showLoading" class="container-fluid loading-message">
+        Loading...
+      </div>
+      <div ng-if="!overview.showGetStarted && !overview.showLoading">
+        <div class="middle-header header-toolbar">
+          <div class="container-fluid toolbar-container">
+            <div class="data-toolbar" role="toolbar" aria-label="Filter Toolbar">
+              <div class="data-toolbar-filter" role="group">
+                <ui-select
+                  class="data-toolbar-dropdown"
+                  ng-model="overview.filterBy"
+                  search-enabled="false"
+                  append-to-body="true"
+                  ng-disabled="overview.disableFilter">
+                  <ui-select-match>{{$select.selected.label}}</ui-select-match>
+                  <ui-select-choices repeat="option.id as option in overview.filterByOptions">
+                    {{option.label}}
+                  </ui-select-choices>
+                </ui-select>
+                <div ng-if="overview.filterBy === 'label'" class="label-filter">
+                  <!-- FIXME: This disables the add button but not the label filter selectize controlers. -->
+                  <fieldset ng-disabled="overview.disableFilter">
+                    <project-filter></project-filter>
+                  </fieldset>
+                </div>
+                <div ng-if="overview.filterBy === 'name'" class="name-filter">
+                  <form role="form" class="search-pf has-button">
+                    <div class="form-group filter-controls has-clear">
+                      <div class="search-pf-input-group">
+                        <label for="name-filter" class="sr-only">Filter by name</label>
+                        <input
+                          type="text"
+                          class="form-control"
+                          ng-model="overview.filterText"
+                          placeholder="Filter by name"
+                          autocorrect="off"
+                          autocapitalize="off"
+                          spellcheck="false"
+                          ng-disabled="overview.disableFilter">
+                        <button
+                          type="button"
+                          class="clear"
+                          aria-hidden="true"
+                          ng-if="overview.filterText && !overview.disableFilter"
+                          ng-click="overview.filterText = ''">
+                          <span class="pficon pficon-close"></span>
+                        </button>
+                      </div>
+                    </div>
+                  </form>
+                </div>
+              </div>
+              <div class="vertical-divider"></div>
+              <div class="view-by-options">
+                <span class="data-toolbar-label">List by</span>
+                <ui-select class="data-toolbar-dropdown" ng-model="overview.viewBy" search-enabled="false">
+                  <ui-select-match>{{$select.selected.label}}</ui-select-match>
+                  <ui-select-choices repeat="option.id as option in overview.viewByOptions">
+                    {{option.label}}
+                  </ui-select-choices>
+                </ui-select>
+              </div>
+            </div>
+            <div ng-if="overview.filterActive" class="filter-status">
+              <span ng-if="overview.viewBy !== 'pipeline'">
+                Showing <strong>{{overview.filteredSize}}</strong> of <strong>{{overview.size}}</strong> items
+              </span>
+              <span ng-if="overview.viewBy === 'pipeline' && overview.pipelineBuildConfigs | hashSize">
+                Showing <strong>{{overview.filteredPipelineBuildConfigs | hashSize}}</strong> of <strong>{{overview.pipelineBuildConfigs | hashSize}}</strong> pipelines
+              </span>
+            </div>
+          </div>
+        </div>
+        <div class="middle-content">
+          <div class="container-fluid">
+            <tasks></tasks>
+            <alerts alerts="overview.state.alerts"></alerts>
+          </div>
+          <div class="container-fluid">
+            <div ng-if="overview.everythingFiltered && overview.viewBy !== 'pipeline'">
+              <div class="empty-state-message text-center h2">
+                The filter is hiding all resources.
+                <a href="" ng-click="overview.clearFilter()">Clear Filter</a>
+              </div>
+            </div>
+            <div ng-if="!overview.everythingFiltered || overview.viewBy === 'pipeline'">
+              <div ng-if="overview.viewBy === 'app'" ng-repeat="app in overview.apps">
+                <div ng-if="app" class="app-heading">
+                  <h2>
+                    <div class="component-label">Application</div>
+                    <span ng-bind-html="app | highlightKeywords : overview.state.filterKeywords"></span>
+                  </h2>
+                  <div ng-if="route = overview.bestRouteByApp[app]" class="pull-right">
+                    <h3 class="overview-route">
+                      <span ng-if="route | isWebRoute">
+                        <a ng-href="{{route | routeWebURL}}" target="_blank">{{route | routeLabel}}</a>
+                        <i class="fa fa-external-link small" aria-hidden="true"></i>
+                      </span>
+                      <span ng-if="!(route | isWebRoute)">{{route | routeLabel}}</span>
+                    </h3>
+                  </div>
+                </div>
+                <h2 ng-if="!app">
+                  Other Resources
+                </h2>
+                <div class="list-pf">
+                  <overview-list-row
+                       ng-repeat="deploymentConfig in overview.filteredDeploymentConfigsByApp[app] track by (deploymentConfig | uid)"
+                       ng-init="dcName = deploymentConfig.metadata.name"
+                       api-object="deploymentConfig"
+                       current="overview.currentByDeploymentConfig[dcName]"
+                       previous="overview.getPreviousReplicationController(deploymentConfig)"
+                       state="overview.state">
+                  </overview-list-row>
+                  <overview-list-row
+                       ng-repeat="deployment in overview.filteredDeploymentsByApp[app] track by (deployment | uid)"
+                       api-object="deployment"
+                       current="overview.currentByDeployment[deployment.metadata.name]"
+                       previous="overview.replicaSetsByDeployment[deployment.metadata.name][1]"
+                       state="overview.state">
+                  </overview-list-row>
+                  <overview-list-row
+                       ng-repeat="replicationController in overview.filteredReplicationControllersByApp[app] track by (replicationController | uid)"
+                       api-object="replicationController"
+                       current="replicationController"
+                       state="overview.state">
+                  </overview-list-row>
+                  <overview-list-row
+                       ng-repeat="replicaSet in overview.filteredReplicaSetsByApp[app] track by (replicaSet | uid)"
+                       api-object="replicaSet"
+                       state="overview.state">
+                  </overview-list-row>
+                  <overview-list-row
+                       ng-repeat="statefulSet in overview.filteredStatefulSetsByApp[app] track by (statefulSet | uid)"
+                       api-object="statefulSet"
+                       state="overview.state">
+                  </overview-list-row>
+                  <overview-list-row
+                       ng-repeat="pod in overview.filteredMonopodsByApp[app] track by (pod | uid)"
+                       api-object="pod"
+                       state="overview.state">
+                  </overview-list-row>
+                </div>
+              </div>
+              <div ng-if="overview.viewBy === 'resource'">
+                <div ng-if="overview.filteredDeploymentConfigs | hashSize">
+                  <h2>
+                    <span ng-if="overview.deployments | hashSize">
+                      Deployment Configs
+                    </span>
+                    <span ng-if="!(overview.deployments | hashSize)">
+                      Deployments
+                    </span>
+                  </h2>
+                  <div class="list-pf">
+                    <overview-list-row
+                         ng-repeat="deploymentConfig in overview.filteredDeploymentConfigs track by (deploymentConfig | uid)"
+                         ng-init="dcName = deploymentConfig.metadata.name"
+                         api-object="deploymentConfig"
+                         current="overview.currentByDeploymentConfig[dcName]"
+                         previous="overview.getPreviousReplicationController(deploymentConfig)"
+                         state="overview.state">
+                    </overview-list-row>
+                  </div>
+                </div>
+                <div ng-if="overview.filteredDeployments | hashSize">
+                  <h2>Deployments</h2>
+                  <div class="list-pf">
+                    <overview-list-row
+                         ng-repeat="deployment in overview.filteredDeployments track by (deployment | uid)"
+                         api-object="deployment"
+                         current="overview.currentByDeployment[deployment.metadata.name]"
+                         previous="overview.replicaSetsByDeployment[deployment.metadata.name][1]"
+                         state="overview.state">
+                    </overview-list-row>
+                  </div>
+                </div>
+                <div ng-if="overview.filteredReplicationControllers | hashSize">
+                  <h2>Replication Controllers</h2>
+                  <div class="list-pf">
+                    <overview-list-row
+                         ng-repeat="replicationController in overview.filteredReplicationControllers track by (replicationController | uid)"
+                         api-object="replicationController"
+                         state="overview.state">
+                    </overview-list-row>
+                  </div>
+                </div>
+                <div ng-if="overview.filteredReplicaSets | hashSize">
+                  <h2>Replica Sets</h2>
+                  <div class="list-pf">
+                    <overview-list-row
+                         ng-repeat="replicaSet in overview.filteredReplicaSets track by (replicaSet | uid)"
+                         api-object="replicaSet"
+                         state="overview.state">
+                    </overview-list-row>
+                  </div>
+                </div>
+                <div ng-if="overview.filteredStatefulSets | hashSize">
+                  <h2>Stateful Sets</h2>
+                  <div class="list-pf">
+                    <overview-list-row
+                         ng-repeat="statefulSet in overview.filteredStatefulSets track by (statefulSet | uid)"
+                         api-object="statefulSet"
+                         state="overview.state">
+                    </overview-list-row>
+                  </div>
+                </div>
+                <div ng-if="overview.filteredMonopods | hashSize">
+                  <h2>Pods</h2>
+                  <div class="list-pf">
+                    <overview-list-row
+                         ng-repeat="pod in overview.filteredMonopods track by (pod | uid)"
+                         api-object="pod"
+                         state="overview.state">
+                    </overview-list-row>
+                  </div>
+                </div>
+              </div>
+              <div ng-if="overview.viewBy === 'pipeline'">
+                <!-- TODO: Reuse pipelines empty state message from pipelines.html -->
+                <div ng-if="!overview.pipelineBuildConfigs.length" class="empty-state-message text-center">
+                  <h2>No pipelines.</h2>
+                  <div ng-if="project.metadata.name | canIAddToProject">
+                    <p>
+                      No pipelines have been added to project {{projectName}}.
+                      <br>
+                      Learn more about
+                      <a ng-href="{{ 'pipeline-builds' | helpLink}}" target="_blank">Pipeline Builds</a>
+                      and the
+                      <a ng-href="{{ 'pipeline-plugin' | helpLink}}" target="_blank">OpenShift Pipeline Plugin</a>.
+                    </p>
+                    <p ng-if="(project.metadata.name | canIAddToProject) && overview.samplePipelineURL">
+                      <a ng-href="{{overview.samplePipelineURL}}" class="btn btn-lg btn-primary">
+                        Create Sample Pipeline
+                      </a>
+                    </p>
+                  </div>
+                  <div ng-if="!(project.metadata.name | canIAddToProject)">
+                    <ng-include src="'views/_request-access.html'"></ng-include>
+                  </div>
+                </div>
+                <div ng-if="(overview.pipelineBuildConfigs | hashSize) && !(overview.filteredPipelineBuildConfigs | hashSize)">
+                  <div class="empty-state-message text-center h2">
+                    All pipelines are filtered.
+                    <a href="" ng-click="overview.clearFilter()">Clear Filter</a>
+                  </div>
+                </div>
+                <div ng-repeat="pipeline in overview.filteredPipelineBuildConfigs track by (pipeline | uid)">
+                  <div ng-if="'buildconfigs/instantiate' | canI : 'create'" class="pull-right">
+                    <button
+                        class="btn btn-default"
+                        ng-if="'buildconfigs/instantiate' | canI : 'create'"
+                        ng-click="overview.startBuild(pipeline)">
+                      Start Pipeline
+                    </button>
+                  </div>
+                  <h2>
+                    <div class="component-label">Pipeline</div>
+                    <span ng-bind-html="pipeline.metadata.name | highlightKeywords : overview.state.filterKeywords"></span>
+                  </h2>
+                  <div ng-if="!(overview.recentPipelinesByBuildConfig[pipeline.metadata.name] | hashSize)" class="mar-bottom-lg">
+                    No pipeline runs.
+                  </div>
+                  <div ng-if="overview.recentPipelinesByBuildConfig[pipeline.metadata.name] | hashSize" class="build-pipelines">
+                    <div ng-repeat="pipeline in overview.recentPipelinesByBuildConfig[pipeline.metadata.name] track by (pipeline | uid)"
+                         class="row build-pipeline-wrapper animate-repeat">
+                      <div class="col-sm-12">
+                        <build-pipeline build="pipeline" build-config-name-on-expanded="true" collapse-pending="true"></build-pipeline>
+                      </div>
+                    </div>
+                  </div>
+                  <div ng-if="!overview.deploymentConfigsByPipeline[pipeline.metadata.name].length" class="mar-bottom-lg">
+                    This pipeline is not associated with any deployments.
+                  </div>
+                  <div ng-if="overview.deploymentConfigsByPipeline[pipeline.metadata.name].length" class="list-pf">
+                    <overview-list-row
+                         ng-repeat="dcName in overview.deploymentConfigsByPipeline[pipeline.metadata.name]"
+                         api-object="overview.deploymentConfigs[dcName]"
+                         current="overview.currentByDeploymentConfig[dcName]"
+                         previous="overview.getPreviousReplicationController(deploymentConfig)"
+                         state="overview.state"
+                         hide-pipelines="true">
+                    </overview-list-row>
+                  </div>
+
+                  <!-- Currently we only filter the pipelines. -->
+                  <div class="list-pf" ng-if="overview.pipelineViewHasOtherResources && !overview.filterActive">
+                    <h2>Other Resources</h2>
+                    <overview-list-row
+                         ng-repeat="deploymentConfig in overview.deploymentConfigsNoPipeline track by (deploymentConfig | uid)"
+                         ng-init="dcName = deploymentConfig.metadata.name"
+                         api-object="deploymentConfig"
+                         current="overview.currentByDeploymentConfig[dcName]"
+                         previous="overview.getPreviousReplicationController(deploymentConfig)"
+                         state="overview.state">
+                    </overview-list-row>
+                    <overview-list-row
+                         ng-repeat="deployment in overview.deployments track by (deployment | uid)"
+                         api-object="deployment"
+                         current="overview.currentByDeployment[deployment.metadata.name]"
+                         previous="overview.replicaSetsByDeployment[deployment.metadata.name][1]"
+                         state="overview.state">
+                    </overview-list-row>
+                    <overview-list-row
+                         ng-repeat="replicationController in overview.vanillaReplicationControllers track by (replicationController | uid)"
+                         api-object="replicationController"
+                         current="replicationController"
+                         state="overview.state">
+                    </overview-list-row>
+                    <overview-list-row
+                         ng-repeat="replicaSet in overview.vanillaReplicaSets track by (replicaSet | uid)"
+                         api-object="replicaSet"
+                         state="overview.state">
+                    </overview-list-row>
+                    <overview-list-row
+                         ng-repeat="statefulSet in overview.statefulSets track by (statefulSet | uid)"
+                         api-object="statefulSet"
+                         state="overview.state">
+                    </overview-list-row>
+                    <overview-list-row
+                         ng-repeat="pod in overview.monopods track by (pod | uid)"
+                         api-object="pod"
+                         state="overview.state">
+                    </overview-list-row>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</project-page>

--- a/app/views/overview.html
+++ b/app/views/overview.html
@@ -4,7 +4,7 @@
   <!-- Middle section -->
   <div class="middle-section">
     <div class="middle-container">
-      <div class="middle-content surface-shaded" in-view-container>
+      <div class="middle-content surface-shaded">
         <div class="container-fluid surface-shaded">
           <tasks></tasks>
           <alerts alerts="alerts"></alerts>

--- a/app/views/overview/_build-counts.html
+++ b/app/views/overview/_build-counts.html
@@ -1,0 +1,27 @@
+<span ng-if="buildCounts.show" class="animate-if">
+  <span ng-if="buildCounts.label" class="builds-label">
+    {{buildCounts.label}}
+  </span>
+  <span ng-repeat="phase in buildCounts.interestingPhases"
+        ng-if="buildCounts.countByPhase[phase]"
+        class="icon-count">
+    <span dynamic-content="{{buildCounts.countByPhase[phase]}} {{phase}}"
+          data-toggle="tooltip"
+          data-trigger="hover"
+          aria-hidden="true">
+      <span ng-switch="phase" class="hide-ng-leave">
+        <span ng-switch-when="Failed" class="status-icon">
+          <i class="pficon pficon-error-circle-o text-danger"></i>
+        </span>
+        <span ng-switch-default>
+          <status-icon status="phase"></status-icon>
+        </span>
+      </span>
+      {{buildCounts.countByPhase[phase]}}
+      <span class="sr-only">{{phase}}</span>
+    </span>
+  </span>
+  <span ng-if="buildCounts.currentStage" class="running-stage">
+    Stage {{buildCounts.currentStage.name}}
+  </span>
+</span>

--- a/app/views/overview/_builds.html
+++ b/app/views/overview/_builds.html
@@ -1,0 +1,45 @@
+<div ng-if="overviewBuilds.buildConfigs.length" class="expanded-section">
+  <div class="section-title hidden-xs">Builds</div>
+  <div ng-repeat="buildConfig in overviewBuilds.buildConfigs track by (buildConfig | uid)" class="row">
+    <div class="col-sm-5">
+      <h3 class="mar-top-xs">
+        <a ng-href="{{buildConfig | navigateResourceURL}}">{{buildConfig.metadata.name}}</a>
+      </h3>
+    </div>
+    <div class="col-sm-7">
+      <div ng-if="!(overviewBuilds.recentBuildsByBuildConfig[buildConfig.metadata.name] | hashSize)">
+        No builds.
+      </div>
+      <div ng-repeat="build in overviewBuilds.recentBuildsByBuildConfig[buildConfig.metadata.name] track by (build | uid)" class="mar-bottom-sm animate-repeat">
+        <span ng-if="overviewBuilds.showLogs(build)" class="small pull-right">
+          <a ng-if="!!['New', 'Pending'].indexOf(build.status.phase) && (build | buildLogURL)" ng-href="{{build | buildLogURL}}">View Full Log</a>
+        </span>
+        <span ng-switch="build.status.phase" class="hide-ng-leave">
+          <span ng-switch-when="Failed" class="status-icon">
+            <i class="pficon pficon-error-circle-o text-danger"></i>
+          </span>
+          <span ng-switch-default>
+            <status-icon status="build.status.phase"></status-icon>
+          </span>
+        </span>
+        <span class="h5">
+          Build
+          <a ng-href="{{build | navigateResourceURL}}"><span
+              ng-if="build | annotation : 'buildNumber'">#{{build | annotation : 'buildNumber'}}</span><span
+              ng-if="!(build | annotation : 'buildNumber')">{{build.metadata.name}}</span></a>
+          <span ng-switch="build.status.phase" class="hide-ng-leave">
+            <span ng-switch-when="Failed">failed</span>
+            <span ng-switch-when="Error">encountered an error</span>
+            <span ng-switch-when="Cancelled">was cancelled</span>
+            <span ng-switch-default>is {{build.status.phase | lowercase}}</span>
+          </span>
+          <ellipsis-pulser ng-if="build | isIncompleteBuild" color="dark" size="sm" display="inline" msg=""></ellipsis-pulser>
+          <small class="text-muted mar-left-md">created <span am-time-ago="build.metadata.creationTimestamp"></span></small>
+        </span>
+        <div ng-if="overviewBuilds.showLogs(build)" class="animate-if">
+          <mini-log api-object="build" context="overviewBuilds.context"></mini-log>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/overview/_list-row-actions.html
+++ b/app/views/overview/_list-row-actions.html
@@ -1,0 +1,64 @@
+<!-- Always show `<div class="list-pf-actions">` so everything lines up even if the kebab is hidden.  -->
+<div class="list-pf-actions">
+  <div ng-if="row.canIDoAny()">
+    <div ng-switch="row.apiObject.kind">
+      <div ng-switch-when="DeploymentConfig">
+        <div uib-dropdown>
+          <a href=""
+          uib-dropdown-toggle
+          class="actions-dropdown-kebab"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+          <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu role="menu">
+            <li ng-if="('buildconfigs/instantiate' | canI : 'create') && row.pipelines.length === 1" role="menuitem">
+              <a href=""
+              ng-click="row.startBuild(row.pipelines[0])">Start Pipeline</a>
+            </li>
+            <li ng-if="('buildconfigs/instantiate' | canI : 'create') && row.buildConfigs.length === 1 && !row.pipelines.length" role="menuitem">
+              <a href=""
+              ng-click="row.startBuild(row.buildConfigs[0])">Start Build</a>
+            </li>
+            <li ng-if="'deploymentconfigs' | canI : 'update'" role="menuitem">
+              <a href=""
+              ng-click="row.startDeployment()">Deploy</a>
+            </li>
+            <li ng-if="'deploymentconfigs' | canI : 'update'" role="menuitem">
+              <a ng-href="{{row.apiObject | editResourceURL}}">Edit</a>
+            </li>
+            <li ng-if="row.current && ('deploymentconfigs/log' | canI : 'get')" role="menuitem">
+              <a ng-href="{{row.current | navigateResourceURL}}?tab=logs">View Logs</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div ng-switch-when="Pod">
+        <div uib-dropdown>
+          <a href=""
+          uib-dropdown-toggle
+          class="actions-dropdown-kebab"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+          <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu role="menu">
+            <li role="menuitem" ng-if="'pods' | canI : 'update'">
+              <a ng-href="{{row.apiObject | editYamlURL}}">Edit YAML</a>
+            </li>
+            <li role="menuitem" ng-if="('pods/log' | canI : 'get')">
+              <a ng-href="{{row.apiObject | navigateResourceURL}}?tab=logs">View Logs</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div ng-switch-default>
+        <div uib-dropdown>
+          <a href=""
+          uib-dropdown-toggle
+          class="actions-dropdown-kebab"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+          <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu role="menu">
+            <li role="menuitem" ng-if="row.rgv | canI : 'update'">
+              <a ng-href="{{row.apiObject | editYamlURL}}">Edit YAML</a>
+            </li>
+            <li ng-if="(pod = row.firstPod(row.current)) && ('pods/log' | canI : 'get')" role="menuitem">
+              <a ng-href="{{pod | navigateResourceURL}}?tab=logs">View Logs</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div><!-- /list-pf-actions-->

--- a/app/views/overview/_list-row-content.html
+++ b/app/views/overview/_list-row-content.html
@@ -1,0 +1,86 @@
+<div class="list-pf-name">
+  <h3>
+    <div class="component-label">
+      <span ng-if="row.apiObject.kind === 'DeploymentConfig'">
+        Deployment
+      </span>
+      <span ng-if="row.apiObject.kind !== 'DeploymentConfig'">
+        {{row.apiObject.kind | humanizeKind}}
+      </span>
+    </div>
+    <a ng-href="{{row.apiObject | navigateResourceURL}}"><span ng-bind-html="row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords"></span></a><span ng-if="row.apiObject.kind === 'DeploymentConfig' && row.current">,
+      <a ng-href="{{row.current | navigateResourceURL}}">#{{row.apiObject.status.latestVersion}}</a>
+    </span><span ng-if="row.apiObject.kind === 'Deployment' && row.current">,
+      <a ng-href="{{row.current | navigateResourceURL}}">#{{row.current | annotation : 'deployment.kubernetes.io/revision'}}</a>
+    </span>
+  </h3>
+  <div class="status-icons">
+    <notification-icon ng-if="!row.expanded" alerts="row.notifications"></notification-icon>
+    <span class="build-count">
+      <span ng-if="!row.expanded && !row.hidePipelines && (row.recentPipelines | hashSize)" class="pipelines">
+        <build-counts
+          builds="row.recentPipelines"
+          label="Pipelines"
+          show-running-stage="true">
+        </build-counts>
+      </span>
+      <span ng-if="!row.expanded && (row.recentBuilds | hashSize)" class="builds">
+        <build-counts builds="row.recentBuilds" label="Builds"></build-counts>
+      </span>
+    </span>
+  </div>
+</div>
+<div ng-if="row.apiObject.kind === 'DeploymentConfig' && !row.current && !row.expanded" class="list-pf-details hidden-xs hidden-sm">
+  <span>
+    No deployments for <a ng-href="{{row.apiObject | navigateResourceURL}}">{{row.apiObject.metadata.name}}</a>
+  </span>
+</div>
+<div ng-if="row.isDeploymentInProgress()" class="list-pf-details">
+  <div ng-if="row.apiObject.kind === 'DeploymentConfig'">
+    <span class="mar-right-sm">
+      <span class="hidden-xs">
+        {{row.apiObject.spec.strategy.type}} deployment
+        {{row.current | deploymentStatus | lowercase}}&thinsp;<ellipsis-pulser color="dark" size="sm" display="inline" msg=""></ellipsis-pulser>
+      </span>
+      <!-- Don't show the strategy at phone resolutions to save space. -->
+      <span class="hidden visible-xs-inline nowrap">
+        <ellipsis-pulser color="dark" size="sm" display="inline" msg="Deploying"></ellipsis-pulser>
+      </span>
+    </span>
+    <span ng-if="'replicationcontrollers' | canI : 'update'">
+      <a href="" ng-click="row.cancelDeployment()" role="button">Cancel</a>
+    </span>
+  </div>
+  <div ng-if="row.apiObject.kind === 'Deployment'">
+    <span class="hidden-xs">
+      {{row.apiObject.spec.strategy.type | sentenceCase}}&nbsp;<ellipsis-pulser color="dark" size="sm" display="inline" msg="in progress"></ellipsis-pulser>
+    </span>
+    <span class="hidden visible-xs-inline nowrap">
+      <ellipsis-pulser color="dark" size="sm" display="inline" msg="Deploying"></ellipsis-pulser>
+    </span>
+  </div>
+</div>
+<div ng-if="row.current && !row.isDeploymentInProgress() && !row.expanded" class="list-pf-details">
+  <div ng-if="row.state.showMetrics && row.state.breakpoint === 'md' || row.state.breakpoint === 'lg'" class="truncate metrics-collapsed">
+    <div ng-if="row.apiObject.kind === 'Pod'">
+      <metrics-summary
+        pods="[row.apiObject]"
+        containers="row.apiObject.spec.containers">
+      </metrics-summary>
+    </div>
+    <div ng-if="row.apiObject.kind !== 'Pod' && row.current">
+      <metrics-summary
+        pods="row.getPods(row.current)"
+        containers="row.current.spec.template.spec.containers">
+      </metrics-summary>
+    </div>
+  </div>
+  <div class="pods hidden-xs">
+    <div ng-if="row.apiObject.kind === 'Pod'">
+      <pod-donut pods="[row.apiObject]" mini="true"></pod-donut>
+    </div>
+    <div ng-if="row.apiObject.kind !== 'Pod'">
+      <pod-donut pods="row.getPods(row.current)" mini="true"></pod-donut>
+    </div>
+  </div>
+</div>

--- a/app/views/overview/_list-row-empty-state.html
+++ b/app/views/overview/_list-row-empty-state.html
@@ -1,0 +1,38 @@
+<h2>No deployments.</h2>
+<div ng-if="row.imageChangeTriggers.length">
+  A new deployment will start automatically when
+  <span ng-if="row.imageChangeTriggers.length === 1">
+    an image is available for
+    <a ng-href="{{row.urlForImageChangeTrigger(row.imageChangeTriggers[0])}}">
+      {{row.imageChangeTriggers[0].imageChangeParams.from | imageObjectRef : row.apiObject.metadata.namespace}}</a>.
+  </span>
+  <span ng-if="row.imageChangeParams.length > 1">
+    one of the images referenced by this deployment config changes.
+  </span>
+</div>
+<div ng-if="!row.imageChangeTriggers.length">
+  <p>
+    No deployments for {{row.apiObject.kind | humanizeKind}}
+    <a ng-href="{{row.apiObject | navigateResourceURL}}">{{row.apiObject.metadata.name}}</a>.
+  </p>
+  <div ng-if="row.apiObject.kind === 'DeploymentConfig'">
+    <div ng-if="pipeline = row.pipelines[0]">
+      <p>
+        This deployment config is part of the pipeline
+        <a ng-href="{{pipeline | navigateResourceURL}}">{{pipeline.metadata.name}}</a>.
+      </p>
+      <div ng-if="('buildconfigs/instantiate' | canI : 'create')">
+        <button class="btn btn-primary" ng-click="row.startBuild(pipeline)">
+          Start Pipeline
+        </button>
+      </div>
+    </div>
+    <div ng-if="!row.pipelines.length">
+      <button ng-if="'deploymentconfigs' | canI : 'update'"
+              class="btn btn-primary"
+              ng-click="row.startDeployment()">
+        Start Deployment
+      </button>
+    </div>
+  </div>
+</div>

--- a/app/views/overview/_list-row-expanded.html
+++ b/app/views/overview/_list-row-expanded.html
@@ -1,0 +1,186 @@
+<div class="list-pf-container">
+  <div class="list-pf-content">
+    <alerts alerts="row.notifications"></alerts>
+    <div ng-if="row.current">
+      <div class="row">
+        <div ng-if="row.state.breakpoint !== 'xs'">
+          <div ng-class="{
+                'col-sm-7 col-md-8 col-lg-9': !row.state.showMetrics && !row.previous,
+                'col-sm-12 col-md-4 col-lg-5': row.state.showMetrics && !row.previous,
+                'hidden-sm col-md-5 col-lg-5': row.previous
+              }">
+            <!-- TODO: markup semantics suggest div.component-label in <pod-template> should be an h4,
+                       but only here on the overview -->
+            <pod-template
+              pod-template="row.current | podTemplate"
+              images-by-docker-reference="row.state.imagesByDockerReference"
+              builds="row.state.builds"></pod-template>
+          </div>
+          <div ng-if="row.state.showMetrics && !row.previous" class="col-sm-7 col-md-4 col-lg-4">
+            <div ng-if="row.apiObject.kind === 'Pod'">
+              <deployment-metrics
+                pods="[row.apiObject]"
+                containers="row.apiObject.spec.containers"
+                profile="compact"
+                alerts="row.state.alerts"
+                class="overview-metrics">
+              </deployment-metrics>
+              <h4 class="h5">Usage <small>Last 15 Minutes</small></h4>
+            </div>
+            <div ng-if="row.apiObject.kind !== 'Pod'">
+              <deployment-metrics
+                pods="row.getPods(row.current)"
+                containers="row.current.spec.template.spec.containers"
+                profile="compact"
+                alerts="row.state.alerts"
+                class="overview-metrics">
+              </deployment-metrics>
+              <h4 class="h5">Average Usage <small>Last 15 Minutes</small></h4>
+            </div>
+          </div>
+        </div>
+        <div ng-if="row.previous" class="col-sm-5 col-md-3">
+          <deployment-donut
+            rc="row.previous"
+            deployment-config="row.apiObject"
+            pods="row.getPods(row.previous)"
+            hpa="row.hpa"
+            limit-ranges="row.state.limitRanges"
+            quotas="row.state.quotas"
+            cluster-quotas="row.state.clusterQuotas"
+            scalable="false"
+            alerts="row.state.alerts">
+          </deployment-donut>
+        </div>
+        <div ng-if="row.previous" class="col-sm-2 col-md-1 col-lg-1">
+          <div class="deployment-connector-arrow" aria-hidden="true">
+            &rarr;
+          </div>
+        </div>
+        <div class="col-sm-5 col-md-3">
+          <div ng-if="row.apiObject.kind === 'Pod'">
+            <a ng-href="{{row.apiObject | navigateResourceURL}}">
+              <pod-donut pods="[row.apiObject]"></pod-donut>
+            </a>
+          </div>
+          <div ng-if="row.apiObject.kind !== 'Pod'">
+            <deployment-donut
+              rc="row.current"
+              deployment-config="row.apiObject"
+              pods="row.getPods(row.current)"
+              hpa="row.hpa"
+              limit-ranges="row.state.limitRanges"
+              quotas="row.state.quotas"
+              cluster-quotas="row.state.clusterQuotas"
+              scalable="row.isScalable()"
+              alerts="row.state.alerts">
+            </deployment-donut>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Empty State Message -->
+    <div ng-if="!row.current" class="empty-state-message">
+      <div ng-include src=" 'views/overview/_list-row-empty-state.html' "></div>
+    </div>
+
+    <div ng-if="row.state.breakpoint === 'xs' && !row.state.previous" class="row">
+      <div class="col-sm-12">
+        <!-- Only show the tabset if any of the tabs are visible. -->
+        <uib-tabset ng-if="row.current || (row.services | hashSize) || row.recentPipelines.length || row.buildConfigs.length" class="list-row-tabset">
+          <uib-tab active="row.selectedTab.networking" ng-if="row.services | hashSize">
+            <uib-tab-heading>Networking</uib-tab-heading>
+            <overview-networking
+              services="row.services"
+              routes-by-service="row.state.routesByService">
+            </overview-networking>
+          </uib-tab>
+          <uib-tab ng-if="row.current" active="row.selectedTab.containers">
+            <uib-tab-heading>Containers</uib-tab-heading>
+            <!-- TODO: markup semantics suggest div.component-label in <pod-template> should be an h4,
+                       but only here on the overview -->
+            <pod-template
+              pod-template="row.current | podTemplate"
+              images-by-docker-reference="row.state.imagesByDockerReference"
+              builds="row.state.builds"></pod-template>
+          </uib-tab>
+          <uib-tab ng-if="row.current && row.state.showMetrics" active="row.selectedTab.metrics">
+            <uib-tab-heading>Metrics</uib-tab-heading>
+            <!-- Use ng-if to avoid requesting metrics when the tab is not active. -->
+            <div ng-if="row.selectedTab.metrics">
+              <div ng-if="row.apiObject.kind === 'Pod'">
+                <deployment-metrics
+                  pods="[row.apiObject]"
+                  containers="row.apiObject.spec.containers"
+                  profile="compact"
+                  alerts="row.state.alerts"
+                  class="overview-metrics">
+                </deployment-metrics>
+                <h4 class="h5">Usage <small>Last 15 Minutes</small></h4>
+              </div>
+              <div ng-if="row.apiObject.kind !== 'Pod'">
+                <deployment-metrics
+                  pods="row.getPods(row.current)"
+                  containers="row.current.spec.template.spec.containers"
+                  profile="compact"
+                  alerts="row.state.alerts"
+                  class="overview-metrics">
+                </deployment-metrics>
+                <h4 class="h5">Average Usage <small>Last 15 Minutes</small></h4>
+              </div>
+            </div>
+          </uib-tab>
+          <uib-tab ng-if="!row.hidePipelines && row.recentPipelines.length" active="row.selectedTab.pipelines">
+            <uib-tab-heading>
+              Pipelines
+              <span class="build-count">
+                <build-counts builds="row.recentPipelines"></build-counts>
+              </span>
+            </uib-tab-heading>
+            <overview-pipelines
+              recent-pipelines="row.recentPipelines">
+            </overview-pipelines>
+          </uib-tab>
+          <uib-tab ng-if="row.buildConfigs.length" active="row.selectedTab.builds">
+            <uib-tab-heading>
+              Builds
+              <span class="build-count">
+                <build-counts builds="row.recentBuilds"></build-counts>
+              </span>
+            </uib-tab-heading>
+            <overview-builds
+              build-configs="row.buildConfigs"
+              recent-builds-by-build-config="row.state.recentBuildsByBuildConfig"
+              context="row.state.context"
+              hide-log="row.state.limitWatches">
+            </overview-builds>
+          </uib-tab>
+        </uib-tabset>
+      </div>
+    </div>
+
+    <!-- Networking Section -->
+    <overview-networking
+      ng-if="row.state.breakpoint !== 'xs'"
+      services="row.services"
+      routes-by-service="row.state.routesByService">
+    </overview-networking>
+
+    <!-- Pipelines Section -->
+    <overview-pipelines
+      ng-if="!row.hidePipelines && row.state.breakpoint !== 'xs'"
+      recent-pipelines="row.recentPipelines">
+    </overview-pipelines>
+
+    <!-- Builds Section -->
+    <overview-builds
+      ng-if="row.state.breakpoint !== 'xs'"
+      build-configs="row.buildConfigs"
+      recent-builds-by-build-config="row.state.recentBuildsByBuildConfig"
+      context="row.state.context"
+      hide-log="row.state.limitWatches">
+    </overview-builds>
+
+  </div><!-- /list-pf-content -->
+</div> <!-- /list-pf-container -->

--- a/app/views/overview/_list-row.html
+++ b/app/views/overview/_list-row.html
@@ -1,0 +1,21 @@
+<div class="list-pf-item" ng-class="{ active: row.expanded }">
+  <div class="list-pf-container" ng-click="row.toggleExpand($event)">
+    <div class="list-pf-chevron">
+      <a href="" ng-click="row.toggleExpand($event, true)" class="toggle-expand-link">
+        <span ng-if="row.expanded">
+          <span class="fa fa-angle-down" aria-hidden="true"></span>
+          <span class="sr-only">Collapse</span>
+        </span>
+        <span ng-if="!row.expanded">
+          <span class="fa fa-angle-right" aria-hidden="true"></span>
+          <span class="sr-only">Expand</span>
+        </span>
+      </a>
+    </div>
+    <div ng-include src=" 'views/overview/_list-row-content.html' " class="list-pf-content"></div>
+    <div ng-include src=" 'views/overview/_list-row-actions.html' "></div>
+  </div>
+  <div class="list-pf-expansion collapse" ng-if="row.expanded" ng-class="{ in: row.expanded }">
+    <div ng-include src=" 'views/overview/_list-row-expanded.html' "></div>
+  </div>
+</div>

--- a/app/views/overview/_metrics-summary.html
+++ b/app/views/overview/_metrics-summary.html
@@ -1,0 +1,16 @@
+<div in-view="metricsSummary.updateInView($inview)" in-view-options="{ throttle: 50 }">
+  <div ng-repeat="metric in metricsSummary.metrics" class="metrics-summary">
+    <div class="usage-value">
+      <span class="fade-inline" ng-hide="metric.currentUsage | isNil">
+        {{metric.formatUsage(metric.currentUsage)}}
+      </span>
+      <span ng-if="metric.currentUsage | isNil" class="text-muted" aria-hidden="true">
+        --
+      </span>
+    </div>
+    <div class="usage-label">
+      {{metric.usageUnits(metric.currentUsage) | capitalize}}
+      {{metric.label}}
+    </div>
+  </div>
+</div>

--- a/app/views/overview/_mini-log.html
+++ b/app/views/overview/_mini-log.html
@@ -1,0 +1,7 @@
+<div ng-if="miniLog.lines.length" class="mini-log">
+  <div class="mini-log-content">
+    <div ng-repeat="line in miniLog.lines track by line.id"
+         ng-bind-html="::line.markup"
+         class="mini-log-line"></div>
+  </div>
+</div>

--- a/app/views/overview/_networking.html
+++ b/app/views/overview/_networking.html
@@ -1,0 +1,56 @@
+<div ng-if="networking.services | hashSize" class="expanded-section networking-section">
+  <div class="section-title hidden-xs">Networking</div>
+  <div ng-repeat="service in networking.services" class="row">
+    <div class="col-sm-5">
+      <div class="component-label">
+        Service
+        <span class="sublabel">Internal Traffic</span>
+      </div>
+      <h3>
+        <a ng-href="{{service | navigateResourceURL}}">{{service.metadata.name}}</a>
+      </h3>
+      <span ng-repeat="portMapping in service.spec.ports | limitTo : 1">
+        {{portMapping.port}}/{{portMapping.protocol}} <span ng-if="portMapping.name">({{portMapping.name}})</span>
+        <i class="fa fa-long-arrow-right text-muted"></i>
+        {{portMapping.targetPort}}
+      </span>
+      <span ng-if="service.spec.ports.length >= 2">
+        and
+        <span class="nowrap">
+          {{service.spec.ports.length - 1}}
+          <span ng-if="service.spec.ports.length > 2">others</span>
+          <span ng-if="service.spec.ports.length === 2">other</span>
+        </span>
+      </span>
+    </div>
+    <div class="col-sm-7">
+      <div class="component-label">
+        Routes
+        <span class="sublabel">External Traffic</span>
+      </div>
+      <div ng-if="networking.routesByService[service.metadata.name] | hashSize">
+        <div ng-repeat="route in networking.routesByService[service.metadata.name] | limitTo : 2 track by (route | uid)" class="overview-routes">
+          <h3>
+            <span ng-if="route | isWebRoute">
+              <a ng-href="{{route | routeWebURL}}" target="_blank">{{route | routeLabel}}</a>
+              <i class="fa fa-external-link small" aria-hidden="true"></i>
+            </span>
+            <span ng-if="!(route | isWebRoute)">{{route | routeLabel}}</span>
+            <route-warnings route="route" service="service"></route-warnings>
+          </h3>
+          <div class="overview-route">
+            Route <a ng-href="{{route | navigateResourceURL}}">{{route.metadata.name}}</a><span ng-if="route.spec.port.targetPort">,
+            target port {{route.spec.port.targetPort}}</span>
+          </div>
+          <div ng-if="route | hasAlternateBackends">
+            <route-service-bar-chart route="route" highlight-service="service.metadata.name"></route-service-bar-chart>
+          </div>
+        </div>
+      </div>
+      <div ng-if="!(networking.routesByService[service.metadata.name] | hashSize)">
+        <a ng-if="'routes' | canI : 'create'" ng-href="project/{{service.metadata.namespace}}/create-route?service={{service.metadata.name}}">Create Route</a>
+        <span ng-if="!('routes' | canI : 'create')" class="text-muted">No Routes</span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/overview/_notification-icon.html
+++ b/app/views/overview/_notification-icon.html
@@ -1,0 +1,34 @@
+<div ng-if="notification.byType.error" class="notification-icon-count animate-if">
+  <span
+    dynamic-content="{{notification.byType.error}}"
+    data-toggle="tooltip"
+    data-trigger="hover">
+    <span
+      class="pficon pficon-error-circle-o"
+      aria-hidden="true"></span>
+    {{notification.countByType.error}}
+    <span ng-if="notification.countByType.error === 1">
+      Error
+    </span>
+    <span ng-if="notification.countByType.error !== 1">
+      Errors
+    </span>
+  </span>
+</div>
+<div ng-if="notification.byType.warning" class="notification-icon-count animate-if">
+  <span
+    dynamic-content="{{notification.byType.warning}}"
+    data-toggle="tooltip"
+    data-trigger="hover">
+    <span
+      class="pficon pficon-warning-triangle-o"
+      aria-hidden="true"></span>
+    {{notification.countByType.warning}}
+    <span ng-if="notification.countByType.warning === 1">
+      Warning
+    </span>
+    <span ng-if="notification.countByType.warning !== 1">
+      Warnings
+    </span>
+  </span>
+</div>

--- a/app/views/overview/_pipelines.html
+++ b/app/views/overview/_pipelines.html
@@ -1,0 +1,7 @@
+<div ng-if="overviewPipelines.recentPipelines.length" class="expanded-section">
+  <div class="section-title no-border hidden-xs">Pipelines</div>
+  <div ng-repeat="pipeline in overviewPipelines.recentPipelines track by (pipeline | uid)"
+       class="build-pipeline-wrapper animate-repeat">
+    <build-pipeline build="pipeline" build-config-name-on-expanded="true" collapse-pending="true"></build-pipeline>
+  </div>
+</div>

--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
     "ng-sortable": "1.3.4",
     "ui-select": "angular-ui-select#0.19.4",
     "matchHeight": "0.7.0",
-    "angular-inview": "1.5.7",
+    "angular-inview": "2.2.0",
     "js-yaml": "3.6.1",
     "angular-moment": "1.0.0",
     "angular-utf8-base64": "0.0.5",

--- a/dist/scripts/vendor.js
+++ b/dist/scripts/vendor.js
@@ -57824,147 +57824,173 @@ a.put("selectize/choices.tpl.html", '<div ng-show="$select.open" class="ui-selec
 a.put("selectize/select.tpl.html", '<div class="ui-select-container selectize-control single" ng-class="{\'open\': $select.open}"><div class="selectize-input" ng-class="{\'focus\': $select.open, \'disabled\': $select.disabled, \'selectize-focus\' : $select.focus}" ng-click="$select.open && !$select.searchEnabled ? $select.toggle($event) : $select.activate()"><div class="ui-select-match"></div><input type="search" autocomplete="off" tabindex="-1" class="ui-select-search ui-select-toggle" ng-class="{\'ui-select-search-hidden\':!$select.searchEnabled}" ng-click="$select.toggle($event)" placeholder="{{$select.placeholder}}" ng-model="$select.search" ng-hide="!$select.isEmpty() && !$select.open" ng-disabled="$select.disabled" aria-label="{{ $select.baseTitle }}"></div><div class="ui-select-choices"></div><div class="ui-select-no-choice"></div></div>');
 } ]), function() {
 "use strict";
-var a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t = [].slice;
-e = angular.module("angular-inview", []).directive("inView", [ "$parse", function(a) {
+function a(a) {
 return {
 restrict:"A",
-require:"?^inViewContainer",
-link:function(b, c, e, f) {
-var i, j, k, l, n, o;
-if (e.inView) return i = a(e.inView), j = {
-element:c,
-wasInView:!1,
-offset:0,
-customDebouncedCheck:null,
-callback:function(a, d, e) {
-return null == a && (a = {}), b.$evalAsync(function(f) {
-return function() {
-return a.inViewTarget = c[0], i(b, {
-$event:a,
-$inview:d,
-$inviewpart:e
-});
+require:"?^^inViewContainer",
+link:function(b, g, h, i) {
+var l = {};
+h.inViewOptions && (l = b.$eval(h.inViewOptions)), l.offset && (l.offset = e(l.offset)), l.viewportOffset && (l.viewportOffset = e(l.viewportOffset));
+var m = k({
+type:"initial"
+}).merge(j(window, "checkInView click ready wheel mousewheel DomMouseScroll MozMousePixelScroll resize scroll touchmove mouseup keydown"));
+i && (m = m.merge(i.eventsSignal)), l.throttle && (m = m.throttle(l.throttle));
+var n = m.map(function(a) {
+var b;
+b = i ? i.getViewportRect() :c(), b = f(b, l.viewportOffset);
+var e = f(g[0].getBoundingClientRect(), l.offset), h = !!(g[0].offsetWidth || g[0].offsetHeight || g[0].getClientRects().length), j = {
+inView:h && d(e, b),
+event:a,
+element:g,
+elementRect:e,
+viewportRect:b
 };
-}(this));
-}
-}, null != e.inViewOptions && (k = b.$eval(e.inViewOptions)) && (j.offset = k.offset || [ k.offsetTop || 0, k.offsetBottom || 0 ], k.debounce && (j.customDebouncedCheck = h(function(a) {
-return g([ j ], c[0], a);
-}, k.debounce))), l = null != (n = null != (o = j.customDebouncedCheck) ? o :null != f ? f.checkInView :void 0) ? n :r, null != f ? f.addItem(j) :d(j), setTimeout(l), b.$on("$destroy", function() {
-return null != f && f.removeItem(j), m(j);
+return l.generateParts && j.inView && (j.parts = {}, j.parts.top = e.top >= b.top, j.parts.left = e.left >= b.left, j.parts.bottom = e.bottom <= b.bottom, j.parts.right = e.right <= b.right), j;
+}).scan({}, function(a, b) {
+return l.generateDirection && b.inView && a.elementRect && (b.direction = {
+horizontal:b.elementRect.left - a.elementRect.left,
+vertical:b.elementRect.top - a.elementRect.top
+}), b.changed = b.inView !== a.inView || !angular.equals(b.parts, a.parts) || !angular.equals(b.direction, a.direction), b;
+}).filter(function(a) {
+return !!a.changed && !("initial" === a.event.type && !a.inView);
+}), o = a(h.inView), p = n.subscribe(function(a) {
+b.$applyAsync(function() {
+o(b, {
+$inview:a.inView,
+$inviewInfo:a
 });
+});
+});
+b.$on("$destroy", p);
 }
 };
-} ]).directive("inViewContainer", function() {
+}
+function b() {
 return {
-restrict:"AC",
+restrict:"A",
 controller:[ "$element", function(a) {
-return this.items = [], this.addItem = function(a) {
-return this.items.push(a);
-}, this.removeItem = function(a) {
-var b;
-return this.items = function() {
-var c, d, e, f;
-for (e = this.items, f = [], c = 0, d = e.length; c < d; c++) b = e[c], b !== a && f.push(b);
-return f;
-}.call(this);
-}, this.checkInView = function(b) {
-return function(c) {
-var d, e, f, h;
-for (h = b.items, e = 0, f = h.length; e < f; e++) d = h[e], null != d.customDebouncedCheck && d.customDebouncedCheck();
-return g(function() {
-var a, b, c, e;
-for (c = this.items, e = [], a = 0, b = c.length; a < b; a++) d = c[a], null == d.customDebouncedCheck && e.push(d);
-return e;
-}.call(b), a[0], c);
+this.element = a, this.eventsSignal = j(a, "scroll"), this.getViewportRect = function() {
+return a[0].getBoundingClientRect();
 };
-}(this), this;
-} ],
-link:function(a, b, c, d) {
-return b.bind("scroll", d.checkInView), n(d), a.$on("$destroy", function() {
-return b.unbind("scroll", d.checkInView), q(d);
+} ]
+};
+}
+function c() {
+var a = {
+top:0,
+left:0,
+width:window.innerWidth,
+right:window.innerWidth,
+height:window.innerHeight,
+bottom:window.innerHeight
+};
+if (a.height) return a;
+var b = document.compatMode;
+return "CSS1Compat" === b ? (a.width = a.right = document.documentElement.clientWidth, a.height = a.bottom = document.documentElement.clientHeight) :(a.width = a.right = document.body.clientWidth, a.height = a.bottom = document.body.clientHeight), a;
+}
+function d(a, b) {
+return !(b.left > a.right || b.right < a.left || b.top > a.bottom || b.bottom < a.top);
+}
+function e(a) {
+return angular.isArray(a) ? 2 == a.length ? a.concat(a) :3 == a.length ? a.concat([ a[1] ]) :a :[ a, a, a, a ];
+}
+function f(a, b) {
+if (!b) return a;
+var c = {
+top:g(b[0]) ? parseFloat(b[0]) * a.height :b[0],
+right:g(b[1]) ? parseFloat(b[1]) * a.width :b[1],
+bottom:g(b[2]) ? parseFloat(b[2]) * a.height :b[2],
+left:g(b[3]) ? parseFloat(b[3]) * a.width :b[3]
+};
+return {
+top:a.top - c.top,
+left:a.left - c.left,
+bottom:a.bottom + c.bottom,
+right:a.right + c.right,
+height:a.height + c.top + c.bottom,
+width:a.width + c.left + c.right
+};
+}
+function g(a) {
+return angular.isString(a) && a.indexOf("%") > 0;
+}
+function h(a) {
+this.didSubscribeFunc = a;
+}
+function i() {
+var a = arguments;
+return new h(function(b) {
+for (var c = [], d = a.length - 1; d >= 0; d--) c.push(a[d].subscribe(function() {
+b.apply(null, arguments);
+}));
+b.$dispose = function() {
+for (var a = c.length - 1; a >= 0; a--) c[a] && c[a]();
+};
 });
 }
+function j(a, b) {
+return new h(function(c) {
+var d = function(a) {
+c(a);
+}, e = angular.element(a);
+e.on(b, d), c.$dispose = function() {
+e.off(b, d);
 };
-}), c = [], d = function(a) {
-return c.push(a), f();
-}, m = function(a) {
-var b;
-return c = function() {
-var d, e, f;
-for (f = [], d = 0, e = c.length; d < e; d++) b = c[d], b !== a && f.push(b);
-return f;
-}(), p();
-}, a = [], n = function(b) {
-return a.push(b), f();
-}, q = function(b) {
-var c;
-return a = function() {
-var d, e, f;
-for (f = [], d = 0, e = a.length; d < e; d++) c = a[d], c !== b && f.push(c);
-return f;
-}(), p();
-}, b = !1, s = function(b) {
-var d, e, f;
-for (e = 0, f = a.length; e < f; e++) d = a[e], d.checkInView(b);
-if (c.length) return r(b);
-}, f = function() {
-if (!b) return b = !0, angular.element(window).bind("checkInView click ready wheel mousewheel DomMouseScroll MozMousePixelScroll resize scroll touchmove mouseup", s);
-}, p = function() {
-if (b && !c.length && !a.length) return b = !1, angular.element(window).unbind("checkInView click ready wheel mousewheel DomMouseScroll MozMousePixelScroll resize scroll touchmove mouseup", s);
-}, o = function(a, b, c, d, e) {
-var f, g;
-if (c) {
-if (f = i(b.element[0]).top + window.pageYOffset, g = d && e && "neither" || d && "top" || e && "bottom" || "both", !b.wasInView || b.wasInView !== g || f !== b.lastOffsetTop) return b.lastOffsetTop = f, b.wasInView = g, b.callback(a, !0, g);
-} else if (b.wasInView) return b.wasInView = !1, b.callback(a, !1);
-}, g = function(a, b, c) {
-var d, e, f, g, h, m, n, p, q, r, s, t, u, v, w;
-if (w = {
-top:0,
-bottom:k()
-}, b && b !== window) {
-if (d = i(b), d.top > w.bottom || d.bottom < w.top) {
-for (m = 0, p = a.length; m < p; m++) h = a[m], o(c, h, !1);
-return;
+});
 }
-d.top > w.top && (w.top = d.top), d.bottom < w.bottom && (w.bottom = d.bottom);
+function k(a) {
+return new h(function(b) {
+setTimeout(function() {
+b(a);
+});
+});
 }
-for (v = [], n = 0, q = a.length; n < q; n++) h = a[n], g = h.element[0], d = i(g), f = d.top + (l(h.offset) ? j(d, h.offset) :parseInt(null != (r = null != (s = h.offset) ? s[0] :void 0) ? r :h.offset)), e = d.bottom + (l(h.offset) ? j(d, h.offset) :parseInt(null != (t = null != (u = h.offset) ? u[1] :void 0) ? t :h.offset)), f < w.bottom && e >= w.top ? v.push(o(c, h, !0, e > w.bottom, f < w.top)) :v.push(o(c, h, !1));
-return v;
-}, l = function(a) {
-return "string" == typeof a && "%" === a.slice(-1);
-}, j = function(a, b) {
-var c;
-return c = b.substring(0, b.length - 1), (a.bottom - a.top) * (c / 100);
-}, k = function() {
-var a, b, c;
-return (a = window.innerHeight) ? a :(b = document.compatMode, !b && ("undefined" != typeof $ && null !== $ && null != (c = $.support) ? c.boxModel :void 0) || (a = "CSS1Compat" === b ? document.documentElement.clientHeight :document.body.clientHeight), a);
-}, i = function(a) {
-var b, c, d;
-if (null != a.getBoundingClientRect) return a.getBoundingClientRect();
-for (d = 0, b = a; b; ) d += b.offsetTop, b = b.offsetParent;
-for (c = a.parentElement; c; ) null != c.scrollTop && (d -= c.scrollTop), c = c.parentElement;
-return {
-top:d,
-bottom:d + a.offsetHeight
+var l = angular.module("angular-inview", []).directive("inView", [ "$parse", a ]).directive("inViewContainer", b);
+h.prototype.subscribe = function(a) {
+this.didSubscribeFunc(a);
+var b = function() {
+a.$dispose && (a.$dispose(), a.$dispose = null);
 };
-}, h = function(a, b) {
-var c;
-return c = null, function() {
-var d;
-return d = 1 <= arguments.length ? t.call(arguments, 0) :[], null != c && clearTimeout(c), c = setTimeout(function() {
-return a.apply(null, d);
-}, null != b ? b :100);
+return b;
+}, h.prototype.map = function(a) {
+var b = this;
+return new h(function(c) {
+c.$dispose = b.subscribe(function(b) {
+c(a(b));
+});
+});
+}, h.prototype.filter = function(a) {
+var b = this;
+return new h(function(c) {
+c.$dispose = b.subscribe(function(b) {
+a(b) && c(b);
+});
+});
+}, h.prototype.scan = function(a, b) {
+var c = this;
+return new h(function(d) {
+var e = a;
+d.$dispose = c.subscribe(function(a) {
+e = b(e, a), d(e);
+});
+});
+}, h.prototype.merge = function(a) {
+return i(this, a);
+}, h.prototype.throttle = function(a) {
+var b, c, d = this;
+return new h(function(e) {
+var f = d.subscribe(function() {
+var d = +new Date(), f = arguments;
+b && d < b + a ? (clearTimeout(c), c = setTimeout(function() {
+b = d, e.apply(null, f);
+}, a)) :(b = d, e.apply(null, f));
+});
+e.$dispose = function() {
+clearTimeout(c), f && f();
 };
-}, r = function(a) {
-var b, d, e;
-for (d = 0, e = c.length; d < e; d++) b = c[d], null != b.customDebouncedCheck && b.customDebouncedCheck();
-return g(function() {
-var a, d, e;
-for (e = [], a = 0, d = c.length; a < d; a++) b = c[a], null == b.customDebouncedCheck && e.push(b);
-return e;
-}(), null, a);
-}, "function" == typeof define && define.amd ? define([ "angular" ], e) :"undefined" != typeof module && module && module.exports && (module.exports = e);
-}.call(this), function(a) {
+});
+}, "function" == typeof define && define.amd ? define([ "angular" ], l) :"undefined" != typeof module && module && module.exports && (module.exports = l);
+}(), function(a) {
 if ("object" == typeof exports && "undefined" != typeof module) module.exports = a(); else if ("function" == typeof define && define.amd) define([], a); else {
 var b;
 b = "undefined" != typeof window ? window :"undefined" != typeof global ? global :"undefined" != typeof self ? self :this, b.jsyaml = a();

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -1,6 +1,7 @@
 div.code,pre,textarea{overflow:auto}
 .text-left,caption,th{text-align:left}
-.bootstrap-select.btn-group .dropdown-menu li a,.datepicker table{-ms-user-select:none;-webkit-user-select:none;-moz-user-select:none}
+.btn,.datepicker table{-webkit-user-select:none;-moz-user-select:none}
+.navbar-fixed-bottom .navbar-collapse,.navbar-fixed-top .navbar-collapse,.pre-scrollable{max-height:340px}
 .c3 svg,html{-webkit-tap-highlight-color:transparent}
 .list-view-pf-top-align .list-view-pf-actions,.list-view-pf-top-align .list-view-pf-checkbox{align-self:flex-start}
 @font-face{font-family:"Open Sans";font-style:normal;font-weight:300;src:url(../styles/fonts/OpenSans-Light-webfont.eot);src:local("Open Sans Light"),local("OpenSans-Light"),url(../styles/fonts/OpenSans-Light-webfont.eot?#iefix) format("embedded-opentype"),url(../styles/fonts/OpenSans-Light-webfont.woff2) format("woff2"),url(../styles/fonts/OpenSans-Light-webfont.woff) format("woff"),url(../styles/fonts/OpenSans-Light-webfont.ttf) format("truetype"),url(../styles/fonts/OpenSans-Light-webfont.svg#OpenSans) format("svg")}
@@ -425,7 +426,7 @@ div.code,pre{padding:10px;margin:0 0 10.5px;font-size:12px;line-height:1.6666666
 pre code,table{background-color:transparent}
 pre code{padding:0;font-size:inherit;color:inherit;white-space:pre-wrap;border-radius:0}
 .container,.container-fluid{padding-left:20px;padding-right:20px}
-.pre-scrollable{max-height:340px;overflow-y:scroll}
+.pre-scrollable{overflow-y:scroll}
 @media (min-width:768px){.container{width:760px}
 }
 @media (min-width:992px){.container{width:980px}
@@ -766,7 +767,7 @@ select[multiple].input-lg,textarea.input-lg{height:auto}
 @media (min-width:768px){.form-horizontal .form-group-lg .control-label{padding-top:7px;font-size:15px}
 .form-horizontal .form-group-sm .control-label{padding-top:3px;font-size:11px}
 }
-.btn{display:inline-block;margin-bottom:0;font-weight:600;text-align:center;vertical-align:middle;touch-action:manipulation;cursor:pointer;border:1px solid transparent;white-space:nowrap;padding:2px 6px;font-size:13px;line-height:1.66666667;border-radius:1px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+.btn{display:inline-block;margin-bottom:0;font-weight:600;text-align:center;vertical-align:middle;touch-action:manipulation;cursor:pointer;border:1px solid transparent;white-space:nowrap;padding:2px 6px;font-size:13px;line-height:1.66666667;border-radius:1px;-ms-user-select:none;user-select:none}
 .btn.active.focus,.btn.active:focus,.btn.focus,.btn:active.focus,.btn:active:focus,.btn:focus{outline:dotted thin!important;outline:-webkit-focus-ring-color auto 5px!important;outline-offset:-2px!important}
 .btn.focus,.btn:focus,.btn:hover{color:#4d5258;text-decoration:none}
 .btn.active,.btn:active{outline:0;-webkit-box-shadow:inset 0 3px 5px rgba(0,0,0,.125);box-shadow:inset 0 3px 5px rgba(0,0,0,.125)}
@@ -952,7 +953,6 @@ select[multiple].input-group-sm>.form-control,select[multiple].input-group-sm>.i
 .navbar-fixed-bottom .navbar-collapse,.navbar-fixed-top .navbar-collapse,.navbar-static-top .navbar-collapse{padding-left:0;padding-right:0}
 }
 .embed-responsive,.modal,.modal-open,.progress{overflow:hidden}
-.navbar-fixed-bottom .navbar-collapse,.navbar-fixed-top .navbar-collapse{max-height:340px}
 @media (max-device-width:480px) and (orientation:landscape){.navbar-fixed-bottom .navbar-collapse,.navbar-fixed-top .navbar-collapse{max-height:200px}
 }
 .container-fluid>.navbar-collapse,.container-fluid>.navbar-header,.container>.navbar-collapse,.container>.navbar-header{margin-right:-20px;margin-left:-20px}
@@ -2319,7 +2319,7 @@ td>.progress:first-child:last-child{margin-bottom:0;margin-top:3px}
 .datepicker-dropdown.datepicker-orient-bottom:after{top:-6px}
 .datepicker-dropdown.datepicker-orient-top:before{bottom:-7px;border-bottom:0;border-top:7px solid #bbb}
 .datepicker-dropdown.datepicker-orient-top:after{bottom:-6px;border-bottom:0;border-top:6px solid #fff}
-.datepicker table{margin:0;-webkit-touch-callout:none;-khtml-user-select:none;user-select:none}
+.datepicker table{margin:0;-webkit-touch-callout:none;-khtml-user-select:none;-ms-user-select:none;user-select:none}
 .datepicker table tr td,.datepicker table tr th{text-align:center;width:30px;height:30px;border:none}
 .datepicker table tr td.new,.datepicker table tr td.old{color:#9c9c9c}
 .datepicker table tr td.day:hover,.datepicker table tr td.focused{background:#f1f1f1;cursor:pointer}
@@ -2425,8 +2425,7 @@ select.bs-select-hidden,select.selectpicker{display:none!important}
 .bootstrap-select.btn-group .dropdown-menu.inner{position:static;float:none;border:0;padding:0;margin:0;border-radius:0;box-shadow:none}
 .bootstrap-select.btn-group .dropdown-menu li{position:relative}
 .bootstrap-select.btn-group .dropdown-menu li.active small{color:#fff}
-.bootstrap-select.btn-group .dropdown-menu li a{cursor:pointer;user-select:none}
-.bootstrap-switch,.c3 text{-webkit-user-select:none;-moz-user-select:none}
+.bootstrap-select.btn-group .dropdown-menu li a{cursor:pointer;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
 .bootstrap-select.btn-group .dropdown-menu li a.opt{position:relative;padding-left:2.25em}
 .bootstrap-select.btn-group .dropdown-menu li a span.check-mark{display:none}
 .bootstrap-select.btn-group .dropdown-menu li a span.text{display:inline-block}
@@ -2453,7 +2452,8 @@ select.bs-select-hidden,select.selectpicker{display:none!important}
 .bs-donebutton .btn-group button{width:100%}
 .bs-searchbox+.bs-actionsbox{padding:0 8px 4px}
 .bs-searchbox .form-control{margin-bottom:0;width:100%;float:none}
-.bootstrap-switch{display:inline-block;direction:ltr;cursor:pointer;border-radius:1px;border:1px solid #bbb;position:relative;text-align:left;overflow:hidden;line-height:8px;z-index:0;-ms-user-select:none;user-select:none;vertical-align:middle;-webkit-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;-o-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s}
+.bootstrap-switch{display:inline-block;direction:ltr;cursor:pointer;border-radius:1px;border:1px solid #bbb;position:relative;text-align:left;overflow:hidden;line-height:8px;z-index:0;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;vertical-align:middle;-webkit-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;-o-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s}
+.c3 text,.log-line-number{-moz-user-select:none;-webkit-user-select:none}
 .bootstrap-switch .bootstrap-switch-container{display:inline-block;top:0;border-radius:1px;-webkit-transform:translate3d(0,0,0);transform:translate3d(0,0,0)}
 .bootstrap-switch .bootstrap-switch-handle-off,.bootstrap-switch .bootstrap-switch-handle-on,.bootstrap-switch .bootstrap-switch-label{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;cursor:pointer;display:inline-block!important;height:100%;padding:2px 6px;font-size:13px;line-height:21px}
 .ie9.layout-pf-alt-fixed .nav-pf-vertical-alt,.ie9.layout-pf-fixed .nav-pf-secondary-nav,.ie9.layout-pf-fixed .nav-pf-tertiary-nav,.ie9.layout-pf-fixed .nav-pf-vertical,.list-group-item-header{box-sizing:content-box}
@@ -2937,8 +2937,8 @@ select.bs-select-hidden,select.selectpicker{display:none!important}
 .layout-pf-alt.layout-pf-alt-fixed .container-pf-alt-nav-pf-vertical-alt.collapsed-nav{margin-left:75px}
 .layout-pf-alt.layout-pf-alt-fixed .container-pf-alt-nav-pf-vertical-alt.hidden-nav{margin-left:0}
 a.disabled{color:#8b8d8f;cursor:not-allowed;text-decoration:none}
-.list-pf{border-bottom:1px solid #ededed}
-.list-pf-item{border-color:#ededed #fff;border-style:solid;border-width:1px;border-bottom:none}
+.list-pf{border-bottom:1px solid #dcdcdc}
+.list-pf-item{border-color:#dcdcdc #fff;border-style:solid;border-width:1px;border-bottom:none}
 .list-pf-item:hover{background-color:#fafafa}
 .list-pf-item.active{background-color:#ededed;border-color:#bbb;border-bottom-width:1px;border-bottom-style:solid}
 .list-pf-expansion{background-color:#fff}
@@ -3648,7 +3648,7 @@ table.dataTable th:active{outline:0}
 .wizard-pf-row{bottom:58px;position:absolute;overflow:hidden;top:172px;width:100%}
 .word-break{word-break:break-word;overflow-wrap:break-word;min-width:0}
 .word-break-all{word-break:break-all;word-break:break-word;overflow-wrap:break-word}
-.modal-resource-action h1,.resource-description,.row-cards-pf-flex .card-pf-body p{word-wrap:break-word;word-break:break-word}
+.modal-resource-action h1,.resource-description,.row-cards-pf-flex .card-pf-body p{word-break:break-word;word-wrap:break-word}
 .pre-wrap{white-space:pre-wrap}
 .visible-xlg-inline-block{display:none!important}
 @media (max-width:767px){.td-long-string{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
@@ -3675,6 +3675,7 @@ table.dataTable th:active{outline:0}
 .copy-to-clipboard input.form-control:read-only{background-color:#fff;color:#363636}
 .copy-to-clipboard-multiline{position:relative;width:100%}
 .copy-to-clipboard-multiline a{box-shadow:none;position:absolute;right:0;top:0}
+.card-pf,.tile{box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09)}
 .copy-to-clipboard-multiline pre{background-color:#fff;max-width:100%;overflow-x:auto}
 .input-group-addon.wildcard-prefix{padding-left:10px}
 .editor-examples{padding:19px;margin-bottom:20px;border:1px solid #d1d1d1}
@@ -3692,7 +3693,6 @@ table.dataTable th:active{outline:0}
 .osc-file-input textarea{font-family:Menlo,Monaco,Consolas,monospace;margin:5px 0}
 .health-checks-form .pause-rollouts-checkbox,.set-limits-form .pause-rollouts-checkbox{margin-top:21px}
 .checkbox-inline,.checkbox-inline+.checkbox-inline,.radio-inline,.radio-inline+.radio-inline{margin-left:0;margin-right:10px}
-.card-pf{box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09)}
 .card-pf .image-icon,.card-pf .template-icon{font-size:28px;line-height:1;margin-right:15px;opacity:.38}
 .card-pf-badge{color:#999;font-size:11px;text-transform:uppercase}
 .card-pf-body{margin-bottom:0}
@@ -3799,11 +3799,13 @@ code.command{display:inline-block;line-height:1.3;margin-right:2px}
 }
 .builds-block .builds .build:first-child{margin-top:0}
 .builds-block .builds .build+.build:after{background-color:#e0e0e0;top:-6px;content:"";display:block;height:1px;left:0;right:0;position:absolute}
-.deployment-well.detailed .deployment-summary-status,.deployment-well.detailed .deployment-summary-toggler,.deployment-well:not(.detailed) .deployment-details,.pod-donut .c3-tooltip-name--Empty .name{display:none}
 .clickable{cursor:pointer}
+.pod-donut.mini{display:inline-block;margin:0 0 0 -8px;min-width:45px;min-height:45px;top:3px;vertical-align:middle}
 .pod-donut .c3-defocused{opacity:.5!important}
 .pod-donut .c3-tooltip-container{top:-27px!important;left:50%!important;transform:translateX(-50%);white-space:nowrap}
 .pod-donut path.c3-arc-Empty{stroke:#d1d1d1;cursor:inherit!important}
+.pod-donut .c3-tooltip-name--Empty .name{display:none}
+.donut-mini-text{display:inline-block;min-width:50px}
 .deployment-donut{justify-content:center}
 .deployment-donut .scaling-controls{justify-content:center;font-size:24px}
 .deployment-donut .scaling-controls a{color:#bbb}
@@ -3818,6 +3820,7 @@ code.command{display:inline-block;line-height:1.3;margin-right:2px}
 .deployment-well:not(.detailed) .deployment-summary h3{margin-bottom:5px;text-transform:lowercase}
 .deployment-well:not(.detailed) .deployment-summary .deployment-summary-status{font-size:90%;margin-left:7px}
 .deployment-well:not(.detailed) .deployment-summary .deployment-summary-toggler{float:right!important;font-size:80%}
+.deployment-well.detailed .deployment-summary-status,.deployment-well.detailed .deployment-summary-toggler,.deployment-well:not(.detailed) .deployment-details{display:none}
 .popover{font-size:13px;line-height:1.66667;min-width:300px;word-wrap:break-word}
 .build-well,.deployment-well,.pod-well{overflow:hidden;margin-bottom:10px}
 .build-well .build-detail,.build-well .deployment-detail,.build-well .pod-detail,.deployment-well .build-detail,.deployment-well .deployment-detail,.deployment-well .pod-detail,.pod-well .build-detail,.pod-well .deployment-detail,.pod-well .pod-detail{margin-bottom:3px}
@@ -3894,6 +3897,7 @@ mark{padding:0;background-color:rgba(252,248,160,.5)}
 .build-trends-responsive .build-trends-container .c3-tooltip-container{top:0;left:0}
 .build-trends-responsive .build-trends-container .c3-xgrid-focus{display:none}
 .build-trends-responsive .build-trends-container .build-trends-avg-line{stroke:#d1d1d1;stroke-dasharray:8,5;stroke-width:1}
+.overview .metrics-compact .c3-line,.overview-new .c3-line{stroke-width:1px}
 .build-trends-responsive .build-trends-container .avg-duration{margin-right:30px}
 .build-trends-responsive .build-trends-container .avg-duration-text{vertical-align:top;font-size:12px}
 .metrics .metrics-options .form-group{margin-bottom:0}
@@ -3913,25 +3917,29 @@ mark{padding:0;background-color:rgba(252,248,160,.5)}
 }
 @media (max-width:950px){.monitoring-page.sidebar-open .metrics-sparkline .c3-axis-x .tick{display:none}
 }
-.metrics-compact{margin-bottom:10px;white-space:nowrap}
-.metrics-compact .metrics-sparkline{display:none;height:27px;border-bottom:1px solid #ededed}
-@media (min-width:1200px){.metrics-compact{margin-bottom:5px}
-.metrics-compact .metrics-sparkline{display:inline-block;width:150px;vertical-align:-6px}
+.overview .metrics-compact{margin-bottom:10px;white-space:nowrap}
+.overview .metrics-compact .metrics-sparkline{display:none;height:27px;border-bottom:1px solid #ededed}
+@media (min-width:1200px){.overview .metrics-compact{margin-bottom:5px}
+.overview .metrics-compact .metrics-sparkline{display:inline-block;width:150px;vertical-align:-6px}
 }
-@media (min-width:1400px){.metrics-compact .metrics-sparkline{width:230px}
+@media (min-width:1400px){.overview .metrics-compact .metrics-sparkline{width:230px}
 }
-.about .about-icon img,.command-line .about-icon img,.osc-form .template-options .form-group{width:100%}
-.metrics-compact .metrics-usage{display:block;margin-left:10px}
-@media (min-width:1200px){.metrics-compact .metrics-usage{display:inline-block}
+.overview .metrics-compact .metrics-usage{display:block;margin-left:10px}
+@media (min-width:1200px){.overview .metrics-compact .metrics-usage{display:inline-block}
 }
-.metrics-compact .usage-value{font-size:22px;font-weight:300;line-height:1;margin:3px 0}
-.metrics-compact .usage-value .fa{color:#9c9c9c;font-size:10px;vertical-align:2px}
-.metrics-compact .usage-label{font-size:84%;color:#9c9c9c;line-height:1;margin-bottom:-1px}
-.metrics-compact .c3-line{stroke-width:1px}
-@media (max-width:991px){.metrics-compact{text-align:center;display:inline-block;margin:10px}
-.metrics-compact .metrics-usage .usage-value{font-size:22px}
+.overview .metrics-compact .usage-value{font-size:22px;font-weight:300;line-height:1;margin:3px 0}
+.overview .metrics-compact .usage-value .fa{color:#9c9c9c;font-size:10px;vertical-align:2px}
+.overview .metrics-compact .usage-label{font-size:84%;color:#9c9c9c;line-height:1;margin-bottom:-1px}
+@media (max-width:991px){.overview .metrics-compact{text-align:center;display:inline-block;margin:10px}
+.overview .metrics-compact .metrics-usage .usage-value{font-size:22px}
 }
 .quota-chart{margin:0 20px}
+.route-service-bar-chart .service-name,.route-service-bar-chart .service-weight{font-size:84%;color:#9c9c9c;display:inline-block;vertical-align:middle}
+.route-service-bar-chart .service-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;width:125px}
+.route-service-bar-chart .service-weight{margin-left:5px}
+.route-service-bar-chart .progress{background:0 0;box-shadow:none;display:inline-block;margin:0;width:125px;-webkit-box-shadow:none}
+.about .about-icon img,.command-line .about-icon img,.osc-form .template-options .form-group{width:100%}
+.route-service-bar-chart .progress:not(.highlight) .progress-bar{background-color:#d1d1d1}
 label.checkbox{font-weight:400}
 .form-group .checkbox{margin-bottom:inherit}
 .drag-and-drop-zone{display:none}
@@ -4179,6 +4187,27 @@ copy-to-clipboard .input-group.limit-width{max-width:300px}
 70%{transform:scale(.66)}
 100%{opacity:.33;z-index:1}
 }
+.list-pf-actions .actions-dropdown-kebab{font-size:18px;margin-right:-5px}
+.list-pf-actions .dropdown .btn-link{color:#252525;font-size:17px;line-height:1;padding:4px 10px;margin-left:-10px;margin-right:-10px}
+.list-pf-actions .dropdown .btn-link:active,.list-pf-actions .dropdown .btn-link:focus,.list-pf-actions .dropdown .btn-link:hover{color:#0088ce}
+.list-pf-actions .dropdown .dropdown-menu{left:-15px;margin-top:11px}
+.list-pf-actions .dropdown .dropdown-menu.dropdown-menu-right{left:auto}
+.list-pf-actions .dropdown .dropdown-menu.dropdown-menu-right:after,.list-pf-actions .dropdown .dropdown-menu.dropdown-menu-right:before{left:auto;right:6px}
+.list-pf-actions .dropdown .dropdown-menu:after,.list-pf-actions .dropdown .dropdown-menu:before{border-bottom-color:#bbb;border-bottom-style:solid;border-bottom-width:10px;border-left:10px solid transparent;border-right:10px solid transparent;content:"";display:inline-block;left:6px;position:absolute;top:-11px}
+.list-pf-actions .dropdown .dropdown-menu:after{border-bottom-color:#fff;top:-10px}
+.list-pf-actions .dropdown.dropup .dropdown-menu{margin-bottom:11px;margin-top:0}
+.list-pf-actions .dropdown.dropup .dropdown-menu:after,.list-pf-actions .dropdown.dropup .dropdown-menu:before{border-bottom:none;border-top-color:#bbb;border-top-style:solid;border-top-width:10px;bottom:-11px;top:auto}
+.list-pf-actions .dropdown.dropup .dropdown-menu:after{border-top-color:#fff;bottom:-10px}
+.list-pf-actions .dropdown .dropdown-menu.dropdown-menu-right{right:-10px}
+.list-pf-content{flex-grow:1}
+.list-pf-content .alert:first-child{margin-top:0}
+.list-pf-content .alert-wrapper:last-child{margin-bottom:20px}
+.list-pf-chevron+.list-pf-content{align-items:center;display:flex}
+.list-pf-chevron+.list-pf-content .list-pf-details,.list-pf-chevron+.list-pf-content .list-pf-name{flex-grow:1}
+.list-pf-chevron+.list-pf-content .list-pf-details{align-items:center;display:flex;width:55%}
+.list-pf-chevron+.list-pf-content .list-pf-name{width:45%}
+.list-pf-item:not(.active) .list-pf-chevron+.list-pf-content{border-left-color:#dcdcdc}
+.list-pf-name{margin:0}
 .list-group-expanded-section{border:1px solid #d1d1d1;border-top:0;padding:15px}
 .list-group-expanded-section+.list-group-item-expandable.expanded,.list-group-expanded-section.expanded+.list-group-item-expandable{border-top:0}
 .monitoring-page .list-group-expanded-section .log-fixed-height.empty-state-message,.monitoring-page .list-group-expanded-section .metrics .empty-state-message{margin:10px 0 0;padding:0;text-align:left}
@@ -4292,6 +4321,7 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .navbar-flex-btn a{color:#fff;cursor:pointer;display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;font-size:18px}
 .navbar-flex-btn a:active,.navbar-flex-btn a:focus,.navbar-flex-btn a:hover{background-color:#383f47;color:#dbdada}
 }
+.build-count .icon-count,.build-count .icon-count [data-toggle=tooltip],.notification-icon-count [data-toggle=tooltip]{cursor:help}
 @media (max-width:479px){.navbar-flex-btn{-webkit-flex:0 0 40px;-moz-flex:0 0 40px;-ms-flex:0 0 40px;flex:0 0 40px}
 }
 @media (min-width:768px){.navbar-pf-alt .navbar-header{height:60px;width:143px}
@@ -4300,7 +4330,6 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .navbar-flex-btn.toggle-menu{display:none}
 .navbar-flex-btn.project-action{-webkit-flex:0 0 120px;-moz-flex:0 0 120px;-ms-flex:0 0 120px;flex:0 0 120px}
 .navbar-flex-btn.project-action .project-action-btn{border-right:1px solid #050505}
-.overview .standalone-service .service-group-body .overview-services{min-height:352px}
 }
 .font-icon,[data-icon]:before{speak:none;font-weight:400;font-variant:normal;text-transform:none;line-height:1;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
 @media (min-width:992px){.navbar-pf-alt .navbar-iconic .username{max-width:150px}
@@ -4466,11 +4495,107 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .icon-dotnet:before{content:"\f140"}
 .icon-apache:before{content:"\f138"}
 .icon-casadra:before{content:"\f139"}
+.build-count .builds,.build-count .pipelines{display:block}
+.build-count .icon-count{display:inline-block;margin-right:5px}
+.build-count .running-stage{font-size:84%;color:#9c9c9c}
+.builds-label{margin-right:5px}
+.mini-log{background-color:#fafafa;border:1px solid #d1d1d1;color:#4d5258;font-family:Menlo,Monaco,Consolas,monospace;font-size:11px;margin-bottom:5px;margin-top:5px;padding:5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.mini-log .mini-log-content{line-height:13px;min-height:91px}
+.mini-log .mini-log-content .mini-log-line{white-space:pre}
+.notification-icon-count{display:inline-block;margin:0 5px 0 0}
+.overview-new .app-heading{display:flex;justify-content:space-between}
+@media (max-width:991px){.overview-new .app-heading{flex-direction:column;justify-content:flex-start}
+.overview-new .app-heading .overview-route{font-family:inherit;font-weight:500;line-height:1.1;color:inherit;font-size:14px;margin-top:-5px;margin-bottom:15px}
+.overview-new .app-heading .overview-route .small,.overview-new .app-heading .overview-route small{font-weight:400;line-height:1;color:#9c9c9c;font-size:75%}
+}
+.overview-new .build-pipeline{border-color:#d6d6d6}
+.overview-new .build-pipelines{margin-top:10px;margin-bottom:20px}
+.overview-new .component-label{font-size:11px;font-weight:500;padding:0 0 4px;color:#9c9c9c;text-transform:uppercase}
+.overview-new .component-label .sublabel{font-size:10px;margin-left:2px;text-transform:none}
+.overview-new .data-toolbar-dropdown{display:inline-block}
+.overview-new .data-toolbar-filter{display:flex}
+.overview-new .data-toolbar-filter .label-filter,.overview-new .data-toolbar-filter .name-filter{flex-grow:1}
+.overview-new .data-toolbar-filter .label-filter,.overview-new .data-toolbar-filter .name-filter input{border-left:0}
+.overview-new .data-toolbar-filter .label-filter .label-filter-key .selectize-input.not-full{width:auto}
+.overview-new .data-toolbar-filter .name-filter form,.overview-new .data-toolbar-filter .name-filter input{width:100%}
+.overview-new .data-toolbar-filter .name-filter input{padding-left:5px}
+.overview-new .data-toolbar-filter .ui-select-container{width:100px}
+.overview-new .data-toolbar-filter .label-filter-add.btn,.overview-new .data-toolbar-filter .ui-select-container .ui-select-match .btn{box-shadow:none;-webkit-box-shadow:none}
+.overview-new .data-toolbar-label{margin-right:7px}
+.overview-new .deployment-connector-arrow{display:inline-block;font-size:300%;line-height:1;margin:50px 0 0 10px;text-align:center;color:#9c9c9c}
+@media (max-width:767px){.overview-new .deployment-connector-arrow{margin:-3px auto 0 -4px;transform:rotate(90deg);width:100%}
+}
+.overview-new .expanded-section{margin-top:20px}
+.overview-new .expanded-section>.row>[class^=col-]{margin-bottom:10px}
+.overview-new .expanded-section h3{line-height:1.4;margin-bottom:5px;margin-top:0;width:100%;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
+.overview-new .expanded-section .section-title{font-family:inherit;font-weight:500;line-height:1.1;color:inherit;margin-top:10.5px;margin-bottom:10.5px;font-size:14px;border-bottom:1px solid #dcdcdc;padding-bottom:10px}
+.overview-new .expanded-section .section-title .small,.overview-new .expanded-section .section-title small{font-weight:400;line-height:1;color:#9c9c9c;font-size:75%}
+.overview-new .expanded-section .section-title.no-border{border-bottom:0;padding-bottom:0}
+.overview-new .filter-status{margin-bottom:5px}
+.overview-new h1,.overview-new h2{line-height:normal;min-width:130px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.overview-new h2{margin-top:0}
+.overview-new h2>.component-label{padding-bottom:0}
+.overview-new .list-pf{border-bottom-color:#dcdcdc;margin-bottom:50px}
+.overview-new .list-pf-actions{min-width:19px}
+.overview-new .list-pf-expansion.in .empty-state-message p,.overview-new .list-pf-name h3 a,.overview-new .overview-route{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
+@media (min-width:768px){.overview-new .list-pf-details{justify-content:flex-end}
+}
+.overview-new .list-pf-expansion.in .deployment-donut>div[row]{justify-content:center}
+.overview-new .list-pf-expansion.in .empty-state-message{margin-bottom:30px;margin-top:20px;max-width:none;padding:0;text-align:center}
+.overview-new .list-pf-expansion.in .list-pf-content{max-width:100%}
+.overview-new .list-pf-expansion.in .list-pf-container{display:block}
+.overview-new .list-pf-expansion.in .pod-donut{text-align:center}
+.overview-new .list-pf-item{border-top-color:#dcdcdc}
+.overview-new .list-pf-item.active{border-top-color:#bbb}
+.overview-new .list-pf-item>.list-pf-container{cursor:pointer}
+@media (max-width:767px){.overview-new .list-pf-item>.list-pf-container>.list-pf-content{align-items:stretch;flex-direction:column;width:100%;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
+}
+.overview-new .list-pf-item>.list-pf-container .toggle-expand-link{color:inherit}
+.overview-new .list-pf-name{display:flex;flex-direction:column}
+@media (max-width:991px){.overview-new .list-pf-name{width:auto!important}
+}
+.overview-new .list-pf-name h3{line-height:1;margin:0 15px 0 0}
+@media (min-width:992px){.overview-new .list-pf-name{align-items:center;flex-direction:row}
+.overview-new .list-pf-name h3{width:60%}
+}
+.overview-new .list-row-tabset{margin-top:20px}
+@media (min-width:768px){.overview-new .list-pf-item>.list-pf-container>.list-pf-content{min-height:45px;padding-right:15px}
+.overview-new .list-row-tabset{margin-top:0}
+.overview .standalone-service .service-group-body .overview-services{min-height:352px}
+}
+.overview-new .list-row-tabset .nav-tabs>li.active>a .build-count{color:#4d5258}
+.overview-new .list-view-pf-actions .actions-dropdown-kebab{font-size:18px;width:100%}
+.overview-new .loading-message{margin-top:20px}
+.overview-new .metrics-collapsed{flex-grow:1;text-align:center}
+.overview-new .metrics-summary{display:inline-block;text-align:center}
+.overview-new .metrics-summary+.metrics-summary{margin-left:20px}
+.overview-new .metrics-compact{white-space:nowrap}
+.overview-new .metrics-compact .metrics-sparkline{border-bottom:1px solid #ededed;display:inline-block;height:28px;max-width:300px;vertical-align:-6px;width:calc(100% - 80px)}
+.overview-new .metrics-compact .metrics-usage{display:inline-block;margin-left:10px;max-width:80px}
+.overview-new .metrics-compact .usage-label{line-height:1;margin-bottom:-1px}
+.overview-new .metrics-compact .usage-value{line-height:1;margin:3px 0}
+.overview-new .middle .middle-container>div{width:100%}
+.overview-new .middle .middle-container .container-fluid{padding-left:20px;padding-right:20px}
+.overview-new .networking-section .row+.row:before{content:'';display:block;border-top:1px solid #dcdcdc;margin:0 20px 10px}
+.overview-new overview-list-row+overview-list-row .list-pf-item.active{margin-top:-1px}
+.overview-new .overview-routes+.overview-routes{margin-top:10px}
+.overview-new .overview-row-inline-actions{margin-left:10px}
+.overview-new pod-donut[mini]{align-items:center;display:flex}
+.overview-new .status-icons{margin-top:5px}
+@media (min-width:992px){.overview-new .status-icons{margin-right:15px;margin-top:0;width:40%}
+}
+.overview-new :not(.tab-pane)>overview-pipelines>.expanded-section{margin-bottom:30px}
+.overview-new .toolbar-container{margin-top:10px;margin-bottom:5px}
+.overview-new .triggers{margin-bottom:20px}
+.overview-new .usage-value{font-size:18px;font-weight:300;line-height:1}
+.overview-new .usage-label{font-size:84%;color:#9c9c9c}
+.overview-new .view-by-options{align-items:center;display:flex}
 .overview{font-weight:300}
 .overview .middle{background-color:#f2f2f2}
 .overview h2{line-height:1.4}
 .overview .link-service-button{font-size:13px}
-@media (max-width:767px){.overview .overview-timestamp{display:block}
+@media (max-width:767px){.overview-new .view-by-options{margin-top:10px}
+.overview .overview-timestamp{display:block}
 }
 .overview .container-fluid{margin-top:20px}
 @media (min-width:992px){.overview .container-fluid{margin-top:30px}
@@ -4571,7 +4696,7 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview .overview-tile .overview-tile-body{-webkit-flex-direction:row;-moz-flex-direction:row;-ms-flex-direction:row;flex-direction:row;-webkit-justify-content:space-between;-moz-justify-content:space-between;justify-content:space-between}
 }
 .overview .overview-tile.deployment-in-progress{overflow:hidden}
-.overview .empty-dc,.overview .empty-tile{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0;text-align:center}
+.overview .empty-dc,.overview .empty-tile{overflow-wrap:break-word;min-width:0;word-wrap:break-word;word-break:break-word;text-align:center}
 .overview .overview-tile .overview-donut,.overview .overview-tile .overview-metrics{-webkit-align-items:center;-moz-align-items:center;align-items:center}
 @media (min-width:1200px){.overview .overview-tile .overview-metrics .metrics-sparkline{width:60%}
 }
@@ -4991,7 +5116,6 @@ dl.secret-data dd{margin-left:180px}
 .events-sidebar .right-content .event .event-details .event-reason{order:2}
 .events-sidebar .right-content .event .event-details .event-timestamp{text-align:right;margin-left:5px;min-width:100px}
 }
-.table.table-layout-fixed td,h1.contains-actions{min-width:0;word-wrap:break-word;word-break:break-word}
 .events-sidebar .right-content .event.highlight+.event{border-top:1px solid #d1d1d1}
 .events-badge{font-size:14px}
 .events-badge:hover{text-decoration:none}
@@ -5079,7 +5203,7 @@ body,html{margin:0;padding:0}
 .table.table-bordered>tbody>tr td,.table.table-bordered>tbody>tr th,.table.table-bordered>thead>tr td,.table.table-bordered>thead>tr th{border-left:0;border-right:0;padding-bottom:8px;padding-top:8px;vertical-align:middle}
 .table-filter-wrapper,.table.table-bordered.table-bordered-columns tbody>tr td,.table.table-bordered.table-bordered-columns tbody>tr th,.table.table-bordered.table-bordered-columns thead>tr td,.table.table-bordered.table-bordered-columns thead>tr th{border-left:1px solid #d1d1d1;border-right:1px solid #d1d1d1}
 .table.table-layout-fixed{table-layout:fixed}
-.table.table-layout-fixed td{overflow-wrap:break-word}
+.table.table-layout-fixed td{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .table>tbody+tbody{border-top-width:1px}
 .table th .pficon-help{color:#999;cursor:help}
 .tile-click:hover .tile-target,.tile:hover a.tile-target{color:#00659c}
@@ -5101,6 +5225,7 @@ body,html{margin:0;padding:0}
 .table-responsive .table.table-bordered>tbody>tr>td:first-child,.table-responsive .table.table-bordered>tbody>tr>th:first-child,.table-responsive .table.table-bordered>thead>tr>td:first-child,.table-responsive .table.table-bordered>thead>tr>th:first-child{border-left:0}
 .table-responsive .table.table-bordered>tbody>tr>td:last-child,.table-responsive .table.table-bordered>tbody>tr>th:last-child,.table-responsive .table.table-bordered>thead>tr>td:last-child,.table-responsive .table.table-bordered>thead>tr>th:last-child{border-right:0}
 }
+.tooltip-inner,h1.contains-actions{overflow-wrap:break-word;min-width:0;word-wrap:break-word;word-break:break-word}
 .table-responsive{margin-bottom:21px}
 .table>tbody>tr.disabled>td,.table>tbody>tr.disabled>th,.table>tbody>tr>td.disabled,.table>tbody>tr>th.disabled,.table>tfoot>tr.disabled>td,.table>tfoot>tr.disabled>th,.table>tfoot>tr>td.disabled,.table>tfoot>tr>th.disabled,.table>thead>tr.disabled>td,.table>thead>tr.disabled>th,.table>thead>tr>td.disabled,.table>thead>tr>th.disabled{background-color:#f5f5f5}
 .table-hover>tbody>tr.disabled:hover>td,.table-hover>tbody>tr.disabled:hover>th,.table-hover>tbody>tr:hover>.disabled,.table-hover>tbody>tr>td.disabled:hover,.table-hover>tbody>tr>th.disabled:hover{background-color:#e8e8e8}
@@ -5108,7 +5233,7 @@ td[role=presentation].arrow:after{content:"\2193"}
 @media (min-width:768px){.table-responsive .table{margin-bottom:0}
 td[role=presentation].arrow:after{content:"\2192"}
 }
-.tile{background:#fff;box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09);padding:20px;margin-bottom:20px;word-wrap:break-word;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;overflow-x:hidden}
+.tile{background:#fff;padding:20px;margin-bottom:20px;word-wrap:break-word;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;overflow-x:hidden}
 .tile h1,.tile h2,.tile h3{margin:10.5px 0px}
 .tile-click{cursor:pointer;position:relative}
 .tile-click:hover .image-icon,.tile-click:hover .template-icon{opacity:.75}
@@ -5145,7 +5270,6 @@ kubernetes-topology-graph{height:700px}
 .console-os .section-header{border-color:#e4e4e4;padding-left:20px;padding-right:20px;border-bottom:none;padding-bottom:10px;margin:20px -20px 0}
 .action-inline,.learn-more-inline{margin-left:5px;font-size:11px}
 .console-os .section-header .actions{margin-top:0}
-h1.contains-actions{overflow-wrap:break-word}
 h1 .build-config-summary .meta,h1 .deployment-config-summary .meta,h1 small.meta{font-size:12px}
 @media (max-width:480px){h1 .build-config-summary .meta,h1 .deployment-config-summary .meta,h1 small.meta{display:block;margin-top:5px}
 }
@@ -5309,7 +5433,7 @@ a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;borde
 .log-link-external i{font-size:10px;margin-left:5px}
 .log-line:hover{background-color:#22262b;color:#ededed}
 .log-line-number:before{content:attr(data-line-number)}
-.log-line-number{-moz-user-select:none;-webkit-user-select:none;-ms-user-select:none;border-right:1px #272b30 solid;padding-right:10px;vertical-align:top;white-space:nowrap;width:60px;color:#72767b}
+.log-line-number{-ms-user-select:none;border-right:1px #272b30 solid;padding-right:10px;vertical-align:top;white-space:nowrap;width:60px;color:#72767b}
 .log-line-text{padding:0 10px;white-space:pre-wrap;width:100%;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .log-line-text::-moz-selection{color:#101214;background:#e5e5e5}
 .table-log-pods{background-color:#fff;border:1px solid #D1D1D1}


### PR DESCRIPTION
https://trello.com/c/QxbqJsoK

Updated overview using the Patternfly list view with rows that expand to reveal more detail.

![screen shot 2017-03-09 at 5 02 30 pm](https://cloud.githubusercontent.com/assets/1167259/23772772/3a1a722a-04ea-11e7-8d77-0144a7e404f4.png)

<img width="1492" alt="screen shot 2017-03-09 at 6 52 11 pm" src="https://cloud.githubusercontent.com/assets/1167259/23776013/98268f20-04f9-11e7-8d81-80acfa28aad4.png">

Contains code from @rhamilto. Based on designs from @ajacobs21e @lizsurette and @ncameronbritt 

Fixes #236
Fixes #619
Fixes #658 
Fixes #729

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1389458
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1401134

**TODO**

- [x] Generalize some directives so they're not specific to the overview.
- [x] Add in-view logic back to overview metrics
- [x] Move `getBreakpoint` to a service
- [x] Use namespaced resize event listener
- [x] Make `view-by` local storage key specific to overview
- [x] Don't show scaled down replication controllers from a deployment config that was deleted
- [x] Add some missing `canI` checks for kebab actions
- [x] Hide kebab menu when none of the actions are visible
- [x] Fix bug where filtering doesn't trigger in-view updates for metrics
- [x] Remove `renderOptions`
- [x] Colorize and linkify mini log
- [x] Use `row.state.breakpoint` rather than `hidden-*` classes to show and hide the metrics summary
- [x] Reorder DataService calls
- [x] Order RCs by deployment number instead of date
- [x] Test failed rollouts of replica sets
- [x] Fix pipeline sorting
- [x] Consistently use `DEFAULT_POLL_INTERVAL`
- [x] Fix `visibleReplicaSets` typo
- [x] get/setBuildConfigsForDeploymentConfig -> get/setBuildConfigsForObject 
- [x] Don't pass dummy pod template to `LabelSelector.matches`
- [x] Don't sort `recentPipelinesByBuildConfig` in the view
- [x] Use `AlertMessageService.permanentlyHideAlert` in `ResourceAlertsService`
- [x] Fall back to comparing names if service weights are equal when sorting
- [x] Fix initial tab selection for mobile when there are no services
- [x] Improve "deployment no longer latest" error message
- [x] Handle NaN deployment versions when sorting
- [x] Show < 0.01 cores for very small CPU usage

**Follow-on Work**

- [ ] Support types other than deployment configs for pipeline annotation `pipeline.alpha.openshift.io/uses`
- [ ] Show headless services
- [ ] Remove previous overview code
- [x] Show basic route info in collapsed state
- [ ] Make cancel deployment dialog generic and reuse it on the deployment config page