### PR TITLE
Remove misleading placeholders from HPA form

### DIFF
--- a/app/views/directives/osc-autoscaling.html
+++ b/app/views/directives/osc-autoscaling.html
@@ -13,7 +13,6 @@
           ng-readonly="nameReadOnly"
           ng-pattern="nameValidation.pattern"
           ng-maxlength="nameValidation.maxlength"
-          placeholder="my-hpa"
           select-on-focus
           autocorrect="off"
           autocapitalize="off"
@@ -46,7 +45,6 @@
              class="form-control"
              min="1"
              name="minReplicas"
-             placeholder="1"
              ng-model="autoscaling.minReplicas"
              ng-pattern="/^\d+$/"
              aria-describedby="min-replicas-help">
@@ -73,7 +71,6 @@
       <input type="number"
              class="form-control"
              name="maxReplicas"
-             placeholder="4"
              required
              min="{{autoscaling.minReplicas || 1}}"
              ng-model="autoscaling.maxReplicas"
@@ -112,7 +109,6 @@
              class="form-control"
              min="1"
              name="targetCPU"
-             ng-attr-placeholder="{{defaultTargetCPUDisplayValue}}"
              ng-model="targetCPUInput.percent"
              ng-pattern="/^\d+$/"
              aria-describedby="target-cpu-help">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7785,7 +7785,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-show=\"showNameInput\" class=\"form-group\">\n" +
     "<label for=\"hpa-name\" class=\"required\">Autoscaler Name</label>\n" +
     "<span ng-class=\"{ 'has-error': form.name.$touched && form.name.$invalid }\">\n" +
-    "<input id=\"hpa-name\" class=\"form-control\" type=\"text\" name=\"name\" ng-model=\"autoscaling.name\" ng-required=\"showNameInput\" ng-readonly=\"nameReadOnly\" ng-pattern=\"nameValidation.pattern\" ng-maxlength=\"nameValidation.maxlength\" placeholder=\"my-hpa\" select-on-focus autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"hpa-name-help\">\n" +
+    "<input id=\"hpa-name\" class=\"form-control\" type=\"text\" name=\"name\" ng-model=\"autoscaling.name\" ng-required=\"showNameInput\" ng-readonly=\"nameReadOnly\" ng-pattern=\"nameValidation.pattern\" ng-maxlength=\"nameValidation.maxlength\" select-on-focus autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\" aria-describedby=\"hpa-name-help\">\n" +
     "</span>\n" +
     "<div>\n" +
     "<span id=\"hpa-name-help\" class=\"help-block\">\n" +
@@ -7809,7 +7809,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"form-group\">\n" +
     "<label>Min Pods</label>\n" +
     "<span ng-class=\"{ 'has-error': form.minReplicas.$dirty && form.minReplicas.$invalid }\">\n" +
-    "<input type=\"number\" class=\"form-control\" min=\"1\" name=\"minReplicas\" placeholder=\"1\" ng-model=\"autoscaling.minReplicas\" ng-pattern=\"/^\\d+$/\" aria-describedby=\"min-replicas-help\">\n" +
+    "<input type=\"number\" class=\"form-control\" min=\"1\" name=\"minReplicas\" ng-model=\"autoscaling.minReplicas\" ng-pattern=\"/^\\d+$/\" aria-describedby=\"min-replicas-help\">\n" +
     "</span>\n" +
     "<div id=\"min-replicas-help\" class=\"help-block\">\n" +
     "The lower limit for the number of pods that can be set by the autoscaler. If not specified, defaults to 1.\n" +
@@ -7829,7 +7829,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"form-group\">\n" +
     "<label class=\"required\">Max Pods</label>\n" +
     "<span ng-class=\"{ 'has-error': (form.minReplicas.$dirty || form.maxReplicas.$dirty) && form.maxReplicas.$invalid }\">\n" +
-    "<input type=\"number\" class=\"form-control\" name=\"maxReplicas\" placeholder=\"4\" required min=\"{{autoscaling.minReplicas || 1}}\" ng-model=\"autoscaling.maxReplicas\" ng-pattern=\"/^\\d+$/\" aria-describedby=\"max-replicas-help\">\n" +
+    "<input type=\"number\" class=\"form-control\" name=\"maxReplicas\" required min=\"{{autoscaling.minReplicas || 1}}\" ng-model=\"autoscaling.maxReplicas\" ng-pattern=\"/^\\d+$/\" aria-describedby=\"max-replicas-help\">\n" +
     "</span>\n" +
     "<div id=\"max-replicas-help\" class=\"help-block\">\n" +
     "The upper limit for the number of pods that can be set by the autoscaler.\n" +
@@ -7859,7 +7859,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Target\n" +
     "</label>\n" +
     "<div class=\"input-group\" ng-class=\"{ 'has-error': form.targetCPU.$invalid && form.targetCPU.$touched }\">\n" +
-    "<input type=\"number\" class=\"form-control\" min=\"1\" name=\"targetCPU\" ng-attr-placeholder=\"{{defaultTargetCPUDisplayValue}}\" ng-model=\"targetCPUInput.percent\" ng-pattern=\"/^\\d+$/\" aria-describedby=\"target-cpu-help\">\n" +
+    "<input type=\"number\" class=\"form-control\" min=\"1\" name=\"targetCPU\" ng-model=\"targetCPUInput.percent\" ng-pattern=\"/^\\d+$/\" aria-describedby=\"target-cpu-help\">\n" +
     "<span class=\"input-group-addon\">%</span>\n" +
     "</div>\n" +
     "<div id=\"target-cpu-help\" class=\"help-block\">\n" +


### PR DESCRIPTION
Remove the placeholder text for max pods and other inputs when adding an
HPA. It looks too much like either the required field has a value or 4
is a default. This is especially confusing in the add to project form,
where it's easy to miss required fields in a large form.

![openshift web console 2017-05-04 15-12-01](https://cloud.githubusercontent.com/assets/1167259/25720820/492cd9ba-30dc-11e7-88e1-be767b0c6d6c.png)

cc @liggitt 