### PR TITLE
Fix timing issue showing service class display name on overview

### DIFF
--- a/app/scripts/directives/overview/serviceInstanceRow.js
+++ b/app/scripts/directives/overview/serviceInstanceRow.js
@@ -35,7 +35,7 @@ function ServiceInstanceRow($filter, DataService, rowMethods, $uibModal) {
     return _.get(row, ['state','serviceClasses', serviceClassName, 'description']);
   };
 
-  row.$onChanges = function() {
+  row.$doCheck = function() {
     row.notifications = rowMethods.getNotifications(row.apiObject, row.state);
     row.displayName = getDisplayName();
     row.description = getDescription();

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1147,7 +1147,7 @@ return c || a || b;
 var a = e.apiObject.spec.serviceClassName;
 return _.get(e, [ "state", "serviceClasses", a, "description" ]);
 };
-e.$onChanges = function() {
+e.$doCheck = function() {
 e.notifications = c.getNotifications(e.apiObject, e.state), e.displayName = g(), e.description = h();
 }, e.getSecretForBinding = function(a) {
 return a && _.get(e, [ "state", "secrets", a.spec.secretName ]);


### PR DESCRIPTION
Previously if the service instances loaded before the service classes,
the display name was not correctly displayed in the instance row on the
overview.