### PR TITLE
Incorporation of UI animation effects for deployment transitions on the overview

### DIFF
--- a/app/scripts/services/html.js
+++ b/app/scripts/services/html.js
@@ -6,6 +6,10 @@ angular.module("openshiftConsole")
     return {
       // Ge the breakpoint for the current screen width.
       getBreakpoint: function() {
+        if (window.innerWidth < BREAKPOINTS.screenXsMin) {
+          return 'xxs';
+        }
+
         if (window.innerWidth < BREAKPOINTS.screenSmMin) {
           return 'xs';
         }

--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -145,24 +145,47 @@
   .data-toolbar-label {
     margin-right: 7px;
   }
-  // TODO: improve on this as it's pretty hacky
-  .deployment-connector-arrow {
-    display: inline-block;
-    font-size: 300%;
-    line-height: 1;
-    margin: 50px 0 0 10px;
-    text-align: center;
-    .text-muted();
-    @media (max-width: @screen-xs-max) {
-      margin: -3px auto 0 -4px;
-      transform: rotate(90deg);
-      width: 100%
+  .deployment-connector {
+    align-items: flex-end;
+    display: flex;
+    flex: 1 1 auto;
+    justify-content: center;
+    @media (min-width: @screen-xs-min) {
+      align-items: center;
+      justify-content: flex-end;
+    }
+    .deployment-connector-arrow {
+      align-items: center;
+      display: flex;
+      font-size: 300%;
+      .text-muted();
+      &:before {
+        content: '\2192';
+        // center arrow
+        margin-top: -8px;
+        padding-right: 0;
+      }
+      @media (max-width: @screen-xxs-max) {
+        &:before {
+          content: '\2191';
+          // center arrow when donuts stacked
+          margin-top: -20px;
+          padding-right: 23px;
+        }
+      }
     }
   }
   .expanded-section {
     margin-top: 20px;
     > .row > [class^=col-] {
       margin-bottom: 10px;
+      @media (min-width: @screen-lg-min) {
+        // aligns 2nd columns with metrics
+        &.overview-builds-msg,
+        &.overview-routes {
+          padding-left: 0;
+        }
+      }
     }
     h3 {
       line-height: 1.4;
@@ -205,6 +228,7 @@
     min-width: 19px;
   }
   .list-pf-details {
+    .fade-in();
     @media (min-width: @screen-sm-min) {
       justify-content: flex-end;
     }
@@ -229,6 +253,9 @@
     }
     .list-pf-container {
       display: block; // so that .word-break() will work in IE
+      @media (max-width: @screen-xs-max) {
+        overflow: hidden; // so animation offsets are hidden when sliding in vertically
+      }
     }
     .pod-donut {
       .text-center();
@@ -238,6 +265,9 @@
     border-top-color: @list-pf-border-color;
     &.active {
       border-top-color: @list-pf-item-active-border-color;
+      @media (min-width: @screen-xs-min) {
+        overflow: hidden; // so animation offsets are hidden when sliding in horizontally
+      }
     }
     > .list-pf-container {
       cursor: pointer;
@@ -324,7 +354,7 @@
       max-width: 80px;
     }
     .usage-label {
-      // Make sure the labels align with the bottom of the chart.
+    // Make sure the labels align with the bottom of the chart.
       line-height: 1;
       margin-bottom: -1px;
     }
@@ -348,10 +378,6 @@
     display: block;
     border-top: 1px solid @list-pf-border-color;
     margin: 0 20px 10px;
-  }
-  overview-list-row + overview-list-row .list-pf-item.active {
-    // avoid double borders when list-pf-item is open
-    margin-top: -1px;
   }
   .overview-route {
     .word-break();
@@ -400,7 +426,145 @@
       margin-top: 10px;
     }
   }
-}
+
+  // Deployment animations
+  @keyframes deploymentSlideDown {
+    0% {
+      // align previous and latest donut start position
+      transform: translateY(-220px);
+    }
+    100% {
+      transform: translateX(0);
+    }
+  }
+
+  @keyframes deploymentSlideIn {
+    0% {
+      // align previous and latest donut start position
+      transform: translateX(240px);
+    }
+    100% {
+      transform: translateX(0);
+    }
+  }
+
+  .row-expanded-top {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    @media (min-width: @screen-lg-min) {
+      // width needed to enable flex to trigger word-break on content
+      .overview-animation-block,
+      .overview-pod-template {
+        width: 50%;
+      }
+    }
+    .overview-animation-block {
+      display: flex;
+      flex: 1 1 auto;
+      justify-content: center;
+      @media (min-width: @screen-sm-min) {
+        &.animation-in-progress .overview-deployment-donut .latest-donut {
+          justify-content: flex-end;
+        }
+      }
+      .overview-deployment-donut {
+        @media (min-width: @screen-xs-min) {
+          display: flex;
+          flex: 1 1 auto;
+          // prevents resize jump; set height since the donut isn't displayed exactly when expanded-section is rendered
+          height: 150px;
+          max-width: 450px;
+        }
+        &.ng-enter {
+          animation: deploymentSlideIn 750ms ease forwards;
+        }
+        &.stacked-template {
+          .overview-pod-template {
+            min-width: 100%;
+          }
+          @media (max-width: @screen-xxs-max) {
+            display: flex;
+            // stack latest deployment-donut above previous-donut
+            flex-direction: column-reverse;
+            &.ng-enter {
+              animation: deploymentSlideDown 750ms ease forwards;
+            }
+          }
+        }
+        .latest-donut {
+          display: flex;
+          flex: 1 1 auto;
+          // right align donut
+          justify-content: flex-end;
+        }
+        .previous-donut {
+          display: flex;
+          flex: 1 1 auto;
+          .fade-out();
+          &.ng-enter-prepare {
+            // prevent previous-donut initial "flash" before animation
+            display: none;
+          }
+          @media (max-width: @screen-xxs-max) {
+            flex-direction: column;
+            deployment-donut {
+              // move arrow to point at latest deployment-donut
+              order: 2;
+            }
+          }
+        }
+      }
+    }
+    &.metrics-active {
+      @media (max-width: @screen-md-max) {
+        flex-direction: column;
+        .overview-pod-template {
+          min-width: 100%;
+          order: 3;
+        }
+      }
+      .overview-animation-block {
+        @media (min-width: @screen-xs-min) and (max-width: @screen-md-max) {
+          justify-content: space-between;
+          // add spacing when pod-template-block is stacked beneath
+          padding-bottom: 20px;
+          &.animation-in-progress {
+            justify-content: center;
+          }
+        }
+      }
+      .overview-metrics {
+        display:none;
+        // display metrics beside donut
+        @media (min-width: @screen-xs-min) {
+          display:block;
+          .fade-in();
+          .fade-out();
+          width: 50%;
+        }
+      }
+    }
+    &.metrics-not-active {
+      .overview-pod-template {
+        // prevent wrapping of flex containers
+        width: 50%;
+      }
+    }
+    .overview-pod-template {
+      flex: 1 1 auto;
+      .pod-template-block {
+        // add space so text can't touch metrics or doughnut
+        padding-right: 10px;
+        &.ng-leave-prepare {
+          // prevent previous-donut initial "flash" before animation
+          display: none;
+        }
+      }
+    }
+  }
+
+} // end overview-new
 
 .overview {
   font-weight: @overview-font-weight;

--- a/app/views/_pod-template.html
+++ b/app/views/_pod-template.html
@@ -56,7 +56,7 @@
           <div class="icon-wrap">
             <span class="fa fa-code" aria-hidden="true"></span>
           </div>
-          <div flex>
+          <div flex class="word-break">
             <span class="pod-template-key">Source:</span>
             <span ng-switch="build.spec.source.type">
               <span ng-switch-when="Git">

--- a/app/views/overview/_builds.html
+++ b/app/views/overview/_builds.html
@@ -1,12 +1,12 @@
 <div ng-if="overviewBuilds.buildConfigs.length" class="expanded-section">
   <div class="section-title hidden-xs">Builds</div>
   <div ng-repeat="buildConfig in overviewBuilds.buildConfigs track by (buildConfig | uid)" class="row">
-    <div class="col-sm-5">
+    <div class="col-sm-5 col-md-6">
       <h3 class="mar-top-xs">
         <a ng-href="{{buildConfig | navigateResourceURL}}">{{buildConfig.metadata.name}}</a>
       </h3>
     </div>
-    <div class="col-sm-7">
+    <div class="col-sm-7 col-md-6 overview-builds-msg">
       <div ng-if="!(overviewBuilds.recentBuildsByBuildConfig[buildConfig.metadata.name] | hashSize)">
         No builds.
       </div>

--- a/app/views/overview/_list-row-expanded.html
+++ b/app/views/overview/_list-row-expanded.html
@@ -2,82 +2,96 @@
   <div class="list-pf-content">
     <alerts alerts="row.notifications"></alerts>
     <div ng-if="row.current">
-      <div class="row">
-        <div ng-if="row.state.breakpoint !== 'xs'">
-          <div ng-class="{
-                'col-sm-7 col-md-8 col-lg-9': !row.state.showMetrics && !row.previous,
-                'col-sm-12 col-md-4 col-lg-5': row.state.showMetrics && !row.previous,
-                'hidden-sm col-md-5 col-lg-5': row.previous
-              }">
-            <!-- TODO: markup semantics suggest div.component-label in <pod-template> should be an h4,
-                       but only here on the overview -->
-            <pod-template
-              pod-template="row.current | podTemplate"
-              images-by-docker-reference="row.state.imagesByDockerReference"
-              builds="row.state.builds"></pod-template>
-          </div>
-          <div ng-if="row.state.showMetrics && !row.previous" class="col-sm-7 col-md-4 col-lg-4">
-            <div ng-if="row.apiObject.kind === 'Pod'">
-              <deployment-metrics
-                pods="[row.apiObject]"
-                containers="row.apiObject.spec.containers"
-                profile="compact"
-                alerts="row.state.alerts"
-                class="overview-metrics">
-              </deployment-metrics>
-              <h4 class="h5">Usage <small>Last 15 Minutes</small></h4>
-            </div>
-            <div ng-if="row.apiObject.kind !== 'Pod'">
-              <deployment-metrics
-                pods="row.getPods(row.current)"
-                containers="row.current.spec.template.spec.containers"
-                profile="compact"
-                alerts="row.state.alerts"
-                class="overview-metrics">
-              </deployment-metrics>
-              <h4 class="h5">Average Usage <small>Last 15 Minutes</small></h4>
-            </div>
-          </div>
-        </div>
-        <div ng-if="row.previous" class="col-sm-5 col-md-3">
-          <deployment-donut
-            rc="row.previous"
-            deployment-config="row.apiObject"
-            pods="row.getPods(row.previous)"
-            hpa="row.hpa"
-            limit-ranges="row.state.limitRanges"
-            quotas="row.state.quotas"
-            cluster-quotas="row.state.clusterQuotas"
-            scalable="false"
-            alerts="row.state.alerts">
-          </deployment-donut>
-        </div>
-        <div ng-if="row.previous" class="col-sm-2 col-md-1 col-lg-1">
-          <div class="deployment-connector-arrow" aria-hidden="true">
-            &rarr;
-          </div>
-        </div>
-        <div class="col-sm-5 col-md-3">
+      <div class="row-expanded-top" ng-class="{
+            'metrics-active': row.state.showMetrics,
+            'metrics-not-active': !row.state.showMetrics
+      }">
+        <div ng-if="row.state.breakpoint !== 'xxs' && row.state.breakpoint !== 'xs'" class="overview-pod-template" ng-class="{
+          'ng-enter': row.previous,
+          'hidden-sm hidden-md': row.previous
+        }">
+          <!-- TODO: markup semantics suggest div.component-label in <pod-template> should be an h4, but only here on the overview -->
+          <pod-template
+            pod-template="row.current | podTemplate"
+            images-by-docker-reference="row.state.imagesByDockerReference"
+            builds="row.state.builds"
+            class="hide-ng-leave">
+          </pod-template>
+        </div><!-- /overview-pod-template -->
+
+      <div class="overview-animation-block" ng-class="{
+        'animation-in-progress': row.previous
+      }">
+        <div ng-if="row.state.showMetrics && !row.previous" class="overview-metrics" ng-class="{
+          'ng-enter': row.previous
+        }">
           <div ng-if="row.apiObject.kind === 'Pod'">
-            <a ng-href="{{row.apiObject | navigateResourceURL}}">
-              <pod-donut pods="[row.apiObject]"></pod-donut>
-            </a>
+            <deployment-metrics
+              pods="[row.apiObject]"
+              containers="row.apiObject.spec.containers"
+              profile="compact"
+              alerts="row.state.alerts"
+              class="overview-metrics">
+            </deployment-metrics>
+            <h4 class="h5">Usage <small>Last 15 Minutes</small></h4>
           </div>
           <div ng-if="row.apiObject.kind !== 'Pod'">
-            <deployment-donut
-              rc="row.current"
-              deployment-config="row.apiObject"
+            <deployment-metrics
               pods="row.getPods(row.current)"
-              hpa="row.hpa"
-              limit-ranges="row.state.limitRanges"
-              quotas="row.state.quotas"
-              cluster-quotas="row.state.clusterQuotas"
-              scalable="row.isScalable()"
+              containers="row.current.spec.template.spec.containers"
+              profile="compact"
               alerts="row.state.alerts">
-            </deployment-donut>
+            </deployment-metrics>
+            <h4 class="h5">Average Usage <small>Last 15 Minutes</small></h4>
+          </div>
+        </div><!-- /overview-metrics -->
+
+        <div class="overview-deployment-donut" ng-class="{
+            'ng-enter': row.previous,
+            'stacked-template': row.state.breakpoint !== 'lg'
+        }">
+          <div ng-if="row.previous" class="previous-donut">
+              <deployment-donut
+                rc="row.previous"
+                deployment-config="row.apiObject"
+                pods="row.getPods(row.previous)"
+                hpa="row.hpa"
+                limit-ranges="row.state.limitRanges"
+                quotas="row.state.quotas"
+                cluster-quotas="row.state.clusterQuotas"
+                scalable="false"
+                alerts="row.state.alerts">
+              </deployment-donut>
+            <div ng-if="row.previous" class="deployment-connector">
+              <div class="deployment-connector-arrow" aria-hidden="true">
+              </div>
+            </div>
+          </div>
+
+          <div class="latest-donut">
+            <div ng-if="row.apiObject.kind === 'Pod'">
+              <a ng-href="{{row.apiObject | navigateResourceURL}}">
+                <pod-donut pods="[row.apiObject]"></pod-donut>
+              </a>
+            </div>
+            <div ng-if="row.apiObject.kind !== 'Pod'">
+              <deployment-donut
+                rc="row.current"
+                deployment-config="row.apiObject"
+                pods="row.getPods(row.current)"
+                hpa="row.hpa"
+                limit-ranges="row.state.limitRanges"
+                quotas="row.state.quotas"
+                cluster-quotas="row.state.clusterQuotas"
+                scalable="row.isScalable()"
+                alerts="row.state.alerts">
+              </deployment-donut>
+            </div>
           </div>
         </div>
-      </div>
+      </div><!-- /overview-animation-block -->
+
+      </div><!-- /row-expanded-top -->
     </div>
 
     <!-- Empty State Message -->
@@ -85,7 +99,7 @@
       <div ng-include src=" 'views/overview/_list-row-empty-state.html' "></div>
     </div>
 
-    <div ng-if="row.state.breakpoint === 'xs' && !row.state.previous" class="row">
+    <div ng-if="(row.state.breakpoint === 'xxs' || row.state.breakpoint === 'xs') && !row.state.previous" class="row">
       <div class="col-sm-12">
         <!-- Only show the tabset if any of the tabs are visible. -->
         <uib-tabset ng-if="row.current || (row.services | hashSize) || row.recentPipelines.length || row.buildConfigs.length" class="list-row-tabset">
@@ -105,7 +119,7 @@
               images-by-docker-reference="row.state.imagesByDockerReference"
               builds="row.state.builds"></pod-template>
           </uib-tab>
-          <uib-tab ng-if="row.current && row.state.showMetrics" active="row.selectedTab.metrics">
+          <uib-tab ng-if="row.current && row.state.showMetrics && row.state.breakpoint === 'xxs'" active="row.selectedTab.metrics">
             <uib-tab-heading>Metrics</uib-tab-heading>
             <!-- Use ng-if to avoid requesting metrics when the tab is not active. -->
             <div ng-if="row.selectedTab.metrics">
@@ -160,27 +174,27 @@
       </div>
     </div>
 
-    <!-- Networking Section -->
-    <overview-networking
-      ng-if="row.state.breakpoint !== 'xs'"
-      services="row.services"
-      routes-by-service="row.state.routesByService">
-    </overview-networking>
+    <div ng-if="row.state.breakpoint !== 'xxs' && row.state.breakpoint !== 'xs'">
+      <!-- Networking Section -->
+      <overview-networking
+        services="row.services"
+        routes-by-service="row.state.routesByService">
+      </overview-networking>
 
-    <!-- Pipelines Section -->
-    <overview-pipelines
-      ng-if="!row.hidePipelines && row.state.breakpoint !== 'xs'"
-      recent-pipelines="row.recentPipelines">
-    </overview-pipelines>
+      <!-- Pipelines Section -->
+      <overview-pipelines
+        ng-if="!row.hidePipelines"
+        recent-pipelines="row.recentPipelines">
+      </overview-pipelines>
 
-    <!-- Builds Section -->
-    <overview-builds
-      ng-if="row.state.breakpoint !== 'xs'"
-      build-configs="row.buildConfigs"
-      recent-builds-by-build-config="row.state.recentBuildsByBuildConfig"
-      context="row.state.context"
-      hide-log="row.state.limitWatches">
-    </overview-builds>
+      <!-- Builds Section -->
+      <overview-builds
+        build-configs="row.buildConfigs"
+        recent-builds-by-build-config="row.state.recentBuildsByBuildConfig"
+        context="row.state.context"
+        hide-log="row.state.limitWatches">
+      </overview-builds>
+    </div>
 
   </div><!-- /list-pf-content -->
 </div> <!-- /list-pf-container -->

--- a/app/views/overview/_networking.html
+++ b/app/views/overview/_networking.html
@@ -1,7 +1,7 @@
 <div ng-if="networking.services | hashSize" class="expanded-section networking-section">
   <div class="section-title hidden-xs">Networking</div>
   <div ng-repeat="service in networking.services" class="row">
-    <div class="col-sm-5">
+    <div class="col-sm-5 col-md-6">
       <div class="component-label">
         Service
         <span class="sublabel">Internal Traffic</span>
@@ -23,7 +23,7 @@
         </span>
       </span>
     </div>
-    <div class="col-sm-7">
+    <div class="col-sm-7 col-md-6 overview-routes">
       <div class="component-label">
         Routes
         <span class="sublabel">External Traffic</span>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4141,7 +4141,7 @@ getLogsCommand:c
 } ]), angular.module("openshiftConsole").factory("HTMLService", [ "BREAKPOINTS", function(a) {
 return {
 getBreakpoint:function() {
-return window.innerWidth < a.screenSmMin ? "xs" :window.innerWidth < a.screenMdMin ? "sm" :window.innerWidth < a.screenLgMin ? "md" :"lg";
+return window.innerWidth < a.screenXsMin ? "xxs" :window.innerWidth < a.screenSmMin ? "xs" :window.innerWidth < a.screenMdMin ? "sm" :window.innerWidth < a.screenLgMin ? "md" :"lg";
 },
 linkify:function(a, b, c) {
 return a ? (c || (a = _.escape(a)), a.replace(/https?:\/\/[A-Za-z0-9._%+-]+\S*[^\s.;,(){}<>"\u201d\u2019]/gm, function(a) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -345,7 +345,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"icon-wrap\">\n" +
     "<span class=\"fa fa-code\" aria-hidden=\"true\"></span>\n" +
     "</div>\n" +
-    "<div flex>\n" +
+    "<div flex class=\"word-break\">\n" +
     "<span class=\"pod-template-key\">Source:</span>\n" +
     "<span ng-switch=\"build.spec.source.type\">\n" +
     "<span ng-switch-when=\"Git\">\n" +
@@ -11847,12 +11847,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"overviewBuilds.buildConfigs.length\" class=\"expanded-section\">\n" +
     "<div class=\"section-title hidden-xs\">Builds</div>\n" +
     "<div ng-repeat=\"buildConfig in overviewBuilds.buildConfigs track by (buildConfig | uid)\" class=\"row\">\n" +
-    "<div class=\"col-sm-5\">\n" +
+    "<div class=\"col-sm-5 col-md-6\">\n" +
     "<h3 class=\"mar-top-xs\">\n" +
     "<a ng-href=\"{{buildConfig | navigateResourceURL}}\">{{buildConfig.metadata.name}}</a>\n" +
     "</h3>\n" +
     "</div>\n" +
-    "<div class=\"col-sm-7\">\n" +
+    "<div class=\"col-sm-7 col-md-6 overview-builds-msg\">\n" +
     "<div ng-if=\"!(overviewBuilds.recentBuildsByBuildConfig[buildConfig.metadata.name] | hashSize)\">\n" +
     "No builds.\n" +
     "</div>\n" +
@@ -12292,39 +12292,48 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"list-pf-content\">\n" +
     "<alerts alerts=\"row.notifications\"></alerts>\n" +
     "<div ng-if=\"row.current\">\n" +
-    "<div class=\"row\">\n" +
-    "<div ng-if=\"row.state.breakpoint !== 'xs'\">\n" +
-    "<div ng-class=\"{\n" +
-    "                'col-sm-7 col-md-8 col-lg-9': !row.state.showMetrics && !row.previous,\n" +
-    "                'col-sm-12 col-md-4 col-lg-5': row.state.showMetrics && !row.previous,\n" +
-    "                'hidden-sm col-md-5 col-lg-5': row.previous\n" +
-    "              }\">\n" +
+    "<div class=\"row-expanded-top\" ng-class=\"{\n" +
+    "            'metrics-active': row.state.showMetrics,\n" +
+    "            'metrics-not-active': !row.state.showMetrics\n" +
+    "      }\">\n" +
+    "<div ng-if=\"row.state.breakpoint !== 'xxs' && row.state.breakpoint !== 'xs'\" class=\"overview-pod-template\" ng-class=\"{\n" +
+    "          'ng-enter': row.previous,\n" +
+    "          'hidden-sm hidden-md': row.previous\n" +
+    "        }\">\n" +
     "\n" +
-    "<pod-template pod-template=\"row.current | podTemplate\" images-by-docker-reference=\"row.state.imagesByDockerReference\" builds=\"row.state.builds\"></pod-template>\n" +
+    "<pod-template pod-template=\"row.current | podTemplate\" images-by-docker-reference=\"row.state.imagesByDockerReference\" builds=\"row.state.builds\" class=\"hide-ng-leave\">\n" +
+    "</pod-template>\n" +
     "</div>\n" +
-    "<div ng-if=\"row.state.showMetrics && !row.previous\" class=\"col-sm-7 col-md-4 col-lg-4\">\n" +
+    "<div class=\"overview-animation-block\" ng-class=\"{\n" +
+    "        'animation-in-progress': row.previous\n" +
+    "      }\">\n" +
+    "<div ng-if=\"row.state.showMetrics && !row.previous\" class=\"overview-metrics\" ng-class=\"{\n" +
+    "          'ng-enter': row.previous\n" +
+    "        }\">\n" +
     "<div ng-if=\"row.apiObject.kind === 'Pod'\">\n" +
     "<deployment-metrics pods=\"[row.apiObject]\" containers=\"row.apiObject.spec.containers\" profile=\"compact\" alerts=\"row.state.alerts\" class=\"overview-metrics\">\n" +
     "</deployment-metrics>\n" +
     "<h4 class=\"h5\">Usage <small>Last 15 Minutes</small></h4>\n" +
     "</div>\n" +
     "<div ng-if=\"row.apiObject.kind !== 'Pod'\">\n" +
-    "<deployment-metrics pods=\"row.getPods(row.current)\" containers=\"row.current.spec.template.spec.containers\" profile=\"compact\" alerts=\"row.state.alerts\" class=\"overview-metrics\">\n" +
+    "<deployment-metrics pods=\"row.getPods(row.current)\" containers=\"row.current.spec.template.spec.containers\" profile=\"compact\" alerts=\"row.state.alerts\">\n" +
     "</deployment-metrics>\n" +
     "<h4 class=\"h5\">Average Usage <small>Last 15 Minutes</small></h4>\n" +
     "</div>\n" +
     "</div>\n" +
-    "</div>\n" +
-    "<div ng-if=\"row.previous\" class=\"col-sm-5 col-md-3\">\n" +
+    "<div class=\"overview-deployment-donut\" ng-class=\"{\n" +
+    "            'ng-enter': row.previous,\n" +
+    "            'stacked-template': row.state.breakpoint !== 'lg'\n" +
+    "        }\">\n" +
+    "<div ng-if=\"row.previous\" class=\"previous-donut\">\n" +
     "<deployment-donut rc=\"row.previous\" deployment-config=\"row.apiObject\" pods=\"row.getPods(row.previous)\" hpa=\"row.hpa\" limit-ranges=\"row.state.limitRanges\" quotas=\"row.state.quotas\" cluster-quotas=\"row.state.clusterQuotas\" scalable=\"false\" alerts=\"row.state.alerts\">\n" +
     "</deployment-donut>\n" +
-    "</div>\n" +
-    "<div ng-if=\"row.previous\" class=\"col-sm-2 col-md-1 col-lg-1\">\n" +
+    "<div ng-if=\"row.previous\" class=\"deployment-connector\">\n" +
     "<div class=\"deployment-connector-arrow\" aria-hidden=\"true\">\n" +
-    "&rarr;\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"col-sm-5 col-md-3\">\n" +
+    "</div>\n" +
+    "<div class=\"latest-donut\">\n" +
     "<div ng-if=\"row.apiObject.kind === 'Pod'\">\n" +
     "<a ng-href=\"{{row.apiObject | navigateResourceURL}}\">\n" +
     "<pod-donut pods=\"[row.apiObject]\"></pod-donut>\n" +
@@ -12337,11 +12346,13 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
     "\n" +
     "<div ng-if=\"!row.current\" class=\"empty-state-message\">\n" +
     "<div ng-include src=\" 'views/overview/_list-row-empty-state.html' \"></div>\n" +
     "</div>\n" +
-    "<div ng-if=\"row.state.breakpoint === 'xs' && !row.state.previous\" class=\"row\">\n" +
+    "<div ng-if=\"(row.state.breakpoint === 'xxs' || row.state.breakpoint === 'xs') && !row.state.previous\" class=\"row\">\n" +
     "<div class=\"col-sm-12\">\n" +
     "\n" +
     "<uib-tabset ng-if=\"row.current || (row.services | hashSize) || row.recentPipelines.length || row.buildConfigs.length\" class=\"list-row-tabset\">\n" +
@@ -12355,7 +12366,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<pod-template pod-template=\"row.current | podTemplate\" images-by-docker-reference=\"row.state.imagesByDockerReference\" builds=\"row.state.builds\"></pod-template>\n" +
     "</uib-tab>\n" +
-    "<uib-tab ng-if=\"row.current && row.state.showMetrics\" active=\"row.selectedTab.metrics\">\n" +
+    "<uib-tab ng-if=\"row.current && row.state.showMetrics && row.state.breakpoint === 'xxs'\" active=\"row.selectedTab.metrics\">\n" +
     "<uib-tab-heading>Metrics</uib-tab-heading>\n" +
     "\n" +
     "<div ng-if=\"row.selectedTab.metrics\">\n" +
@@ -12394,15 +12405,17 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</uib-tabset>\n" +
     "</div>\n" +
     "</div>\n" +
+    "<div ng-if=\"row.state.breakpoint !== 'xxs' && row.state.breakpoint !== 'xs'\">\n" +
     "\n" +
-    "<overview-networking ng-if=\"row.state.breakpoint !== 'xs'\" services=\"row.services\" routes-by-service=\"row.state.routesByService\">\n" +
+    "<overview-networking services=\"row.services\" routes-by-service=\"row.state.routesByService\">\n" +
     "</overview-networking>\n" +
     "\n" +
-    "<overview-pipelines ng-if=\"!row.hidePipelines && row.state.breakpoint !== 'xs'\" recent-pipelines=\"row.recentPipelines\">\n" +
+    "<overview-pipelines ng-if=\"!row.hidePipelines\" recent-pipelines=\"row.recentPipelines\">\n" +
     "</overview-pipelines>\n" +
     "\n" +
-    "<overview-builds ng-if=\"row.state.breakpoint !== 'xs'\" build-configs=\"row.buildConfigs\" recent-builds-by-build-config=\"row.state.recentBuildsByBuildConfig\" context=\"row.state.context\" hide-log=\"row.state.limitWatches\">\n" +
+    "<overview-builds build-configs=\"row.buildConfigs\" recent-builds-by-build-config=\"row.state.recentBuildsByBuildConfig\" context=\"row.state.context\" hide-log=\"row.state.limitWatches\">\n" +
     "</overview-builds>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div> "
   );
@@ -12461,7 +12474,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"networking.services | hashSize\" class=\"expanded-section networking-section\">\n" +
     "<div class=\"section-title hidden-xs\">Networking</div>\n" +
     "<div ng-repeat=\"service in networking.services\" class=\"row\">\n" +
-    "<div class=\"col-sm-5\">\n" +
+    "<div class=\"col-sm-5 col-md-6\">\n" +
     "<div class=\"component-label\">\n" +
     "Service\n" +
     "<span class=\"sublabel\">Internal Traffic</span>\n" +
@@ -12483,7 +12496,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</span>\n" +
     "</div>\n" +
-    "<div class=\"col-sm-7\">\n" +
+    "<div class=\"col-sm-7 col-md-6 overview-routes\">\n" +
     "<div class=\"component-label\">\n" +
     "Routes\n" +
     "<span class=\"sublabel\">External Traffic</span>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4524,11 +4524,17 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview-new .data-toolbar-filter .ui-select-container{width:100px}
 .overview-new .data-toolbar-filter .label-filter-add.btn,.overview-new .data-toolbar-filter .ui-select-container .ui-select-match .btn{box-shadow:none;-webkit-box-shadow:none}
 .overview-new .data-toolbar-label{margin-right:7px}
-.overview-new .deployment-connector-arrow{display:inline-block;font-size:300%;line-height:1;margin:50px 0 0 10px;text-align:center;color:#9c9c9c}
-@media (max-width:767px){.overview-new .deployment-connector-arrow{margin:-3px auto 0 -4px;transform:rotate(90deg);width:100%}
+.overview-new .deployment-connector{align-items:flex-end;display:flex;flex:1 1 auto;justify-content:center}
+@media (min-width:480px){.overview-new .deployment-connector{align-items:center;justify-content:flex-end}
+}
+.overview-new .deployment-connector .deployment-connector-arrow{align-items:center;display:flex;font-size:300%;color:#9c9c9c}
+.overview-new .deployment-connector .deployment-connector-arrow:before{content:'\2192';margin-top:-8px;padding-right:0}
+@media (max-width:479px){.overview-new .deployment-connector .deployment-connector-arrow:before{content:'\2191';margin-top:-20px;padding-right:23px}
 }
 .overview-new .expanded-section{margin-top:20px}
 .overview-new .expanded-section>.row>[class^=col-]{margin-bottom:10px}
+@media (min-width:1200px){.overview-new .expanded-section>.row>[class^=col-].overview-builds-msg,.overview-new .expanded-section>.row>[class^=col-].overview-routes{padding-left:0}
+}
 .overview-new .expanded-section h3{line-height:1.4;margin-bottom:5px;margin-top:0;width:100%;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .overview-new .expanded-section .section-title{font-family:inherit;font-weight:500;line-height:1.1;color:inherit;margin-top:10.5px;margin-bottom:10.5px;font-size:14px;border-bottom:1px solid #dcdcdc;padding-bottom:10px}
 .overview-new .expanded-section .section-title .small,.overview-new .expanded-section .section-title small{font-weight:400;line-height:1;color:#9c9c9c;font-size:75%}
@@ -4539,16 +4545,22 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview-new h2>.component-label{padding-bottom:0}
 .overview-new .list-pf{border-bottom-color:#dcdcdc;margin-bottom:50px}
 .overview-new .list-pf-actions{min-width:19px}
-.overview-new .list-pf-expansion.in .empty-state-message p,.overview-new .list-pf-name h3 a,.overview-new .overview-route{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
+.overview-new .list-pf-details.ng-enter,.overview-new .list-pf-details.ng-hide-remove{animation:.3s appear cubic-bezier(.55,.055,.675,.19)}
 @media (min-width:768px){.overview-new .list-pf-details{justify-content:flex-end}
 }
 .overview-new .list-pf-expansion.in .deployment-donut>div[row]{justify-content:center}
 .overview-new .list-pf-expansion.in .empty-state-message{margin-bottom:30px;margin-top:20px;max-width:none;padding:0;text-align:center}
+.overview-new .list-pf-expansion.in .empty-state-message p{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .overview-new .list-pf-expansion.in .list-pf-content{max-width:100%}
 .overview-new .list-pf-expansion.in .list-pf-container{display:block}
+@media (max-width:767px){.overview-new .list-pf-expansion.in .list-pf-container{overflow:hidden}
+}
 .overview-new .list-pf-expansion.in .pod-donut{text-align:center}
 .overview-new .list-pf-item{border-top-color:#dcdcdc}
 .overview-new .list-pf-item.active{border-top-color:#bbb}
+@media (min-width:480px){.overview-new .list-pf-item.active{overflow:hidden}
+}
+.overview-new .list-pf-name h3 a,.overview-new .overview-route{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .overview-new .list-pf-item>.list-pf-container{cursor:pointer}
 @media (max-width:767px){.overview-new .list-pf-item>.list-pf-container>.list-pf-content{align-items:stretch;flex-direction:column;width:100%;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 }
@@ -4563,7 +4575,6 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview-new .list-row-tabset{margin-top:20px}
 @media (min-width:768px){.overview-new .list-pf-item>.list-pf-container>.list-pf-content{min-height:45px;padding-right:15px}
 .overview-new .list-row-tabset{margin-top:0}
-.overview .standalone-service .service-group-body .overview-services{min-height:352px}
 }
 .overview-new .list-row-tabset .nav-tabs>li.active>a .build-count{color:#4d5258}
 .overview-new .list-view-pf-actions .actions-dropdown-kebab{font-size:18px;width:100%}
@@ -4579,7 +4590,6 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview-new .middle .middle-container>div{width:100%}
 .overview-new .middle .middle-container .container-fluid{padding-left:20px;padding-right:20px}
 .overview-new .networking-section .row+.row:before{content:'';display:block;border-top:1px solid #dcdcdc;margin:0 20px 10px}
-.overview-new overview-list-row+overview-list-row .list-pf-item.active{margin-top:-1px}
 .overview-new .overview-routes+.overview-routes{margin-top:10px}
 .overview-new .overview-row-inline-actions{margin-left:10px}
 .overview-new pod-donut[mini]{align-items:center;display:flex}
@@ -4592,6 +4602,47 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview-new .usage-value{font-size:18px;font-weight:300;line-height:1}
 .overview-new .usage-label{font-size:84%;color:#9c9c9c}
 .overview-new .view-by-options{align-items:baseline;display:flex}
+@keyframes deploymentSlideDown{0%{transform:translateY(-220px)}
+100%{transform:translateX(0)}
+}
+@keyframes deploymentSlideIn{0%{transform:translateX(240px)}
+100%{transform:translateX(0)}
+}
+.overview-new .row-expanded-top{display:flex;flex-wrap:wrap;justify-content:space-between}
+@media (min-width:1200px){.overview-new .row-expanded-top .overview-animation-block,.overview-new .row-expanded-top .overview-pod-template{width:50%}
+}
+.overview-new .row-expanded-top .overview-animation-block{display:flex;flex:1 1 auto;justify-content:center}
+@media (min-width:768px){.overview-new .row-expanded-top .overview-animation-block.animation-in-progress .overview-deployment-donut .latest-donut{justify-content:flex-end}
+.overview .standalone-service .service-group-body .overview-services{min-height:352px}
+}
+@media (min-width:480px){.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut{display:flex;flex:1 1 auto;height:150px;max-width:450px}
+}
+.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut.ng-enter{animation:deploymentSlideIn 750ms ease forwards}
+.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut.stacked-template .overview-pod-template{min-width:100%}
+@media (max-width:479px){.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut.stacked-template{display:flex;flex-direction:column-reverse}
+.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut.stacked-template.ng-enter{animation:deploymentSlideDown 750ms ease forwards}
+}
+.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut .latest-donut{display:flex;flex:1 1 auto;justify-content:flex-end}
+.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut .previous-donut{display:flex;flex:1 1 auto}
+.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut .previous-donut.ng-enter-prepare,.overview-new .row-expanded-top.metrics-active .overview-metrics{display:none}
+.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut .previous-donut.ng-hide-add,.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut .previous-donut.ng-leave{animation:150ms disappear cubic-bezier(.215,.61,.355,1)}
+@media (max-width:479px){.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut .previous-donut{flex-direction:column}
+.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut .previous-donut deployment-donut{order:2}
+}
+@media (max-width:1199px){.overview-new .row-expanded-top.metrics-active{flex-direction:column}
+.overview-new .row-expanded-top.metrics-active .overview-pod-template{min-width:100%;order:3}
+}
+@media (min-width:480px) and (max-width:1199px){.overview-new .row-expanded-top.metrics-active .overview-animation-block{justify-content:space-between;padding-bottom:20px}
+.overview-new .row-expanded-top.metrics-active .overview-animation-block.animation-in-progress{justify-content:center}
+}
+@media (min-width:480px){.overview-new .row-expanded-top.metrics-active .overview-metrics{display:block;width:50%}
+.overview-new .row-expanded-top.metrics-active .overview-metrics.ng-enter,.overview-new .row-expanded-top.metrics-active .overview-metrics.ng-hide-remove{animation:.3s appear cubic-bezier(.55,.055,.675,.19)}
+.overview-new .row-expanded-top.metrics-active .overview-metrics.ng-hide-add,.overview-new .row-expanded-top.metrics-active .overview-metrics.ng-leave{animation:150ms disappear cubic-bezier(.215,.61,.355,1)}
+}
+.overview-new .row-expanded-top.metrics-not-active .overview-pod-template{width:50%}
+.overview-new .row-expanded-top .overview-pod-template{flex:1 1 auto}
+.overview-new .row-expanded-top .overview-pod-template .pod-template-block{padding-right:10px}
+.overview-new .row-expanded-top .overview-pod-template .pod-template-block.ng-leave-prepare{display:none}
 .overview{font-weight:300}
 .overview .middle{background-color:#f2f2f2}
 .overview h2{line-height:1.4}


### PR DESCRIPTION
The `.row-expanded-top` contains the pod template and animation block. `.overview-animation-block` contains metrics if active, and the overview-deployment-donut. During deployment the previous and current deployment donut charts are grouped and either slideIn from the left or slideDown at mobile widths. At >992 because of space constraints the pod-template and metrics fade out and hidden to allow for both donuts and arrow, and fade in when complete. As the previous-donut scales down and removed it fades out.

- Markup structure is controlled by flexbox and 50% widths
- Metrics are only beneath a tab when >480
- Networking and builds sections using col-md-6 to match 50% widths above

**Issues**
[] at the start of animation, scale arrows and directional arrow display briefly before the row.previous donut chart is displayed.
[] at the end of the deployment, the pod-template and metrics nodes appear before the previous deployment donut is removed causing some position jumping.

**Screen recording with source code of both issues**
[metrics](https://drive.google.com/open?id=0B3F2EMy0q8RjMlB3STR2OHlHdzA)
[pod-tempate](https://drive.google.com/open?id=0B3F2EMy0q8RjQzJHbVI2d01zcWc)