### PR TITLE
Update search placeholder text for projects page

### DIFF
--- a/app/views/projects.html
+++ b/app/views/projects.html
@@ -33,11 +33,11 @@
                             <form role="form" class="search-pf has-button">
                               <div class="form-group has-clear">
                                 <div class="search-pf-input-group">
-                                  <label for="search-projects" class="sr-only">Search</label>
+                                  <label for="search-projects" class="sr-only">Filter by keyword</label>
                                   <input
                                     type="search"
                                     class="form-control"
-                                    placeholder="Search"
+                                    placeholder="Filter by keyword"
                                     id="search-projects"
                                     ng-model="search.text">
                                   <button

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -12886,8 +12886,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<form role=\"form\" class=\"search-pf has-button\">\n" +
     "<div class=\"form-group has-clear\">\n" +
     "<div class=\"search-pf-input-group\">\n" +
-    "<label for=\"search-projects\" class=\"sr-only\">Search</label>\n" +
-    "<input type=\"search\" class=\"form-control\" placeholder=\"Search\" id=\"search-projects\" ng-model=\"search.text\">\n" +
+    "<label for=\"search-projects\" class=\"sr-only\">Filter by keyword</label>\n" +
+    "<input type=\"search\" class=\"form-control\" placeholder=\"Filter by keyword\" id=\"search-projects\" ng-model=\"search.text\">\n" +
     "<button type=\"button\" class=\"clear\" aria-hidden=\"true\" ng-if=\"search.text\" ng-click=\"search.text = ''\">\n" +
     "<span class=\"pficon pficon-close\"></span>\n" +
     "</button>\n" +


### PR DESCRIPTION
Per @serenamarie125, the placeholder for the projects page search should be "Filter by keyword." This also matches the placeholder text we use on other pages like overview, monitoring, and events