### PR TITLE
[WIP] disambiguate kinds on other resources by showing group

### DIFF
--- a/app/scripts/controllers/otherResources.js
+++ b/app/scripts/controllers/otherResources.js
@@ -57,6 +57,14 @@ angular.module('openshiftConsole')
       }).toString();
     };
 
+    var counts;
+    $scope.isDuplicateKind = function(kind) {
+      if(!counts) {
+        counts = _.countBy($scope.kinds, 'kind');
+      }
+      return counts[kind] > 1;
+    };
+
     // get and clear any alerts
     AlertMessageService.getAlerts().forEach(function(alert) {
       $scope.alerts[alert.name] = alert.data;

--- a/app/views/other-resources.html
+++ b/app/views/other-resources.html
@@ -14,6 +14,7 @@
               <ui-select-match placeholder="Choose a resource to list...">{{$select.selected.kind | humanizeKind : true}}</ui-select-match>
               <ui-select-choices repeat="kind in kinds | filter : {kind: $select.search} : matchKind | orderBy : 'kind'">
                 <div ng-bind-html="(kind.kind | humanizeKind : true) | highlight: $select.search"></div>
+                <small ng-if="isDuplicateKind(kind.kind)" ng-bind-html="kind.group | highlight: $select.search" class="text-muted"></small>
               </ui-select-choices>
             </ui-select>
             <div class="vertical-divider"></div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7482,10 +7482,14 @@ projectName:a.project,
 kind:b,
 group:_.get(c, "kindSelector.selected.group", "")
 }).toString() :"";
+};
+var n;
+c.isDuplicateKind = function(a) {
+return n || (n = _.countBy(c.kinds, "kind")), n[a] > 1;
 }, d.getAlerts().forEach(function(a) {
 c.alerts[a.name] = a.data;
 }), d.clearAlerts();
-var n = function(a, b) {
+var o = function(a, b) {
 return _.some(c.kinds, function(c) {
 return c.kind === a && (!c.group && !b || c.group === b);
 });
@@ -7497,13 +7501,13 @@ resource:k.kindToResource(a.kind),
 group:a.group || ""
 };
 return !!e.checkResource(b.resource) && e.canI(b, "list", c.projectName);
-}), c.project = b, c.context = d, c.kindSelector.disabled = !1, a.kind && n(a.kind, a.group) && (_.set(c, "kindSelector.selected.kind", a.kind), _.set(c, "kindSelector.selected.group", a.group || ""));
+}), c.project = b, c.context = d, c.kindSelector.disabled = !1, a.kind && o(a.kind, a.group) && (_.set(c, "kindSelector.selected.kind", a.kind), _.set(c, "kindSelector.selected.group", a.group || ""));
 })), c.loadKind = m, c.$watch("kindSelector.selected", function() {
 c.alerts = {}, m();
 });
-var o = h("humanizeKind");
+var p = h("humanizeKind");
 c.matchKind = function(a, b) {
-return o(a).toLowerCase().indexOf(b.toLowerCase()) !== -1;
+return p(a).toLowerCase().indexOf(b.toLowerCase()) !== -1;
 }, i.onActiveFiltersChanged(function(a) {
 c.$apply(function() {
 c.resources = a.select(c.unfilteredResources), l();

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -11667,6 +11667,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<ui-select-match placeholder=\"Choose a resource to list...\">{{$select.selected.kind | humanizeKind : true}}</ui-select-match>\n" +
     "<ui-select-choices repeat=\"kind in kinds | filter : {kind: $select.search} : matchKind | orderBy : 'kind'\">\n" +
     "<div ng-bind-html=\"(kind.kind | humanizeKind : true) | highlight: $select.search\"></div>\n" +
+    "<small ng-if=\"isDuplicateKind(kind.kind)\" ng-bind-html=\"kind.group | highlight: $select.search\" class=\"text-muted\"></small>\n" +
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
     "<div class=\"vertical-divider\"></div>\n" +


### PR DESCRIPTION
Getting started on this.  Most of the work is in [this PR](https://github.com/openshift/origin-web-common/pull/51) in `web-common`.

- [ ] bump version in origin-web-common when APIService dedupe is merged
- [x] show groups for resources in the drop down to make it possible to interact with different resources that happen to have the same name.

I'm not sure if simply listing the group under the kind is extremely clear, but its what we typically do:

![screen shot 2017-04-26 at 2 23 10 pm](https://cloud.githubusercontent.com/assets/280512/25450124/ebd36762-2a8b-11e7-81f4-fe049cb480ce.png)