### PR TITLE
Switch to v1 HPA

### DIFF
--- a/app/scripts/controllers/deployment.js
+++ b/app/scripts/controllers/deployment.js
@@ -256,8 +256,9 @@ angular.module('openshiftConsole')
         }));
 
         watches.push(DataService.watch({
-          group: "extensions",
-          resource: "horizontalpodautoscalers"
+          group: "autoscaling",
+          resource: "horizontalpodautoscalers",
+          version: "v1"
         }, context, function(hpa) {
           $scope.autoscalers =
             HPAService.filterHPA(hpa.by("metadata.name"), 'Deployment', $routeParams.deployment);

--- a/app/scripts/controllers/deploymentConfig.js
+++ b/app/scripts/controllers/deploymentConfig.js
@@ -301,8 +301,9 @@ angular.module('openshiftConsole')
         }));
 
         watches.push(DataService.watch({
-          group: "extensions",
-          resource: "horizontalpodautoscalers"
+          group: "autoscaling",
+          resource: "horizontalpodautoscalers",
+          version: "v1"
         }, context, function(hpa) {
           $scope.autoscalers =
             HPAService.filterHPA(hpa.by("metadata.name"), 'DeploymentConfig', $routeParams.deploymentconfig);

--- a/app/scripts/controllers/newOverview.js
+++ b/app/scripts/controllers/newOverview.js
@@ -1246,8 +1246,9 @@ function OverviewController($scope,
     }, {poll: limitWatches, pollInterval: DEFAULT_POLL_INTERVAL}));
 
     watches.push(DataService.watch({
-      group: "extensions",
-      resource: "horizontalpodautoscalers"
+      group: "autoscaling",
+      resource: "horizontalpodautoscalers",
+      version: "v1"
     }, context, function(hpaData) {
       overview.horizontalPodAutoscalers = hpaData.by("metadata.name");
       groupHPAs();

--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -238,13 +238,13 @@ angular.module('openshiftConsole')
     var groupHPAs = function() {
       hpaByResource = {};
       _.each(horizontalPodAutoscalers, function(hpa) {
-        var name = hpa.spec.scaleRef.name, kind = hpa.spec.scaleRef.kind;
+        var name = hpa.spec.scaleTargetRef.name, kind = hpa.spec.scaleTargetRef.kind;
         if (!name || !kind) {
           return;
         }
 
-        // TODO: Handle groups and subresources in hpa.spec.scaleRef
-        // var groupVersion = APIService.parseGroupVersion(hpa.spec.scaleRef.apiVersion) || {};
+        // TODO: Handle groups and subresources in hpa.spec.scaleTargetRef
+        // var groupVersion = APIService.parseGroupVersion(hpa.spec.scaleTargetRef.apiVersion) || {};
         // var group = groupVersion.group || '';
         // if (!_.has(hpaByResource, [group, kind, name])) {
         //   _.set(hpaByResource, [group, kind, name], []);
@@ -703,8 +703,9 @@ angular.module('openshiftConsole')
         }));
 
         watches.push(DataService.watch({
-          group: "extensions",
-          resource: "horizontalpodautoscalers"
+          group: "autoscaling",
+          resource: "horizontalpodautoscalers",
+          version: "v1"
         }, context, function(hpaData) {
           horizontalPodAutoscalers = hpaData.by("metadata.name");
           groupHPAs();

--- a/app/scripts/controllers/replicaSet.js
+++ b/app/scripts/controllers/replicaSet.js
@@ -532,8 +532,9 @@ angular.module('openshiftConsole')
         }));
 
         watches.push(DataService.watch({
-          group: "extensions",
-          resource: "horizontalpodautoscalers"
+          group: "autoscaling",
+          resource: "horizontalpodautoscalers",
+          version: "v1"
         }, context, function(data) {
           allHPA = data.by("metadata.name");
           updateHPA();

--- a/app/scripts/controllers/topology.js
+++ b/app/scripts/controllers/topology.js
@@ -224,13 +224,14 @@ angular.module('openshiftConsole')
         };
 
         watches.push(DataService.watch({
-          group: "extensions",
-          resource: "horizontalpodautoscalers"
+          group: "autoscaling",
+          resource: "horizontalpodautoscalers",
+          version: "v1"
         }, context, function(horizontalPodAutoscalers) {
           hpaByDC = {};
           hpaByRC = {};
           angular.forEach(horizontalPodAutoscalers.by("metadata.name"), function(hpa) {
-            var name = hpa.spec.scaleRef.name, kind = hpa.spec.scaleRef.kind;
+            var name = hpa.spec.scaleTargetRef.name, kind = hpa.spec.scaleTargetRef.kind;
             if (!name || !kind) {
               return;
             }
@@ -245,7 +246,7 @@ angular.module('openshiftConsole')
               hpaByRC[name].push(hpa);
               break;
             default:
-              Logger.warn("Unexpected HPA scaleRef kind", kind);
+              Logger.warn("Unexpected HPA scaleTargetRef kind", kind);
             }
           });
         }));

--- a/app/scripts/directives/deleteLink.js
+++ b/app/scripts/directives/deleteLink.js
@@ -68,7 +68,7 @@ angular.module("openshiftConsole")
         var deleteHPA = function(hpa) {
           return DataService.delete({
             resource: 'horizontalpodautoscalers',
-            group: 'extensions'
+            group: 'autoscaling'
           }, hpa.metadata.name, { namespace: scope.projectName })
           .then(function() {
             showAlert({

--- a/app/scripts/filters/canI.js
+++ b/app/scripts/filters/canI.js
@@ -16,15 +16,15 @@ angular
         {group: '', resource: 'configmaps', verbs: ['update', 'delete']}
       ],
       'deployments': [
-        {group: 'extensions', resource: 'horizontalpodautoscalers', verbs: ['create', 'update']},
-        {group: 'extensions', resource: 'deployments',              verbs: ['create', 'update']}
+        {group: 'autoscaling', resource: 'horizontalpodautoscalers', verbs: ['create', 'update']},
+        {group: 'extensions',  resource: 'deployments',              verbs: ['create', 'update']}
       ],
       'deploymentConfigs': [
-        {group: 'extensions', resource: 'horizontalpodautoscalers', verbs: ['create', 'update']},
-        {group: '',            resource: 'deploymentconfigs',       verbs: ['create', 'update']}
+        {group: 'autoscaling', resource: 'horizontalpodautoscalers', verbs: ['create', 'update']},
+        {group: '',            resource: 'deploymentconfigs',        verbs: ['create', 'update']}
       ],
       'horizontalPodAutoscalers': [
-        {group: 'extensions', resource: 'horizontalpodautoscalers', verbs: ['update', 'delete']}
+        {group: 'autoscaling', resource: 'horizontalpodautoscalers', verbs: ['update', 'delete']}
       ],
       'imageStreams': [
         {group: '', resource: 'imagestreams', verbs: ['update', 'delete']}
@@ -37,8 +37,8 @@ angular
         {group: '', resource: 'deploymentconfigs', verbs: ['update']}
       ],
       'replicaSets': [
-        {group: 'extensions', resource: 'horizontalpodautoscalers', verbs: ['create', 'update']},
-        {group: 'extensions', resource: 'replicasets',              verbs: ['update', 'delete']}
+        {group: 'autoscaling', resource: 'horizontalpodautoscalers', verbs: ['create', 'update']},
+        {group: 'extensions',  resource: 'replicasets',              verbs: ['update', 'delete']}
       ],
       'replicationControllers': [
         {group: '',           resource: 'replicationcontrollers',   verbs: ['update', 'delete']}

--- a/app/scripts/services/applicationGenerator.js
+++ b/app/scripts/services/applicationGenerator.js
@@ -259,7 +259,7 @@ angular.module("openshiftConsole")
 
     scope._generateHPA = function(input, dc) {
       var hpa = {
-        apiVersion: "extensions/v1beta1",
+        apiVersion: "autoscaling/v1",
         kind: "HorizontalPodAutoscaler",
         metadata: {
           name: input.name,
@@ -267,7 +267,7 @@ angular.module("openshiftConsole")
           annotations: input.annotations
         },
         spec: {
-          scaleRef: {
+          scaleTargetRef: {
             kind: "DeploymentConfig",
             name: dc.metadata.name,
             apiVersion: "extensions/v1beta1",
@@ -275,9 +275,7 @@ angular.module("openshiftConsole")
           },
           minReplicas: input.scaling.minReplicas,
           maxReplicas: input.scaling.maxReplicas,
-          cpuUtilization: {
-            targetPercentage: input.scaling.targetCPU || input.scaling.defaultTargetCPU
-          }
+          targetCPUUtilizationPercentage: input.scaling.targetCPU || input.scaling.defaultTargetCPU || null
         }
       };
 

--- a/app/scripts/services/hpa.js
+++ b/app/scripts/services/hpa.js
@@ -110,7 +110,7 @@ angular.module("openshiftConsole")
     // Filters the HPAs for those referencing kind/name.
     var filterHPA = function(hpaResources, kind, name) {
       return _.filter(hpaResources, function(hpa) {
-        return hpa.spec.scaleRef.kind === kind && hpa.spec.scaleRef.name === name;
+        return hpa.spec.scaleTargetRef.kind === kind && hpa.spec.scaleTargetRef.name === name;
       });
     };
 
@@ -175,7 +175,7 @@ angular.module("openshiftConsole")
         // not its parent DC.
         var targetsRC = function() {
           return _.some(hpaResources, function(hpa) {
-            return _.get(hpa, 'spec.scaleRef.kind') === 'ReplicationController';
+            return _.get(hpa, 'spec.scaleTargetRef.kind') === 'ReplicationController';
           });
         };
 
@@ -201,13 +201,13 @@ angular.module("openshiftConsole")
     var groupHPAs = function(horizontalPodAutoscalers) {
       var hpaByResource = {};
       _.each(horizontalPodAutoscalers, function(hpa) {
-        var name = hpa.spec.scaleRef.name, kind = hpa.spec.scaleRef.kind;
+        var name = hpa.spec.scaleTargetRef.name, kind = hpa.spec.scaleTargetRef.kind;
         if (!name || !kind) {
           return;
         }
 
-        // TODO: Handle groups and subresources in hpa.spec.scaleRef
-        // var groupVersion = APIService.parseGroupVersion(hpa.spec.scaleRef.apiVersion) || {};
+        // TODO: Handle groups and subresources in hpa.spec.scaleTargetRef
+        // var groupVersion = APIService.parseGroupVersion(hpa.spec.scaleTargetRef.apiVersion) || {};
         // var group = groupVersion.group || '';
         // if (!_.has(hpaByResource, [group, kind, name])) {
         //   _.set(hpaByResource, [group, kind, name], []);

--- a/app/views/browse/_replica-set-actions.html
+++ b/app/views/browse/_replica-set-actions.html
@@ -15,7 +15,7 @@
       <a ng-href="project/{{project.metadata.name}}/attach-pvc?kind=ReplicaSet&name={{replicaSet.metadata.name}}&group=extensions"
          role="button">Add Storage</a>
     </li>
-    <li ng-if="!autoscalers.length && ({ group: 'extensions', resource: 'horizontalpodautoscalers' } | canI : 'create')">
+    <li ng-if="!autoscalers.length && ({ group: 'autoscaling', resource: 'horizontalpodautoscalers' } | canI : 'create')">
       <a ng-href="project/{{projectName}}/edit/autoscaler?kind=ReplicaSet&name={{replicaSet.metadata.name}}&group=extensions"
          ng-if="!deployment"
          role="button">Add Autoscaler</a>

--- a/app/views/browse/_replica-set-details.html
+++ b/app/views/browse/_replica-set-details.html
@@ -180,7 +180,7 @@
 
   <!-- Create autoscaler -->
   <div ng-if="!autoscalers.length">
-    <span ng-if="{resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create'">
+    <span ng-if="{resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create'">
       <a ng-if="replicaSet.kind === 'ReplicaSet' && !deployment"
          ng-href="project/{{projectName}}/edit/autoscaler?kind=ReplicaSet&name={{replicaSet.metadata.name}}&group=extensions"
          role="button">Add Autoscaler</a>
@@ -194,7 +194,7 @@
          ng-href="project/{{projectName}}/edit/autoscaler?kind=DeploymentConfig&name={{deploymentConfigName}}"
          role="button">Add Autoscaler</a>
     </span>
-    <span ng-if="!({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create')">
+    <span ng-if="!({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create')">
       Autoscaling is not enabled. There are no autoscalers for this
       <span ng-if="deploymentConfigName">deployment config or deployment.</span>
       <span ng-if="!deploymentConfigName">{{replicaSet.kind | humanizeKind}}.</span>
@@ -204,7 +204,7 @@
   <!-- HPA details -->
   <div ng-repeat="hpa in autoscalers | orderBy : 'name'">
     <hpa hpa="hpa"
-         show-scale-target="hpa.spec.scaleRef.kind !== 'ReplicationController'"
+         show-scale-target="hpa.spec.scaleTargetRef.kind !== 'ReplicationController'"
          alerts="alerts">
     </hpa>
   </div>

--- a/app/views/browse/_replication-controller-actions.html
+++ b/app/views/browse/_replication-controller-actions.html
@@ -1,4 +1,4 @@
-<div ng-if="(('replicationControllers' | canIDoAny) || (!deploymentConfigName && !autoscalers.length && ({ group: 'extensions', resource: 'horizontalpodautoscalers' } | canI : 'create')))" class="pull-right dropdown">
+<div ng-if="(('replicationControllers' | canIDoAny) || (!deploymentConfigName && !autoscalers.length && ({ group: 'autoscaling', resource: 'horizontalpodautoscalers' } | canI : 'create')))" class="pull-right dropdown">
   <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
     Actions
     <span class="caret"></span>
@@ -15,7 +15,7 @@
       <a ng-href="project/{{project.metadata.name}}/attach-pvc?kind=ReplicationController&name={{replicaSet.metadata.name}}"
          role="button">Add Storage</a>
     </li>
-    <li ng-if="!autoscalers.length && ({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create')">
+    <li ng-if="!autoscalers.length && ({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create')">
       <!-- Create a new HPA. -->
       <a ng-href="project/{{projectName}}/edit/autoscaler?kind=ReplicationController&name={{replicaSet.metadata.name}}"
          ng-if="!deploymentConfigName"

--- a/app/views/browse/deployment-config.html
+++ b/app/views/browse/deployment-config.html
@@ -50,14 +50,14 @@
                       <a ng-href="project/{{project.metadata.name}}/attach-pvc?kind=DeploymentConfig&name={{deploymentConfig.metadata.name}}"
                          role="button">Add Storage</a>
                     </li>
-                    <li ng-if="!autoscalers.length && ({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create')">
+                    <li ng-if="!autoscalers.length && ({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create')">
                       <!-- Create a new HPA. -->
                       <a ng-href="project/{{projectName}}/edit/autoscaler?kind=DeploymentConfig&name={{deploymentConfig.metadata.name}}"
                          role="button">Add Autoscaler</a>
                     </li>
-                    <li ng-if="autoscalers.length === 1 && ({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'update')">
+                    <li ng-if="autoscalers.length === 1 && ({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'update')">
                       <!-- Edit an existing HPA. -->
-                      <a ng-href="project/{{projectName}}/edit/autoscaler?kind=HorizontalPodAutoscaler&group=extensions&name={{autoscalers[0].metadata.name}}"
+                      <a ng-href="project/{{projectName}}/edit/autoscaler?kind=HorizontalPodAutoscaler&group=autoscaling&name={{autoscalers[0].metadata.name}}"
                         role="button">Edit Autoscaler</a>
                     </li>
                     <li ng-if="'deploymentconfigs' | canI : 'update'">
@@ -269,9 +269,9 @@
 
                           <!-- Create autoscaler -->
                           <div ng-if="!autoscalers.length">
-                            <a ng-if="{resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create'" ng-href="project/{{projectName}}/edit/autoscaler?kind=DeploymentConfig&name={{deploymentConfig.metadata.name}}"
+                            <a ng-if="{resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create'" ng-href="project/{{projectName}}/edit/autoscaler?kind=DeploymentConfig&name={{deploymentConfig.metadata.name}}"
                                role="button">Add Autoscaler</a>
-                            <span ng-if="!({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create')">Autoscaling is not enabled. There are no autoscalers for this deployment config.</span>
+                            <span ng-if="!({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create')">Autoscaling is not enabled. There are no autoscalers for this deployment config.</span>
                           </div>
 
                           <!-- HPA details -->

--- a/app/views/browse/deployment.html
+++ b/app/views/browse/deployment.html
@@ -30,14 +30,14 @@
                     <a ng-href="project/{{project.metadata.name}}/attach-pvc?kind=Deployment&name={{deployment.metadata.name}}&group=extensions"
                        role="button">Add Storage</a>
                   </li>
-                  <li ng-if="!autoscalers.length && ({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create')">
+                  <li ng-if="!autoscalers.length && ({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create')">
                     <!-- Create a new HPA. -->
                     <a ng-href="project/{{projectName}}/edit/autoscaler?kind=Deployment&name={{deployment.metadata.name}}&group=extensions"
                        role="button">Add Autoscaler</a>
                   </li>
-                  <li ng-if="autoscalers.length === 1 && ({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'update')">
+                  <li ng-if="autoscalers.length === 1 && ({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'update')">
                     <!-- Edit an existing HPA. -->
-                    <a ng-href="project/{{projectName}}/edit/autoscaler?kind=HorizontalPodAutoscaler&group=extensions&name={{autoscalers[0].metadata.name}}"
+                    <a ng-href="project/{{projectName}}/edit/autoscaler?kind=HorizontalPodAutoscaler&group=autoscaling&name={{autoscalers[0].metadata.name}}"
                       role="button">Edit Autoscaler</a>
                   </li>
                   <li ng-if="{ group: 'extensions', resource: 'deployments' } | canI : 'update'">
@@ -233,9 +233,9 @@
 
                         <!-- Create autoscaler -->
                         <div ng-if="!autoscalers.length">
-                          <a ng-if="{resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create'" ng-href="project/{{projectName}}/edit/autoscaler?kind=Deployment&name={{deployment.metadata.name}}&group=extensions"
+                          <a ng-if="{resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create'" ng-href="project/{{projectName}}/edit/autoscaler?kind=Deployment&name={{deployment.metadata.name}}&group=extensions"
                              role="button">Add Autoscaler</a>
-                          <span ng-if="!({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create')">none</span>
+                          <span ng-if="!({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create')">none</span>
                         </div>
 
                         <!-- HPA details -->

--- a/app/views/directives/hpa.html
+++ b/app/views/directives/hpa.html
@@ -2,13 +2,13 @@
   {{hpa.metadata.name}}
   <!-- HPA actions -->
   <span ng-if="'horizontalPodAutoscalers' | canIDoAny" class="header-actions">
-    <a ng-if="{resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'update'" ng-href="project/{{hpa.metadata.namespace}}/edit/autoscaler?kind=HorizontalPodAutoscaler&group=extensions&name={{hpa.metadata.name}}"
+    <a ng-if="{resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'update'" ng-href="project/{{hpa.metadata.namespace}}/edit/autoscaler?kind=HorizontalPodAutoscaler&group=autoscaling&name={{hpa.metadata.name}}"
        role="button">Edit</a>
     <span class="action-divider">|</span>
     <delete-link
-        ng-if="{resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'delete'"
+        ng-if="{resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'delete'"
         kind="HorizontalPodAutoscaler"
-        group="extensions"
+        group="autoscaling"
         resource-name="{{hpa.metadata.name}}"
         project-name="{{hpa.metadata.namespace}}"
         label="Remove"
@@ -18,21 +18,21 @@
   </span>
 </h4>
 <dl class="dl-horizontal left" style="margin-bottom: 10px;">
-  <dt ng-if-start="showScaleTarget && hpa.spec.scaleRef.kind && hpa.spec.scaleRef.name">{{hpa.spec.scaleRef.kind | humanizeKind : true}}:</dt>
+  <dt ng-if-start="showScaleTarget && hpa.spec.scaleTargetRef.kind && hpa.spec.scaleTargetRef.name">{{hpa.spec.scaleTargetRef.kind | humanizeKind : true}}:</dt>
   <dd ng-if-end>
-    <a ng-href="{{hpa.spec.scaleRef.name | navigateResourceURL : hpa.spec.scaleRef.kind : hpa.metadata.namespace}}">{{hpa.spec.scaleRef.name}}</a>
+    <a ng-href="{{hpa.spec.scaleTargetRef.name | navigateResourceURL : hpa.spec.scaleTargetRef.kind : hpa.metadata.namespace}}">{{hpa.spec.scaleTargetRef.name}}</a>
   </dd>
   <dt>Min Pods:</dt>
   <dd>{{hpa.spec.minReplicas || 1}}</dd>
   <dt>Max Pods:</dt>
   <dd>{{hpa.spec.maxReplicas}}</dd>
-  <dt ng-if-start="hpa.spec.cpuUtilization.targetPercentage">
+  <dt ng-if-start="hpa.spec.targetCPUUtilizationPercentage">
       CPU
       <span ng-if="'cpu' | isRequestCalculated : project">Limit</span>
       <span ng-if="!('cpu' | isRequestCalculated : project)">Request</span>
       Target:
   </dt>
-  <dd ng-if-end>{{hpa.spec.cpuUtilization.targetPercentage | hpaCPUPercent : project}}%</dd>
+  <dd ng-if-end>{{hpa.spec.targetCPUUtilizationPercentage | hpaCPUPercent : project}}%</dd>
   <dt>
     Current Usage:
   </dt>

--- a/app/views/directives/osc-autoscaling.html
+++ b/app/views/directives/osc-autoscaling.html
@@ -124,7 +124,7 @@
       <span ng-if="!isRequestCalculated">request</span>
       that each pod should ideally be using. Pods will be added or removed
       periodically when CPU usage exceeds or drops below this target value.
-      Defaults to {{defaultTargetCPUDisplayValue}}%.
+      <span ng-if="defaultTargetCPUDisplayValue">Defaults to {{defaultTargetCPUDisplayValue}}%.</span>
     </div>
     <div class="learn-more-block">
       <a href="{{'compute_resources' | helpLink}}" target="_blank">Learn More&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></a>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -432,8 +432,9 @@ v.buildConfigs = a.by("metadata.name"), La(), Ra(), Ta(), da(), p.log("buildconf
 poll:w,
 pollInterval:x
 })), Xa.push(h.watch({
-group:"extensions",
-resource:"horizontalpodautoscalers"
+group:"autoscaling",
+resource:"horizontalpodautoscalers",
+version:"v1"
 }, c, function(a) {
 v.horizontalPodAutoscalers = a.by("metadata.name"), Ia(), p.log("autoscalers (subscribe)", v.horizontalPodAutoscalers);
 }, {
@@ -2035,7 +2036,7 @@ type:"ConfigChange"
 }), i;
 }, f._generateHPA = function(a, b) {
 var c = {
-apiVersion:"extensions/v1beta1",
+apiVersion:"autoscaling/v1",
 kind:"HorizontalPodAutoscaler",
 metadata:{
 name:a.name,
@@ -2043,7 +2044,7 @@ labels:a.labels,
 annotations:a.annotations
 },
 spec:{
-scaleRef:{
+scaleTargetRef:{
 kind:"DeploymentConfig",
 name:b.metadata.name,
 apiVersion:"extensions/v1beta1",
@@ -2051,9 +2052,7 @@ subresource:"scale"
 },
 minReplicas:a.scaling.minReplicas,
 maxReplicas:a.scaling.maxReplicas,
-cpuUtilization:{
-targetPercentage:a.scaling.targetCPU || a.scaling.defaultTargetCPU
-}
+targetCPUUtilizationPercentage:a.scaling.targetCPU || a.scaling.defaultTargetCPU || null
 }
 };
 return c;
@@ -3472,7 +3471,7 @@ return l(a, "defaultLimit", b, c);
 return !(!j("cpu", a) && !m("cpu", b, d)) || (!(!k("cpu", a) && !n("cpu", b, a)) || !!c.isLimitCalculated("cpu", d) && (k("memory", a) || n("memory", b, d)));
 }, p = function(a, b, c) {
 return _.filter(a, function(a) {
-return a.spec.scaleRef.kind === b && a.spec.scaleRef.name === c;
+return a.spec.scaleTargetRef.kind === b && a.spec.scaleTargetRef.name === c;
 });
 }, q = a("humanizeKind"), r = a("hasDeploymentConfig"), s = function(a, e, f, g) {
 return !a || _.isEmpty(e) ? b.when([]) :d.isAvailable().then(function(b) {
@@ -3491,7 +3490,7 @@ reason:"MultipleHPA"
 });
 var k = function() {
 return _.some(e, function(a) {
-return "ReplicationController" === _.get(a, "spec.scaleRef.kind");
+return "ReplicationController" === _.get(a, "spec.scaleTargetRef.kind");
 });
 };
 return "ReplicationController" === a.kind && r(a) && _.some(e, k) && d.push({
@@ -3502,7 +3501,7 @@ reason:"DeploymentHasHPA"
 }, t = function(a) {
 var b = {};
 return _.each(a, function(a) {
-var c = a.spec.scaleRef.name, d = a.spec.scaleRef.kind;
+var c = a.spec.scaleTargetRef.name, d = a.spec.scaleTargetRef.kind;
 c && d && (_.has(b, [ d, c ]) || _.set(b, [ d, c ], []), b[d][c].push(a));
 }), b;
 };
@@ -5054,7 +5053,7 @@ matchTemplate:!0
 }));
 }, Z = function() {
 C = {}, _.each(B, function(a) {
-var b = a.spec.scaleRef.name, c = a.spec.scaleRef.kind;
+var b = a.spec.scaleTargetRef.name, c = a.spec.scaleTargetRef.kind;
 b && c && (_.has(C, [ c, b ]) || _.set(C, [ c, b ], []), C[c][b].push(a));
 });
 }, $ = function(a) {
@@ -5235,8 +5234,9 @@ resource:"deployments"
 }, b, function(a) {
 s = a.by("metadata.name"), Q(), X(), ma(), i.log("deployments (subscribe)", s);
 })), D.push(f.watch({
-group:"extensions",
-resource:"horizontalpodautoscalers"
+group:"autoscaling",
+resource:"horizontalpodautoscalers",
+version:"v1"
 }, b, function(a) {
 B = a.by("metadata.name"), Z();
 }, {
@@ -5445,11 +5445,12 @@ return !_.isEmpty(b);
 b.getHPA = function(a, b) {
 return G && H ? b ? (G[b] = G[b] || [], G[b]) :(H[a] = H[a] || [], H[a]) :null;
 }, v.push(c.watch({
-group:"extensions",
-resource:"horizontalpodautoscalers"
+group:"autoscaling",
+resource:"horizontalpodautoscalers",
+version:"v1"
 }, e, function(a) {
 G = {}, H = {}, angular.forEach(a.by("metadata.name"), function(a) {
-var b = a.spec.scaleRef.name, c = a.spec.scaleRef.kind;
+var b = a.spec.scaleTargetRef.name, c = a.spec.scaleTargetRef.kind;
 if (b && c) switch (c) {
 case "DeploymentConfig":
 G[b] = G[b] || [], G[b].push(a);
@@ -5460,7 +5461,7 @@ H[b] = H[b] || [], H[b].push(a);
 break;
 
 default:
-l.warn("Unexpected HPA scaleRef kind", c);
+l.warn("Unexpected HPA scaleTargetRef kind", c);
 }
 });
 })), b.isScalable = function(a, c) {
@@ -6550,8 +6551,9 @@ y = r(b.by("metadata.name")), a.valueFromObjects = y.concat(x);
 var c = b.by("metadata.name");
 i.buildDockerRefMapForImageStreams(c, o), a.deployment && i.fetchReferencedImageStreamImages([ a.deployment.spec.template ], a.imagesByDockerReference, o, k), l.log("imagestreams (subscribe)", a.imageStreams);
 })), u.push(e.watch({
-group:"extensions",
-resource:"horizontalpodautoscalers"
+group:"autoscaling",
+resource:"horizontalpodautoscalers",
+version:"v1"
 }, k, function(b) {
 a.autoscalers = h.filterHPA(b.by("metadata.name"), "Deployment", c.deployment), w();
 })), u.push(e.watch("builds", k, function(b) {
@@ -6722,8 +6724,9 @@ j.buildDockerRefMapForImageStreams(c, r), a.deploymentConfig && j.fetchReference
 })), z.push(f.watch("builds", e, function(b) {
 a.builds = b.by("metadata.name"), m.log("builds (subscribe)", a.builds);
 })), z.push(f.watch({
-group:"extensions",
-resource:"horizontalpodautoscalers"
+group:"autoscaling",
+resource:"horizontalpodautoscalers",
+version:"v1"
 }, e, function(b) {
 a.autoscalers = i.filterHPA(b.by("metadata.name"), "DeploymentConfig", c.deploymentconfig), D();
 })), p.onActiveFiltersChanged(function(b) {
@@ -6991,8 +6994,9 @@ k.buildDockerRefMapForImageStreams(b, w), S(), l.log("imagestreams (subscribe)",
 })), x.push(g.watch("builds", i, function(b) {
 a.builds = b.by("metadata.name"), l.log("builds (subscribe)", a.builds);
 })), x.push(g.watch({
-group:"extensions",
-resource:"horizontalpodautoscalers"
+group:"autoscaling",
+resource:"horizontalpodautoscalers",
+version:"v1"
 }, i, function(a) {
 r = a.by("metadata.name"), J(), M();
 }, {
@@ -8207,19 +8211,19 @@ a.project = b;
 var l = "HorizontalPodAutoscaler" === c.kind ? "update" :"create";
 if (!f.canI({
 resource:"horizontalpodautoscalers",
-group:"extensions"
+group:"autoscaling"
 }, l, c.project)) return void k.toErrorPage("You do not have authority to " + l + " horizontal pod autoscalers in project " + c.project + ".", "access_denied");
 var n = function() {
 a.disableInputs = !0;
 var b = {
-apiVersion:"extensions/v1beta1",
+apiVersion:"autoscaling/v1",
 kind:"HorizontalPodAutoscaler",
 metadata:{
 name:a.autoscaling.name,
 labels:m.mapEntries(m.compactEntries(a.labels))
 },
 spec:{
-scaleRef:{
+scaleTargetRef:{
 kind:c.kind,
 name:c.name,
 apiVersion:"extensions/v1beta1",
@@ -8227,44 +8231,44 @@ subresource:"scale"
 },
 minReplicas:a.autoscaling.minReplicas,
 maxReplicas:a.autoscaling.maxReplicas,
-cpuUtilization:{
-targetPercentage:a.autoscaling.targetCPU || a.autoscaling.defaultTargetCPU
-}
+targetCPUUtilizationPercentage:a.autoscaling.targetCPU || a.autoscaling.defaultTargetCPU || null
 }
 };
 h.create({
 resource:"horizontalpodautoscalers",
-group:"extensions"
+group:"autoscaling"
 }, null, b, j).then(function() {
 d.history.back();
 }, function(b) {
 a.disableInputs = !1, p("An error occurred creating the horizontal pod autoscaler.", b);
 });
 }, o = function(b) {
-a.disableInputs = !0, b = angular.copy(b), b.metadata.labels = m.mapEntries(m.compactEntries(a.labels)), b.spec.minReplicas = a.autoscaling.minReplicas, b.spec.maxReplicas = a.autoscaling.maxReplicas, b.spec.cpuUtilization = {
-targetPercentage:a.autoscaling.targetCPU || a.autoscaling.defaultTargetCPU
-}, h.update({
+a.disableInputs = !0, b = angular.copy(b), b.metadata.labels = m.mapEntries(m.compactEntries(a.labels)), b.spec.minReplicas = a.autoscaling.minReplicas, b.spec.maxReplicas = a.autoscaling.maxReplicas, b.spec.targetCPUUtilizationPercentage = a.autoscaling.targetCPU || a.autoscaling.defaultTargetCPU || null, h.update({
 resource:"horizontalpodautoscalers",
-group:"extensions"
+group:"autoscaling"
 }, b.metadata.name, b, j).then(function() {
 d.history.back();
 }, function(c) {
 a.disableInputs = !1, p('An error occurred updating horizontal pod autoscaler "' + b.metadata.name + '".', c);
 });
-}, q = {
+}, q = {};
+q = "HorizontalPodAutoscaler" === c.kind ? {
+resource:"horizontalpodautoscalers",
+group:"autoscaling",
+version:"v1"
+} :{
 resource:e.kindToResource(c.kind),
 group:c.group
-};
-h.get(q, c.name, j).then(function(d) {
+}, h.get(q, c.name, j).then(function(d) {
 if (a.labels = _.map(_.get(d, "metadata.labels", {}), function(a, b) {
 return {
 name:b,
 value:a
 };
-}), "HorizontalPodAutoscaler" === c.kind) a.targetKind = _.get(d, "spec.scaleRef.kind"), a.targetName = _.get(d, "spec.scaleRef.name"), _.assign(a.autoscaling, {
+}), "HorizontalPodAutoscaler" === c.kind) a.targetKind = _.get(d, "spec.scaleTargetRef.kind"), a.targetName = _.get(d, "spec.scaleTargetRef.name"), _.assign(a.autoscaling, {
 minReplicas:_.get(d, "spec.minReplicas"),
 maxReplicas:_.get(d, "spec.maxReplicas"),
-targetCPU:_.get(d, "spec.cpuUtilization.targetPercentage")
+targetCPU:_.get(d, "spec.targetCPUUtilizationPercentage")
 }), a.disableInputs = !1, a.save = function() {
 o(d);
 }, a.breadcrumbs = g.getBreadcrumbs({
@@ -9708,7 +9712,7 @@ e.stayOnCurrentPage ? e.alerts[a.name] = a.data :h.addAlert(a);
 }, n = function(a) {
 return g["delete"]({
 resource:"horizontalpodautoscalers",
-group:"extensions"
+group:"autoscaling"
 }, a.metadata.name, {
 namespace:e.projectName
 }).then(function() {
@@ -15055,7 +15059,7 @@ resource:"configmaps",
 verbs:[ "update", "delete" ]
 } ],
 deployments:[ {
-group:"extensions",
+group:"autoscaling",
 resource:"horizontalpodautoscalers",
 verbs:[ "create", "update" ]
 }, {
@@ -15064,7 +15068,7 @@ resource:"deployments",
 verbs:[ "create", "update" ]
 } ],
 deploymentConfigs:[ {
-group:"extensions",
+group:"autoscaling",
 resource:"horizontalpodautoscalers",
 verbs:[ "create", "update" ]
 }, {
@@ -15073,7 +15077,7 @@ resource:"deploymentconfigs",
 verbs:[ "create", "update" ]
 } ],
 horizontalPodAutoscalers:[ {
-group:"extensions",
+group:"autoscaling",
 resource:"horizontalpodautoscalers",
 verbs:[ "update", "delete" ]
 } ],
@@ -15097,7 +15101,7 @@ resource:"deploymentconfigs",
 verbs:[ "update" ]
 } ],
 replicaSets:[ {
-group:"extensions",
+group:"autoscaling",
 resource:"horizontalpodautoscalers",
 verbs:[ "create", "update" ]
 }, {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1507,7 +1507,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<li ng-if=\"!deployment && ({ group: 'extensions', resource: 'replicasets' } | canI : 'update')\">\n" +
     "<a ng-href=\"project/{{project.metadata.name}}/attach-pvc?kind=ReplicaSet&name={{replicaSet.metadata.name}}&group=extensions\" role=\"button\">Add Storage</a>\n" +
     "</li>\n" +
-    "<li ng-if=\"!autoscalers.length && ({ group: 'extensions', resource: 'horizontalpodautoscalers' } | canI : 'create')\">\n" +
+    "<li ng-if=\"!autoscalers.length && ({ group: 'autoscaling', resource: 'horizontalpodautoscalers' } | canI : 'create')\">\n" +
     "<a ng-href=\"project/{{projectName}}/edit/autoscaler?kind=ReplicaSet&name={{replicaSet.metadata.name}}&group=extensions\" ng-if=\"!deployment\" role=\"button\">Add Autoscaler</a>\n" +
     "<a ng-href=\"project/{{projectName}}/edit/autoscaler?kind=Deployment&name={{deployment.metadata.name}}&group=extensions\" ng-if=\"deployment\" role=\"button\">Add Autoscaler</a>\n" +
     "</li>\n" +
@@ -1679,13 +1679,13 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "\n" +
     "<div ng-if=\"!autoscalers.length\">\n" +
-    "<span ng-if=\"{resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create'\">\n" +
+    "<span ng-if=\"{resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create'\">\n" +
     "<a ng-if=\"replicaSet.kind === 'ReplicaSet' && !deployment\" ng-href=\"project/{{projectName}}/edit/autoscaler?kind=ReplicaSet&name={{replicaSet.metadata.name}}&group=extensions\" role=\"button\">Add Autoscaler</a>\n" +
     "<a ng-if=\"replicaSet.kind === 'ReplicaSet' && deployment\" ng-href=\"project/{{projectName}}/edit/autoscaler?kind=Deployment&name={{deployment.metadata.name}}&group=extensions\" role=\"button\">Add Autoscaler</a>\n" +
     "<a ng-if=\"replicaSet.kind === 'ReplicationController' && !deploymentConfigName\" ng-href=\"project/{{projectName}}/edit/autoscaler?kind=ReplicationController&name={{replicaSet.metadata.name}}\" role=\"button\">Add Autoscaler</a>\n" +
     "<a ng-if=\"replicaSet.kind === 'ReplicationController' && deploymentConfigName\" ng-href=\"project/{{projectName}}/edit/autoscaler?kind=DeploymentConfig&name={{deploymentConfigName}}\" role=\"button\">Add Autoscaler</a>\n" +
     "</span>\n" +
-    "<span ng-if=\"!({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create')\">\n" +
+    "<span ng-if=\"!({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create')\">\n" +
     "Autoscaling is not enabled. There are no autoscalers for this\n" +
     "<span ng-if=\"deploymentConfigName\">deployment config or deployment.</span>\n" +
     "<span ng-if=\"!deploymentConfigName\">{{replicaSet.kind | humanizeKind}}.</span>\n" +
@@ -1693,7 +1693,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "\n" +
     "<div ng-repeat=\"hpa in autoscalers | orderBy : 'name'\">\n" +
-    "<hpa hpa=\"hpa\" show-scale-target=\"hpa.spec.scaleRef.kind !== 'ReplicationController'\" alerts=\"alerts\">\n" +
+    "<hpa hpa=\"hpa\" show-scale-target=\"hpa.spec.scaleTargetRef.kind !== 'ReplicationController'\" alerts=\"alerts\">\n" +
     "</hpa>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -1704,7 +1704,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/browse/_replication-controller-actions.html',
-    "<div ng-if=\"(('replicationControllers' | canIDoAny) || (!deploymentConfigName && !autoscalers.length && ({ group: 'extensions', resource: 'horizontalpodautoscalers' } | canI : 'create')))\" class=\"pull-right dropdown\">\n" +
+    "<div ng-if=\"(('replicationControllers' | canIDoAny) || (!deploymentConfigName && !autoscalers.length && ({ group: 'autoscaling', resource: 'horizontalpodautoscalers' } | canI : 'create')))\" class=\"pull-right dropdown\">\n" +
     "<button type=\"button\" class=\"dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs\" data-toggle=\"dropdown\">\n" +
     "Actions\n" +
     "<span class=\"caret\"></span>\n" +
@@ -1717,7 +1717,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<li ng-if=\"!deploymentConfigName && ('replicationcontrollers' | canI : 'update')\">\n" +
     "<a ng-href=\"project/{{project.metadata.name}}/attach-pvc?kind=ReplicationController&name={{replicaSet.metadata.name}}\" role=\"button\">Add Storage</a>\n" +
     "</li>\n" +
-    "<li ng-if=\"!autoscalers.length && ({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create')\">\n" +
+    "<li ng-if=\"!autoscalers.length && ({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create')\">\n" +
     "\n" +
     "<a ng-href=\"project/{{projectName}}/edit/autoscaler?kind=ReplicationController&name={{replicaSet.metadata.name}}\" ng-if=\"!deploymentConfigName\" role=\"button\">Add Autoscaler</a>\n" +
     "<a ng-href=\"project/{{projectName}}/edit/autoscaler?kind=DeploymentConfig&name={{deploymentConfigName}}\" ng-if=\"deploymentConfigName\" role=\"button\">Add Autoscaler</a>\n" +
@@ -2471,13 +2471,13 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<li ng-if=\"'deploymentconfigs' | canI : 'update'\">\n" +
     "<a ng-href=\"project/{{project.metadata.name}}/attach-pvc?kind=DeploymentConfig&name={{deploymentConfig.metadata.name}}\" role=\"button\">Add Storage</a>\n" +
     "</li>\n" +
-    "<li ng-if=\"!autoscalers.length && ({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create')\">\n" +
+    "<li ng-if=\"!autoscalers.length && ({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create')\">\n" +
     "\n" +
     "<a ng-href=\"project/{{projectName}}/edit/autoscaler?kind=DeploymentConfig&name={{deploymentConfig.metadata.name}}\" role=\"button\">Add Autoscaler</a>\n" +
     "</li>\n" +
-    "<li ng-if=\"autoscalers.length === 1 && ({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'update')\">\n" +
+    "<li ng-if=\"autoscalers.length === 1 && ({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'update')\">\n" +
     "\n" +
-    "<a ng-href=\"project/{{projectName}}/edit/autoscaler?kind=HorizontalPodAutoscaler&group=extensions&name={{autoscalers[0].metadata.name}}\" role=\"button\">Edit Autoscaler</a>\n" +
+    "<a ng-href=\"project/{{projectName}}/edit/autoscaler?kind=HorizontalPodAutoscaler&group=autoscaling&name={{autoscalers[0].metadata.name}}\" role=\"button\">Edit Autoscaler</a>\n" +
     "</li>\n" +
     "<li ng-if=\"'deploymentconfigs' | canI : 'update'\">\n" +
     "<a ng-href=\"project/{{projectName}}/set-limits?kind=DeploymentConfig&name={{deploymentConfig.metadata.name}}\" role=\"button\">Edit Resource Limits</a>\n" +
@@ -2656,8 +2656,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "\n" +
     "<div ng-if=\"!autoscalers.length\">\n" +
-    "<a ng-if=\"{resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create'\" ng-href=\"project/{{projectName}}/edit/autoscaler?kind=DeploymentConfig&name={{deploymentConfig.metadata.name}}\" role=\"button\">Add Autoscaler</a>\n" +
-    "<span ng-if=\"!({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create')\">Autoscaling is not enabled. There are no autoscalers for this deployment config.</span>\n" +
+    "<a ng-if=\"{resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create'\" ng-href=\"project/{{projectName}}/edit/autoscaler?kind=DeploymentConfig&name={{deploymentConfig.metadata.name}}\" role=\"button\">Add Autoscaler</a>\n" +
+    "<span ng-if=\"!({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create')\">Autoscaling is not enabled. There are no autoscalers for this deployment config.</span>\n" +
     "</div>\n" +
     "\n" +
     "<div ng-repeat=\"hpa in autoscalers\">\n" +
@@ -2773,13 +2773,13 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<li ng-if=\"{ group: 'extensions', resource: 'deployments' } | canI : 'update'\">\n" +
     "<a ng-href=\"project/{{project.metadata.name}}/attach-pvc?kind=Deployment&name={{deployment.metadata.name}}&group=extensions\" role=\"button\">Add Storage</a>\n" +
     "</li>\n" +
-    "<li ng-if=\"!autoscalers.length && ({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create')\">\n" +
+    "<li ng-if=\"!autoscalers.length && ({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create')\">\n" +
     "\n" +
     "<a ng-href=\"project/{{projectName}}/edit/autoscaler?kind=Deployment&name={{deployment.metadata.name}}&group=extensions\" role=\"button\">Add Autoscaler</a>\n" +
     "</li>\n" +
-    "<li ng-if=\"autoscalers.length === 1 && ({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'update')\">\n" +
+    "<li ng-if=\"autoscalers.length === 1 && ({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'update')\">\n" +
     "\n" +
-    "<a ng-href=\"project/{{projectName}}/edit/autoscaler?kind=HorizontalPodAutoscaler&group=extensions&name={{autoscalers[0].metadata.name}}\" role=\"button\">Edit Autoscaler</a>\n" +
+    "<a ng-href=\"project/{{projectName}}/edit/autoscaler?kind=HorizontalPodAutoscaler&group=autoscaling&name={{autoscalers[0].metadata.name}}\" role=\"button\">Edit Autoscaler</a>\n" +
     "</li>\n" +
     "<li ng-if=\"{ group: 'extensions', resource: 'deployments' } | canI : 'update'\">\n" +
     "<a ng-href=\"project/{{projectName}}/set-limits?kind=Deployment&name={{deployment.metadata.name}}&group=extensions\" role=\"button\">Edit Resource Limits</a>\n" +
@@ -2937,8 +2937,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "\n" +
     "<div ng-if=\"!autoscalers.length\">\n" +
-    "<a ng-if=\"{resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create'\" ng-href=\"project/{{projectName}}/edit/autoscaler?kind=Deployment&name={{deployment.metadata.name}}&group=extensions\" role=\"button\">Add Autoscaler</a>\n" +
-    "<span ng-if=\"!({resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'create')\">none</span>\n" +
+    "<a ng-if=\"{resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create'\" ng-href=\"project/{{projectName}}/edit/autoscaler?kind=Deployment&name={{deployment.metadata.name}}&group=extensions\" role=\"button\">Add Autoscaler</a>\n" +
+    "<span ng-if=\"!({resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'create')\">none</span>\n" +
     "</div>\n" +
     "\n" +
     "<div ng-repeat=\"hpa in autoscalers\">\n" +
@@ -7248,28 +7248,28 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "{{hpa.metadata.name}}\n" +
     "\n" +
     "<span ng-if=\"'horizontalPodAutoscalers' | canIDoAny\" class=\"header-actions\">\n" +
-    "<a ng-if=\"{resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'update'\" ng-href=\"project/{{hpa.metadata.namespace}}/edit/autoscaler?kind=HorizontalPodAutoscaler&group=extensions&name={{hpa.metadata.name}}\" role=\"button\">Edit</a>\n" +
+    "<a ng-if=\"{resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'update'\" ng-href=\"project/{{hpa.metadata.namespace}}/edit/autoscaler?kind=HorizontalPodAutoscaler&group=autoscaling&name={{hpa.metadata.name}}\" role=\"button\">Edit</a>\n" +
     "<span class=\"action-divider\">|</span>\n" +
-    "<delete-link ng-if=\"{resource: 'horizontalpodautoscalers', group: 'extensions'} | canI : 'delete'\" kind=\"HorizontalPodAutoscaler\" group=\"extensions\" resource-name=\"{{hpa.metadata.name}}\" project-name=\"{{hpa.metadata.namespace}}\" label=\"Remove\" alerts=\"alerts\" stay-on-current-page=\"true\">\n" +
+    "<delete-link ng-if=\"{resource: 'horizontalpodautoscalers', group: 'autoscaling'} | canI : 'delete'\" kind=\"HorizontalPodAutoscaler\" group=\"autoscaling\" resource-name=\"{{hpa.metadata.name}}\" project-name=\"{{hpa.metadata.namespace}}\" label=\"Remove\" alerts=\"alerts\" stay-on-current-page=\"true\">\n" +
     "</delete-link>\n" +
     "</span>\n" +
     "</h4>\n" +
     "<dl class=\"dl-horizontal left\" style=\"margin-bottom: 10px\">\n" +
-    "<dt ng-if-start=\"showScaleTarget && hpa.spec.scaleRef.kind && hpa.spec.scaleRef.name\">{{hpa.spec.scaleRef.kind | humanizeKind : true}}:</dt>\n" +
+    "<dt ng-if-start=\"showScaleTarget && hpa.spec.scaleTargetRef.kind && hpa.spec.scaleTargetRef.name\">{{hpa.spec.scaleTargetRef.kind | humanizeKind : true}}:</dt>\n" +
     "<dd ng-if-end>\n" +
-    "<a ng-href=\"{{hpa.spec.scaleRef.name | navigateResourceURL : hpa.spec.scaleRef.kind : hpa.metadata.namespace}}\">{{hpa.spec.scaleRef.name}}</a>\n" +
+    "<a ng-href=\"{{hpa.spec.scaleTargetRef.name | navigateResourceURL : hpa.spec.scaleTargetRef.kind : hpa.metadata.namespace}}\">{{hpa.spec.scaleTargetRef.name}}</a>\n" +
     "</dd>\n" +
     "<dt>Min Pods:</dt>\n" +
     "<dd>{{hpa.spec.minReplicas || 1}}</dd>\n" +
     "<dt>Max Pods:</dt>\n" +
     "<dd>{{hpa.spec.maxReplicas}}</dd>\n" +
-    "<dt ng-if-start=\"hpa.spec.cpuUtilization.targetPercentage\">\n" +
+    "<dt ng-if-start=\"hpa.spec.targetCPUUtilizationPercentage\">\n" +
     "CPU\n" +
     "<span ng-if=\"'cpu' | isRequestCalculated : project\">Limit</span>\n" +
     "<span ng-if=\"!('cpu' | isRequestCalculated : project)\">Request</span>\n" +
     "Target:\n" +
     "</dt>\n" +
-    "<dd ng-if-end>{{hpa.spec.cpuUtilization.targetPercentage | hpaCPUPercent : project}}%</dd>\n" +
+    "<dd ng-if-end>{{hpa.spec.targetCPUUtilizationPercentage | hpaCPUPercent : project}}%</dd>\n" +
     "<dt>\n" +
     "Current Usage:\n" +
     "</dt>\n" +
@@ -7858,7 +7858,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "The percentage of the CPU\n" +
     "<span ng-if=\"isRequestCalculated\">limit</span>\n" +
     "<span ng-if=\"!isRequestCalculated\">request</span>\n" +
-    "that each pod should ideally be using. Pods will be added or removed periodically when CPU usage exceeds or drops below this target value. Defaults to {{defaultTargetCPUDisplayValue}}%.\n" +
+    "that each pod should ideally be using. Pods will be added or removed periodically when CPU usage exceeds or drops below this target value.\n" +
+    "<span ng-if=\"defaultTargetCPUDisplayValue\">Defaults to {{defaultTargetCPUDisplayValue}}%.</span>\n" +
     "</div>\n" +
     "<div class=\"learn-more-block\">\n" +
     "<a href=\"{{'compute_resources' | helpLink}}\" target=\"_blank\">Learn More&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></a>\n" +


### PR DESCRIPTION
* Switch from extensions/v1beta1 to autoscaling/v1 for HPA objects
* Explicitly get/list/watch/edit v1 HPA objects (since v2alpha1 changes the schema in ways we don't handle yet)
* Switch to new field names:
  * spec.scaleRef -> spec.scaleTargetRef
  * spec.cpuUtilization.targetPercentage -> spec.targetCPUUtilizationPercentage
* Allow for null targetCPUUtilizationPercentage as default and as value