### PR TITLE
Correctly clear label filter from overview

### DIFF
--- a/app/scripts/controllers/newOverview.js
+++ b/app/scripts/controllers/newOverview.js
@@ -1053,7 +1053,7 @@ function OverviewController($scope,
   };
 
   overview.clearFilter = function() {
-    LabelFilter.getLabelSelector().clearConjuncts();
+    LabelFilter.clear();
     overview.filterText = '';
   };
 

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "microplugin": "0.0.3",
     "selectize": "0.12.1",
     "messenger": "1.4.1",
-    "kubernetes-label-selector": "1.4.3",
+    "kubernetes-label-selector": "1.4.4",
     "kubernetes-topology-graph": "0.0.23",
     "kubernetes-container-terminal": "1.0.3",
     "registry-image-widgets": "0.0.2",

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -348,7 +348,7 @@ return f.sortBuilds(a, !0);
 t.setGenericQuotaWarning(L.quotas, L.clusterQuotaData, c.project, L.alerts);
 };
 v.clearFilter = function() {
-n.getLabelSelector().clearConjuncts(), v.filterText = "";
+n.clear(), v.filterText = "";
 }, a.$watch(function() {
 return v.filterText;
 }, _.debounce(function(b, c) {

--- a/dist/scripts/vendor.js
+++ b/dist/scripts/vendor.js
@@ -42954,7 +42954,7 @@ var d = this, c = c || {};
 this._labelFilterRootElement = a, this._labelFilterActiveFiltersRootElement = b;
 var e = $("<div>").addClass("label-filter").appendTo(a);
 this._labelFilterKeyInput = $("<select>").addClass("label-filter-key").attr("placeholder", "Filter by label ").appendTo(e), this._labelFilterOperatorInput = $("<select>").addClass("label-filter-operator").attr("placeholder", "matching(...)").hide().appendTo(e), this._labelFilterValuesInput = $("<select>").addClass("label-filter-values").attr("placeholder", "Value(s)").attr("multiple", !0).hide().appendTo(e), this._labelFilterAddBtn = $("<button>").addClass("label-filter-add btn btn-default disabled").attr("disabled", !0).appendTo(a).append($("<span>").text(c.addButtonText || "Add Filter")), this._labelFilterActiveFiltersElement = $("<span>").addClass("label-filter-active-filters").appendTo(b), this._labelFilterActiveElement = $("<span>").addClass("label-filter-clear").hide().appendTo(this._labelFilterActiveFiltersElement).append($("<a>").addClass("label-filtering-remove-all label label-primary").prop("href", "javascript:;").append($("<i>").addClass("fa fa-filter")).append($("<span>").text("Clear filters"))).click(function() {
-$(this).hide(), d._labelFilterActiveFiltersElement.find(".label-filter-active-filter").remove(), d._clearActiveFilters();
+d.clear();
 }), this._labelFilterKeyInput.selectize({
 dropdownParent:"body",
 valueField:"key",
@@ -43061,13 +43061,13 @@ this._labelFilterActiveElement.show(), this._addActiveFilter(a, b, c);
 }, b.prototype._addActiveFilter = function(a, b, c) {
 var d = this._labelSelector.addConjunct(a, b, c);
 this._persistState(), this._onActiveFiltersChangedCallbacks.fire(this._labelSelector), this._renderActiveFilter(d);
+}, b.prototype.clear = function() {
+this._labelFilterActiveFiltersElement && this._labelFilterActiveFiltersElement.find(".label-filter-active-filter").remove(), this._labelFilterActiveElement && this._labelFilterActiveElement.hide(), this._labelSelector.clearConjuncts(), this._persistState(), this._onActiveFiltersChangedCallbacks.fire(this._labelSelector);
 }, b.prototype._renderActiveFilter = function(a) {
 $("<a>").addClass("label label-default label-filter-active-filter").prop("href", "javascript:;").prop("filter-label-id", a.id).click($.proxy(this, "_removeActiveFilter")).append($("<span>").text(a.string)).append($("<i>").addClass("fa fa-times")).appendTo(this._labelFilterActiveFiltersElement);
 }, b.prototype._removeActiveFilter = function(a) {
 var b = $(a.target).closest(".label-filter-active-filter"), c = b.prop("filter-label-id");
 b.remove(), 0 == $(".label-filter-active-filter", this._labelFilterActiveFiltersElement).length && this._labelFilterActiveElement.hide(), this._labelSelector.removeConjunct(c), this._persistState(), this._onActiveFiltersChangedCallbacks.fire(this._labelSelector);
-}, b.prototype._clearActiveFilters = function() {
-this._labelSelector.clearConjuncts(), this._persistState(), this._onActiveFiltersChangedCallbacks.fire(this._labelSelector);
 }, b.prototype.toggleFilterWidget = function(a) {
 this._labelFilterRootElement && (a ? this._labelFilterRootElement.show() :this._labelFilterRootElement.hide()), this._labelFilterActiveFiltersRootElement && (a ? this._labelFilterActiveFiltersRootElement.show() :this._labelFilterActiveFiltersRootElement.hide());
 }, new b();


### PR DESCRIPTION
Actually clear label filters from the "Clear filter" link in the everything hidden empty state message on the overview.

Fixes #1413