### PR TITLE
Restoring popup container default to body to fix popover clipping bug

### DIFF
--- a/app/scripts/directives/popups.js
+++ b/app/scripts/directives/popups.js
@@ -24,7 +24,7 @@ angular.module('openshiftConsole')
       },
       link: function($scope, element, attrs) {
         var popupConfig = {
-          container: attrs.container || ".middle",
+          container: attrs.container || "body",
           placement: attrs.placement || "auto"
         };
         if (attrs) {

--- a/app/views/directives/_copy-to-clipboard.html
+++ b/app/views/directives/_copy-to-clipboard.html
@@ -17,6 +17,7 @@
         ng-disabled="isDisabled"
         data-toggle="tooltip"
         data-placement="left"
+        data-container=".middle"
         title="Copy to clipboard"
         role="button"
         class="btn btn-default"><i class="fa fa-clipboard"/></a>
@@ -26,6 +27,7 @@
         ng-disabled="isDisabled"
         data-toggle="tooltip"
         data-placement="left"
+        data-container=".middle"
         title="Copy to clipboard"
         role="button"
         class="btn btn-default"><i class="fa fa-clipboard"/></a>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -11229,7 +11229,7 @@ dynamicContent:"@?"
 },
 link:function(a, b, c) {
 var d = {
-container:c.container || ".middle",
+container:c.container || "body",
 placement:c.placement || "auto"
 };
 if (c) switch (c.toggle) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5666,8 +5666,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<input ng-if=\"!multiline\" id=\"{{id}}\" type=\"text\" class=\"form-control\" value=\"{{inputText || clipboardText}}\" ng-disabled=\"isDisabled\" ng-readonly=\"!isDisabled\" select-on-focus>\n" +
     "<pre ng-if=\"multiline\" id=\"{{id}}\">{{inputText || clipboardText}}</pre>\n" +
     "<span ng-class=\"{ 'input-group-btn': !multiline }\" ng-hide=\"hidden\">\n" +
-    "<a ng-show=\"!inputText\" data-clipboard-target=\"#{{id}}\" href=\"\" ng-disabled=\"isDisabled\" data-toggle=\"tooltip\" data-placement=\"left\" title=\"Copy to clipboard\" role=\"button\" class=\"btn btn-default\"><i class=\"fa fa-clipboard\"/></a>\n" +
-    "<a ng-show=\"inputText\" data-clipboard-text=\"{{clipboardText}}\" href=\"\" ng-disabled=\"isDisabled\" data-toggle=\"tooltip\" data-placement=\"left\" title=\"Copy to clipboard\" role=\"button\" class=\"btn btn-default\"><i class=\"fa fa-clipboard\"/></a>\n" +
+    "<a ng-show=\"!inputText\" data-clipboard-target=\"#{{id}}\" href=\"\" ng-disabled=\"isDisabled\" data-toggle=\"tooltip\" data-placement=\"left\" data-container=\".middle\" title=\"Copy to clipboard\" role=\"button\" class=\"btn btn-default\"><i class=\"fa fa-clipboard\"/></a>\n" +
+    "<a ng-show=\"inputText\" data-clipboard-text=\"{{clipboardText}}\" href=\"\" ng-disabled=\"isDisabled\" data-toggle=\"tooltip\" data-placement=\"left\" data-container=\".middle\" title=\"Copy to clipboard\" role=\"button\" class=\"btn btn-default\"><i class=\"fa fa-clipboard\"/></a>\n" +
     "</span>\n" +
     "</div>"
   );


### PR DESCRIPTION
Fixes #1463

![screen shot 2017-04-24 at 11 44 49 am](https://cloud.githubusercontent.com/assets/895728/25345578/750d8f30-28e3-11e7-8535-14e34987c4cf.PNG)

In restoring the popup container default to body, [popovers and tooltips once again scroll away
from their content](https://github.com/openshift/origin-web-console/pull/1456), but this is a less egregious bug than clipping of
popovers or tooltips; however, we can add a data-containter=“.middle”
to any popover or tooltip instances we don’t want to scroll away from
their content.  I’ve done so for copy-to-clipboard but not any other
existing instances.