### PR TITLE
Updates to to label filter so that it maintains a large click target …

### DIFF
--- a/app/styles/_data-toolbar.less
+++ b/app/styles/_data-toolbar.less
@@ -3,10 +3,6 @@
 ---------------------------------------------------------------------------- */
 // @screen-md-min - (sidebar-left + left + right margin); 992 - (145 + 30 + 30) = 787
 @data-toolbar-filter-max-width:   (@screen-md-min - (@sidebar-left-width-md + @middle-content-container-padding-lg + @middle-content-container-padding-lg));
-@label-filter-input-width-lg: 730px; // max width available for input at > 992
-@label-filter-input-width-md: 540px; // max width available for input at > 768
-@label-filter-input-width-sm: 400px; // max width available for input at > 480
-@label-filter-input-width-xs: 240px; // 320 - (40 + 40); container - ((left + right margin) + button)
 
 
 .data-toolbar {
@@ -29,6 +25,10 @@
     }
   }
   .data-toolbar-filter {
+    project-filter {
+      .flex-direction(@direction: column);
+      .flex-display(@display: flex);
+    }
     @media (min-width: @screen-sm-min) {
       .flex(@columns: 1 1 0%);
     }
@@ -40,12 +40,17 @@
         font-size: @font-size-base;
       }
     }
-    .label-filter-key .selectize-input.not-full {
-      // Increase default input click target
-      width: @label-filter-input-width-xs;
-      @media (min-width: @screen-xs-min) { width: @label-filter-input-width-sm;}
-      @media (min-width: @screen-sm-min) { width: @label-filter-input-width-md;}
-      @media (min-width: @screen-md-min) { width: @label-filter-input-width-lg;}
+    .label-filter {
+      .selectize-control {
+        &.label-filter-key {
+          // Change from inline-block, allowing the empty input to expand to full width, giving it a large click target.
+          display: inline;
+        }
+        .selectize-input.full {
+          // Now make width match content
+          width: auto;
+        }
+      }
     }
     .form-group {
       margin-bottom: 0;

--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -119,11 +119,6 @@
       // Avoid double border since the input is directly beside the filter select.
       border-left: 0;
     }
-    .label-filter .label-filter-key .selectize-input.not-full {
-      // FIXME: temp workaround for problem created by
-      // https://github.com/openshift/origin-web-console/pull/1216
-      width: auto;
-    }
     .name-filter {
       form,
       input {

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4145,17 +4145,14 @@ copy-to-clipboard .input-group.limit-width{max-width:300px}
 .data-toolbar{padding:5px 0}
 .data-toolbar.other-resources-toolbar .data-toolbar-dropdown{min-width:210px}
 .data-toolbar .checkbox{margin-bottom:0;margin-top:10px}
-.data-toolbar .data-toolbar-filter .label-filter-key .selectize-input.not-full{width:240px}
-@media (min-width:480px){.data-toolbar .data-toolbar-filter .label-filter-key .selectize-input.not-full{width:400px}
-}
 @media (min-width:768px){.data-toolbar{display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex}
 .data-toolbar .checkbox{-webkit-flex:1 1 0%;-moz-flex:1 1 0%;-ms-flex:1 1 0%;flex:1 1 0%;margin-left:20px;margin-top:3px;text-align:right}
-.data-toolbar .data-toolbar-filter{-webkit-flex:1 1 0%;-moz-flex:1 1 0%;-ms-flex:1 1 0%;flex:1 1 0%}
-.data-toolbar .data-toolbar-filter .label-filter-key .selectize-input.not-full{width:540px}
 }
-@media (min-width:992px){.data-toolbar .data-toolbar-filter{max-width:787px}
-.data-toolbar .data-toolbar-filter .label-filter-key .selectize-input.not-full{width:730px}
+.data-toolbar .data-toolbar-filter project-filter{-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex}
+@media (min-width:768px){.data-toolbar .data-toolbar-filter{-webkit-flex:1 1 0%;-moz-flex:1 1 0%;-ms-flex:1 1 0%;flex:1 1 0%}
 }
+.data-toolbar .data-toolbar-filter .label-filter .selectize-control.label-filter-key{display:inline}
+.data-toolbar .data-toolbar-filter .label-filter .selectize-control .selectize-input.full{width:auto}
 .data-toolbar .data-toolbar-filter .form-group{margin-bottom:0}
 .data-toolbar .data-toolbar-views{-webkit-flex:0 1 auto;-moz-flex:0 1 auto;-ms-flex:0 1 auto;flex:0 1 auto;text-align:right}
 @media (min-width:1200px){.data-toolbar .data-toolbar-views{-webkit-flex:0 1 auto;-moz-flex:0 1 auto;-ms-flex:0 1 auto;flex:0 1 auto}
@@ -4229,7 +4226,8 @@ h2+.list-view-pf{margin-top:20px}
 .list-view-pf-additional-info-item{display:inline-block;text-align:left}
 .list-view-pf-description{-ms-flex:1 0 55%;flex:1 0 55%}
 .list-view-pf-main-info{padding-bottom:10px;padding-top:10px}
-@media (min-width:992px){.list-view-pf .list-group-item-heading,.list-view-pf .list-group-item-text{-ms-flex:1 0 auto;flex:1 0 auto;margin:0;padding:0 20px 0 0;width:50%}
+@media (min-width:992px){.data-toolbar .data-toolbar-filter{max-width:787px}
+.list-view-pf .list-group-item-heading,.list-view-pf .list-group-item-text{-ms-flex:1 0 auto;flex:1 0 auto;margin:0;padding:0 20px 0 0;width:50%}
 .list-view-pf-additional-info{width:40%}
 .list-view-pf-description{width:60%}
 }
@@ -4518,7 +4516,6 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview-new .data-toolbar-filter{display:flex}
 .overview-new .data-toolbar-filter .label-filter,.overview-new .data-toolbar-filter .name-filter{flex-grow:1}
 .overview-new .data-toolbar-filter .label-filter,.overview-new .data-toolbar-filter .name-filter input{border-left:0}
-.overview-new .data-toolbar-filter .label-filter .label-filter-key .selectize-input.not-full{width:auto}
 .overview-new .data-toolbar-filter .name-filter form,.overview-new .data-toolbar-filter .name-filter input{width:100%}
 .overview-new .data-toolbar-filter .name-filter input{padding-left:5px}
 .overview-new .data-toolbar-filter .ui-select-container{width:100px}


### PR DESCRIPTION
…at empty state, by allowing it to expand, but doesn't use hard widths that causes breakage when combined with select options on overview and other resources.
Tested in Chrome, Firefox, Safari, IE

Fixes https://github.com/openshift/origin-web-console/issues/1365

<img width="737" alt="empty" src="https://cloud.githubusercontent.com/assets/1874151/24173036/d6270852-0e60-11e7-9056-a7baf98330e9.png">
<img width="730" alt="full" src="https://cloud.githubusercontent.com/assets/1874151/24173043/ddf833e4-0e60-11e7-8da9-2491a091acaf.png">

