### PR TITLE
Fix Custom Metrics Graphs

### DIFF
--- a/app/scripts/directives/podMetrics.js
+++ b/app/scripts/directives/podMetrics.js
@@ -358,6 +358,11 @@ angular.module('openshiftConsole')
               // get the unit value if specified
               var unit =  metric.unit || "";
 
+              // A typical metric ID is of the form "pod/<pod-id>/custom/<some-endpoint-info>"
+              // such as "pod/be381d4b-87fc-11e5-b2a3-525400b33d1d/custom/JVM-Heap-Memory-Used".
+              // We only want part of the metric ID - "custom/" and everything after it.
+              var datasetId = "custom/" + metric.id.replace(/.*\/custom\//, '');
+
               scope.metrics.push({
                 label: label,
                 units: unit,
@@ -366,7 +371,7 @@ angular.module('openshiftConsole')
 
                 datasets: [
                   {
-                    id: "custom/" + metric.name,
+                    id: datasetId,
                     label: label,
                     type: metric.type,
                     data: []

--- a/app/scripts/services/metrics.js
+++ b/app/scripts/services/metrics.js
@@ -204,6 +204,7 @@ angular.module("openshiftConsole")
         }).then(function(response) {
           return _.map(response.data, function(value) {
             return {
+              id: value.id,
               name: value.tags.metric_name,
               unit: value.tags.units,
               description: value.tags.description,

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1876,6 +1876,7 @@ params:f
 }).then(function(a) {
 return _.map(a.data, function(a) {
 return {
+id:a.id,
 name:a.tags.metric_name,
 unit:a.tags.units,
 description:a.tags.description,
@@ -10848,14 +10849,14 @@ delete m.alerts[b], L = 1, A();
 function w() {
 return window.OPENSHIFT_CONSTANTS.DISABLE_CUSTOM_METRICS ? e.when({}) :j.getCustomMetrics(m.pod).then(function(a) {
 angular.forEach(a, function(a) {
-var b = a.description || a.name, c = a.unit || "";
+var b = a.description || a.name, c = a.unit || "", d = "custom/" + a.id.replace(/.*\/custom\//, "");
 m.metrics.push({
 label:b,
 units:c,
 chartPrefix:"custom-" + _.uniqueId("custom-metric-"),
 chartType:"spline",
 datasets:[ {
-id:"custom/" + a.name,
+id:d,
 label:b,
 type:a.type,
 data:[]


### PR DESCRIPTION
Custom metrics can be defined with IDs which are different than their names. We need to use the ID and not name for the dataset ID. Without this fix, some metrics graphs in the console will be blank (particularly those from Prometheus endpoints that have labeled time series data).