### PR TITLE
Make appearance of provisioned services consistent with that of deployments

### DIFF
--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -322,11 +322,6 @@
       }
     }
   }
-  .list-row-longname {
-    .text-muted();
-    font-size: @component-label;
-    margin-top: 3px;
-  }
   .list-row-tabset {
     margin-top: 20px;
     @media (min-width: @screen-sm-min) {

--- a/app/views/overview/_service-instance-row.html
+++ b/app/views/overview/_service-instance-row.html
@@ -6,8 +6,8 @@
     <div class="list-pf-content">
       <div class="list-pf-name">
         <h3>
-          <span ng-bind-html="row.displayName | highlightKeywords : row.state.filterKeywords"></span>
-          <div ng-bind-html="row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords" class="list-row-longname"></div>
+          <div ng-bind-html="row.displayName | highlightKeywords : row.state.filterKeywords" class="component-label"></div>
+          <span ng-bind-html="row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords"></span>
         </h3>
         <div class="status-icons">
           <notification-icon ng-if="!row.expanded" alerts="row.notifications"></notification-icon>

--- a/app/views/overview/_service-instance-row.html
+++ b/app/views/overview/_service-instance-row.html
@@ -7,7 +7,10 @@
       <div class="list-pf-name">
         <h3>
           <div ng-bind-html="row.displayName | highlightKeywords : row.state.filterKeywords" class="component-label"></div>
-          <span ng-bind-html="row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords"></span>
+          <span ng-if="!row.apiObject.status.dashboardURL" ng-bind-html="row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords"></span>
+          <span ng-if="row.apiObject.status.dashboardURL">
+            <a ng-href="{{row.apiObject.status.dashboardURL}}" target="_blank">
+              <span ng-bind-html="row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords"></span></a></span>
         </h3>
         <div class="status-icons">
           <notification-icon ng-if="!row.expanded" alerts="row.notifications"></notification-icon>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -12721,7 +12721,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"list-pf-name\">\n" +
     "<h3>\n" +
     "<div ng-bind-html=\"row.displayName | highlightKeywords : row.state.filterKeywords\" class=\"component-label\"></div>\n" +
-    "<span ng-bind-html=\"row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords\"></span>\n" +
+    "<span ng-if=\"!row.apiObject.status.dashboardURL\" ng-bind-html=\"row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords\"></span>\n" +
+    "<span ng-if=\"row.apiObject.status.dashboardURL\">\n" +
+    "<a ng-href=\"{{row.apiObject.status.dashboardURL}}\" target=\"_blank\">\n" +
+    "<span ng-bind-html=\"row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords\"></span></a></span>\n" +
     "</h3>\n" +
     "<div class=\"status-icons\">\n" +
     "<notification-icon ng-if=\"!row.expanded\" alerts=\"row.notifications\"></notification-icon>\n" +

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -12720,8 +12720,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"list-pf-content\">\n" +
     "<div class=\"list-pf-name\">\n" +
     "<h3>\n" +
-    "<span ng-bind-html=\"row.displayName | highlightKeywords : row.state.filterKeywords\"></span>\n" +
-    "<div ng-bind-html=\"row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords\" class=\"list-row-longname\"></div>\n" +
+    "<div ng-bind-html=\"row.displayName | highlightKeywords : row.state.filterKeywords\" class=\"component-label\"></div>\n" +
+    "<span ng-bind-html=\"row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords\"></span>\n" +
     "</h3>\n" +
     "<div class=\"status-icons\">\n" +
     "<notification-icon ng-if=\"!row.expanded\" alerts=\"row.notifications\"></notification-icon>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4571,7 +4571,6 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 @media (min-width:992px){.overview-new .list-pf-name{align-items:center;flex-direction:row}
 .overview-new .list-pf-name h3{width:60%}
 }
-.overview-new .list-row-longname{color:#9c9c9c;font-size:11px;margin-top:3px}
 .overview-new .list-row-tabset{margin-top:20px}
 @media (min-width:768px){.overview-new .list-pf-item>.list-pf-container>.list-pf-content{min-height:45px;padding-right:15px}
 .overview-new .list-row-tabset{margin-top:0}


### PR DESCRIPTION
Previously, the service type was emphasized, whereas the name of the service instance was shown in a small font. I believe this should be reversed (e.g. should be just like deployments are displayed - "DEPLOYMENT" in small font, name of deployment slightly larger and emphasized).

The new look:

![screenshot](https://ibin.co/3KO7cTYLHyF8.png)

And the old look:

![screenshot](https://ibin.co/3KO9EhJgJIiB.png)
