### PR TITLE
Change button label for "Home" for new landing page

### DIFF
--- a/app/views/directives/header/project-header.html
+++ b/app/views/directives/header/project-header.html
@@ -1,6 +1,14 @@
 <nav class="navbar navbar-pf-alt" role="navigation">
   <div class="navbar-header hidden-xs">
-    <a class="navbar-home" href="./"><span class="fa-fw pficon pficon-home" aria-hidden="true"></span> <span class="visible-xlg-inline-block"> Projects</span></a>
+    <a class="navbar-home" href="./"><span class="fa-fw pficon pficon-home" aria-hidden="true"></span>
+      <span class="visible-xlg-inline-block">
+        <span ng-if="'service_catalog_landing_page' | enableTechPreviewFeature">
+          Home
+        </span>
+        <span ng-if="!('service_catalog_landing_page' | enableTechPreviewFeature)">
+          Projects
+        </span>
+      </span></a>
   </div>
   <div class="nav navbar-project-menu">
     <!-- mobile nav menu -->

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7222,7 +7222,15 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   $templateCache.put('views/directives/header/project-header.html',
     "<nav class=\"navbar navbar-pf-alt\" role=\"navigation\">\n" +
     "<div class=\"navbar-header hidden-xs\">\n" +
-    "<a class=\"navbar-home\" href=\"./\"><span class=\"fa-fw pficon pficon-home\" aria-hidden=\"true\"></span> <span class=\"visible-xlg-inline-block\"> Projects</span></a>\n" +
+    "<a class=\"navbar-home\" href=\"./\"><span class=\"fa-fw pficon pficon-home\" aria-hidden=\"true\"></span>\n" +
+    "<span class=\"visible-xlg-inline-block\">\n" +
+    "<span ng-if=\"'service_catalog_landing_page' | enableTechPreviewFeature\">\n" +
+    "Home\n" +
+    "</span>\n" +
+    "<span ng-if=\"!('service_catalog_landing_page' | enableTechPreviewFeature)\">\n" +
+    "Projects\n" +
+    "</span>\n" +
+    "</span></a>\n" +
     "</div>\n" +
     "<div class=\"nav navbar-project-menu\">\n" +
     "\n" +


### PR DESCRIPTION
With the new landing page experience enabled, show the label "Home" rather than "Projects" for the home button in the page upper left.

Fixes #1483