### PR TITLE
Add new service related objects to "overview", not "state"

### DIFF
--- a/app/scripts/controllers/newOverview.js
+++ b/app/scripts/controllers/newOverview.js
@@ -1220,7 +1220,7 @@ function OverviewController($scope,
         group: 'servicecatalog.k8s.io',
         resource: 'instances'
       }, context, function(serviceInstances) {
-        state.serviceInstances = serviceInstances.by('metadata.name');
+        overview.serviceInstances = serviceInstances.by('metadata.name');
       }, {poll: limitWatches, pollInterval: DEFAULT_POLL_INTERVAL}));
     }
 
@@ -1229,7 +1229,7 @@ function OverviewController($scope,
         group: 'servicecatalog.k8s.io',
         resource: 'bindings'
       }, context, function(serviceBindings) {
-        state.serviceBindings = serviceBindings.by('metadata.name');
+        overview.serviceBindings = serviceBindings.by('metadata.name');
       }, {poll: limitWatches, pollInterval: DEFAULT_POLL_INTERVAL}));
     }
 
@@ -1246,7 +1246,7 @@ function OverviewController($scope,
         group: 'servicecatalog.k8s.io',
         resource: 'serviceclasses'
       }, context, function(serviceClasses) {
-        state.serviceClasses = serviceClasses.by('metadata.name');
+        overview.serviceClasses = serviceClasses.by('metadata.name');
       });
     }
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -441,7 +441,7 @@ pollInterval:x
 group:"servicecatalog.k8s.io",
 resource:"instances"
 }, c, function(a) {
-L.serviceInstances = a.by("metadata.name");
+v.serviceInstances = a.by("metadata.name");
 }, {
 poll:w,
 pollInterval:x
@@ -449,7 +449,7 @@ pollInterval:x
 group:"servicecatalog.k8s.io",
 resource:"bindings"
 }, c, function(a) {
-L.serviceBindings = a.by("metadata.name");
+v.serviceBindings = a.by("metadata.name");
 }, {
 poll:w,
 pollInterval:x
@@ -459,7 +459,7 @@ L.limitRanges = a.by("metadata.name");
 group:"servicecatalog.k8s.io",
 resource:"serviceclasses"
 }, c, function(a) {
-L.serviceClasses = a.by("metadata.name");
+v.serviceClasses = a.by("metadata.name");
 });
 var e = g.SAMPLE_PIPELINE_TEMPLATE;
 e && h.get("templates", e.name, {


### PR DESCRIPTION
Oops on my part, getting into the `NewOverviewController`.  I put the new objects in the wrong place.  Quick fix

@jwforres 
@spadgett as well in case I'm goofing anything else up :smile: 
