### PR TITLE
Support for Gitlab and Bitbucket webhooks in the BC editor

### DIFF
--- a/app/scripts/controllers/edit/buildConfig.js
+++ b/app/scripts/controllers/edit/buildConfig.js
@@ -107,10 +107,29 @@ angular.module('openshiftConsole')
 
     $scope.triggers = {
       githubWebhooks: [],
+      gitlabWebhooks: [],
+      bitbucketWebhooks: [],
       genericWebhooks: [],
       imageChangeTriggers: [],
       builderImageChangeTrigger: {},
       configChangeTrigger: {}
+    };
+
+    $scope.createTriggerSelect = {
+      selectedType: "",
+      options: [{
+        type: 'github',
+        label: 'GitHub'
+      }, {
+        type: 'gitlab',
+        label: 'GitLab'
+      }, {
+        type: 'bitbucket',
+        label: 'Bitbucket'
+      }, {
+        type: 'generic',
+        label: 'Generic'
+      }]
     };
 
     $scope.runPolicyTypes = [
@@ -381,6 +400,12 @@ angular.module('openshiftConsole')
           case "GitHub":
             triggerMap.githubWebhooks.push({disabled: false, data: trigger});
             break;
+          case "GitLab":
+            triggerMap.gitlabWebhooks.push({disabled: false, data: trigger});
+            break;
+          case "Bitbucket":
+            triggerMap.bitbucketWebhooks.push({disabled: false, data: trigger});
+            break;
           case "ImageChange":
             var imageChangeFrom = trigger.imageChange.from;
             if (!imageChangeFrom) {
@@ -460,6 +485,8 @@ angular.module('openshiftConsole')
 
     var updateTriggers = function() {
       var triggers = [].concat($scope.triggers.githubWebhooks,
+                              $scope.triggers.gitlabWebhooks,
+                              $scope.triggers.bitbucketWebhooks,
                               $scope.triggers.genericWebhooks,
                               $scope.triggers.imageChangeTriggers,
                               $scope.triggers.builderImageChangeTrigger,
@@ -520,6 +547,23 @@ angular.module('openshiftConsole')
         sourceMap[key] = true;
       });
       return sourceMap;
+    };
+
+    $scope.addWebhookTrigger = function(webhookLabel) {
+      if (!webhookLabel) {
+        return;
+      }
+      var webhook = {
+        disabled: false,
+        data: {
+          type: webhookLabel
+        }
+      };
+      var webhookType = _.find($scope.createTriggerSelect.options, function(o) {return o.label === webhookLabel}).type
+      webhook.data[webhookType] = {
+        secret: ApplicationGenerator._generateSecret()
+      };
+      $scope.triggers[webhookType + "Webhooks"].push(webhook);
     };
 
     $scope.save = function() {

--- a/app/scripts/directives/editWebhookTriggers.js
+++ b/app/scripts/directives/editWebhookTriggers.js
@@ -2,7 +2,7 @@
 
 angular.module('openshiftConsole')
   // Element directive edit BC webhook triggers
-  .directive('editWebhookTriggers', function(ApplicationGenerator) {
+  .directive('editWebhookTriggers', function() {
     return {
       restrict: 'E',
       scope: {
@@ -13,21 +13,6 @@ angular.module('openshiftConsole')
         projectName: "=",
         form: "="
       },
-      templateUrl: 'views/directives/edit-webhook-triggers.html',
-      controller: function($scope) {
-        $scope.addWebhookTrigger = function(type) {
-          var webhook = {
-            disabled: false,
-            data: {
-              type: type
-            }
-          };
-          webhook.data[(type === "GitHub") ? "github" : "generic"] = {
-            secret: ApplicationGenerator._generateSecret()
-          };
-          $scope.triggers.push(webhook);
-          $scope.form.$setDirty();
-        };
-      }
+      templateUrl: 'views/directives/edit-webhook-triggers.html'
     };
   });

--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -1037,19 +1037,29 @@ a.disabled-link {
     margin: 10px 0;
   }
 
+  .select-webhook-type {
+    width: 300px;
+  }
+
+  .add-webhook {
+    padding-bottom: 10px;
+    padding-top: 5px;
+  }
+
   .trigger-info {
     margin: 10px 0px 10px 0px;
     .trigger-url {
       display: inline-block;
       vertical-align: middle;
     }
-    .trigger-actions {
-      display: inline-block;
-      margin-left: 5px;
-      .action-icon,
-      .action-icon:hover {
-        color: @color-pf-black-700;
-      }
+  }
+
+  .trigger-actions {
+    display: inline-block;
+    margin-left: 5px;
+    .action-icon,
+    .action-icon:hover {
+      color: @color-pf-black-700;
     }
   }
 

--- a/app/views/directives/edit-webhook-triggers.html
+++ b/app/views/directives/edit-webhook-triggers.html
@@ -1,32 +1,31 @@
-<h5>{{type}} webhooks
-  <span class="help action-inline">
-    <a href="" aria-hidden="true">
+<div class="display-webhooks">
+  <h5>{{type}} Webhooks
+    <span class="help action-inline">
       <span class="sr-only">{{typeInfo}}</span>
-      <i class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="{{typeInfo}}"></i>
-    </a>
-  </span>
-</h5>
-<div ng-repeat="trigger in triggers">
-  <div class="trigger-info">
-    <span class="trigger-url">
-      <copy-to-clipboard is-disabled="trigger.disabled" clipboard-text="bcName | webhookURL : trigger.data.type : trigger.data[(type === 'GitHub') ? 'github' : 'generic'].secret : projectName"></copy-to-clipboard>
-    </span>
-    <span class="visible-xs-inline trigger-actions">
-      <a href="" ng-if="!trigger.disabled" class="action-icon" ng-click="trigger.disabled = true; form.$setDirty()" role="button">
-        <span class="pficon pficon-close" aria-hidden="true" title="Remove"></span>
-        <span class="sr-only">Remove</span>
-      </a>
-      <a href="" ng-if="trigger.disabled" class="action-icon" ng-click="trigger.disabled = false" role="button">
-        <span class="fa fa-repeat" aria-hidden="true" title="Undo"></span>
-        <span class="sr-only">Undo</span>
+      <a href="" aria-hidden="true">
+        <i class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="{{typeInfo}}"></i>
       </a>
     </span>
-    <span class="hidden-xs trigger-actions">
-      <a href="" role="button" ng-if="!trigger.disabled" ng-click="trigger.disabled = true; form.$setDirty()">Remove</a>
-      <a href="" role="button" ng-if="trigger.disabled" ng-click="trigger.disabled = false">Undo</a>
-    </span>
+  </h5>
+  <div ng-repeat="trigger in triggers">
+    <div class="trigger-info">
+      <span class="trigger-url">
+        <copy-to-clipboard is-disabled="trigger.disabled" clipboard-text="bcName | webhookURL : trigger.data.type : trigger.data[webhookType].secret : projectName"></copy-to-clipboard>
+      </span>
+      <span class="visible-xs-inline trigger-actions">
+        <a href="" ng-if="!trigger.disabled" class="action-icon" ng-click="trigger.disabled = true; form.$setDirty()" role="button">
+          <span class="pficon pficon-close" aria-hidden="true" title="Remove"></span>
+          <span class="sr-only">Remove</span>
+        </a>
+        <a href="" ng-if="trigger.disabled" class="action-icon" ng-click="trigger.disabled = false" role="button">
+          <span class="fa fa-repeat" aria-hidden="true" title="Undo"></span>
+          <span class="sr-only">Undo</span>
+        </a>
+      </span>
+      <span class="hidden-xs trigger-actions">
+        <a href="" role="button" ng-if="!trigger.disabled" ng-click="trigger.disabled = true; form.$setDirty()">Remove</a>
+        <a href="" role="button" ng-if="trigger.disabled" ng-click="trigger.disabled = false">Undo</a>
+      </span>
+    </div>
   </div>
 </div>
-<span>
-  <a href="" role="button" ng-click="addWebhookTrigger(type)">Add {{type}} Webhook</a>
-</span>

--- a/app/views/edit/build-config.html
+++ b/app/views/edit/build-config.html
@@ -452,6 +452,7 @@
 
                             <div ng-if="sources.git">
                               <edit-webhook-triggers
+                                ng-if="triggers.githubWebhooks.length"
                                 type="GitHub"
                                 type-info="The GitHub source repository must be configured to use the webhook to trigger a build when source is committed."
                                 triggers="triggers.githubWebhooks"
@@ -460,6 +461,7 @@
                                 project-name="project.metadata.name">
                               </edit-webhook-triggers>
                               <edit-webhook-triggers
+                                ng-if="triggers.genericWebhooks.length"
                                 type="Generic"
                                 type-info="A generic webhook can be triggered by any system capable of making a web request."
                                 triggers="triggers.genericWebhooks"
@@ -467,6 +469,52 @@
                                 bc-name="buildConfig.metadata.name"
                                 project-name="project.metadata.name">
                               </edit-webhook-triggers>
+                              <edit-webhook-triggers
+                                ng-if="triggers.gitlabWebhooks.length"
+                                type="GitLab"
+                                type-info="The GitLab source repository must be configured to use the webhook to trigger a build when source is committed."
+                                triggers="triggers.gitlabWebhooks"
+                                form="form"
+                                bc-name="buildConfig.metadata.name"
+                                project-name="project.metadata.name">
+                              </edit-webhook-triggers>
+                              <edit-webhook-triggers
+                                ng-if="triggers.bitbucketWebhooks.length"
+                                type="Bitbucket"
+                                type-info="The Bitbucket source repository must be configured to use the webhook to trigger a build when source is committed."
+                                triggers="triggers.bitbucketWebhooks"
+                                form="form"
+                                bc-name="buildConfig.metadata.name"
+                                project-name="project.metadata.name">
+                              </edit-webhook-triggers>
+                              <div class="add-webhook">
+                                <h5>Add Webhook</h5>
+                                <div class="trigger-info">
+                                  <span class="trigger-url">
+                                    <ui-select ng-model="createTriggerSelect.selectedType"
+                                      search-enabled="false"
+                                      title="Select a webhooke type"
+                                      class="select-webhook-type"
+                                      flex>
+                                      <ui-select-match placeholder="Select a webhook type">
+                                        {{ $select.selected.label }}
+                                      </ui-select-match>
+                                      <ui-select-choices repeat="option.label as option in createTriggerSelect.options">
+                                        {{ option.label }}
+                                      </ui-select-choices>
+                                    </ui-select>
+                                  </span>
+                                  <span class="visible-xs-inline trigger-actions">
+                                    <a href="" ng-class="{disabled: !createTriggerSelect.selectedType}" class="action-icon" ng-click="addWebhookTrigger(createTriggerSelect.selectedType)" role="button">
+                                      <span class="fa fa-plus" aria-hidden="true" title="Add"></span>
+                                      <span class="sr-only">Add</span>
+                                    </a>
+                                  </span>
+                                  <span class="hidden-xs trigger-actions">
+                                    <a href="" ng-class="{disabled: !createTriggerSelect.selectedType}" ng-click="addWebhookTrigger(createTriggerSelect.selectedType)" role="button">Add</a>
+                                  </span>
+                                </div>
+                              </div>
                             </div>
 
                             <!-- TODO: Uncomment once ConfigChange trigger will work. Based on https://github.com/openshift/origin-web-console/issues/321  -->

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -6642,10 +6642,27 @@ contextDir:!1,
 none:!0
 }, a.triggers = {
 githubWebhooks:[],
+gitlabWebhooks:[],
+bitbucketWebhooks:[],
 genericWebhooks:[],
 imageChangeTriggers:[],
 builderImageChangeTrigger:{},
 configChangeTrigger:{}
+}, a.createTriggerSelect = {
+selectedType:"",
+options:[ {
+type:"github",
+label:"GitHub"
+}, {
+type:"gitlab",
+label:"GitLab"
+}, {
+type:"bitbucket",
+label:"Bitbucket"
+}, {
+type:"generic",
+label:"Generic"
+} ]
 }, a.runPolicyTypes = [ "Serial", "Parallel", "SerialLatestOnly" ], a.buildHookTypes = [ {
 id:"command",
 label:"Command"
@@ -6791,6 +6808,20 @@ data:a
 });
 break;
 
+case "GitLab":
+c.gitlabWebhooks.push({
+disabled:!1,
+data:a
+});
+break;
+
+case "Bitbucket":
+c.bitbucketWebhooks.push({
+disabled:!1,
+data:a
+});
+break;
+
 case "ImageChange":
 var b = a.imageChange.from;
 b || (b = f);
@@ -6857,7 +6888,7 @@ name:_.last(d)
 }
 return c;
 }, x = function() {
-var b = [].concat(a.triggers.githubWebhooks, a.triggers.genericWebhooks, a.triggers.imageChangeTriggers, a.triggers.builderImageChangeTrigger, a.triggers.configChangeTrigger);
+var b = [].concat(a.triggers.githubWebhooks, a.triggers.gitlabWebhooks, a.triggers.bitbucketWebhooks, a.triggers.genericWebhooks, a.triggers.imageChangeTriggers, a.triggers.builderImageChangeTrigger, a.triggers.configChangeTrigger);
 return b = _.filter(b, function(a) {
 return _.has(a, "disabled") && !a.disabled || a.present;
 }), b = _.map(b, "data");
@@ -6903,7 +6934,21 @@ return "None" === b.type ? a :(a.none = !1, angular.forEach(b, function(b, c) {
 a[c] = !0;
 }), a);
 };
-a.save = function() {
+a.addWebhookTrigger = function(b) {
+if (b) {
+var c = {
+disabled:!1,
+data:{
+type:b
+}
+}, d = _.find(a.createTriggerSelect.options, function(a) {
+return a.label === b;
+}).type;
+c.data[d] = {
+secret:f._generateSecret()
+}, a.triggers[d + "Webhooks"].push(c);
+}
+}, a.save = function() {
 switch (a.disableInputs = !0, p(), r(a.updatedBuildConfig).forcePull = a.options.forcePull, a.strategyType) {
 case "Docker":
 r(a.updatedBuildConfig).noCache = a.options.noCache;
@@ -8887,7 +8932,7 @@ details:c("getErrorDetails")(a)
 };
 }
 };
-} ]), angular.module("openshiftConsole").directive("editWebhookTriggers", [ "ApplicationGenerator", function(a) {
+} ]), angular.module("openshiftConsole").directive("editWebhookTriggers", function() {
 return {
 restrict:"E",
 scope:{
@@ -8898,22 +8943,9 @@ bcName:"=",
 projectName:"=",
 form:"="
 },
-templateUrl:"views/directives/edit-webhook-triggers.html",
-controller:[ "$scope", function(b) {
-b.addWebhookTrigger = function(c) {
-var d = {
-disabled:!1,
-data:{
-type:c
-}
+templateUrl:"views/directives/edit-webhook-triggers.html"
 };
-d.data["GitHub" === c ? "github" :"generic"] = {
-secret:a._generateSecret()
-}, b.triggers.push(d), b.form.$setDirty();
-};
-} ]
-};
-} ]), angular.module("openshiftConsole").directive("editConfigMap", [ "DNS1123_SUBDOMAIN_VALIDATION", function(a) {
+}), angular.module("openshiftConsole").directive("editConfigMap", [ "DNS1123_SUBDOMAIN_VALIDATION", function(a) {
 return {
 require:"^form",
 restrict:"E",

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6611,10 +6611,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/directives/edit-webhook-triggers.html',
-    "<h5>{{type}} webhooks\n" +
+    "<div class=\"display-webhooks\">\n" +
+    "<h5>{{type}} Webhooks\n" +
     "<span class=\"help action-inline\">\n" +
-    "<a href=\"\" aria-hidden=\"true\">\n" +
     "<span class=\"sr-only\">{{typeInfo}}</span>\n" +
+    "<a href=\"\" aria-hidden=\"true\">\n" +
     "<i class=\"pficon pficon-help\" data-toggle=\"tooltip\" aria-hidden=\"true\" data-original-title=\"{{typeInfo}}\"></i>\n" +
     "</a>\n" +
     "</span>\n" +
@@ -6622,7 +6623,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-repeat=\"trigger in triggers\">\n" +
     "<div class=\"trigger-info\">\n" +
     "<span class=\"trigger-url\">\n" +
-    "<copy-to-clipboard is-disabled=\"trigger.disabled\" clipboard-text=\"bcName | webhookURL : trigger.data.type : trigger.data[(type === 'GitHub') ? 'github' : 'generic'].secret : projectName\"></copy-to-clipboard>\n" +
+    "<copy-to-clipboard is-disabled=\"trigger.disabled\" clipboard-text=\"bcName | webhookURL : trigger.data.type : trigger.data[webhookType].secret : projectName\"></copy-to-clipboard>\n" +
     "</span>\n" +
     "<span class=\"visible-xs-inline trigger-actions\">\n" +
     "<a href=\"\" ng-if=\"!trigger.disabled\" class=\"action-icon\" ng-click=\"trigger.disabled = true; form.$setDirty()\" role=\"button\">\n" +
@@ -6640,9 +6641,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<span>\n" +
-    "<a href=\"\" role=\"button\" ng-click=\"addWebhookTrigger(type)\">Add {{type}} Webhook</a>\n" +
-    "</span>"
+    "</div>"
   );
 
 
@@ -9139,10 +9138,38 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dl class=\"dl-horizontal left\">\n" +
     "<div>\n" +
     "<div ng-if=\"sources.git\">\n" +
-    "<edit-webhook-triggers type=\"GitHub\" type-info=\"The GitHub source repository must be configured to use the webhook to trigger a build when source is committed.\" triggers=\"triggers.githubWebhooks\" form=\"form\" bc-name=\"buildConfig.metadata.name\" project-name=\"project.metadata.name\">\n" +
+    "<edit-webhook-triggers ng-if=\"triggers.githubWebhooks.length\" type=\"GitHub\" type-info=\"The GitHub source repository must be configured to use the webhook to trigger a build when source is committed.\" triggers=\"triggers.githubWebhooks\" form=\"form\" bc-name=\"buildConfig.metadata.name\" project-name=\"project.metadata.name\">\n" +
     "</edit-webhook-triggers>\n" +
-    "<edit-webhook-triggers type=\"Generic\" type-info=\"A generic webhook can be triggered by any system capable of making a web request.\" triggers=\"triggers.genericWebhooks\" form=\"form\" bc-name=\"buildConfig.metadata.name\" project-name=\"project.metadata.name\">\n" +
+    "<edit-webhook-triggers ng-if=\"triggers.genericWebhooks.length\" type=\"Generic\" type-info=\"A generic webhook can be triggered by any system capable of making a web request.\" triggers=\"triggers.genericWebhooks\" form=\"form\" bc-name=\"buildConfig.metadata.name\" project-name=\"project.metadata.name\">\n" +
     "</edit-webhook-triggers>\n" +
+    "<edit-webhook-triggers ng-if=\"triggers.gitlabWebhooks.length\" type=\"GitLab\" type-info=\"The GitLab source repository must be configured to use the webhook to trigger a build when source is committed.\" triggers=\"triggers.gitlabWebhooks\" form=\"form\" bc-name=\"buildConfig.metadata.name\" project-name=\"project.metadata.name\">\n" +
+    "</edit-webhook-triggers>\n" +
+    "<edit-webhook-triggers ng-if=\"triggers.bitbucketWebhooks.length\" type=\"Bitbucket\" type-info=\"The Bitbucket source repository must be configured to use the webhook to trigger a build when source is committed.\" triggers=\"triggers.bitbucketWebhooks\" form=\"form\" bc-name=\"buildConfig.metadata.name\" project-name=\"project.metadata.name\">\n" +
+    "</edit-webhook-triggers>\n" +
+    "<div class=\"add-webhook\">\n" +
+    "<h5>Add Webhook</h5>\n" +
+    "<div class=\"trigger-info\">\n" +
+    "<span class=\"trigger-url\">\n" +
+    "<ui-select ng-model=\"createTriggerSelect.selectedType\" search-enabled=\"false\" title=\"Select a webhooke type\" class=\"select-webhook-type\" flex>\n" +
+    "<ui-select-match placeholder=\"Select a webhook type\">\n" +
+    "{{ $select.selected.label }}\n" +
+    "</ui-select-match>\n" +
+    "<ui-select-choices repeat=\"option.label as option in createTriggerSelect.options\">\n" +
+    "{{ option.label }}\n" +
+    "</ui-select-choices>\n" +
+    "</ui-select>\n" +
+    "</span>\n" +
+    "<span class=\"visible-xs-inline trigger-actions\">\n" +
+    "<a href=\"\" ng-class=\"{disabled: !createTriggerSelect.selectedType}\" class=\"action-icon\" ng-click=\"addWebhookTrigger(createTriggerSelect.selectedType)\" role=\"button\">\n" +
+    "<span class=\"fa fa-plus\" aria-hidden=\"true\" title=\"Add\"></span>\n" +
+    "<span class=\"sr-only\">Add</span>\n" +
+    "</a>\n" +
+    "</span>\n" +
+    "<span class=\"hidden-xs trigger-actions\">\n" +
+    "<a href=\"\" ng-class=\"{disabled: !createTriggerSelect.selectedType}\" ng-click=\"addWebhookTrigger(createTriggerSelect.selectedType)\" role=\"button\">Add</a>\n" +
+    "</span>\n" +
+    "</div>\n" +
+    "</div>\n" +
     "</div>\n" +
     "\n" +
     "\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4536,10 +4536,12 @@ a.disabled-link:active,a.disabled-link:focus,a.disabled-link:hover{color:#bbb;te
 .edit-form .labels .form-group{width:44%}
 .edit-form .labels .form-group .form-control{width:100%}
 .edit-form .checkbox{margin:10px 0}
+.edit-form .select-webhook-type{width:300px}
+.edit-form .add-webhook{padding-bottom:10px;padding-top:5px}
 .edit-form .trigger-info{margin:10px 0px}
 .edit-form .trigger-info .trigger-url{display:inline-block;vertical-align:middle}
-.edit-form .trigger-info .trigger-actions{display:inline-block;margin-left:5px}
-.edit-form .trigger-info .trigger-actions .action-icon,.edit-form .trigger-info .trigger-actions .action-icon:hover{color:#4d5258}
+.edit-form .trigger-actions{display:inline-block;margin-left:5px}
+.edit-form .trigger-actions .action-icon,.edit-form .trigger-actions .action-icon:hover{color:#4d5258}
 .edit-form .section{padding-bottom:5px}
 @media (max-width:768px){.edit-form .trigger-url{max-width:90%}
 .edit-form .labels .form-group{width:100%}


### PR DESCRIPTION
https://trello.com/c/yy3ACVjj

Adding support for view/add/remove GitLab and Bitbucket webhooks.
Screen:
![screenshot at 2017-05-11 14-09-39](https://cloud.githubusercontent.com/assets/1668218/25949240/1bfc7736-3657-11e7-8e2d-a4440d8acdc4.png)

![screenshot at 2017-05-11 14-38-43](https://cloud.githubusercontent.com/assets/1668218/25949380/a3529f94-3657-11e7-976c-e6136bd25646.png)


Not really sure if we want to display them by default as the screenshot show, but also not sure if we want to hide them in some "Advanced webhooks settings" since we already have advance view in the BC editor.

@spadgett @jwforres thoughts ?