### PR TITLE
Set donut alignment based on whether metrics are shown and

### DIFF
--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -250,6 +250,13 @@
     }
     .list-pf-content {
       max-width: 100%;
+      // prevent deployment animation from overlaying alerts
+      // TODO set as default for all alerts?
+      alerts {
+        position: relative;
+        z-index: 2;
+        display: block;
+      }
     }
     .list-pf-container {
       display: block; // so that .word-break() will work in IE
@@ -495,8 +502,6 @@
         .latest-donut {
           display: flex;
           flex: 1 1 auto;
-          // right align donut
-          justify-content: flex-end;
         }
         .previous-donut {
           display: flex;
@@ -524,6 +529,9 @@
           order: 3;
         }
       }
+      .latest-donut {
+        justify-content: flex-end;
+      }
       .overview-animation-block {
         @media (min-width: @screen-xs-min) and (max-width: @screen-md-max) {
           justify-content: space-between;
@@ -546,6 +554,13 @@
       }
     }
     &.metrics-not-active {
+      .latest-donut {
+        justify-content: center;
+        @media (min-width: @screen-sm-min) {
+          // right align donut when pod-template is shown
+          justify-content: flex-end;
+        }
+      }
       .overview-pod-template {
         // prevent wrapping of flex containers
         width: 50%;

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4552,6 +4552,7 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview-new .list-pf-expansion.in .empty-state-message{margin-bottom:30px;margin-top:20px;max-width:none;padding:0;text-align:center}
 .overview-new .list-pf-expansion.in .empty-state-message p{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .overview-new .list-pf-expansion.in .list-pf-content{max-width:100%}
+.overview-new .list-pf-expansion.in .list-pf-content alerts{position:relative;z-index:2;display:block}
 .overview-new .list-pf-expansion.in .list-pf-container{display:block}
 @media (max-width:767px){.overview-new .list-pf-expansion.in .list-pf-container{overflow:hidden}
 }
@@ -4613,7 +4614,6 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 }
 .overview-new .row-expanded-top .overview-animation-block{display:flex;flex:1 1 auto;justify-content:center}
 @media (min-width:768px){.overview-new .row-expanded-top .overview-animation-block.animation-in-progress .overview-deployment-donut .latest-donut{justify-content:flex-end}
-.overview .standalone-service .service-group-body .overview-services{min-height:352px}
 }
 @media (min-width:480px){.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut{display:flex;flex:1 1 auto;height:150px;max-width:450px}
 }
@@ -4622,8 +4622,7 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 @media (max-width:479px){.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut.stacked-template{display:flex;flex-direction:column-reverse}
 .overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut.stacked-template.ng-enter{animation:deploymentSlideDown 750ms ease forwards}
 }
-.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut .latest-donut{display:flex;flex:1 1 auto;justify-content:flex-end}
-.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut .previous-donut{display:flex;flex:1 1 auto}
+.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut .latest-donut,.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut .previous-donut{display:flex;flex:1 1 auto}
 .overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut .previous-donut.ng-enter-prepare,.overview-new .row-expanded-top.metrics-active .overview-metrics{display:none}
 .overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut .previous-donut.ng-hide-add,.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut .previous-donut.ng-leave{animation:150ms disappear cubic-bezier(.215,.61,.355,1)}
 @media (max-width:479px){.overview-new .row-expanded-top .overview-animation-block .overview-deployment-donut .previous-donut{flex-direction:column}
@@ -4632,12 +4631,17 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 @media (max-width:1199px){.overview-new .row-expanded-top.metrics-active{flex-direction:column}
 .overview-new .row-expanded-top.metrics-active .overview-pod-template{min-width:100%;order:3}
 }
+.overview-new .row-expanded-top.metrics-active .latest-donut{justify-content:flex-end}
 @media (min-width:480px) and (max-width:1199px){.overview-new .row-expanded-top.metrics-active .overview-animation-block{justify-content:space-between;padding-bottom:20px}
 .overview-new .row-expanded-top.metrics-active .overview-animation-block.animation-in-progress{justify-content:center}
 }
 @media (min-width:480px){.overview-new .row-expanded-top.metrics-active .overview-metrics{display:block;width:50%}
 .overview-new .row-expanded-top.metrics-active .overview-metrics.ng-enter,.overview-new .row-expanded-top.metrics-active .overview-metrics.ng-hide-remove{animation:.3s appear cubic-bezier(.55,.055,.675,.19)}
 .overview-new .row-expanded-top.metrics-active .overview-metrics.ng-hide-add,.overview-new .row-expanded-top.metrics-active .overview-metrics.ng-leave{animation:150ms disappear cubic-bezier(.215,.61,.355,1)}
+}
+.overview-new .row-expanded-top.metrics-not-active .latest-donut{justify-content:center}
+@media (min-width:768px){.overview-new .row-expanded-top.metrics-not-active .latest-donut{justify-content:flex-end}
+.overview .standalone-service .service-group-body .overview-services{min-height:352px}
 }
 .overview-new .row-expanded-top.metrics-not-active .overview-pod-template{width:50%}
 .overview-new .row-expanded-top .overview-pod-template{flex:1 1 auto}


### PR DESCRIPTION
prevent deployment animation from overlaying alerts within expanded row

Fixes https://github.com/openshift/origin-web-console/issues/1437

<img width="663" alt="screen shot 2017-04-18 at 2 24 16 pm" src="https://cloud.githubusercontent.com/assets/1874151/25146678/c0355c22-2442-11e7-9949-bfdb82ca5f74.png">

<img width="657" alt="screen shot 2017-04-18 at 1 14 09 pm" src="https://cloud.githubusercontent.com/assets/1874151/25146532/36f7b3d8-2442-11e7-8a0c-c7573e174f0f.png">
**With metrics**
<img width="661" alt="screen shot 2017-04-18 at 2 22 10 pm" src="https://cloud.githubusercontent.com/assets/1874151/25146620/86ea3a14-2442-11e7-801f-0f3c3791df90.png">

**alert issue**
![alerts-overlay](https://cloud.githubusercontent.com/assets/1874151/25146548/48ca8130-2442-11e7-9d1c-5ab452ebbc55.gif)

