### PR TITLE
Add flag for disabling templates in the catalog

### DIFF
--- a/app/scripts/constants.js
+++ b/app/scripts/constants.js
@@ -89,7 +89,10 @@ angular.extend(window.OPENSHIFT_CONSTANTS, {
   ],
 
   ENABLE_TECH_PREVIEW_FEATURE: {
+    // Enable the new landing page and service catalog experience
     service_catalog_landing_page: false,
+    // Set to `true` when the template service broker is enabled for the cluster in master-config.yaml
+    template_service_broker: false,
     pod_presets: false
   },
 

--- a/app/scripts/controllers/landingPage.js
+++ b/app/scripts/controllers/landingPage.js
@@ -27,7 +27,8 @@ angular.module('openshiftConsole')
     };
 
     AuthService.withUser().then(function() {
-      Catalog.getCatalogItems(true).then(function(items) {
+      var includeTemplates = !_.get(Constants, 'ENABLE_TECH_PREVIEW_FEATURE.template_service_broker');
+      Catalog.getCatalogItems(includeTemplates).then(function(items) {
         $scope.catalogItems = items;
       });
     });

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1317,6 +1317,7 @@ DISABLE_WILDCARD_ROUTES:!0,
 AVAILABLE_KINDS_BLACKLIST:[ "Binding", "Ingress", "DeploymentConfigRollback" ],
 ENABLE_TECH_PREVIEW_FEATURE:{
 service_catalog_landing_page:!1,
+template_service_broker:!1,
 pod_presets:!1
 },
 SAMPLE_PIPELINE_TEMPLATE:{
@@ -4730,7 +4731,8 @@ a.template = b;
 }, a.templateDialogClosed = function() {
 a.template = null;
 }, b.withUser().then(function() {
-c.getCatalogItems(!0).then(function(b) {
+var b = !_.get(d, "ENABLE_TECH_PREVIEW_FEATURE.template_service_broker");
+c.getCatalogItems(b).then(function(b) {
 a.catalogItems = b;
 });
 });


### PR DESCRIPTION
Add `ENABLE_TECH_PREVIEW_FEATURE.template_service_broker` flag that will use the template broker for templates rather than listing them using the API.

See #1492 and https://trello.com/c/2A7x5Pbc