### PR TITLE
Fix runtime error when missing apiVersion in template resource

### DIFF
--- a/app/scripts/services/quota.js
+++ b/app/scripts/services/quota.js
@@ -194,6 +194,10 @@ angular.module("openshiftConsole")
         var filteredClusterQuotas = filterQuotasForResource(resource, clusterQuotas);
 
         var rgv = APIService.objectToResourceGroupVersion(resource);
+        if (!rgv) {
+          return;
+        }
+
         var humanizedResource = APIService.kindToResource(resource.kind, true);
         var humanizedKind = humanizeKind(resource.kind);
         var quotaKey = "";

--- a/app/scripts/services/securityCheck.js
+++ b/app/scripts/services/securityCheck.js
@@ -40,7 +40,7 @@ angular.module("openshiftConsole")
       });
       if (unrecognizedResources.length) {
         var unrecognizedStrs = _.uniq(_.map(unrecognizedResources, function(resource) {
-          var apiVersion = _.get(resource, 'apiVersion', '<unknown-version>');
+          var apiVersion = _.get(resource, 'apiVersion', '<none>');
           return 'API version ' + apiVersion + ' for kind ' + humanizeKind(resource.kind);
         }));
         alerts.push({

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3994,7 +3994,9 @@ i && c.push(i);
 }, r = function(b, c, d) {
 var e = [];
 return b && c ? (_.each(b, function(b) {
-var h = k(b, c), i = k(b, d), j = a.objectToResourceGroupVersion(b), l = a.kindToResource(b.kind, !0), n = m(b.kind), o = "";
+var h = k(b, c), i = k(b, d), j = a.objectToResourceGroupVersion(b);
+if (j) {
+var l = a.kindToResource(b.kind, !0), n = m(b.kind), o = "";
 j.group && (o = j.group + "/"), o += j.resource;
 var p = function(a) {
 var c = a.status.total || a.status;
@@ -4010,6 +4012,7 @@ target:"_blank"
 }), e = e.concat(q(b, a));
 };
 _.each(h, p), _.each(i, p);
+}
 }), e) :e;
 }, s = function(a, b) {
 var f, g, h = [];
@@ -4061,7 +4064,7 @@ var f = _.get(b, "roleRef.name");
 }
 }), g.length) {
 var l = _.uniq(_.map(g, function(a) {
-var b = _.get(a, "apiVersion", "<unknown-version>");
+var b = _.get(a, "apiVersion", "<none>");
 return "API version " + b + " for kind " + d(a.kind);
 }));
 f.push({


### PR DESCRIPTION
Fixes #1385

Related to #1512, but fixes an additional runtime error in `QuotaService` when `apiVersion` is missing entirely. I also changed the display value to `<none>` to match the error message from the server if you click "Create Anyway."

![screen shot 2017-05-04 at 4 49 36 pm](https://cloud.githubusercontent.com/assets/1167259/25724364/be7e7bda-30e9-11e7-87d9-d55510350d4c.png)

