### PR TITLE
View all projects should go to projects page, not landing page

### DIFF
--- a/app/scripts/directives/nav.js
+++ b/app/scripts/directives/nav.js
@@ -127,7 +127,7 @@ angular.module('openshiftConsole')
           })
           .change(function() {
             var val = $(this).val();
-            var newURL = (val === "") ? "/" : projectOverviewURLFilter(val);
+            var newURL = (val === "") ? "projects" : projectOverviewURLFilter(val);
             $scope.$apply(function() {
               $location.url(newURL);
             });

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -11200,7 +11200,7 @@ f = a.by("metadata.name"), k();
 iconBase:"fa",
 tickIcon:"fa-check"
 }).change(function() {
-var c = $(this).val(), d = "" === c ? "/" :e(c);
+var c = $(this).val(), d = "" === c ? "projects" :e(c);
 a.$apply(function() {
 b.url(d);
 });


### PR DESCRIPTION
With the new catalog experience enabled, the view all projects link in
the projects dropdown should go to the projects list rather than the
landing page, which is now a different URL.

Fixes #1484