### PR TITLE
Apply transient class during deployment animation to hide offset ui elements

### DIFF
--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -260,9 +260,6 @@
     }
     .list-pf-container {
       display: block; // so that .word-break() will work in IE
-      @media (max-width: @screen-xs-max) {
-        overflow: hidden; // so animation offsets are hidden when sliding in vertically
-      }
     }
     .pod-donut {
       .text-center();
@@ -272,8 +269,16 @@
     border-top-color: @list-pf-border-color;
     &.active {
       border-top-color: @list-pf-item-active-border-color;
-      @media (min-width: @screen-xs-min) {
-        overflow: hidden; // so animation offsets are hidden when sliding in horizontally
+    }
+    &.deployment-in-progress {
+      // So animation offsets are hidden when sliding in horizontally
+      // Only use this style when a deployment is in progress so that chart
+      // tooltips aren't clipped.
+      overflow:hidden;
+      .list-pf-expansion {
+        @media (max-width: @screen-xs-max) {
+          overflow: hidden; // Hidden when sliding in vertically
+        }
       }
     }
     > .list-pf-container {

--- a/app/views/overview/_list-row.html
+++ b/app/views/overview/_list-row.html
@@ -1,4 +1,7 @@
-<div class="list-pf-item" ng-class="{ active: row.expanded }">
+<div class="list-pf-item" ng-class="{
+  'active': row.expanded,
+  'deployment-in-progress': row.previous
+}">
   <div class="list-pf-container" ng-click="row.toggleExpand($event)">
     <div class="list-pf-chevron">
       <div ng-include src=" 'views/overview/_list-row-chevron.html' " class="list-pf-content"></div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -12422,7 +12422,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/overview/_list-row.html',
-    "<div class=\"list-pf-item\" ng-class=\"{ active: row.expanded }\">\n" +
+    "<div class=\"list-pf-item\" ng-class=\"{\n" +
+    "  'active': row.expanded,\n" +
+    "  'deployment-in-progress': row.previous\n" +
+    "}\">\n" +
     "<div class=\"list-pf-container\" ng-click=\"row.toggleExpand($event)\">\n" +
     "<div class=\"list-pf-chevron\">\n" +
     "<div ng-include src=\" 'views/overview/_list-row-chevron.html' \" class=\"list-pf-content\"></div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4554,17 +4554,15 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview-new .list-pf-expansion.in .list-pf-content{max-width:100%}
 .overview-new .list-pf-expansion.in .list-pf-content alerts{position:relative;z-index:2;display:block}
 .overview-new .list-pf-expansion.in .list-pf-container{display:block}
-@media (max-width:767px){.overview-new .list-pf-expansion.in .list-pf-container{overflow:hidden}
-}
 .overview-new .list-pf-expansion.in .pod-donut{text-align:center}
 .overview-new .list-pf-item{border-top-color:#dcdcdc}
 .overview-new .list-pf-item.active{border-top-color:#bbb}
-@media (min-width:480px){.overview-new .list-pf-item.active{overflow:hidden}
+.overview-new .list-pf-item.deployment-in-progress{overflow:hidden}
+@media (max-width:767px){.overview-new .list-pf-item.deployment-in-progress .list-pf-expansion{overflow:hidden}
+.overview-new .list-pf-item>.list-pf-container>.list-pf-content{align-items:stretch;flex-direction:column;width:100%;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 }
 .overview-new .list-pf-name h3 a,.overview-new .overview-route{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .overview-new .list-pf-item>.list-pf-container{cursor:pointer}
-@media (max-width:767px){.overview-new .list-pf-item>.list-pf-container>.list-pf-content{align-items:stretch;flex-direction:column;width:100%;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
-}
 .overview-new .list-pf-item>.list-pf-container .toggle-expand-link{color:inherit}
 .overview-new .list-pf-name{display:flex;flex-direction:column}
 @media (max-width:991px){.overview-new .list-pf-name{width:auto!important}


### PR DESCRIPTION
Sets `display:hidden` on `.list-pf-item` by default and on `.list-pf-expansion` when animation enters vertically.

Fixes https://github.com/openshift/origin-web-console/issues/1454

<img width="309" alt="screen shot 2017-04-24 at 10 11 34 am" src="https://cloud.githubusercontent.com/assets/1874151/25341597/53fb2fde-28d7-11e7-9f29-324144aead2a.png">

tooltip above alert
<img width="255" alt="screen shot 2017-04-24 at 10 11 10 am" src="https://cloud.githubusercontent.com/assets/1874151/25341596/53fa6b58-28d7-11e7-8fc0-49bdbf8b2425.png">

