### PR TITLE
Fix inconsistent behavior in kve between a standard row & a ui-select row

### DIFF
--- a/app/scripts/services/keyValueEditorUtils.js
+++ b/app/scripts/services/keyValueEditorUtils.js
@@ -141,7 +141,12 @@
                     entries,
                     function(entry) {
                       entry = cleanEntry(entry);
-                      return (entry.name || entry.value || entry.valueFrom) ? entry : undefined;
+                      var hasValueFrom = entry.valueFrom;
+                      if(!hasValueFrom) {
+                        return (entry.name || entry.value) ? entry : undefined;
+                      }
+                      // if the valueFrom is an empty object, this entry is invalid and should be discarded
+                      return _.keys(entry.valueFrom).length ? entry : undefined;
                     }));
         };
 

--- a/app/views/directives/key-value-editor.html
+++ b/app/views/directives/key-value-editor.html
@@ -142,7 +142,7 @@
           </div>
           <div ng-if="!isValueFromReadonly(entry)">
             <div class="ui-select">
-              <ui-select ng-model="entry.selectedValueFrom" ng-required="true" on-select="valueFromObjectSelected(entry, $select.selected)">
+              <ui-select ng-model="entry.selectedValueFrom" on-select="valueFromObjectSelected(entry, $select.selected)">
                 <ui-select-match placeholder="Select a resource">
                   <span>
                     {{$select.selected.metadata.name}}
@@ -157,7 +157,7 @@
               </ui-select>
             </div>
             <div class="ui-select">
-              <ui-select ng-model="entry.selectedValueFromKey" ng-required="true" on-select="valueFromKeySelected(entry, $select.selected)">
+              <ui-select ng-model="entry.selectedValueFromKey" on-select="valueFromKeySelected(entry, $select.selected)">
                 <ui-select-match placeholder="Select key">
                   {{$select.selected}}
                 </ui-select-match>


### PR DESCRIPTION
Re [bugzilla #1448830](https://bugzilla.redhat.com/show_bug.cgi?id=1448830)
There are currently two different behaviors with how we are handling rows in the kve:

1. We allow the user to save a default row that has a key w/o a value:
![screen shot 2017-05-08 at 5 27 05 pm](https://cloud.githubusercontent.com/assets/280512/25826151/acf7edce-3413-11e7-8b13-9b1b79208e73.png)

2.  We do not allow the user to save if the row includes a ui-select to choose from a config map or secret:
![screen shot 2017-05-08 at 5 27 21 pm](https://cloud.githubusercontent.com/assets/280512/25826150/acf3548a-3413-11e7-987d-e3db397522cd.png)

In this case the user must manually remove the row if they decide they no longer need to select the env var.  

This PR would allow the user to save the form, but would delete the key_with_no_value row if the user doesn't actually select a `valueFrom` from a `configmap` or `secret`:

![screen shot 2017-05-08 at 5 34 40 pm](https://cloud.githubusercontent.com/assets/280512/25826381/a7480b24-3414-11e7-94fe-668e10e35245.png)

I'm not 100% sure this is a better experience, though.  By automatically eliminating the incomplete row, we might put the user into an unexpected state. Though the original experience is a bit inconsistent, it might be more correct.

Its also possible I'm missing something.  Thoughts?

@jwforres @spadgett @rhamilto 
