### PR TITLE
Position "Follow" log btn based on whether chromeless log-view has a scrollbar

### DIFF
--- a/app/styles/_log.less
+++ b/app/styles/_log.less
@@ -203,18 +203,25 @@
   bottom: 5px;
   left: 10px;
 }
+
 .chromeless {
   background-color:  @log-bg-color;
   color: #d1d1d1;
-  .log-pending-ellipsis {
-    background-color: @log-bg-color;
-    padding: @grid-gutter-width 0 0 (@grid-gutter-width - 10px);
+  .log-view {
+    .log-pending-ellipsis {
+      background-color: @log-bg-color;
+      padding: @grid-gutter-width 0 0 (@grid-gutter-width - 10px);
+    }
+    .log-scroll-top.affix {
+      right: 0px; // align to edge of log-view when showScrollLinks is false
+      &.log-has-scroll {
+        right: @scrollbar-width; // align to edge of scrollbar when showScrollLinks is true
+      }
+    }
   }
-  .log-scroll-top.affix {
-    right: 0px; // override
-  }
-  .log-scroll-top.affix.target-logger-node {
-    right: @scrollbar-width;  // override
+  ::-webkit-scrollbar-track {
+    // add border to dark scrollbar-track since it's so close in color to log-view background
+    border-left: 1px solid lighten(@log-bg-color, 10%);
   }
 }
 

--- a/app/styles/_scrollbars.less
+++ b/app/styles/_scrollbars.less
@@ -31,7 +31,7 @@
   // box-shadow: inset 1px 0 0 rgba(0,0,0,.1);
 }
 
-.log-view.log-fixed-height, .navbar-project-menu {
+.log-view.log-fixed-height, .navbar-project-menu, .chromeless {
   ::-webkit-scrollbar-thumb {
     background-color: @scrollbar-thumb-inverse;
     -webkit-box-shadow: inset 1px 1px 0 rgba(255,255,255,.1),inset 0 -1px 0 rgba(255,255,255,.07);

--- a/app/views/directives/logs/_log-viewer.html
+++ b/app/views/directives/logs/_log-viewer.html
@@ -73,7 +73,8 @@
   <div class="log-view" ng-attr-id="{{logViewerID}}" ng-class="{'log-fixed-height': fixedHeight}">
     <div
       id="{{logViewerID}}-affixedFollow"
-      class="log-scroll log-scroll-top">
+      class="log-scroll log-scroll-top"
+      ng-class="{'log-has-scroll':showScrollLinks}">
       <a ng-if="loading" href="" ng-click="toggleAutoScroll()">
         <span ng-if="!autoScrollActive">Follow</span>
         <span ng-if="autoScrollActive">Stop Following</span>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7593,7 +7593,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<div ng-show=\"state=='logs'\" ng-class=\"{ invisible: !sized }\">\n" +
     "<div class=\"log-view\" ng-attr-id=\"{{logViewerID}}\" ng-class=\"{'log-fixed-height': fixedHeight}\">\n" +
-    "<div id=\"{{logViewerID}}-affixedFollow\" class=\"log-scroll log-scroll-top\">\n" +
+    "<div id=\"{{logViewerID}}-affixedFollow\" class=\"log-scroll log-scroll-top\" ng-class=\"{'log-has-scroll':showScrollLinks}\">\n" +
     "<a ng-if=\"loading\" href=\"\" ng-click=\"toggleAutoScroll()\">\n" +
     "<span ng-if=\"!autoScrollActive\">Follow</span>\n" +
     "<span ng-if=\"autoScrollActive\">Stop Following</span>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4869,9 +4869,9 @@ td.visible-print,th.visible-print{display:table-cell!important}
 ::-webkit-scrollbar-thumb{background-color:rgba(0,0,0,.08);background-clip:padding-box;border:solid transparent;border-width:1px;min-height:28px;max-height:60px;padding:100px 0 0;-webkit-box-shadow:inset 1px 1px 0 rgba(0,0,0,.1),inset 0 -1px 0 rgba(0,0,0,.07);box-shadow:inset 1px 1px 0 rgba(0,0,0,.1),inset 0 -1px 0 rgba(0,0,0,.07)}
 ::-webkit-scrollbar-thumb:active,::-webkit-scrollbar-thumb:hover{background-color:rgba(0,0,0,.18)}
 ::-webkit-scrollbar-track{background-clip:padding-box;background-color:rgba(0,0,0,.03)}
-.log-view.log-fixed-height ::-webkit-scrollbar-thumb,.navbar-project-menu ::-webkit-scrollbar-thumb{background-color:rgba(255,255,255,.25);-webkit-box-shadow:inset 1px 1px 0 rgba(255,255,255,.1),inset 0 -1px 0 rgba(255,255,255,.07);box-shadow:inset 1px 1px 0 rgba(255,255,255,.1),inset 0 -1px 0 rgba(255,255,255,.07)}
-.log-view.log-fixed-height ::-webkit-scrollbar-thumb:active,.log-view.log-fixed-height ::-webkit-scrollbar-thumb:hover,.navbar-project-menu ::-webkit-scrollbar-thumb:active,.navbar-project-menu ::-webkit-scrollbar-thumb:hover{background-color:rgba(255,255,255,.35)}
-.log-view.log-fixed-height ::-webkit-scrollbar-track,.navbar-project-menu ::-webkit-scrollbar-track{background-color:#050505}
+.chromeless ::-webkit-scrollbar-thumb,.log-view.log-fixed-height ::-webkit-scrollbar-thumb,.navbar-project-menu ::-webkit-scrollbar-thumb{background-color:rgba(255,255,255,.25);-webkit-box-shadow:inset 1px 1px 0 rgba(255,255,255,.1),inset 0 -1px 0 rgba(255,255,255,.07);box-shadow:inset 1px 1px 0 rgba(255,255,255,.1),inset 0 -1px 0 rgba(255,255,255,.07)}
+.chromeless ::-webkit-scrollbar-thumb:active,.chromeless ::-webkit-scrollbar-thumb:hover,.log-view.log-fixed-height ::-webkit-scrollbar-thumb:active,.log-view.log-fixed-height ::-webkit-scrollbar-thumb:hover,.navbar-project-menu ::-webkit-scrollbar-thumb:active,.navbar-project-menu ::-webkit-scrollbar-thumb:hover{background-color:rgba(255,255,255,.35)}
+.chromeless ::-webkit-scrollbar-track,.log-view.log-fixed-height ::-webkit-scrollbar-track,.navbar-project-menu ::-webkit-scrollbar-track{background-color:#050505}
 .log-view.log-fixed-height ::-webkit-scrollbar{width:17px}
 .log-view.log-fixed-height ::-webkit-scrollbar-track{background-color:rgba(255,255,255,.1)}
 .surface-shaded .ui-select-bootstrap .ui-select-match>.btn{background-color:#fff;background-image:linear-gradient(to bottom,#fff 0%,#fbfbfb 100%)}
@@ -5302,9 +5302,10 @@ a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;borde
 .log-end-msg{font-size:12px;color:#72767b;position:absolute;bottom:5px;left:10px}
 .chromeless,.log-line{color:#d1d1d1}
 .chromeless{background-color:#101214}
-.chromeless .log-pending-ellipsis{background-color:#101214;padding:40px 0 0 30px}
-.chromeless .log-scroll-top.affix{right:0px}
-.chromeless .log-scroll-top.affix.target-logger-node{right:15px}
+.chromeless .log-view .log-pending-ellipsis{background-color:#101214;padding:40px 0 0 30px}
+.chromeless .log-view .log-scroll-top.affix{right:0px}
+.chromeless .log-view .log-scroll-top.affix.log-has-scroll{right:15px}
+.chromeless ::-webkit-scrollbar-track{border-left:1px solid #272b30}
 .log-link-external a{margin-left:20px;margin-right:10px;white-space:nowrap}
 .log-link-external i{font-size:10px;margin-left:5px}
 .log-line:hover{background-color:#22262b;color:#ededed}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin-web-console/issues/1322

**When no scrollbar is present**
<img width="234" alt="screen shot 2017-03-13 at 2 53 49 pm" src="https://cloud.githubusercontent.com/assets/1874151/23871239/e62c5a66-07ff-11e7-93cd-83c599d3d407.png">
<img width="258" alt="screen shot 2017-03-13 at 2 53 44 pm" src="https://cloud.githubusercontent.com/assets/1874151/23871256/fdec48e6-07ff-11e7-8db4-8311d073dbfb.png">

**With scrollbar**

<img width="265" alt="screen shot 2017-03-13 at 2 46 21 pm" src="https://cloud.githubusercontent.com/assets/1874151/23871240/e62e2562-07ff-11e7-9e84-8d7e7de6e347.png">

<img width="271" alt="screen shot 2017-03-13 at 2 47 14 pm" src="https://cloud.githubusercontent.com/assets/1874151/23871257/fdf02376-07ff-11e7-882c-10560240a1c5.png">

