### PR TITLE
Modify appearance of log btns to improve cross-browser consistency

### DIFF
--- a/app/scripts/directives/logViewer.js
+++ b/app/scripts/directives/logViewer.js
@@ -153,9 +153,6 @@ angular.module('openshiftConsole')
               }
             };
 
-
-            // the class .target-logger-node is needed to adjust some
-            // css when the target is not the window.
             // TODO: resize event breaks the affix, even with this if/else.
             // however, on first load of either mobile or non this works fine.
             var affix = function() {
@@ -165,7 +162,6 @@ angular.module('openshiftConsole')
               }
               if(window.innerWidth < BREAKPOINTS.screenSmMin && !$scope.fixedHeight) {
                 $affixableNode
-                  .removeClass('target-logger-node')
                   .affix({
                     target:  window,
                     offset: {
@@ -174,7 +170,6 @@ angular.module('openshiftConsole')
                   });
               } else {
                 $affixableNode
-                  .addClass('target-logger-node')
                   .affix({
                     target:  $cachedScrollableNode,
                     offset: {
@@ -510,6 +505,7 @@ angular.module('openshiftConsole')
               onScrollTop: function() {
                 $scope.autoScrollActive = false;
                 logLinks.scrollTop(scrollableDOMNode);
+                $('#' + $scope.logViewerID + '-affixedFollow').affix('checkPosition');
               },
               toggleAutoScroll: toggleAutoScroll,
               goChromeless: logLinks.chromelessLink,

--- a/app/styles/_log.less
+++ b/app/styles/_log.less
@@ -1,3 +1,12 @@
+.chromeless {
+  background-color:  @log-bg-color;
+  color: #d1d1d1;
+  .log-loading-msg {
+    .empty-state-message();
+    .h2();
+    .text-center();
+  }
+}
 .log-title {
   margin-top: 0;
 }
@@ -70,9 +79,9 @@
   // Make sure log-actions are not hidden behind log if they wrap.
   clear: both;
   font-family: @font-family-monospace;
+  .mar-bottom-xl();
   padding: 0;
   position: relative;
-  .mar-bottom-xl();
   .chromeless & {
     margin-bottom: 0;
   }
@@ -83,61 +92,48 @@
     overflow: visible;
     padding: 0 10px;
   }
-  .log-scroll {
-    background-color: @log-bg-color;
-    border: 1px solid lighten(@log-bg-color, 10%);
+  .log-scroll a {
+    background-color: lighten(@log-bg-color, 30%);
+    border-radius: 1px;
+    box-shadow: 0 0 5px 7px rgba(0,0,0,.9);
+    color: @color-pf-white;
     display: inline-block;
+    font-family: @font-family-base;
+    font-size: @font-size-base - 1;
+    padding: 2px 6px;
+    &:focus,
     &:hover {
-      border-color: lighten(@log-bg-color, 15%);
-    }
-    a {
-      display: inline-block;
-      font-family: @font-family-base;
-      font-size: @font-size-base - 1;
-      padding: 4px 10px;
-    }
-    a:hover,a:focus {
-      background-color: darken(@log-bg-color, 10%);
-      color: @link-hover-color-bright;
+      background-color: lighten(@log-bg-color, 35%);
+      color: @color-pf-white;
       text-decoration: none;
     }
   }
+  .log-scroll-bottom {
+    bottom: @log-scroll-offset-bottom;
+    position: absolute;
+    right: @log-scroll-offset-right;
+  }
   .log-scroll-top {
     position: absolute;
-    right: 0;
-    border-right-width: 0;
-    border-top: 0;
-  }
-  // starting position
-  .log-scroll-top.affix-top {
-    position: absolute;
-    right: 0;
-    top: 0;
-  }
-  // once affixed, has this position
-  .log-scroll-top.affix {
-    position: fixed;
-    right: 20px;
-    top: 0;
-  }
-  // TODO: hacky, need to encapsulate this better
-  // '.target-logger-node' is a class indicating the target is not 'window'
-  // this is toggled in JS
-  .log-scroll-top.affix.target-logger-node {
-    position: fixed;
-    right: @log-scroll-top-offset;
-    @media (min-width: @screen-md-min) {
-      right: @log-scroll-top-offset-lg;
+    right: @log-scroll-offset-right;
+    top: @log-scroll-offset-top;
+    &.affix {
+      position: fixed;
+      right: @log-scroll-top-offset-right-xs;
+      @media (min-width: @screen-sm-min) {
+        right: @log-scroll-top-offset-right-sm;
+        top: (@log-scroll-offset-top + @navbar-os-header-height-desktop);
+      }
+      @media (min-width: @screen-md-min) {
+        right: @log-scroll-top-offset-right-lg;
+      }
+      .chromeless & {
+        right: @log-scroll-offset-right;
+        @media (min-width: @screen-sm-min) {
+          right: (@log-scroll-offset-right + @scrollbar-width);
+        }
+      }
     }
-    top: 60px !important;
-  }
-
-  .log-scroll-bottom {
-    position: absolute;
-    border-bottom: 0;
-    border-right-width: 0;
-    bottom: 0;
-    right: 0;
   }
   .log-view-output {
     font-size: 11px;
@@ -160,7 +156,7 @@
       bottom: 0;
       #gradient > .vertical(transparent, @log-bg-color, 0%, 15%);
       height: 30px;
-      right: @scrollbar-width-log-viewer;
+      right: @scrollbar-width;
       width: auto;
       &.dots div {
         left: 50%;
@@ -171,9 +167,10 @@
       margin: 20px 0 -35px 10px;
       position: static;
     }
-    .log-scroll-bottom, .log-scroll-top {
-      border-right-width: 1px;
-      right: @scrollbar-width-log-viewer; // width of IE11 scrollbar
+    .log-scroll-top.affix {
+      position: absolute;
+      right: @log-scroll-offset-right;
+      top: @log-scroll-offset-top;
     }
     .log-view-output {
       overflow: auto;
@@ -194,6 +191,9 @@
   display: inline-block;
   padding-top: @grid-gutter-width / 2;
   width: 100%;
+  .chromeless & {
+    padding-left: (@grid-gutter-width - 10px);
+  }
 }
 .log-end-msg {
   font-family: @font-family-base;
@@ -203,22 +203,6 @@
   bottom: 5px;
   left: 10px;
 }
-.chromeless {
-  background-color:  @log-bg-color;
-  color: #d1d1d1;
-  .log-pending-ellipsis {
-    background-color: @log-bg-color;
-    padding: @grid-gutter-width 0 0 (@grid-gutter-width - 10px);
-  }
-  .log-scroll-top.affix {
-    right: 0px; // override
-  }
-  .log-scroll-top.affix.target-logger-node {
-    right: @scrollbar-width;  // override
-  }
-}
-
-
 .log-link-external {
   text-align: right;
   a {
@@ -274,10 +258,4 @@
 
 .log-fixed-height.empty-state-message {
   margin-top: 0;
-}
-
-.chromeless .log-loading-msg {
-  .h2();
-  .empty-state-message();
-  .text-center();
 }

--- a/app/styles/_scrollbars.less
+++ b/app/styles/_scrollbars.less
@@ -32,9 +32,10 @@
   background-color: @scrollbar-track;
 }
 
+.chromeless .middle,
 .landing,
 .landing-side-bar,
-.log-view.log-fixed-height .log-view-output,
+.log-view .log-view-output,
 .navbar-project-menu .dropdown-menu {
   &::-webkit-scrollbar-thumb {
     background-color: @scrollbar-thumb-inverse;
@@ -52,15 +53,6 @@
 
 .landing-side-bar::-webkit-scrollbar-track {
   background-color: @scrollbar-track-landing-side-bar;
-}
-
-.log-view.log-fixed-height .log-view-output {
-  &::-webkit-scrollbar {
-    width: @scrollbar-width-log-viewer;
-  }
-  &::-webkit-scrollbar-track {
-    background-color: @scrollbar-track-inverse-alt;
-  }
 }
 
 .navbar-project-menu ::-webkit-scrollbar-track {

--- a/app/styles/_variables.less
+++ b/app/styles/_variables.less
@@ -46,8 +46,12 @@
 @link-hover-color-bright: lighten(@link-color, 13%);
 @list-view-expanded-bg: #f5f5f5;
 @log-bg-color: #101214;
-@log-scroll-top-offset: (@scrollbar-width + @middle-content-container-padding);
-@log-scroll-top-offset-lg: (@scrollbar-width + @middle-content-container-padding-lg);
+@log-scroll-offset-bottom: @log-scroll-offset-top;
+@log-scroll-offset-right: 25px;
+@log-scroll-offset-top: 10px;
+@log-scroll-top-offset-right-xs: (@log-scroll-offset-right + @middle-content-container-padding);
+@log-scroll-top-offset-right-sm: (@log-scroll-offset-right + @scrollbar-width + @middle-content-container-padding);
+@log-scroll-top-offset-right-lg: (@log-scroll-offset-right + @scrollbar-width + @middle-content-container-padding-lg);
 // The log viewer needs to be udpated if this value changes.  It accounts for
 // bottom margin when resizing the log in JavaScript.
 @middle-content-bottom-margin: @grid-gutter-width;
@@ -110,7 +114,6 @@
 @scrollbar-track-landing: #042e43;
 @scrollbar-track-landing-side-bar: darken(#2C343D, 5%); // #2C343D is @landing-side-bar-bg in catalog
 @scrollbar-width: 15px;
-@scrollbar-width-log-viewer: 17px;
 @status-bg-color: #E6ECF1;
 @status-border-color: #BFCEDB;
 @tileHeadingIconFontSize: 33px;

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12477,12 +12477,12 @@ b.autoScrollActive = !1;
 }, A = function() {
 o.off("scroll", z), n.off("scroll", z), window.innerWidth <= m.screenSmMin && !b.fixedHeight ? n.on("scroll", z) :o.on("scroll", z);
 }, B = function() {
-b.fixedHeight || (window.innerWidth < m.screenSmMin && !b.fixedHeight ? r.removeClass("target-logger-node").affix({
+b.fixedHeight || (window.innerWidth < m.screenSmMin && !b.fixedHeight ? r.affix({
 target:window,
 offset:{
 top:b.followAffixTop || 0
 }
-}) :r.addClass("target-logger-node").affix({
+}) :r.affix({
 target:o,
 offset:{
 top:b.followAffixTop || 0
@@ -12607,7 +12607,7 @@ onScrollBottom:function() {
 l.scrollBottom(q);
 },
 onScrollTop:function() {
-b.autoScrollActive = !1, l.scrollTop(q);
+b.autoScrollActive = !1, l.scrollTop(q), $("#" + b.logViewerID + "-affixedFollow").affix("checkPosition");
 },
 toggleAutoScroll:I,
 goChromeless:l.chromelessLink,

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5058,7 +5058,7 @@ ul.messenger-theme-flat .messenger-message.alert-info .messenger-message-inner:b
 .overview .overview-tile .overview-tile-body{-webkit-flex-direction:row;-moz-flex-direction:row;-ms-flex-direction:row;flex-direction:row;-webkit-justify-content:space-between;-moz-justify-content:space-between;justify-content:space-between}
 }
 .overview .overview-tile.deployment-in-progress{overflow:hidden}
-.overview .empty-dc,.overview .empty-tile{word-break:break-word;overflow-wrap:break-word;min-width:0;word-wrap:break-word;text-align:center}
+.overview .empty-dc,.overview .empty-tile{word-break:break-word;overflow-wrap:break-word;min-width:0;text-align:center;word-wrap:break-word}
 .overview .overview-tile .overview-donut,.overview .overview-tile .overview-metrics{-webkit-align-items:center;-moz-align-items:center;align-items:center}
 @media (min-width:1200px){.overview .overview-tile .overview-metrics .metrics-sparkline{width:60%}
 }
@@ -5346,12 +5346,10 @@ td.visible-print,th.visible-print{display:table-cell!important}
 ::-webkit-scrollbar-thumb{background-clip:padding-box;background-color:rgba(0,0,0,.08);border:solid transparent;border-width:1px;box-shadow:inset 1px 1px 0 rgba(0,0,0,.1),inset 0 -1px 0 rgba(0,0,0,.07);max-height:60px;min-height:28px;padding:100px 0 0}
 ::-webkit-scrollbar-thumb:active,::-webkit-scrollbar-thumb:hover{background-color:rgba(0,0,0,.18)}
 ::-webkit-scrollbar-track{background-clip:padding-box;background-color:rgba(0,0,0,.03)}
-.landing-side-bar::-webkit-scrollbar-thumb,.landing::-webkit-scrollbar-thumb,.log-view.log-fixed-height .log-view-output::-webkit-scrollbar-thumb,.navbar-project-menu .dropdown-menu::-webkit-scrollbar-thumb{background-color:rgba(255,255,255,.25);box-shadow:inset 1px 1px 0 rgba(255,255,255,.1),inset 0 -1px 0 rgba(255,255,255,.07)}
-.landing-side-bar::-webkit-scrollbar-thumb:active,.landing-side-bar::-webkit-scrollbar-thumb:hover,.landing::-webkit-scrollbar-thumb:active,.landing::-webkit-scrollbar-thumb:hover,.log-view.log-fixed-height .log-view-output::-webkit-scrollbar-thumb:active,.log-view.log-fixed-height .log-view-output::-webkit-scrollbar-thumb:hover,.navbar-project-menu .dropdown-menu::-webkit-scrollbar-thumb:active,.navbar-project-menu .dropdown-menu::-webkit-scrollbar-thumb:hover{background-color:rgba(255,255,255,.35)}
+.chromeless .middle::-webkit-scrollbar-thumb,.landing-side-bar::-webkit-scrollbar-thumb,.landing::-webkit-scrollbar-thumb,.log-view .log-view-output::-webkit-scrollbar-thumb,.navbar-project-menu .dropdown-menu::-webkit-scrollbar-thumb{background-color:rgba(255,255,255,.25);box-shadow:inset 1px 1px 0 rgba(255,255,255,.1),inset 0 -1px 0 rgba(255,255,255,.07)}
+.chromeless .middle::-webkit-scrollbar-thumb:active,.chromeless .middle::-webkit-scrollbar-thumb:hover,.landing-side-bar::-webkit-scrollbar-thumb:active,.landing-side-bar::-webkit-scrollbar-thumb:hover,.landing::-webkit-scrollbar-thumb:active,.landing::-webkit-scrollbar-thumb:hover,.log-view .log-view-output::-webkit-scrollbar-thumb:active,.log-view .log-view-output::-webkit-scrollbar-thumb:hover,.navbar-project-menu .dropdown-menu::-webkit-scrollbar-thumb:active,.navbar-project-menu .dropdown-menu::-webkit-scrollbar-thumb:hover{background-color:rgba(255,255,255,.35)}
 .landing::-webkit-scrollbar-track{background-color:#042e43}
 .landing-side-bar::-webkit-scrollbar-track{background-color:#21272e}
-.log-view.log-fixed-height .log-view-output::-webkit-scrollbar{width:17px}
-.log-view.log-fixed-height .log-view-output::-webkit-scrollbar-track{background-color:rgba(255,255,255,.1)}
 .navbar-project-menu ::-webkit-scrollbar-track{background-color:#050505}
 .osc-secrets-form .advanced-secrets .help-blocks,.osc-secrets-form .advanced-secrets .input-labels,.osc-secrets-form .basic-secrets .help-blocks,.osc-secrets-form .basic-secrets .input-labels{display:table;padding-right:30px;position:relative;width:100%}
 .osc-secrets-form .advanced-secrets .help-blocks .help-block,.osc-secrets-form .advanced-secrets .help-blocks .input-label,.osc-secrets-form .advanced-secrets .input-labels .help-block,.osc-secrets-form .advanced-secrets .input-labels .input-label,.osc-secrets-form .basic-secrets .help-blocks .help-block,.osc-secrets-form .basic-secrets .help-blocks .input-label,.osc-secrets-form .basic-secrets .input-labels .help-block,.osc-secrets-form .basic-secrets .input-labels .input-label{width:100%;float:left;padding-right:5px}
@@ -5587,6 +5585,7 @@ td[role=presentation].arrow:after{content:"\2192"}
 .tile-row .tile p{margin-bottom:0;margin-top:15px}
 .tile-row .tile-click:hover{box-shadow:0 2px 12px -1px rgba(0,0,0,.3),0 4px 5px 0 rgba(0,0,0,.11),0 1px 10px 0 rgba(0,0,0,.1)}
 .tile-row .tile-item-count{background-color:#ccc;font-weight:600;padding:4px 6px;position:absolute;right:10px;top:10px}
+.chromeless,.log-view{background-color:#101214}
 .tile-row .tile-title{text-align:center}
 .tile-row .tile-title h3{margin:0 20px}
 .overview .alert.toast-pf{padding:6px 10px 6px 44px}
@@ -5630,7 +5629,6 @@ a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;borde
 @media (min-width:1200px){.text-lg-left{text-align:left}
 .text-lg-right{text-align:right}
 }
-.log-line-number,.log-link-external{text-align:right}
 .pad-auto-none{padding:0 auto}
 .mar-auto-none{margin:0 auto}
 .pad-none{padding:0}
@@ -5714,8 +5712,24 @@ a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;borde
 .pad-bottom-xxl{padding-bottom:30px}
 .mar-bottom-xxl{margin-bottom:30px}
 .pad-left-xxl{padding-left:30px}
-.log-header .log-actions .btn-link,.log-view{padding:0}
 .mar-left-xxl{margin-left:30px}
+.chromeless{color:#d1d1d1}
+.chromeless .log-loading-msg{margin:40px auto 60px;max-width:600px;padding:0 20px;line-height:1.4;text-align:center}
+.log-header .log-actions .btn-link,.log-view{padding:0}
+.log-line-number,.log-link-external{text-align:right}
+.chromeless .log-loading-msg .h2,.chromeless .log-loading-msg h2{line-height:1.4}
+.chromeless .log-loading-msg .btn{margin:10px 0 20px}
+.chromeless .log-loading-msg .hero-icon{display:none}
+@media (min-height:600px){.chromeless .log-loading-msg .hero-icon{display:inline-block;font-size:90px}
+}
+@media (min-height:800px){.chromeless .log-loading-msg{margin-top:130px}
+.chromeless .log-loading-msg .hero-icon{font-size:100px}
+alerts+.chromeless .log-loading-msg{margin-top:90px}
+}
+@media (min-height:1024px){.chromeless .log-loading-msg{margin-top:170px}
+.chromeless .log-loading-msg .hero-icon{font-size:120px}
+alerts+.chromeless .log-loading-msg{margin-top:130px}
+}
 .log-title{margin-top:0}
 .log-header{margin-bottom:3px}
 .log-header label{margin-bottom:0}
@@ -5734,42 +5748,39 @@ a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;borde
 .log-size-warning{margin:0}
 @media (max-width:991px){.log-size-warning{margin-top:20px}
 }
-.log-view{background-color:#101214;font-family:Menlo,Monaco,Consolas,monospace;position:relative;margin-bottom:20px}
+.log-view{font-family:Menlo,Monaco,Consolas,monospace;margin-bottom:20px;position:relative}
 .log-end-msg,.log-view .log-scroll a{font-family:"Open Sans",Helvetica,Arial,sans-serif}
 .chromeless .log-view{margin-bottom:0}
 .log-view pre,.log-view pre code{background-color:transparent;border:0;margin-bottom:0;overflow:visible;padding:0 10px}
-.log-view .log-scroll{background-color:#101214;border:1px solid #272b30;display:inline-block}
-.log-view .log-scroll:hover{border-color:#32383f}
-.log-view .log-scroll a{display:inline-block;font-size:12px;padding:4px 10px}
-.log-view .log-scroll a:focus,.log-view .log-scroll a:hover{background-color:#000;color:#11aeff;text-decoration:none}
-.log-view .log-scroll-top{position:absolute;right:0;border-right-width:0;border-top:0}
-.log-view .log-scroll-top.affix-top{position:absolute;right:0;top:0}
-.log-view .log-scroll-top.affix{position:fixed;right:20px;top:0}
-.log-view .log-scroll-top.affix.target-logger-node{position:fixed;right:35px;top:60px!important}
-@media (min-width:992px){.log-view .log-scroll-top.affix.target-logger-node{right:45px}
+.log-view .log-scroll a{background-color:#545e69;border-radius:1px;box-shadow:0 0 5px 7px rgba(0,0,0,.9);color:#fff;display:inline-block;font-size:12px;padding:2px 6px}
+.log-view .log-scroll a:focus,.log-view .log-scroll a:hover{background-color:#5f6b77;color:#fff;text-decoration:none}
+.log-view .log-scroll-bottom{bottom:10px;position:absolute;right:25px}
+.log-view .log-scroll-top{position:absolute;right:25px;top:10px}
+.log-view .log-scroll-top.affix{position:fixed;right:45px}
+@media (min-width:768px){.log-view .log-scroll-top.affix{right:60px;top:70px}
 }
-.log-view .log-scroll-bottom{position:absolute;border-bottom:0;border-right-width:0;bottom:0;right:0}
+@media (min-width:992px){.log-view .log-scroll-top.affix{right:70px}
+}
+.chromeless .log-view .log-scroll-top.affix{right:25px}
 .log-view .log-view-output{font-size:11px;padding:40px 0}
-@media (min-width:768px){.log-view .log-view-output{font-size:12px}
+@media (min-width:768px){.chromeless .log-view .log-scroll-top.affix{right:40px}
+.log-view .log-view-output{font-size:12px}
 }
 @media only screen and (max-device-width:736px) and (-webkit-min-device-pixel-ratio:0){.log-view .log-view-output{padding-bottom:70px}
 }
 .log-view .log-view-output table{table-layout:fixed;width:100%}
-.log-view.log-fixed-height .ellipsis-loader{bottom:0;background-image:-webkit-linear-gradient(top,transparent 0%,#101214 15%);background-image:-o-linear-gradient(top,transparent 0%,#101214 15%);background-image:linear-gradient(to bottom,transparent 0%,#101214 15%);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#ff101214', GradientType=0);height:30px;right:17px;width:auto}
+.log-view.log-fixed-height .ellipsis-loader{bottom:0;background-image:-webkit-linear-gradient(top,transparent 0%,#101214 15%);background-image:-o-linear-gradient(top,transparent 0%,#101214 15%);background-image:linear-gradient(to bottom,transparent 0%,#101214 15%);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#ff101214', GradientType=0);height:30px;right:15px;width:auto}
 .log-view.log-fixed-height .ellipsis-loader.dots div{left:50%;top:12px}
 .log-view.log-fixed-height .log-end-msg{margin:20px 0 -35px 10px;position:static}
-.log-view.log-fixed-height .log-scroll-bottom,.log-view.log-fixed-height .log-scroll-top{border-right-width:1px;right:17px}
+.log-view.log-fixed-height .log-scroll-top.affix{position:absolute;right:25px;top:10px}
 .log-view.log-fixed-height .log-view-output{overflow:auto;padding-bottom:0;padding-top:0}
 .log-view.log-fixed-height .log-view-output table{margin-bottom:40px;margin-top:30px}
 .log-pending-ellipsis{display:inline-block;padding-top:20px;width:100%}
+.chromeless .log-pending-ellipsis{padding-left:30px}
 .log-end-msg{font-size:12px;color:#72767b;position:absolute;bottom:5px;left:10px}
-.chromeless,.log-line{color:#d1d1d1}
-.chromeless{background-color:#101214}
-.chromeless .log-pending-ellipsis{background-color:#101214;padding:40px 0 0 30px}
-.chromeless .log-scroll-top.affix{right:0px}
-.chromeless .log-scroll-top.affix.target-logger-node{right:15px}
 .log-link-external a{margin-left:20px;margin-right:10px;white-space:nowrap}
 .log-link-external i{font-size:10px;margin-left:5px}
+.log-line{color:#d1d1d1}
 .log-line:hover{background-color:#22262b;color:#ededed}
 .log-line-number:before{content:attr(data-line-number)}
 .log-line-number{-moz-user-select:none;-webkit-user-select:none;-ms-user-select:none;border-right:1px #272b30 solid;padding-right:10px;vertical-align:top;white-space:nowrap;width:60px;color:#72767b}
@@ -5778,21 +5789,6 @@ a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;borde
 .table-log-pods{background-color:#fff;border:1px solid #D1D1D1}
 .table-log-pods>tbody+tbody{border-top-width:1px}
 .log-fixed-height.empty-state-message{margin-top:0}
-.chromeless .log-loading-msg{font-family:inherit;line-height:1.1;color:inherit;font-size:19px;font-weight:300;margin:40px auto 60px;max-width:600px;padding:0 20px;text-align:center}
-.chromeless .log-loading-msg .small,.chromeless .log-loading-msg small{font-weight:400;line-height:1;color:#9c9c9c;font-size:65%}
-.chromeless .log-loading-msg .h2,.chromeless .log-loading-msg h2{line-height:1.4}
-.chromeless .log-loading-msg .btn{margin:10px 0 20px}
-.chromeless .log-loading-msg .hero-icon{display:none}
-@media (min-height:600px){.chromeless .log-loading-msg .hero-icon{display:inline-block;font-size:90px}
-}
-@media (min-height:800px){.chromeless .log-loading-msg{margin-top:130px}
-.chromeless .log-loading-msg .hero-icon{font-size:100px}
-alerts+.chromeless .log-loading-msg{margin-top:90px}
-}
-@media (min-height:1024px){.chromeless .log-loading-msg{margin-top:170px}
-.chromeless .log-loading-msg .hero-icon{font-size:120px}
-alerts+.chromeless .log-loading-msg{margin-top:130px}
-}
 .settings-item{margin:4px 8px 4px 0}
 .hide-if-empty:empty{display:none!important}
 .appended-icon{display:inline-block;white-space:nowrap}


### PR DESCRIPTION
Fixes #1322
Replaces #1341 

![screen shot 2017-05-10 at 11 32 35 am](https://cloud.githubusercontent.com/assets/895728/25907654/04305690-3576-11e7-9d4a-0008e43156a2.PNG)
<img width="963" alt="screen shot 2017-05-09 at 2 12 50 pm" src="https://cloud.githubusercontent.com/assets/895728/25865694/b53814ce-34c1-11e7-9f20-6afad799980d.PNG">
<img width="642" alt="screen shot 2017-05-09 at 2 13 06 pm" src="https://cloud.githubusercontent.com/assets/895728/25865696/b53c09da-34c1-11e7-893e-5c510bd54409.PNG">

Known, [pre-existing issue](https://github.com/openshift/origin-web-console/issues/1322):

* in Firefox for macOS with the default scrollbar behavior enabled ("Automatically based on mouse or trackpad"), the Follow/Stop Following/Go to End button is 15 pixels too far to the left when it is affixed; however, the new visual treatment of the buttons makes it a little less obvious this is so.

Before:
<img width="1441" alt="screen shot 2017-05-09 at 2 20 00 pm" src="https://cloud.githubusercontent.com/assets/895728/25865953/c440f692-34c2-11e7-997d-7132d92ea635.PNG">

After:
<img width="1435" alt="screen shot 2017-05-09 at 2 20 30 pm" src="https://cloud.githubusercontent.com/assets/895728/25865964/cd6dac88-34c2-11e7-8972-7f1897e1ce72.PNG">

@spadgett, @sg00dwin, @jwforres, PTAL.  Ideally, one or more of you pulls the branch and verifies I haven't borked something.  :)




