### PR TITLE
Adjusting positioning of landing page so it doesn't overlap navbar

### DIFF
--- a/app/styles/_catalog.less
+++ b/app/styles/_catalog.less
@@ -18,6 +18,6 @@
 
 @media(min-width: @screen-sm-min) {
   .catalog-search, .landing-side-bar {
-    top: @navbar-os-header-height-desktop;
+    top: @navbar-os-header-height-desktop + 1; // add 1 for the bottom border
   }
 }

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3706,7 +3706,7 @@ table.dataTable th:active{outline:0}
 .landing{background:#f2f2f2}
 .landing .catalogs-overlay-modal .wizard-pf-body .wizard-pf-main{margin-left:-20px;margin-right:-20px;padding-left:0;padding-right:0}
 .landing .nav-tabs,.landing h1{margin-bottom:0!important;margin-top:0!important}
-@media (min-width:768px){.catalog-search,.landing-side-bar{top:60px}
+@media (min-width:768px){.catalog-search,.landing-side-bar{top:61px}
 }
 .collapse{display:none}
 .collapse.in{display:block}


### PR DESCRIPTION
Before the navbar bottom border is hidden:
<img width="1371" alt="screen shot 2017-04-12 at 3 09 52 pm" src="https://cloud.githubusercontent.com/assets/895728/24975010/2c64138a-1f92-11e7-97d5-65cc78a79a1e.PNG">

After the navbar bottom border is visible:
<img width="1352" alt="screen shot 2017-04-12 at 3 07 29 pm" src="https://cloud.githubusercontent.com/assets/895728/24975026/3b81acb0-1f92-11e7-8d5e-539e90add539.PNG">
