### PR TITLE
Addition of grid width class to the status column so that message doesn't overlap adjacent column

### DIFF
--- a/app/views/directives/pods-table.html
+++ b/app/views/directives/pods-table.html
@@ -1,6 +1,7 @@
 <table class="table table-bordered table-hover table-mobile table-layout-fixed">
   <colgroup>
     <col class="col-sm-4">
+    <col class="col-sm-3">
   </colgroup>
   <thead>
     <tr>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8722,6 +8722,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<table class=\"table table-bordered table-hover table-mobile table-layout-fixed\">\n" +
     "<colgroup>\n" +
     "<col class=\"col-sm-4\">\n" +
+    "<col class=\"col-sm-3\">\n" +
     "</colgroup>\n" +
     "<thead>\n" +
     "<tr>\n" +


### PR DESCRIPTION
Fixes https://github.com/openshift/origin-web-console/issues/1324

<img width="644" alt="screen shot 2017-03-10 at 10 47 28 am" src="https://cloud.githubusercontent.com/assets/1874151/23802175/77cf1a8a-0580-11e7-9493-f1845217ee7f.png">
