### PR TITLE
Hide failed and cancelled deployments

### DIFF
--- a/app/views/overview/_list-row-content.html
+++ b/app/views/overview/_list-row-content.html
@@ -9,7 +9,7 @@
       </span>
     </div>
     <a ng-href="{{row.apiObject | navigateResourceURL}}"><span ng-bind-html="row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords"></span></a><span ng-if="row.apiObject.kind === 'DeploymentConfig' && row.current">,
-      <a ng-href="{{row.current | navigateResourceURL}}">#{{row.apiObject.status.latestVersion}}</a>
+      <a ng-href="{{row.current | navigateResourceURL}}">#{{row.current | annotation : 'deploymentVersion'}}</a>
     </span><span ng-if="row.apiObject.kind === 'Deployment' && row.current">,
       <a ng-href="{{row.current | navigateResourceURL}}">#{{row.current | annotation : 'deployment.kubernetes.io/revision'}}</a>
     </span>

--- a/app/views/overview/_list-row-empty-state.html
+++ b/app/views/overview/_list-row-empty-state.html
@@ -2,7 +2,7 @@
 <div ng-if="row.imageChangeTriggers.length">
   A new deployment will start automatically when
   <span ng-if="row.imageChangeTriggers.length === 1">
-    an image is available for
+    an image is pushed to
     <a ng-href="{{row.urlForImageChangeTrigger(row.imageChangeTriggers[0])}}">
       {{row.imageChangeTriggers[0].imageChangeParams.from | imageObjectRef : row.apiObject.metadata.namespace}}</a>.
   </span>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -221,22 +221,24 @@ key:"metadata.uid"
 }, za = function(a) {
 if (_.get(a, "status.replicas")) return !0;
 var b = z(a, "deploymentConfig");
-if (!b) return !0;
-var c = _.get(v, [ "deploymentConfigs", b, "status", "latestVersion" ]);
-return c ? c === Number(z(a, "deploymentVersion")) :B(a);
+return !b || B(a);
 }, Aa = function(a) {
 return z(a, "deploymentConfig");
 }, Ba = function() {
 if (v.deploymentConfigs && v.replicationControllers) {
 var a = [];
 v.replicationControllersByDeploymentConfig = {}, v.currentByDeploymentConfig = {}, K = {};
-var b = {};
-_.each(v.replicationControllers, function(c) {
-var d = Aa(c) || "";
-(!d || !v.deploymentConfigs[d] && _.get(c, "status.replicas")) && a.push(c);
-var e = K[d];
-e && !F(c, e) || (K[d] = c), za(c) && _.set(b, [ d, c.metadata.name ], c);
+var b = {}, c = {};
+_.each(v.replicationControllers, function(d) {
+var e = Aa(d) || "";
+(!e || !v.deploymentConfigs[e] && _.get(d, "status.replicas")) && a.push(d);
+var f = K[e];
+f && !F(d, f) || (K[e] = d);
+var g;
+"Complete" === z(d, "deploymentStatus") && (g = b[e], g && !F(d, g) || (b[e] = d)), za(d) && _.set(c, [ e, d.metadata.name ], d);
 }), _.each(b, function(a, b) {
+_.set(c, [ b, a.metadata.name ], a);
+}), _.each(c, function(a, b) {
 var c = i.sortByDeploymentVersion(a, !0);
 v.replicationControllersByDeploymentConfig[b] = c, v.currentByDeploymentConfig[b] = _.head(c);
 }), v.vanillaReplicationControllers = _.sortBy(a, "metadata.name"), oa();

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -12177,7 +12177,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</div>\n" +
     "<a ng-href=\"{{row.apiObject | navigateResourceURL}}\"><span ng-bind-html=\"row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords\"></span></a><span ng-if=\"row.apiObject.kind === 'DeploymentConfig' && row.current\">,\n" +
-    "<a ng-href=\"{{row.current | navigateResourceURL}}\">#{{row.apiObject.status.latestVersion}}</a>\n" +
+    "<a ng-href=\"{{row.current | navigateResourceURL}}\">#{{row.current | annotation : 'deploymentVersion'}}</a>\n" +
     "</span><span ng-if=\"row.apiObject.kind === 'Deployment' && row.current\">,\n" +
     "<a ng-href=\"{{row.current | navigateResourceURL}}\">#{{row.current | annotation : 'deployment.kubernetes.io/revision'}}</a>\n" +
     "</span>\n" +
@@ -12252,7 +12252,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"row.imageChangeTriggers.length\">\n" +
     "A new deployment will start automatically when\n" +
     "<span ng-if=\"row.imageChangeTriggers.length === 1\">\n" +
-    "an image is available for\n" +
+    "an image is pushed to\n" +
     "<a ng-href=\"{{row.urlForImageChangeTrigger(row.imageChangeTriggers[0])}}\">\n" +
     "{{row.imageChangeTriggers[0].imageChangeParams.from | imageObjectRef : row.apiObject.metadata.namespace}}</a>.\n" +
     "</span>\n" +


### PR DESCRIPTION
Fixes a regression from #1429

@jwforres This works with the caveat that it will show the empty state message when the first deployment fails. I'm thinking the simplest might be to adjust the empty state message based on the deployment config conditions.

```yaml
  conditions:
    - type: Available
      status: 'False'
      lastUpdateTime: '2017-04-18T12:22:13Z'
      lastTransitionTime: '2017-04-18T12:22:13Z'
      message: Deployment config does not have minimum availability.
    - type: Progressing
      status: 'False'
      lastUpdateTime: '2017-04-18T12:32:55Z'
      lastTransitionTime: '2017-04-18T12:32:55Z'
      reason: ProgressDeadlineExceeded
      message: replication controller "failing-1" has failed progressing
```

The previous overview had some logic in the view here:

https://github.com/openshift/origin-web-console/blob/master/app/views/overview/_dc.html#L85

Screenshots:

![screen shot 2017-04-18 at 8 37 35 am](https://cloud.githubusercontent.com/assets/1167259/25131051/5e42f9fa-2412-11e7-8e1a-a43729858852.png)
![screen shot 2017-04-18 at 8 37 40 am](https://cloud.githubusercontent.com/assets/1167259/25131056/60f9a9dc-2412-11e7-8125-9a48d2aa6336.png)

For reference, here is how it looks with the previous overview:

![screen shot 2017-04-18 at 8 45 55 am](https://cloud.githubusercontent.com/assets/1167259/25131386/84dab67e-2413-11e7-93a5-b7d07ca05b6d.png)
