### PR TITLE
Make route link icon clickable

### DIFF
--- a/app/views/overview/_service-group.html
+++ b/app/views/overview/_service-group.html
@@ -12,15 +12,13 @@
       </span>
     </h2>
     <h3 class="route-title truncate">
-      <span ng-if="appName && (displayRoute | isWebRoute)">
-        <i class="fa fa-external-link small" aria-hidden="true"></i>
-      </span>
       <span ng-if="!appName">
         <i class="fa fa-angle-down fa-fw" aria-hidden="true" ng-if="!collapse"></i>
         <i class="fa fa-angle-right fa-fw" aria-hidden="true" ng-if="collapse"></i>
       </span>
-      <a ng-if="displayRoute | isWebRoute" target="_blank"
-         ng-href="{{displayRoute | routeWebURL}}">{{displayRoute | routeLabel}}</a>
+      <a ng-if="displayRoute | isWebRoute" target="_blank" ng-href="{{displayRoute | routeWebURL}}">
+         <i class="fa fa-external-link small" aria-hidden="true"></i>{{displayRoute | routeLabel}}
+      </a>
       <span ng-if="displayRoute && !(displayRoute | isWebRoute)" class="non-web-route">{{displayRoute | routeLabel}}</span>
       <span ng-if="routeWarningsByService[service.metadata.name] && routesByService[service.metadata.name].length === 1">
         <route-warnings warnings="routeWarningsByService[service.metadata.name]"></route-warnings>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -11626,14 +11626,13 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</h2>\n" +
     "<h3 class=\"route-title truncate\">\n" +
-    "<span ng-if=\"appName && (displayRoute | isWebRoute)\">\n" +
-    "<i class=\"fa fa-external-link small\" aria-hidden=\"true\"></i>\n" +
-    "</span>\n" +
     "<span ng-if=\"!appName\">\n" +
     "<i class=\"fa fa-angle-down fa-fw\" aria-hidden=\"true\" ng-if=\"!collapse\"></i>\n" +
     "<i class=\"fa fa-angle-right fa-fw\" aria-hidden=\"true\" ng-if=\"collapse\"></i>\n" +
     "</span>\n" +
-    "<a ng-if=\"displayRoute | isWebRoute\" target=\"_blank\" ng-href=\"{{displayRoute | routeWebURL}}\">{{displayRoute | routeLabel}}</a>\n" +
+    "<a ng-if=\"displayRoute | isWebRoute\" target=\"_blank\" ng-href=\"{{displayRoute | routeWebURL}}\">\n" +
+    "<i class=\"fa fa-external-link small\" aria-hidden=\"true\"></i>{{displayRoute | routeLabel}}\n" +
+    "</a>\n" +
     "<span ng-if=\"displayRoute && !(displayRoute | isWebRoute)\" class=\"non-web-route\">{{displayRoute | routeLabel}}</span>\n" +
     "<span ng-if=\"routeWarningsByService[service.metadata.name] && routesByService[service.metadata.name].length === 1\">\n" +
     "<route-warnings warnings=\"routeWarningsByService[service.metadata.name]\"></route-warnings>\n" +


### PR DESCRIPTION
Service group header on 'Overview' screen contains a link to service route. Next to a link there is small icon that indicates that this link will open in new window. But clicking on this icon is handled as click on header and not on service route link (collapses the service group instead of opening the link).

This PR is supposed to improve this behavior - open service route link on icon click. 

![screenshot from 2017-03-14 14-17-16](https://cloud.githubusercontent.com/assets/1605799/23902660/377afec8-08c2-11e7-9138-ddf67eb0f378.png)
