### PR TITLE
Prevent a horizontal scrollbar in Safari when the project menu contains a long name

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -38,9 +38,9 @@
   </head>
 <body class="console-os">
     <!-- Add your site or application content here -->
-
     <toast-notifications></toast-notifications>
-    <div ng-view>
+
+    <div ng-view class="console-os-wrap">
       <!-- Include default simple nav and shaded background as a placeholder until API discovery finishes -->
       <nav class="navbar navbar-pf-alt top-header" role="navigation">
         <div row>

--- a/app/styles/_substructure.less
+++ b/app/styles/_substructure.less
@@ -11,6 +11,9 @@ html,body {
 }
 .console-os {
   background-color: @body-bg;
+  .console-os-wrap {
+    overflow-x: hidden;
+  }
   .top-header {
     .flex-display(@display: flex);
     position:relative;

--- a/dist/index.html
+++ b/dist/index.html
@@ -20,7 +20,7 @@
 </head>
 <body class="console-os">
 <toast-notifications></toast-notifications>
-<div ng-view>
+<div ng-view class="console-os-wrap">
 <nav class="navbar navbar-pf-alt top-header" role="navigation">
 <div row>
 <div class="navbar-header">

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5475,6 +5475,7 @@ dl.secret-data pre{margin-bottom:0}
 body,html{margin:0;padding:0}
 .layout-pf-alt.layout-pf-alt-fixed body{padding-top:0}
 .console-os{background-color:#fff}
+.console-os .console-os-wrap{overflow-x:hidden}
 .console-os .top-header{display:flex;position:relative;height:46px}
 .console-os .wrap{height:100vh;margin-top:-46px;padding-top:46px;position:relative;width:100%;-webkit-backface-visibility:hidden;-moz-backface-visibility:hidden;backface-visibility:hidden;-webkit-flex-direction:column;-moz-flex-direction:column;-ms-flex-direction:column;flex-direction:column;display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex}
 .console-os .wrap.no-sidebar h1{margin:10px 0 20px}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin-web-console/issues/1374

Tested in supported browsers and no issues found.
