### PR TITLE
[WIP] Let users change projects when instantiating template

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -373,7 +373,7 @@ angular
         templateUrl: 'views/create/category.html',
         controller: 'BrowseCategoryController'
       })
-      .when('/project/:project/create/fromtemplate', {
+      .when('/process-template', {
         templateUrl: 'views/newfromtemplate.html',
         controller: 'NewFromTemplateController'
       })
@@ -439,6 +439,10 @@ angular
       })
       .when('/project/:project/browse/deployments-replicationcontrollers/:rc', {
         redirectTo: '/project/:project/browse/rc/:rc'
+      })
+      .when('/project/:project/create/fromtemplate', {
+        // `redirectTo` will preserve `:project` route param
+        redirectTo: '/process-template'
       })
       .otherwise({
         redirectTo: '/'

--- a/app/scripts/controllers/newfromtemplate.js
+++ b/app/scripts/controllers/newfromtemplate.js
@@ -76,6 +76,7 @@ angular.module('openshiftConsole')
       .then(_.spread(function(project) {
         $scope.project = project;
         // Update project breadcrumb with display name.
+        // TODO: What to do with breadcrumbs when project changes (new project?)
         $scope.breadcrumbs[0].title = displayName(project);
 
         // Missing namespace indicates that the template should be received from from the 'CachedTemplateService'.

--- a/app/views/directives/process-template.html
+++ b/app/views/directives/process-template.html
@@ -1,7 +1,7 @@
 <fieldset ng-disabled="disableInputs">
   <form name="$ctrl.templateForm">
     <template-options is-dialog="$ctrl.isDialog" parameters="$ctrl.template.parameters" expand="true" can-toggle="false">
-      <select-project ng-if="!$ctrl.project" selected-project="$ctrl.selectedProject" name-taken="$ctrl.projectNameTaken"></select-project>
+      <select-project selected-project="$ctrl.selectedProject" name-taken="$ctrl.projectNameTaken" stacked-form="!$ctrl.isDialog"></select-project>
     </template-options>
     <!-- TODO: Also support advanced options for new projects. -->
     <div ng-if="$ctrl.selectedProject.metadata.uid" class="row">


### PR DESCRIPTION
Not ready for code review. Let users pick a different project or create a new project from the full template form.

Requires https://github.com/openshift/origin-web-catalog/pull/199/files

<img width="660" alt="screen shot 2017-05-02 at 2 06 17 pm" src="https://cloud.githubusercontent.com/assets/1167259/25632575/27a462ea-2f42-11e7-9869-81375a80eb6a.png">

TODO

- [ ] Update builder form as well
- [ ] Decide what to do with breadcrumbs when project changes or user creates a new project
- [ ] Update `Navigate` service URL building for templates and builders
- [ ] Update create from URL to simply redirect to the template or builder pages
