### PR TITLE
Add delete binding (unbind) action to provisioned services

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -211,7 +211,9 @@
         <script src="scripts/services/apps.js"></script>
         <script src="scripts/services/resourceAlerts.js"></script>
         <script src="scripts/services/listRowUtils.js"></script>
+        <script src="scripts/services/serviceInstances.js"></script>
         <script src="scripts/services/ownerReferences.js"></script>
+        <script src="scripts/services/bindingModalUtils.js"></script>
         <script src="scripts/controllers/landingPage.js"></script>
         <script src="scripts/controllers/projects.js"></script>
         <script src="scripts/controllers/pods.js"></script>
@@ -337,6 +339,7 @@
         <script src="scripts/directives/buildStatus.js"></script>
         <script src="scripts/directives/routeServiceBarChart.js"></script>
         <script src="scripts/directives/bindService.js"></script>
+        <script src="scripts/directives/unbindService.js"></script>
         <script src="scripts/directives/processTemplate.js"></script>
         <script src="scripts/directives/processTemplateDialog.js"></script>
         <script src="scripts/directives/create/nextSteps.js"></script>

--- a/app/scripts/directives/overview/serviceInstanceRow.js
+++ b/app/scripts/directives/overview/serviceInstanceRow.js
@@ -9,6 +9,7 @@
       'BindingService',
       'ListRowUtils',
       'NotificationsService',
+      'ServiceInstancesService',
       ServiceInstanceRow
     ],
     controllerAs: 'row',
@@ -25,18 +26,13 @@
                               DataService,
                               BindingService,
                               ListRowUtils,
-                              NotificationsService) {
+                              NotificationsService,
+                              ServiceInstancesService) {
     var row = this;
     _.extend(row, ListRowUtils.ui);
 
     var getErrorDetails = $filter('getErrorDetails');
-
-    var getDisplayName = function() {
-      var serviceClassName = row.apiObject.spec.serviceClassName;
-      var instanceName = row.apiObject.metadata.name;
-      var serviceClassDisplayName = _.get(row, ['state','serviceClasses', serviceClassName, 'osbMetadata', 'displayName']);
-      return serviceClassDisplayName || serviceClassName || instanceName;
-    };
+    var getDisplayName = ServiceInstancesService.getDisplayName;
 
     var getDescription = function() {
       var serviceClassName = row.apiObject.spec.serviceClassName;
@@ -45,7 +41,7 @@
 
     row.$doCheck = function() {
       row.notifications = ListRowUtils.getNotifications(row.apiObject, row.state);
-      row.displayName = getDisplayName();
+      row.displayName = getDisplayName(row.apiObject, row.serviceClasses);
       row.description = getDescription();
     };
 

--- a/app/scripts/directives/unbindService.js
+++ b/app/scripts/directives/unbindService.js
@@ -1,0 +1,112 @@
+'use strict';
+
+(function() {
+
+  angular.module('openshiftConsole').component('unbindService', {
+    controller: [
+      '$filter',
+      'BindingModalUtils',
+      'DataService',
+      'ServiceInstancesService',
+      UnbindService
+    ],
+    controllerAs: 'ctrl',
+    bindings: {
+      target: '<',
+      bindings: '<',
+      onClose: '<'
+    },
+    templateUrl: 'views/directives/unbind-service.html'
+  });
+
+  function UnbindService($filter, BindingModalUtils, DataService, ServiceInstancesService) {
+    var ctrl = this;
+    var context;
+    var getDisplayName = ServiceInstancesService.getDisplayName;
+    // var sortApplications = BindingModalUtils.sortApplications;
+    // TODO: once we have podPreset
+    // var deploymentConfigs, deployments, replicationControllers, replicaSets, statefulSets;
+
+
+    // TODO: once we have podPreset we will be able to associate the
+    // binding to the application being bound to.
+    // var loadApps = function() {
+    //   // Load all the "application" types
+    //   DataService.list('deploymentconfigs', context).then(function(deploymentConfigData) {
+    //     deploymentConfigs = _.toArray(deploymentConfigData.by('metadata.name'));
+    //     ctrl.applications = sortApplications(deploymentConfigs, deployments, replicationControllers, replicaSets, statefulSets);
+    //   });
+    //   DataService.list('replicationcontrollers', context).then(function(replicationControllerData) {
+    //     replicationControllers = _.reject(replicationControllerData.by('metadata.name'), $filter('hasDeploymentConfig'));
+    //     ctrl.applications = sortApplications(deploymentConfigs, deployments, replicationControllers, replicaSets, statefulSets);
+    //   });
+    //   DataService.list({
+    //     group: 'extensions',
+    //     resource: 'deployments'
+    //   }, context).then(function(deploymentData) {
+    //     deployments = _.toArray(deploymentData.by('metadata.name'));
+    //     ctrl.applications = sortApplications(deploymentConfigs, deployments, replicationControllers, replicaSets, statefulSets);
+    //   });
+    //   DataService.list({
+    //     group: 'extensions',
+    //     resource: 'replicasets'
+    //   }, context).then(function(replicaSetData) {
+    //     replicaSets = _.reject(replicaSetData.by('metadata.name'), $filter('hasDeployment'));
+    //     ctrl.applications = sortApplications(deploymentConfigs, deployments, replicationControllers, replicaSets, statefulSets);
+    //   });
+    //   DataService.list({
+    //     group: 'apps',
+    //     resource: 'statefulsets'
+    //   }, context).then(function(statefulSetData) {
+    //     statefulSets = _.toArray(statefulSetData.by('metadata.name'));
+    //     ctrl.applications = sortApplications(deploymentConfigs, deployments, replicationControllers, replicaSets, statefulSets);
+    //   });
+    // };
+
+    var unbindService = function() {
+      DataService.delete({
+        group: 'servicecatalog.k8s.io',
+        resource: 'bindings'
+      }, ctrl.selectedBinding, context).then(_.noop, function(err) {
+        ctrl.error = err;
+      });
+    };
+
+    var showService = function() {
+      ctrl.nextTitle = 'Unbind';
+    };
+
+    var showConfirm = function() {
+      ctrl.nextTitle = 'Close';
+      ctrl.wizardComplete = true;
+      unbindService();
+    };
+
+    ctrl.$onInit = function() {
+      // loadApps();
+      ctrl.displayName = getDisplayName(ctrl.target);
+      ctrl.steps = [{
+        id: 'service',
+        label: 'Service',
+        view: 'views/directives/bind-service/select-binding.html',
+        onShow: showService
+      }, {
+        id: 'confirmation',
+        label: 'Confirmation',
+        view: 'views/directives/bind-service/remove-binding-confirm.html',
+        onShow: showConfirm
+      }];
+
+      context = {
+        namespace: _.get(ctrl.target, 'metadata.namespace')
+      };
+    };
+
+    ctrl.closeWizard = function() {
+      if (_.isFunction(ctrl.onClose)) {
+        ctrl.onClose();
+      }
+    };
+  }
+
+})();

--- a/app/scripts/services/bindingModalUtils.js
+++ b/app/scripts/services/bindingModalUtils.js
@@ -1,0 +1,24 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .factory('BindingModalUtils', [
+    function() {
+      return {
+        sortApplications: function(deploymentConfigs,
+                                    deployments,
+                                    replicationControllers,
+                                    replicaSets,
+                                    statefulSets) {
+          // Don't waste time sorting on each data load, just sort when we have them all
+          if (deploymentConfigs && deployments && replicationControllers && replicaSets && statefulSets) {
+            var apiObjects = deploymentConfigs.concat(deployments)
+                                              .concat(replicationControllers)
+                                              .concat(replicaSets)
+                                              .concat(statefulSets);
+            return _.sortByAll(apiObjects, ['metadata.name', 'kind']);
+          }
+          return null;
+        }
+      };
+    }
+  ]);

--- a/app/scripts/services/serviceInstances.js
+++ b/app/scripts/services/serviceInstances.js
@@ -1,0 +1,16 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .factory('ServiceInstancesService', function() {
+    return {
+      // NOTE: should this be a filter?
+      // gets the name from the appropriate service class,
+      // otherwise falls back to the instance name
+      getDisplayName: function(instance, serviceClasses) {
+        var serviceClassName = instance.spec.serviceClassName;
+        var instanceName = instance.metadata.name;
+        var serviceClassDisplayName = _.get(serviceClasses, [serviceClassName, 'osbMetadata', 'displayName']);
+        return serviceClassDisplayName || serviceClassName || instanceName;
+      }
+    };
+  });

--- a/app/views/directives/bind-service/remove-binding-confirm.html
+++ b/app/views/directives/bind-service/remove-binding-confirm.html
@@ -1,0 +1,23 @@
+<div>
+  <div ng-if="!ctrl.error">
+    <h3 class="mar-top-none">
+      <strong>{{ctrl.selectedBinding}}</strong> has been unbound
+      <!-- TODO: will need to share the sortApplications() function from bindService (and the resource requests block) -->
+      <!-- from <strong>{{ctrl.target.metadata.name}}</strong>-->
+    </h3>
+    <p class="mar-top-lg">
+      <span class="pficon pficon-info"></span> You will need to redeploy your pods for the un-binding to take effect.
+    </p>
+  </div>
+  <div ng-if="ctrl.error">
+    <div class="title">Deletion of Binding Failed <span class="fa fa-times text-danger"></span></div>
+    <div class="sub-title">
+      <span ng-if="ctrl.error.data.message">
+        {{ctrl.error.data.message | upperFirst}}
+      </span>
+      <span ng-if="!ctrl.error.data.message">
+        An error occurred deleting the binding.
+      </span>
+    </div>
+  </div>
+</div>

--- a/app/views/directives/bind-service/select-binding.html
+++ b/app/views/directives/bind-service/select-binding.html
@@ -1,0 +1,13 @@
+<h3 class="mar-top-none">
+  Select a service to delete from <strong>{{ctrl.displayName}}</strong>
+</h3>
+<form name="ctrl.bindingSelection" class="mar-bottom-lg">
+  <fieldset ng-disabled="ctrl.isDisabled">
+    <div ng-repeat="binding in ctrl.bindings" class="radio">
+      <label>
+          <input type="radio" ng-model="ctrl.selectedBinding" value="{{binding.metadata.name}}">
+          {{binding.metadata.name}}
+      </label>
+    </div>
+  </fieldset>
+</form>

--- a/app/views/directives/unbind-service.html
+++ b/app/views/directives/unbind-service.html
@@ -1,0 +1,29 @@
+<div class="bind-service-wizard unbind-service">
+  <div
+    pf-wizard
+    hide-header="true"
+    hide-sidebar="true"
+    hide-back-button="true"
+    step-class="bind-service-wizard-step"
+    wizard-ready="ctrl.wizardReady"
+    next-title="ctrl.nextTitle"
+    on-finish="ctrl.closeWizard()"
+    on-cancel="ctrl.closeWizard()"
+    wizard-done="ctrl.wizardComplete"
+    class="pf-wizard-no-back">
+    <div
+      pf-wizard-step
+      ng-repeat="step in ctrl.steps track by $index"
+      step-title="{{step.label}}"
+      next-enabled="step.valid"
+      on-show="step.onShow"
+      step-id="{{step.id}}"
+      step-priority="{{$index}}">
+      <div class="wizard-pf-main-inner-shadow-covers">
+        <div class="bind-service-config">
+          <div ng-include="step.view" class="wizard-pf-main-form-contents"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/overview/_service-instance-row.html
+++ b/app/views/overview/_service-instance-row.html
@@ -47,6 +47,9 @@
           <li role="menuitem" ng-if="row.isBindable">
             <a href="" ng-click="row.showOverlayPanel('bindService', {target: row.apiObject})">Create Binding</a>
           </li>
+          <li role="menuitem" ng-if="row.bindings.length">
+            <a href="" ng-click="row.showOverlayPanel('unbindService', {target: row.apiObject})">Delete Binding</a>
+          </li>
           <li role="menuitem">
             <a href="" ng-click="row.deprovision()" role="button">Deprovision</a>
           </li>
@@ -130,5 +133,11 @@
   <div ng-if="row.overlay.panelName === 'bindService'">
     <bind-service target="row.overlay.state.target"
                   on-close="row.closeOverlayPanel"></bind-service>
+  </div>
+  <div ng-if="row.overlay.panelName === 'unbindService'">
+    <unbind-service
+      target="row.overlay.state.target"
+      bindings="row.bindings"
+      on-close="row.closeOverlayPanel"></unbind-service>
   </div>
 </overlay-panel>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4181,6 +4181,13 @@ _.set(this, "selectedTab.networking", !0), b(this);
 }
 }
 };
+}), angular.module("openshiftConsole").factory("ServiceInstancesService", function() {
+return {
+getDisplayName:function(a, b) {
+var c = a.spec.serviceClassName, d = a.metadata.name, e = _.get(b, [ c, "osbMetadata", "displayName" ]);
+return e || c || d;
+}
+};
 }), angular.module("openshiftConsole").factory("OwnerReferencesService", function() {
 var a = function(a) {
 return _.get(a, "metadata.ownerReferences");
@@ -4206,7 +4213,17 @@ controller:!0
 });
 }
 };
-}), angular.module("openshiftConsole").controller("LandingPageController", [ "$scope", "$rootScope", "AuthService", "Catalog", "Constants", "Navigate", "NotificationsService", "RecentlyViewedServiceItems", "GuidedTourService", "$timeout", "$routeParams", "$location", function(a, b, c, d, e, f, g, h, i, j, k, l) {
+}), angular.module("openshiftConsole").factory("BindingModalUtils", [ function() {
+return {
+sortApplications:function(a, b, c, d, e) {
+if (a && b && c && d && e) {
+var f = a.concat(b).concat(c).concat(d).concat(e);
+return _.sortByAll(f, [ "metadata.name", "kind" ]);
+}
+return null;
+}
+};
+} ]), angular.module("openshiftConsole").controller("LandingPageController", [ "$scope", "$rootScope", "AuthService", "Catalog", "Constants", "Navigate", "NotificationsService", "RecentlyViewedServiceItems", "GuidedTourService", "$timeout", "$routeParams", "$location", function(a, b, c, d, e, f, g, h, i, j, k, l) {
 function m() {
 if (o) if (k.startTour) j(function() {
 l.replace(), l.search("startTour", null), a.startGuidedTour();
@@ -12244,111 +12261,148 @@ highlightService:"<"
 templateUrl:"views/directives/route-service-bar-chart.html"
 });
 }(), function() {
-function a(a, b, c, d) {
-var e, f, g, h, i, j, k, l = this, m = b("statusCondition"), n = function() {
+function a(a, b, c, d, e) {
+var f, g, h, i, j, k, l, m = this, n = b("statusCondition"), o = e.sortApplications, p = function() {
 var a, b;
-_.each(l.serviceInstances, function(c) {
-var d = "True" === _.get(m(c, "Ready"), "status");
+_.each(m.serviceInstances, function(c) {
+var d = "True" === _.get(n(c, "Ready"), "status");
 d && (!a || c.metadata.creationTimestamp > a.metadata.creationTimestamp) && (a = c), d || b && !(c.metadata.creationTimestamp > b.metadata.creationTimestamp) || (b = c);
-}), l.serviceToBind = _.get(a, "metadata.name") || _.get(b, "metadata.name");
-}, o = function() {
-l.serviceClasses && l.serviceInstances && (l.orderedServiceInstances = _.sortByAll(l.serviceInstances, function(a) {
-return _.get(l.serviceClasses, [ a.spec.serviceClassName, "osbMetadata", "displayName" ]) || a.spec.serviceClassName;
+}), m.serviceToBind = _.get(a, "metadata.name") || _.get(b, "metadata.name");
+}, q = function() {
+m.serviceClasses && m.serviceInstances && (m.orderedServiceInstances = _.sortByAll(m.serviceInstances, function(a) {
+return _.get(m.serviceClasses, [ a.spec.serviceClassName, "osbMetadata", "displayName" ]) || a.spec.serviceClassName;
 }, function(a) {
 return _.get(a, "metadata.name", "");
 }));
-}, p = function() {
-if (g && h && i && j && k) {
-var a = g.concat(h).concat(i).concat(j).concat(k);
-l.applications = _.sortByAll(a, [ "metadata.name", "kind" ]), l.bindType = l.applications.length ? "application" :"secret-only";
-}
-}, q = function() {
-l.nextTitle = "Bind", e = a.$watch("ctrl.selectionForm.$valid", function(a) {
-l.steps[0].valid = a;
-});
 }, r = function() {
-e && (e(), e = void 0), l.nextTitle = "Close", l.wizardComplete = !0, l.bindService();
+m.nextTitle = "Bind", f = a.$watch("ctrl.selectionForm.$valid", function(a) {
+m.steps[0].valid = a;
+});
 }, s = function() {
+f && (f(), f = void 0), m.nextTitle = "Close", m.wizardComplete = !0, m.bindService();
+}, t = function() {
 var a = {
-namespace:_.get(l.target, "metadata.namespace")
+namespace:_.get(m.target, "metadata.namespace")
 };
 c.list("deploymentconfigs", a).then(function(a) {
-g = _.toArray(a.by("metadata.name")), p();
+h = _.toArray(a.by("metadata.name")), m.applications = o(h, i, j, k, l);
 }), c.list("replicationcontrollers", a).then(function(a) {
-i = _.reject(a.by("metadata.name"), b("hasDeploymentConfig")), p();
+j = _.reject(a.by("metadata.name"), b("hasDeploymentConfig")), m.applications = o(h, i, j, k, l);
 }), c.list({
 group:"extensions",
 resource:"deployments"
 }, a).then(function(a) {
-h = _.toArray(a.by("metadata.name")), p();
+i = _.toArray(a.by("metadata.name")), m.applications = o(h, i, j, k, l);
 }), c.list({
 group:"extensions",
 resource:"replicasets"
 }, a).then(function(a) {
-j = _.reject(a.by("metadata.name"), b("hasDeployment")), p();
+k = _.reject(a.by("metadata.name"), b("hasDeployment")), m.applications = o(h, i, j, k, l);
 }), c.list({
 group:"apps",
 resource:"statefulsets"
 }, a).then(function(a) {
-k = _.toArray(a.by("metadata.name")), p();
+l = _.toArray(a.by("metadata.name")), m.applications = o(h, i, j, k, l);
 });
-}, t = function() {
+}, u = function() {
 var a = {
-namespace:_.get(l.target, "metadata.namespace")
+namespace:_.get(m.target, "metadata.namespace")
 };
 c.list({
 group:"servicecatalog.k8s.io",
 resource:"instances"
 }, a).then(function(a) {
-l.serviceInstances = a.by("metadata.name"), l.serviceToBind || n(), o();
+m.serviceInstances = a.by("metadata.name"), m.serviceToBind || p(), q();
 });
 };
-l.$onInit = function() {
-l.serviceSelection = {};
-var a = "Instance" === l.target.kind ? "Applications" :"Services";
-l.steps = [ {
+m.$onInit = function() {
+m.serviceSelection = {};
+var a = "Instance" === m.target.kind ? "Applications" :"Services";
+m.steps = [ {
 id:"bindForm",
 label:a,
 view:"views/directives/bind-service/bind-service-form.html",
 valid:!0,
-onShow:q
+onShow:r
 }, {
 label:"Results",
 id:"results",
 view:"views/directives/bind-service/results.html",
 valid:!0,
-onShow:r
+onShow:s
 } ], c.list({
 group:"servicecatalog.k8s.io",
 resource:"serviceclasses"
 }, {}).then(function(a) {
-l.serviceClasses = a.by("metadata.name"), "Instance" === l.target.kind && (l.serviceClass = l.serviceClasses[l.target.spec.serviceClassName], l.serviceClassName = l.target.spec.serviceClassName), o();
-}), "Instance" === l.target.kind ? (l.bindType = "secret-only", l.appToBind = null, l.serviceToBind = l.target.metadata.name, s()) :(l.bindType = "application", l.appToBind = l.target, t());
-}, l.$onDestroy = function() {
-e && (e(), e = void 0), f && c.unwatch(f);
-}, l.bindService = function() {
-var a = "Instance" === l.target.kind ? l.target :l.serviceInstances[l.serviceToBind], b = "application" === l.bindType ? l.appToBind :void 0, e = {
+m.serviceClasses = a.by("metadata.name"), "Instance" === m.target.kind && (m.serviceClass = m.serviceClasses[m.target.spec.serviceClassName], m.serviceClassName = m.target.spec.serviceClassName), q();
+}), "Instance" === m.target.kind ? (m.bindType = "secret-only", m.appToBind = null, m.serviceToBind = m.target.metadata.name, t()) :(m.bindType = "application", m.appToBind = m.target, u());
+}, m.$onDestroy = function() {
+f && (f(), f = void 0), g && c.unwatch(g);
+}, m.bindService = function() {
+var a = "Instance" === m.target.kind ? m.target :m.serviceInstances[m.serviceToBind], b = "application" === m.bindType ? m.appToBind :void 0, e = {
 namespace:_.get(a, "metadata.namespace")
 };
 d.bindService(e, _.get(a, "metadata.name"), b).then(function(a) {
-l.binding = a, l.error = null, f = c.watchObject(d.bindingResource, _.get(l.binding, "metadata.name"), e, function(a) {
-l.binding = a;
+m.binding = a, m.error = null, g = c.watchObject(d.bindingResource, _.get(m.binding, "metadata.name"), e, function(a) {
+m.binding = a;
 });
 }, function(a) {
-l.error = a;
+m.error = a;
 });
-}, l.closeWizard = function() {
-_.isFunction(l.onClose) && l.onClose();
+}, m.closeWizard = function() {
+_.isFunction(m.onClose) && m.onClose();
 };
 }
 angular.module("openshiftConsole").component("bindService", {
-controller:[ "$scope", "$filter", "DataService", "BindingService", a ],
+controller:[ "$scope", "$filter", "DataService", "BindingService", "BindingModalUtils", a ],
 controllerAs:"ctrl",
 bindings:{
 target:"<",
 onClose:"<"
 },
 templateUrl:"views/directives/bind-service.html"
+});
+}(), function() {
+function a(a, b, c, d) {
+var e, f = this, g = d.getDisplayName, h = function() {
+c["delete"]({
+group:"servicecatalog.k8s.io",
+resource:"bindings"
+}, f.selectedBinding, e).then(_.noop, function(a) {
+f.error = a;
+});
+}, i = function() {
+f.nextTitle = "Unbind";
+}, j = function() {
+f.nextTitle = "Close", f.wizardComplete = !0, h();
+};
+f.$onInit = function() {
+f.displayName = g(f.target), f.steps = [ {
+id:"service",
+label:"Service",
+view:"views/directives/bind-service/select-binding.html",
+onShow:i
+}, {
+id:"confirmation",
+label:"Confirmation",
+view:"views/directives/bind-service/remove-binding-confirm.html",
+onShow:j
+} ], e = {
+namespace:_.get(f.target, "metadata.namespace")
+};
+}, f.closeWizard = function() {
+_.isFunction(f.onClose) && f.onClose();
+};
+}
+angular.module("openshiftConsole").component("unbindService", {
+controller:[ "$filter", "BindingModalUtils", "DataService", "ServiceInstancesService", a ],
+controllerAs:"ctrl",
+bindings:{
+target:"<",
+bindings:"<",
+onClose:"<"
+},
+templateUrl:"views/directives/unbind-service.html"
 });
 }(), angular.module("openshiftConsole").component("processTemplate", {
 controller:[ "$filter", "$q", "$scope", "$uibModal", "DataService", "Navigate", "NotificationsService", "ProcessedTemplateService", "QuotaService", "SecurityCheckService", "TaskList", "keyValueEditorUtils", ProcessTemplate ],
@@ -12827,30 +12881,27 @@ hidePipelines:"<"
 templateUrl:"views/overview/_list-row.html"
 });
 }(), function() {
-function a(a, b, c, d, e, f) {
-var g = this;
-_.extend(g, e.ui);
-var h = a("getErrorDetails"), i = function() {
-var a = g.apiObject.spec.serviceClassName, b = g.apiObject.metadata.name, c = _.get(g, [ "state", "serviceClasses", a, "osbMetadata", "displayName" ]);
-return c || a || b;
-}, j = function() {
-var a = g.apiObject.spec.serviceClassName;
-return _.get(g, [ "state", "serviceClasses", a, "description" ]);
+function a(a, b, c, d, e, f, g) {
+var h = this;
+_.extend(h, e.ui);
+var i = a("getErrorDetails"), j = g.getDisplayName, k = function() {
+var a = h.apiObject.spec.serviceClassName;
+return _.get(h, [ "state", "serviceClasses", a, "description" ]);
 };
-g.$doCheck = function() {
-g.notifications = e.getNotifications(g.apiObject, g.state), g.displayName = i(), g.description = j();
-}, g.getSecretForBinding = function(a) {
-return a && _.get(g, [ "state", "secrets", a.spec.secretName ]);
-}, g.isBindable = d.isServiceBindable(g.apiObject, g.state.serviceClasses), g.closeOverlayPanel = function() {
-_.set(g, "overlay.panelVisible", !1);
-}, g.showOverlayPanel = function(a, b) {
-_.set(g, "overlay.panelVisible", !0), _.set(g, "overlay.panelName", a), _.set(g, "overlay.state", b);
-}, g.deprovision = function() {
+h.$doCheck = function() {
+h.notifications = e.getNotifications(h.apiObject, h.state), h.displayName = j(h.apiObject, h.serviceClasses), h.description = k();
+}, h.getSecretForBinding = function(a) {
+return a && _.get(h, [ "state", "secrets", a.spec.secretName ]);
+}, h.isBindable = d.isServiceBindable(h.apiObject, h.state.serviceClasses), h.closeOverlayPanel = function() {
+_.set(h, "overlay.panelVisible", !1);
+}, h.showOverlayPanel = function(a, b) {
+_.set(h, "overlay.panelVisible", !0), _.set(h, "overlay.panelName", a), _.set(h, "overlay.state", b);
+}, h.deprovision = function() {
 var a = {
 alerts:{
 deprovision:{
 type:"error",
-message:"Service '" + g.apiObject.spec.serviceClassName + "' will be deleted and no longer available."
+message:"Service '" + h.apiObject.spec.serviceClassName + "' will be deleted and no longer available."
 }
 },
 detailsMarkup:"Deprovision Service?",
@@ -12871,26 +12922,26 @@ return a;
 f.hideNotification("deprovision-service-error"), c["delete"]({
 group:"servicecatalog.k8s.io",
 resource:"instances"
-}, g.apiObject.metadata.name, {
-namespace:g.apiObject.metadata.namespace
+}, h.apiObject.metadata.name, {
+namespace:h.apiObject.metadata.namespace
 }).then(function() {
 f.addNotification({
 type:"success",
-message:"Successfully deprovisioned " + g.apiObject.metadata.name + "."
+message:"Successfully deprovisioned " + h.apiObject.metadata.name + "."
 });
 }, function(a) {
 f.addNotification({
 id:"deprovision-service-error",
 type:"error",
-message:"An error occurred while deprovisioning " + g.apiObject.metadata.name + ".",
-details:h(a)
+message:"An error occurred while deprovisioning " + h.apiObject.metadata.name + ".",
+details:i(a)
 });
 });
 });
 };
 }
 angular.module("openshiftConsole").component("serviceInstanceRow", {
-controller:[ "$filter", "$uibModal", "DataService", "BindingService", "ListRowUtils", "NotificationsService", a ],
+controller:[ "$filter", "$uibModal", "DataService", "BindingService", "ListRowUtils", "NotificationsService", "ServiceInstancesService", a ],
 controllerAs:"row",
 bindings:{
 apiObject:"<",

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5733,9 +5733,53 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/directives/bind-service/remove-binding-confirm.html',
+    "<div>\n" +
+    "<div ng-if=\"!ctrl.error\">\n" +
+    "<h3 class=\"mar-top-none\">\n" +
+    "<strong>{{ctrl.selectedBinding}}</strong> has been unbound\n" +
+    "\n" +
+    "\n" +
+    "</h3>\n" +
+    "<p class=\"mar-top-lg\">\n" +
+    "<span class=\"pficon pficon-info\"></span> You will need to redeploy your pods for the un-binding to take effect.\n" +
+    "</p>\n" +
+    "</div>\n" +
+    "<div ng-if=\"ctrl.error\">\n" +
+    "<div class=\"title\">Deletion of Binding Failed <span class=\"fa fa-times text-danger\"></span></div>\n" +
+    "<div class=\"sub-title\">\n" +
+    "<span ng-if=\"ctrl.error.data.message\">\n" +
+    "{{ctrl.error.data.message | upperFirst}}\n" +
+    "</span>\n" +
+    "<span ng-if=\"!ctrl.error.data.message\">\n" +
+    "An error occurred deleting the binding.\n" +
+    "</span>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>"
+  );
+
+
   $templateCache.put('views/directives/bind-service/results.html',
     "<bind-results error=\"ctrl.error\" binding=\"ctrl.binding\" service-to-bind=\"ctrl.serviceToBind\" bind-type=\"{{ctrl.bindType}}\" application-to-bind=\"ctrl.appToBind.metadata.name\" generated-secret-name=\"ctrl.generatedSecretName\" show-pod-presets=\"'pod_presets' | enableTechPreviewFeature\" secret-href=\"ctrl.generatedSecretName | navigateResourceURL : 'Secret' : ctrl.target.metadata.namespace\">\n" +
     "</bind-results>"
+  );
+
+
+  $templateCache.put('views/directives/bind-service/select-binding.html',
+    "<h3 class=\"mar-top-none\">\n" +
+    "Select a service to delete from <strong>{{ctrl.displayName}}</strong>\n" +
+    "</h3>\n" +
+    "<form name=\"ctrl.bindingSelection\" class=\"mar-bottom-lg\">\n" +
+    "<fieldset ng-disabled=\"ctrl.isDisabled\">\n" +
+    "<div ng-repeat=\"binding in ctrl.bindings\" class=\"radio\">\n" +
+    "<label>\n" +
+    "<input type=\"radio\" ng-model=\"ctrl.selectedBinding\" value=\"{{binding.metadata.name}}\">\n" +
+    "{{binding.metadata.name}}\n" +
+    "</label>\n" +
+    "</div>\n" +
+    "</fieldset>\n" +
+    "</form>"
   );
 
 
@@ -8671,6 +8715,21 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</tr>\n" +
     "</tbody>\n" +
     "</table>"
+  );
+
+
+  $templateCache.put('views/directives/unbind-service.html',
+    "<div class=\"bind-service-wizard unbind-service\">\n" +
+    "<div pf-wizard hide-header=\"true\" hide-sidebar=\"true\" hide-back-button=\"true\" step-class=\"bind-service-wizard-step\" wizard-ready=\"ctrl.wizardReady\" next-title=\"ctrl.nextTitle\" on-finish=\"ctrl.closeWizard()\" on-cancel=\"ctrl.closeWizard()\" wizard-done=\"ctrl.wizardComplete\" class=\"pf-wizard-no-back\">\n" +
+    "<div pf-wizard-step ng-repeat=\"step in ctrl.steps track by $index\" step-title=\"{{step.label}}\" next-enabled=\"step.valid\" on-show=\"step.onShow\" step-id=\"{{step.id}}\" step-priority=\"{{$index}}\">\n" +
+    "<div class=\"wizard-pf-main-inner-shadow-covers\">\n" +
+    "<div class=\"bind-service-config\">\n" +
+    "<div ng-include=\"step.view\" class=\"wizard-pf-main-form-contents\"></div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>"
   );
 
 
@@ -11905,6 +11964,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<li role=\"menuitem\" ng-if=\"row.isBindable\">\n" +
     "<a href=\"\" ng-click=\"row.showOverlayPanel('bindService', {target: row.apiObject})\">Create Binding</a>\n" +
     "</li>\n" +
+    "<li role=\"menuitem\" ng-if=\"row.bindings.length\">\n" +
+    "<a href=\"\" ng-click=\"row.showOverlayPanel('unbindService', {target: row.apiObject})\">Delete Binding</a>\n" +
+    "</li>\n" +
     "<li role=\"menuitem\">\n" +
     "<a href=\"\" ng-click=\"row.deprovision()\" role=\"button\">Deprovision</a>\n" +
     "</li>\n" +
@@ -11952,6 +12014,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<overlay-panel single-column=\"true\" show-panel=\"row.overlay.panelVisible\" show-close=\"true\" handle-close=\"row.closeOverlayPanel\">\n" +
     "<div ng-if=\"row.overlay.panelName === 'bindService'\">\n" +
     "<bind-service target=\"row.overlay.state.target\" on-close=\"row.closeOverlayPanel\"></bind-service>\n" +
+    "</div>\n" +
+    "<div ng-if=\"row.overlay.panelName === 'unbindService'\">\n" +
+    "<unbind-service target=\"row.overlay.state.target\" bindings=\"row.bindings\" on-close=\"row.closeOverlayPanel\"></unbind-service>\n" +
     "</div>\n" +
     "</overlay-panel>"
   );


### PR DESCRIPTION
Depends on #1578

WIP, still some things to do.  Based on [mock-ups from here](https://openshift.github.io/openshift-origin-design/web-console/3-project-details/binding-in-project).  Progress thus far:

![screen shot 2017-05-03 at 12 10 26 pm](https://cloud.githubusercontent.com/assets/280512/25672895/80807856-3003-11e7-8a30-acd5d3ead3c7.png)

![screen shot 2017-05-03 at 12 10 34 pm](https://cloud.githubusercontent.com/assets/280512/25672883/77cd9496-3003-11e7-92ea-4c313a9defd7.png)

![screen shot 2017-05-03 at 12 10 39 pm](https://cloud.githubusercontent.com/assets/280512/25672921/97abf60e-3003-11e7-8180-0fe6b3a76d97.png)

TODO:
- [ ] `<service>` has been unbound from **`<application>`**.  Application name is missing.
- [x] factor `bindService` and `unbindService` duplicate code into separate service, OR collapse `unbindService` into bindService & toggle.

@jwforres @spadgett @ncameronbritt