### PR TITLE
Update config to use vars & reduce repetition

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -1,36 +1,43 @@
-// This is the default configuration for the dev mode of the web console.
-// A generated version of this config is created at run-time when running
-// the web console from the openshift binary.
-//
-// To change configuration for local development, copy this file to
-// assets/app/config.local.js and edit the copy.
-window.OPENSHIFT_CONFIG = {
-  apis: {
-    hostPort: "localhost:8443",
-    prefix: "/apis"
-  },
-  api: {
-    openshift: {
-      hostPort: "localhost:8443",
-      prefix: "/oapi"
-    },
-    k8s: {
-      hostPort: "localhost:8443",
-      prefix: "/api"
-    }
-  },
-  auth: {
-    oauth_authorize_uri: "https://localhost:8443/oauth/authorize",
-    oauth_token_uri: "https://localhost:8443/oauth/token",
-    oauth_redirect_base: "https://localhost:9000/dev-console",
-    oauth_client_id: "openshift-web-console",
-    logout_uri: ""
-  },
-  loggingURL: "",
-  metricsURL: ""
-};
+'use strict';
 
-window.OPENSHIFT_VERSION = {
-  openshift: "dev-mode",
-  kubernetes: "dev-mode"
-};
+(function() {
+  // This is the default configuration for the dev mode of the web console.
+  // A generated version of this config is created at run-time when running
+  // the web console from the openshift binary.
+  //
+  // To change configuration for local development, copy this file to
+  // assets/app/config.local.js and edit the copy.
+  var masterPublicHostname = 'localhost:8443';
+  var devConsoleHostname = 'localhost:9000';
+  window.OPENSHIFT_CONFIG = {
+    apis: {
+      hostPort: masterPublicHostname,
+      prefix: "/apis"
+    },
+    api: {
+      openshift: {
+        hostPort: masterPublicHostname,
+        prefix: "/oapi"
+      },
+      k8s: {
+        hostPort: masterPublicHostname,
+        prefix: "/api"
+      }
+    },
+    auth: {
+      oauth_authorize_uri: 'https://' + masterPublicHostname + "/oauth/authorize",
+      oauth_token_uri: 'https://' + masterPublicHostname + "/oauth/token",
+      oauth_redirect_base: "https://" + devConsoleHostname + "/dev-console",
+      oauth_client_id: "openshift-web-console",
+      logout_uri: ""
+    },
+    loggingURL: "",
+    metricsURL: ""
+  };
+
+  window.OPENSHIFT_VERSION = {
+    openshift: "dev-mode",
+    kubernetes: "dev-mode"
+  };
+
+})();


### PR DESCRIPTION
This is particularly handy when used as a base for `config.local.js` & needing to switch back and forth between a vagrant machine, docker, etc.  Being able to update the `hostIP` to (example)`10.245.2.2` once rather than pick out a half dozen occurrences is handy.