### PR TITLE
Improving copy-to-clipboard display

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -1300,11 +1300,6 @@ pre.clipped {
   }
 }
 
-// don't allow copy-to-clipboard .input-groups get bigger than 600px so Github webhook secrets aren't revealed within the input-group
-copy-to-clipboard .input-group.limit-width {
-  max-width: 300px;
-}
-
 .tech-preview-header {
   justify-content: space-between;
 }

--- a/app/styles/_forms.less
+++ b/app/styles/_forms.less
@@ -3,14 +3,24 @@
   margin-top: 3px;
 }
 
-.copy-to-clipboard input.form-control:read-only {
-  background-color: white;
-  color: @text-color;
+// don't allow copy-to-clipboard .input-groups get bigger than 300px so Github webhook secrets aren't revealed within the input-group
+copy-to-clipboard .input-group.limit-width {
+  max-width: 300px;
+}
+
+.copy-to-clipboard {
+  input.form-control[readonly] {
+    background-color: white;
+    color: @text-color;
+  }
+  .jenkinsfile-examples & {
+    margin-top: 3px;
+  }
 }
 
 .copy-to-clipboard-multiline {
-  position: relative;
-  width: 100%;
+  display: block;
+  overflow-x: auto;
   a {
     box-shadow: none;
     position: absolute;
@@ -19,8 +29,8 @@
   }
   pre {
     background-color: #fff;
-    max-width: 100%;
-    overflow-x: auto;
+    word-break: normal;
+    word-wrap: normal;
   }
 }
 
@@ -28,20 +38,14 @@
   padding-left: 10px;
 }
 
+.input-group-btn .btn {
+  line-height: 1.6154em; // 21px; so that .btn isn't larger than .form-input
+}
+
 .editor-examples {
   padding: 19px;
   margin-bottom: 20px;
   border: 1px solid @color-pf-black-300;
-}
-
-.jenkinsfile-examples {
-  p {
-    // Show scrollbars as needed on small screens.
-    overflow: auto;
-  }
-  .copy-to-clipboard {
-    margin-top: 3px;
-  }
 }
 
 .compute-resource {

--- a/app/styles/_secrets.less
+++ b/app/styles/_secrets.less
@@ -55,19 +55,27 @@
 }
 
 dl.secret-data {
-  overflow: hidden;
-  pre {
-    margin-bottom: 0;
-  }
   dd {
     margin-bottom: 10px;
-    overflow-x: auto;
+    @media (min-width: @screen-md-min) {
+      margin-left: @dl-horizontal-offset;
+    }
     .copy-to-clipboard {
       font-family: @font-family-monospace;
     }
   }
-  @media (min-width: @screen-md-min) {
-    .dl-horizontal();
+  dt {
+    margin-bottom: 5px;
+    @media (min-width: @screen-md-min) {
+      clear: left;
+      float: left;
+      text-align: right;
+      .text-overflow();
+      width: (@dl-horizontal-offset - 20);
+    }
+  }
+  pre {
+    margin-bottom: 0;
   }
 }
 

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3645,7 +3645,6 @@ table.dataTable th:active{outline:0}
 .wizard-pf-row{bottom:58px;position:absolute;overflow:hidden;top:172px;width:100%}
 .word-break{word-break:break-word;overflow-wrap:break-word;min-width:0}
 .word-break-all{word-break:break-all;word-break:break-word;overflow-wrap:break-word}
-.modal-resource-action h1,.resource-description,.row-cards-pf-flex .card-pf-body p{word-break:break-word;word-wrap:break-word}
 .pre-wrap{white-space:pre-wrap}
 .visible-xlg-inline-block{display:none!important}
 @media (max-width:767px){.td-long-string{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
@@ -3669,15 +3668,16 @@ table.dataTable th:active{outline:0}
 .btn-remove:focus,.btn-remove:hover{color:inherit;opacity:1;text-decoration:none}
 .static-form-value-large{font-family:inherit;font-weight:500;line-height:1.1;color:inherit;margin-bottom:10.5px;font-size:16px;margin-top:3px}
 .static-form-value-large .small,.static-form-value-large small{font-weight:400;line-height:1;color:#9c9c9c;font-size:65%}
-.copy-to-clipboard input.form-control:read-only{background-color:#fff;color:#363636}
-.copy-to-clipboard-multiline{position:relative;width:100%}
+copy-to-clipboard .input-group.limit-width{max-width:300px}
+.copy-to-clipboard input.form-control[readonly]{background-color:#fff;color:#363636}
+.jenkinsfile-examples .copy-to-clipboard{margin-top:3px}
+.copy-to-clipboard-multiline{display:block;overflow-x:auto}
 .copy-to-clipboard-multiline a{box-shadow:none;position:absolute;right:0;top:0}
 .card-pf,.tile{box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09)}
-.copy-to-clipboard-multiline pre{background-color:#fff;max-width:100%;overflow-x:auto}
+.copy-to-clipboard-multiline pre{background-color:#fff;word-break:normal;word-wrap:normal}
 .input-group-addon.wildcard-prefix{padding-left:10px}
+.input-group-btn .btn{line-height:1.6154em}
 .editor-examples{padding:19px;margin-bottom:20px;border:1px solid #d1d1d1}
-.jenkinsfile-examples p{overflow:auto}
-.jenkinsfile-examples .copy-to-clipboard{margin-top:3px}
 .compute-resource{margin-bottom:5px}
 @media (max-width:767px){.compute-resource .inline-select{margin-top:5px}
 }
@@ -3699,7 +3699,7 @@ table.dataTable th:active{outline:0}
 .row-cards-pf-flex:before{display:none}
 .row-cards-pf-flex .card-pf,.row-cards-pf-flex [class^=col]{display:flex;flex-direction:column}
 .row-cards-pf-flex .card-pf,.row-cards-pf-flex .card-pf-body{flex-grow:1}
-.row-cards-pf-flex .card-pf-body p{overflow-wrap:break-word;min-width:0}
+.row-cards-pf-flex .card-pf-body p{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .row-cards-pf-flex .card-pf-body-with-version{display:flex;flex-direction:column;justify-content:space-between}
 .row-cards-pf-flex .card-pf-footer .btn{margin-bottom:10px}
 .row-cards-pf-flex .card-pf-title{line-height:1.3;margin:0;overflow:hidden;text-overflow:ellipsis}
@@ -4016,7 +4016,7 @@ label.checkbox{font-weight:400}
 .attention-message,.tasks,div.code,pre.code{background-color:#fff}
 .template-message .resource-description{margin-bottom:0;font-size:12px}
 .resource-metadata,.tasks{margin-bottom:20px}
-.resource-description{margin-bottom:20px;white-space:pre-wrap;overflow-wrap:break-word;min-width:0}
+.resource-description{margin-bottom:20px;white-space:pre-wrap;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .tasks{font-weight:400;padding:20px;position:relative}
 .tasks.success{border:1px solid #3f9c35;border-left:3px solid #3f9c35}
 .tasks.failure{border:1px solid #c00;border-left:3px solid #c00}
@@ -4076,7 +4076,7 @@ a.disabled-link:active,a.disabled-link:focus,a.disabled-link:hover{color:#bbb;te
 }
 .header-actions{font-size:84%;margin-left:5px}
 .modal-resource-action{background-color:#f1f1f1}
-.modal-resource-action h1{font-size:21px;font-weight:500;margin-bottom:20px;overflow-wrap:break-word;min-width:0}
+.modal-resource-action h1{font-size:21px;font-weight:500;margin-bottom:20px;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .modal-resource-action p{font-size:16px}
 .modal-resource-action .help-block{margin-top:0px;margin-bottom:10px}
 .ace_editor.dockerfile-mode .ace_constant.ace_numeric,.editor.yaml-mode .ace_constant.ace_numeric{color:inherit}
@@ -4142,7 +4142,6 @@ pre.clipped.scroll{max-height:150px;overflow:auto;width:100%}
 .environment-variables.table.table-bordered>tbody>tr>td:last-child .env-var-value a{font-family:"Open Sans",Helvetica,Arial,sans-serif}
 .info-popover,.warnings-popover{cursor:help;vertical-align:middle;margin-left:2px}
 .info-popover.pficon-info,.warnings-popover.pficon-info{color:#4d5258}
-copy-to-clipboard .input-group.limit-width{max-width:300px}
 .tech-preview-header{justify-content:space-between}
 @media (max-width:479px){.col-xxs-12{width:100%}
 }
@@ -4980,8 +4979,7 @@ to{background-color:transparent}
 @media (min-width:768px){.navbar-project-menu .form-group{min-width:220px;width:220px}
 }
 @media (min-width:992px){.navbar-project-menu .form-group{min-width:400px;width:400px}
-dl.secret-data.left dt{text-align:left}
-dl.secret-data.indent{margin-left:20px}
+dl.secret-data dd{margin-left:180px}
 }
 .navbar-project-menu .form-group .form-control{background-color:transparent;margin-bottom:0;height:auto}
 @-ms-viewport{width:device-width}
@@ -5045,6 +5043,7 @@ td.visible-print,th.visible-print{display:table-cell!important}
 }
 ::-webkit-scrollbar-corner{background:0 0}
 ::-webkit-scrollbar{height:10px;overflow:visible;width:15px}
+.events-sidebar .right-content .event .event-details,.events-sidebar .right-content .event .event-details .event-message,.events-sidebar .right-content .event .event-details .event-object,.events-sidebar .right-content .event .event-details .event-reason{overflow:hidden;white-space:nowrap;text-overflow:ellipsis}
 ::-webkit-scrollbar-thumb{background-color:rgba(0,0,0,.08);background-clip:padding-box;border:solid transparent;border-width:1px;min-height:28px;max-height:60px;padding:100px 0 0;-webkit-box-shadow:inset 1px 1px 0 rgba(0,0,0,.1),inset 0 -1px 0 rgba(0,0,0,.07);box-shadow:inset 1px 1px 0 rgba(0,0,0,.1),inset 0 -1px 0 rgba(0,0,0,.07)}
 ::-webkit-scrollbar-thumb:active,::-webkit-scrollbar-thumb:hover{background-color:rgba(0,0,0,.18)}
 ::-webkit-scrollbar-track{background-clip:padding-box;background-color:rgba(0,0,0,.03)}
@@ -5061,20 +5060,18 @@ td.visible-print,th.visible-print{display:table-cell!important}
 .osc-secrets-form .advanced-secrets .help-blocks .help-block,.osc-secrets-form .advanced-secrets .help-blocks .input-label,.osc-secrets-form .advanced-secrets .input-labels .help-block,.osc-secrets-form .advanced-secrets .input-labels .input-label{width:50%}
 .osc-secrets-form .advanced-secrets .secret-row .destination-dir,.osc-secrets-form .advanced-secrets .secret-row .secret-name{width:50%;display:inline-block}
 .osc-secrets-form .advanced-secrets .secret-row .destination-dir{padding-left:5px}
-dl.secret-data{overflow:hidden}
-dl.secret-data pre{margin-bottom:0}
-.create-secret-form .help-block,dl.secret-data dd{margin-bottom:10px}
-dl.secret-data dd{overflow-x:auto}
-.events-sidebar .right-content .event .event-details,.events-sidebar .right-content .event .event-details .event-message,.events-sidebar .right-content .event .event-details .event-object,.events-sidebar .right-content .event .event-details .event-reason{overflow:hidden;white-space:nowrap;text-overflow:ellipsis}
+dl.secret-data dd{margin-bottom:10px}
 dl.secret-data dd .copy-to-clipboard{font-family:Menlo,Monaco,Consolas,monospace}
-@media (min-width:992px) and (min-width:415px){dl.secret-data dt{float:left;width:160px;clear:left;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-dl.secret-data dd{margin-left:180px}
+dl.secret-data dt{margin-bottom:5px}
+@media (min-width:992px){dl.secret-data dt{clear:left;float:left;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;width:160px}
 }
 .log-view,.sidebar-left .navbar-sidebar .sidebar-header:after{clear:both}
+dl.secret-data pre{margin-bottom:0}
 .create-secret-modal{background-color:#F5F5F5}
 .create-secret-modal .modal-footer{margin-top:0px}
 .create-secret-modal .modal-body{padding:0px 18px}
 .create-secret-editor{height:150px}
+.create-secret-form .help-block{margin-bottom:10px}
 .nav-sidenav-secondary .dropdown-header{color:#b3b3b3;font-size:12px;padding-bottom:10px;padding-left:37px;padding-top:10px}
 .sidebar-left .navbar-sidebar{border-bottom:0;border-left:0;border-top:0;margin:0;min-height:46px}
 .sidebar-left .navbar-sidebar.visible-xs-block{border:0}


### PR DESCRIPTION
Fixes #1235
Fixes #1236

Fixes issue where dl.secret-data didn’t display properly in IE

Fixes issue where .secret-data readonly inputs weren't getting the right background color and font color in Firefox, IE/Edge

Fixes issue where .btn inside .input-group-btn was 1px too tall in
Firefox, Safari, IE/Edge

<img width="384" alt="screen shot 2017-04-19 at 3 23 58 pm" src="https://cloud.githubusercontent.com/assets/895728/25198076/4ac8a232-2514-11e7-917d-f2c291f013a2.PNG">
