### PR TITLE
Removing pficon variables (overrides)

### DIFF
--- a/app/styles/_variables.less
+++ b/app/styles/_variables.less
@@ -4,12 +4,6 @@
 @icon-font-path: "@{font-path}@{font-path-trailing-slash}"; // Bootstrap glyphicons
 @image-path: "../images";
 
-// Icons
-@pficon-var-error-circle-o: '\e61d';
-@pficon-var-info: '\e604';
-@pficon-var-ok: '\e602';
-@pficon-var-warning-triangle-o: '\e61c';
-
 // Patternfly overrides
 @dropdown-divider-margin: 4px 0;
 @list-view-hover-bg: #fafafa;
@@ -18,7 +12,6 @@
 @sidebar-pf-bg: @body-bg;
 @table-cell-padding-bottom: 8px;
 @table-cell-padding-top: 8px;
-
 
 // OpenShift Console specific
 @openshift-logo-color: #cd202c;

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -2831,7 +2831,7 @@ select.bs-select-hidden,select.selectpicker{display:none!important}
 .pficon-domain:before{content:"\e919"}
 .pficon-edit:before{content:"\e60a"}
 .pficon-enterprise:before{content:"\e906"}
-.pficon-error-circle-o:before{color:#c00;content:'\e61d'}
+.pficon-error-circle-o:before{color:#c00;content:"\e61d"}
 .pficon-export:before{content:"\e616"}
 .pficon-flag:before,.pficon-messages:before{content:"\e603"}
 .pficon-flavor:before{content:"\e907"}
@@ -2842,10 +2842,10 @@ select.bs-select-hidden,select.selectpicker{display:none!important}
 .pficon-home:before{content:"\e618"}
 .pficon-image:before{content:"\e61f"}
 .pficon-import:before{content:"\e615"}
-.pficon-info:before{content:'\e604'}
+.pficon-info:before{content:"\e604"}
 .pficon-memory:before{content:"\e908"}
 .pficon-network:before{content:"\e909"}
-.pficon-ok:before{color:#3f9c35;content:'\e602'}
+.pficon-ok:before{color:#3f9c35;content:"\e602"}
 .pficon-print:before{content:"\e612"}
 .pficon-private:before{content:"\e914"}
 .pficon-project:before{content:"\e622"}
@@ -2876,7 +2876,7 @@ select.bs-select-hidden,select.selectpicker{display:none!important}
 .pficon-users:before{content:"\e60f"}
 .pficon-virtual-machine:before{content:"\e90f"}
 .pficon-volume:before{content:"\e910"}
-.pficon-warning-triangle-o:before{color:#ec7a08;content:'\e61c'}
+.pficon-warning-triangle-o:before{color:#ec7a08;content:"\e61c"}
 .pficon-zone:before{content:"\e911"}
 .navbar-nav>li>.dropdown-menu.infotip{border-top-width:1px!important;margin-top:10px}
 @media (max-width:767px){.navbar-pf .navbar-nav .open .dropdown-menu.infotip{background-color:#fff!important;margin-top:0}
@@ -4236,11 +4236,11 @@ ul.messenger-theme-flat .messenger-message{box-shadow:0 0 6px rgba(0,0,0,.175),i
 ul.messenger-theme-flat .messenger-message .messenger-message-inner:before,ul.messenger-theme-flat .messenger-message:before{font-size:20px;position:absolute;left:15px;top:50%;margin-top:-10px;font-family:PatternFlyIcons-webfont;speak:none;font-style:normal;font-weight:400;font-variant:normal;text-transform:none;line-height:1;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
 ul.messenger-theme-flat .messenger-message .messenger-close{line-height:30px}
 ul.messenger-theme-flat .messenger-message .messenger-actions a{text-decoration:none;color:#aaa;background:#323232}
-ul.messenger-theme-flat .messenger-message.alert-error:before{content:'\e61d';color:#c00;display:inline-block}
+ul.messenger-theme-flat .messenger-message.alert-error:before{content:"\e61d";color:#c00;display:inline-block}
 ul.messenger-theme-flat .messenger-message.alert-error .messenger-message-inner:before{background-color:transparent}
-ul.messenger-theme-flat .messenger-message.alert-warning:before{content:'\e61c';color:#ec7a08;display:inline-block;left:14px;margin-top:-11px}
-ul.messenger-theme-flat .messenger-message.alert-success .messenger-message-inner:before{color:#3f9c35;content:'\e602';display:inline-block;background-color:transparent}
-ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:before{color:#00659c;content:'\e604';display:inline-block;background-color:transparent}
+ul.messenger-theme-flat .messenger-message.alert-warning:before{content:"\e61c";color:#ec7a08;display:inline-block;left:14px;margin-top:-11px}
+ul.messenger-theme-flat .messenger-message.alert-success .messenger-message-inner:before{color:#3f9c35;content:"\e602";display:inline-block;background-color:transparent}
+ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:before{color:#00659c;content:"\e604";display:inline-block;background-color:transparent}
 #header-logo{background-image:url(../images/logo-origin-thin.svg);background-repeat:no-repeat;background-position:center left;background-size:initial;height:46px;width:230px}
 .navbar-pf-alt{background:#292e34;border-bottom:1px solid #050505;border-left:1px solid transparent;border-right:1px solid transparent;border-top:0;min-height:inherit}
 .layout-pf-alt-fixed .navbar-pf-alt{left:0;position:fixed;right:0;top:0;z-index:1030}


### PR DESCRIPTION
PatternFly now includes these vars in its source less, so defining them
in our less can (and will with PatternFly v3.23.0) result in a bug
where icons disappear (PatternFly v3.23.0 changes the unicode values of
a number of icons, thus causing the bug).

@spadgett, PTAL