### PR TITLE
Hide provisioned services for pipeline empty state message

### DIFF
--- a/app/scripts/controllers/newOverview.js
+++ b/app/scripts/controllers/newOverview.js
@@ -196,6 +196,8 @@ function OverviewController($scope,
     overview.showLoading = !loaded && projectEmpty;
 
     overview.everythingFiltered = !projectEmpty && !overview.filteredSize;
+    overview.hidePipelineOtherResources = overview.viewBy === 'pipeline' &&
+                                          (overview.filterActive || _.isEmpty(overview.pipelineBuildConfigs));
   };
 
   // Group a collection of resources by app label. Returns a map where the key

--- a/app/views/new-overview.html
+++ b/app/views/new-overview.html
@@ -313,7 +313,7 @@
                 </div>
 
                 <!-- Currently we only filter the pipelines. Hide "Other Resources" if a pipeline filter is active or if we're showing the pipeline empty state message. -->
-                <div class="list-pf" ng-if="overview.pipelineBuildConfigs.length && overview.pipelineViewHasOtherResources && !overview.filterActive">
+                <div class="list-pf" ng-if="overview.pipelineViewHasOtherResources && !overview.hidePipelineOtherResources">
                   <h2>Other Resources</h2>
                   <overview-list-row
                        ng-repeat="deploymentConfig in overview.deploymentConfigsNoPipeline track by (deploymentConfig | uid)"
@@ -354,8 +354,8 @@
                 </div>
               </div>
 
-              <!-- service instances appear the same way no matter the filter listBy option -->
-              <div ng-if="overview.filteredServiceInstances.length">
+              <!-- Show provisioned services. -->
+              <div ng-if="overview.filteredServiceInstances.length && !overview.hidePipelineOtherResources">
                 <h2>
                   Provisioned Services
                 </h2>
@@ -367,7 +367,6 @@
                     state="overview.state"></service-instance-row>
                 </div>
               </div>
-
             </div>
           </div>
         </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -58,7 +58,7 @@ return _.size(v.filteredDeploymentConfigs) + _.size(v.filteredReplicationControl
 }, R = function() {
 v.size = P(), v.filteredSize = Q();
 var a = 0 === v.size, b = v.deploymentConfigs && v.replicationControllers && v.deployments && v.replicaSets && v.statefulSets && v.pods && v.state.serviceInstances;
-L.expandAll = b && 1 === v.size, v.showGetStarted = b && a, v.showLoading = !b && a, v.everythingFiltered = !a && !v.filteredSize;
+L.expandAll = b && 1 === v.size, v.showGetStarted = b && a, v.showLoading = !b && a, v.everythingFiltered = !a && !v.filteredSize, v.hidePipelineOtherResources = "pipeline" === v.viewBy && (v.filterActive || _.isEmpty(v.pipelineBuildConfigs));
 }, S = function(a) {
 return e.groupByApp(a, "metadata.name");
 }, T = function(a) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -11540,7 +11540,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "\n" +
-    "<div class=\"list-pf\" ng-if=\"overview.pipelineBuildConfigs.length && overview.pipelineViewHasOtherResources && !overview.filterActive\">\n" +
+    "<div class=\"list-pf\" ng-if=\"overview.pipelineViewHasOtherResources && !overview.hidePipelineOtherResources\">\n" +
     "<h2>Other Resources</h2>\n" +
     "<overview-list-row ng-repeat=\"deploymentConfig in overview.deploymentConfigsNoPipeline track by (deploymentConfig | uid)\" ng-init=\"dcName = deploymentConfig.metadata.name\" api-object=\"deploymentConfig\" current=\"overview.currentByDeploymentConfig[dcName]\" previous=\"overview.getPreviousReplicationController(deploymentConfig)\" state=\"overview.state\">\n" +
     "</overview-list-row>\n" +
@@ -11557,7 +11557,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "\n" +
-    "<div ng-if=\"overview.filteredServiceInstances.length\">\n" +
+    "<div ng-if=\"overview.filteredServiceInstances.length && !overview.hidePipelineOtherResources\">\n" +
     "<h2>\n" +
     "Provisioned Services\n" +
     "</h2>\n" +


### PR DESCRIPTION
We should handle provisioned services the same way as "Other Resources."
Don't show the provisioned services below the empty state message for
"View By -> Pipeline"

Fixes #1443