### PR TITLE
Fix the binding list update failure in service instance rows on the overview

### DIFF
--- a/app/scripts/controllers/newOverview.js
+++ b/app/scripts/controllers/newOverview.js
@@ -94,6 +94,7 @@ function OverviewController($scope,
     routesByService: {},
     servicesByObjectUID: {},
     serviceInstances: {},
+    bindingsByInstanceRef: {},
     // Set to true below when metrics are available.
     showMetrics: false
   };
@@ -1072,7 +1073,7 @@ function OverviewController($scope,
   }, 300);
 
   // TODO: code duplicated from directives/bindService.js
-  // extract & share 
+  // extract & share
   var sortServiceInstances = function() {
     if(!state.serviceInstances && !state.serviceClasses) {
       return;
@@ -1252,6 +1253,10 @@ function OverviewController($scope,
         resource: 'instances'
       }, context, function(serviceInstances) {
         state.serviceInstances = serviceInstances.by('metadata.name');
+        _.each(state.serviceInstances, function(instance) {
+          var notifications = ResourceAlertsService.getServiceInstanceAlerts(instance);
+          setNotifications(instance, notifications);  
+        });
         sortServiceInstances();
         updateFilter();
       }, {poll: limitWatches, pollInterval: DEFAULT_POLL_INTERVAL}));
@@ -1263,6 +1268,7 @@ function OverviewController($scope,
         resource: 'bindings'
       }, context, function(bindings) {
         state.bindings = bindings.by('metadata.name');
+        overview.bindingsByInstanceRef = _.groupBy(state.bindings, 'spec.instanceRef.name');
         refreshSecrets(context);
         updateFilter();
       }, {poll: limitWatches, pollInterval: DEFAULT_POLL_INTERVAL}));

--- a/app/scripts/directives/overview/serviceInstanceRow.js
+++ b/app/scripts/directives/overview/serviceInstanceRow.js
@@ -11,7 +11,8 @@ angular.module('openshiftConsole').component('serviceInstanceRow', {
   controllerAs: 'row',
   bindings: {
     apiObject: '<',
-    state: '<'
+    state: '<',
+    bindings: '<'
   },
   templateUrl: 'views/overview/_service-instance-row.html'
 });
@@ -21,7 +22,7 @@ function ServiceInstanceRow($filter, DataService, rowMethods, $uibModal) {
   _.extend(row, rowMethods.ui);
 
   var getErrorDetails = $filter('getErrorDetails');
-
+  
   var getDisplayName = function() {
     var serviceClassName = row.apiObject.spec.serviceClassName;
     var instanceName = row.apiObject.metadata.name;
@@ -34,17 +35,10 @@ function ServiceInstanceRow($filter, DataService, rowMethods, $uibModal) {
     return _.get(row, ['state','serviceClasses', serviceClassName, 'description']);
   };
 
-  var getBindings = function() {
-    return _.filter(row.state.bindings, function(binding) {
-      return binding.spec.instanceRef.name === row.apiObject.metadata.name;
-    });
-  };
-
   row.$onChanges = function() {
     row.notifications = rowMethods.getNotifications(row.apiObject, row.state);
     row.displayName = getDisplayName();
     row.description = getDescription();
-    row.instanceBindings = getBindings();
   };
 
   row.getSecretForBinding = function(binding) {

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -1084,6 +1084,8 @@ angular.module('openshiftConsole')
       return lastFinishTime;
     };
   })
+  // gets the status condition that matches provided type
+  // statusCondition(object, 'Ready')
   .filter('statusCondition', function() {
     return function(apiObject, type) {
       if (!apiObject) {
@@ -1092,6 +1094,14 @@ angular.module('openshiftConsole')
 
       return _.find(_.get(apiObject, 'status.conditions'), {type: type});
     };
+  })
+  .filter('isServiceInstanceReady', function(statusConditionFilter) {
+    return function(apiObject) {
+      return _.get(statusConditionFilter(apiObject, 'Ready'), 'status') === 'True';
+    };
+  })
+  .filter('isBindingReady', function(isServiceInstanceReadyFilter) {
+    return isServiceInstanceReadyFilter;
   })
   .filter('routeIngressCondition', function() {
     return function(ingress, type) {

--- a/app/scripts/services/resourceAlerts.js
+++ b/app/scripts/services/resourceAlerts.js
@@ -147,10 +147,39 @@ angular.module("openshiftConsole")
       return alerts;
     };
 
+    var makeConditionAlert = function(alerts, uid, condition, type) {
+      alerts[uid+'-'+condition.reason] = {
+        type: type,
+        message: condition.message
+      };
+    };
+
+    var getServiceInstanceAlerts = function(instance) {
+      var alerts = {};
+      if(!instance) {
+        return alerts;
+      }
+      var uid = instance.metadata.uid;
+      var namespaceError = _.find(instance.status.conditions, {reason: 'ErrorFindingNamespaceForInstance'});
+      var provisionFail = _.find(instance.status.conditions, {reason: 'ProvisionFailed'});
+      var deprovisionFail = _.find(instance.status.conditions, {reason: 'DeprovisioningFailed'});
+
+      if(namespaceError) {
+        makeConditionAlert(alerts, uid, namespaceError, 'warning');
+      }
+      if(provisionFail) {
+        makeConditionAlert(alerts, uid, provisionFail, 'error');
+      }
+      if(deprovisionFail) {
+        makeConditionAlert(alerts, uid, deprovisionFail, 'error');
+      }
+      return alerts;
+    };
+
     return {
       getPodAlerts: getPodAlerts,
       setGenericQuotaWarning: setGenericQuotaWarning,
-      getDeploymentStatusAlerts: getDeploymentStatusAlerts
+      getDeploymentStatusAlerts: getDeploymentStatusAlerts,
+      getServiceInstanceAlerts: getServiceInstanceAlerts
     };
   });
-

--- a/app/views/directives/bind-service/results.html
+++ b/app/views/directives/bind-service/results.html
@@ -1,13 +1,13 @@
 <div>
   <div ng-if="!ctrl.error">
-    <div ng-if="(ctrl.binding | statusCondition : 'Ready').status !== 'True'">
+    <div ng-if="!(ctrl.binding | isBindingReady)">
       <h3 class="mar-top-none center">
         <span class="fa fa-spinner fa-pulse fa-3x fa-fw" aria-hidden="true"></span>
         <span class="sr-only">Pending</span>
         <div class="mar-top-lg">The binding was created but is not ready yet.</div>
       </h3>
     </div>
-    <div ng-if="(ctrl.binding | statusCondition : 'Ready').status === 'True'">
+    <div ng-if="(ctrl.binding | isBindingReady)">
       <h3 class="mar-top-none">
         <strong>{{ctrl.serviceToBind}}</strong> has been bound to <strong>{{ctrl.target.metadata.name}}</strong> successfully
       </h3>

--- a/app/views/directives/bind-service/select-service.html
+++ b/app/views/directives/bind-service/select-service.html
@@ -8,7 +8,7 @@ for your application to use the service.
       <label>
         <input type="radio" ng-model="ctrl.serviceToBind" value="{{serviceInstance.metadata.name}}">
         {{ctrl.serviceClasses[serviceInstance.spec.serviceClassName].osbMetadata.displayName || serviceInstance.spec.serviceClassName}}
-        <span ng-if="(serviceInstance | statusCondition : 'Ready').status !== 'True'" class="mar-left-sm">
+        <span ng-if="!(serviceInstance | isServiceInstanceReady)" class="mar-left-sm">
           <span class="pficon pficon-info" data-content="This service is not yet ready. If you bind to it, then the binding will be pending until the service is ready." data-toggle="popover" data-trigger="hover"></span>
         </span>
         <div class="help-block mar-top-none">

--- a/app/views/new-overview.html
+++ b/app/views/new-overview.html
@@ -365,6 +365,7 @@
                   <service-instance-row
                     ng-repeat="serviceInstance in overview.state.orderedServiceInstances"
                     api-object="serviceInstance"
+                    bindings="overview.bindingsByInstanceRef[serviceInstance.metadata.name]"
                     state="overview.state"></service-instance-row>
                 </div>
               </div>

--- a/app/views/overview/_service-instance-row.html
+++ b/app/views/overview/_service-instance-row.html
@@ -19,8 +19,7 @@
       </div>
     </div>
 
-    <div
-      class="list-pf-content hidden-xs hidden-sm">
+    <div class="list-pf-content hidden-xs hidden-sm">
       <div class="list-pf-content-right">
         <div>
           <strong ng-if="!row.instanceBindings.length">No Bindings</strong>
@@ -68,62 +67,68 @@
     ng-class="{ in: row.expanded }">
 
     <div class="list-pf-container">
-
-      <!--
-        TODO: follow-on PR
       <div class="expanded-section">
+        <alerts alerts="row.notifications"></alerts>
+        <!--
+          TODO: follow-on PR
+        <div class="expanded-section">
+          <div class="section-title">
+            Configuration Details
+          </div>
+          <div class="row" ng-repeat="item in [{
+            name: 'password',
+            value: '*****'
+          }, {
+            name: 'lorem ipsum',
+            value: 'dolor sit amet'
+          }]">
+            <div class="col-sm-5">{{item.name}}</div>
+            <div class="col-sm-7">{{item.value}}</div>
+          </div>
+        </div>
+        -->
+
+        <div class="row">
+          <div class="col-sm-12" ng-if="row.description">
+            <p class="pre-wrap" ng-bind-html="row.description | linky"></p>
+          </div>
+        </div>
         <div class="section-title">
-          Configuration Details
+          Bindings
         </div>
-        <div class="row" ng-repeat="item in [{
-          name: 'password',
-          value: '*****'
-        }, {
-          name: 'lorem ipsum',
-          value: 'dolor sit amet'
-        }]">
-          <div class="col-sm-5">{{item.name}}</div>
-          <div class="col-sm-7">{{item.value}}</div>
+        <span ng-if="!row.bindings">There are no bindings.</span>
+        <div
+          ng-if="row.bindings"
+          class="row"
+          ng-repeat="(name, binding) in row.bindings">
+          <div class="col-sm-5">
+            <span>{{binding.metadata.name}}</span>
+          </div>
+          <div class="col-sm-7">
+            <!-- TODO: follow-on PR
+            <a ng-href="{{binding | navigateResourceURL}}">View configuration details</a>
+            -->
+            <span ng-if="!(binding | isBindingReady)">
+              <status-icon status="'Pending'"></status-icon> Pending
+            </span>
+            <a
+              ng-if="(binding | isBindingReady) && ('secrets' | canI : 'get')"
+              href="{{row.getSecretForBinding(binding) | navigateResourceURL}}">
+              View secret
+            </a>
+          </div>
         </div>
+        <!-- TODO: follow-on PR
+        <div class="row">
+          <div class="col-sm-12">
+            <a href="#">
+              <i class="fa fa-plus-circle"></i> Create binding
+            </a>
+          </div>
+        </div>
+        -->
       </div>
-      -->
-
-      <div class="row">
-        <div class="col-sm-12" ng-if="row.description">
-          <p class="pre-wrap" ng-bind-html="row.description | linky"></p>
-        </div>
-      </div>
-      <div class="section-title">
-        Bindings
-      </div>
-      <span ng-if="!row.instanceBindings.length">There are no bindings.</span>
-      <div
-        ng-if="row.instanceBindings.length"
-        class="row"
-        ng-repeat="binding in row.instanceBindings">
-        <div class="col-sm-4">
-          <span>{{binding.metadata.name}}</span>
-        </div>
-        <div class="col-sm-8">
-          <!-- TODO: follow-on PR
-          <a ng-href="{{binding | navigateResourceURL}}">View configuration details</a>
-          -->
-          <a href="{{row.getSecretForBinding(binding) | navigateResourceURL}}">
-            View secret
-          </a>
-        </div>
-      </div>
-      <!-- TODO: follow-on PR
-      <div class="row">
-        <div class="col-sm-12">
-          <a href="#">
-            <i class="fa fa-plus-circle"></i> Create binding
-          </a>
-        </div>
-      </div>
-      -->
     </div>
-
   </div>
 
 </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6007,14 +6007,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   $templateCache.put('views/directives/bind-service/results.html',
     "<div>\n" +
     "<div ng-if=\"!ctrl.error\">\n" +
-    "<div ng-if=\"(ctrl.binding | statusCondition : 'Ready').status !== 'True'\">\n" +
+    "<div ng-if=\"!(ctrl.binding | isBindingReady)\">\n" +
     "<h3 class=\"mar-top-none center\">\n" +
     "<span class=\"fa fa-spinner fa-pulse fa-3x fa-fw\" aria-hidden=\"true\"></span>\n" +
     "<span class=\"sr-only\">Pending</span>\n" +
     "<div class=\"mar-top-lg\">The binding was created but is not ready yet.</div>\n" +
     "</h3>\n" +
     "</div>\n" +
-    "<div ng-if=\"(ctrl.binding | statusCondition : 'Ready').status === 'True'\">\n" +
+    "<div ng-if=\"(ctrl.binding | isBindingReady)\">\n" +
     "<h3 class=\"mar-top-none\">\n" +
     "<strong>{{ctrl.serviceToBind}}</strong> has been bound to <strong>{{ctrl.target.metadata.name}}</strong> successfully\n" +
     "</h3>\n" +
@@ -6093,7 +6093,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<label>\n" +
     "<input type=\"radio\" ng-model=\"ctrl.serviceToBind\" value=\"{{serviceInstance.metadata.name}}\">\n" +
     "{{ctrl.serviceClasses[serviceInstance.spec.serviceClassName].osbMetadata.displayName || serviceInstance.spec.serviceClassName}}\n" +
-    "<span ng-if=\"(serviceInstance | statusCondition : 'Ready').status !== 'True'\" class=\"mar-left-sm\">\n" +
+    "<span ng-if=\"!(serviceInstance | isServiceInstanceReady)\" class=\"mar-left-sm\">\n" +
     "<span class=\"pficon pficon-info\" data-content=\"This service is not yet ready. If you bind to it, then the binding will be pending until the service is ready.\" data-toggle=\"popover\" data-trigger=\"hover\"></span>\n" +
     "</span>\n" +
     "<div class=\"help-block mar-top-none\">\n" +
@@ -11543,7 +11543,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Provisioned Services\n" +
     "</h2>\n" +
     "<div class=\"list-pf\">\n" +
-    "<service-instance-row ng-repeat=\"serviceInstance in overview.state.orderedServiceInstances\" api-object=\"serviceInstance\" state=\"overview.state\"></service-instance-row>\n" +
+    "<service-instance-row ng-repeat=\"serviceInstance in overview.state.orderedServiceInstances\" api-object=\"serviceInstance\" bindings=\"overview.bindingsByInstanceRef[serviceInstance.metadata.name]\" state=\"overview.state\"></service-instance-row>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -12721,6 +12721,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"list-pf-expansion collapse\" ng-if=\"row.expanded\" ng-class=\"{ in: row.expanded }\">\n" +
     "<div class=\"list-pf-container\">\n" +
+    "<div class=\"expanded-section\">\n" +
+    "<alerts alerts=\"row.notifications\"></alerts>\n" +
     "\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-sm-12\" ng-if=\"row.description\">\n" +
@@ -12730,19 +12732,23 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"section-title\">\n" +
     "Bindings\n" +
     "</div>\n" +
-    "<span ng-if=\"!row.instanceBindings.length\">There are no bindings.</span>\n" +
-    "<div ng-if=\"row.instanceBindings.length\" class=\"row\" ng-repeat=\"binding in row.instanceBindings\">\n" +
-    "<div class=\"col-sm-4\">\n" +
+    "<span ng-if=\"!row.bindings\">There are no bindings.</span>\n" +
+    "<div ng-if=\"row.bindings\" class=\"row\" ng-repeat=\"(name, binding) in row.bindings\">\n" +
+    "<div class=\"col-sm-5\">\n" +
     "<span>{{binding.metadata.name}}</span>\n" +
     "</div>\n" +
-    "<div class=\"col-sm-8\">\n" +
+    "<div class=\"col-sm-7\">\n" +
     "\n" +
-    "<a href=\"{{row.getSecretForBinding(binding) | navigateResourceURL}}\">\n" +
+    "<span ng-if=\"!(binding | isBindingReady)\">\n" +
+    "<status-icon status=\"'Pending'\"></status-icon> Pending\n" +
+    "</span>\n" +
+    "<a ng-if=\"(binding | isBindingReady) && ('secrets' | canI : 'get')\" href=\"{{row.getSecretForBinding(binding) | navigateResourceURL}}\">\n" +
     "View secret\n" +
     "</a>\n" +
     "</div>\n" +
     "</div>\n" +
     "\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
- `$onChanges` does not see properties of object `row.state` change
- moving `getBindings` to `$doCheck` solves the problem
- this does call the function on every digest loop, but it does not trigger infinite digests
   - it is possible that storing a temp reference to the old bindings & testing against the new before assigning to `row. instanceBindings` could be slightly more performant as it would ensure no DOM updates, but that may be overkill in this situation. 