### PR TITLE
Hide service weight slider when all weights are 0

### DIFF
--- a/app/scripts/directives/oscRouting.js
+++ b/app/scripts/directives/oscRouting.js
@@ -241,6 +241,12 @@ angular.module("openshiftConsole")
           }
 
           if (alternateServicesCount === 1) {
+            // If all weights are 0, don't use the slider.
+            if (scope.route.to.weight === 0 && scope.route.alternateServices[0].weight === 0) {
+              scope.controls.hideSlider = true;
+              return;
+            }
+
             initializingSlider = true;
             scope.controls.rangeSlider = scope.weightAsPercentage(scope.route.to.weight);
           }

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10389,7 +10389,10 @@ return b ? d3.round(e, 1) + "%" :e;
 };
 var k = !1;
 c.$watch("route.alternateServices.length", function(a) {
-0 === a && _.has(c, "route.to.weight") && delete c.route.to.weight, 1 === a && (k = !0, c.controls.rangeSlider = c.weightAsPercentage(c.route.to.weight));
+if (0 === a && _.has(c, "route.to.weight") && delete c.route.to.weight, 1 === a) {
+if (0 === c.route.to.weight && 0 === c.route.alternateServices[0].weight) return void (c.controls.hideSlider = !0);
+k = !0, c.controls.rangeSlider = c.weightAsPercentage(c.route.to.weight);
+}
 }), c.$watch("controls.rangeSlider", function(a, b) {
 return k ? void (k = !1) :void (a !== b && (a = parseInt(a, 10), _.set(c, "route.to.weight", a), _.set(c, "route.alternateServices[0].weight", 100 - a)));
 });


### PR DESCRIPTION
When editing a route with alternate backends where all service weights
are 0, don't use the slider since it can't represent all 0 values.

Fixes #1339