### PR TITLE
Add 12 hours time range to metrics time ranges

### DIFF
--- a/app/scripts/services/metricsCharts.js
+++ b/app/scripts/services/metricsCharts.js
@@ -45,6 +45,9 @@ angular.module("openshiftConsole")
           label: "Last 4 hours",
           value: 4 * 60
         }, {
+          label: "Last 12 hours",
+          value: 12 * 60
+        }, {
           label: "Last day",
           value: 24 * 60
         }, {


### PR DESCRIPTION
As a console user I have a couple of 'Time Range' settings already at my disposal: 1 hour, 4 hours, 1 day, 3 days and 7 days.

There is however an arguably large gap between 4 hours and 24 hours.

This PR adds a 'Last 12 hours' time range to the metrics tab.