### PR TITLE
Remove oscUnique.js from index.html

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -306,7 +306,6 @@
         <script src="scripts/directives/oscKeyValues.js"></script>
         <script src="scripts/directives/oscRouting.js"></script>
         <script src="scripts/directives/oscPersistentVolumeClaim.js"></script>
-        <script src="scripts/directives/oscUnique.js"></script>
         <script src="scripts/directives/oscAutoscaling.js"></script>
         <script src="scripts/directives/oscSecrets.js"></script>
         <script src="scripts/directives/oscSourceSecrets.js"></script>


### PR DESCRIPTION
The directive has moved to origin-web-common. This was an oversight in #1487