### PR TITLE
Add inner scroll shadow to responsive tables

### DIFF
--- a/app/styles/_scroll-shadows-horizontal.less
+++ b/app/styles/_scroll-shadows-horizontal.less
@@ -1,0 +1,59 @@
+// Horizontal scroll drop shadows
+// Adds drop shadows to left and right edges that display when scrollable content is hidden
+// @bg-color should be an rgba color with opacity at 1 (e.g., rgba(255,0,0,1))
+// @bg-color-transparent should be the same rgb color as @bg-color but with opacity at 0 (e.g., rgba(255,0,0,0))
+
+.scroll-shadows-horizontal(@bg-color: @scroll-shadows-bg-color) {
+  background-attachment: scroll;
+  background-color: @bg-color;
+  background-image:
+    radial-gradient(ellipse at left, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0) 75%), // left shadow
+    radial-gradient(ellipse at right, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0) 75%); // right shadow
+  background-position: 0 0, 100% 0;
+  background-repeat: no-repeat;
+  background-size: 8px 100%;
+  -ms-overflow-style: auto; // so Edge will scroll correctly
+  overflow-x: auto; // make horizontally scrollable
+}
+
+// use for elements that are not tables
+// IMPORTANT: requires application of .scroll-shadows-cover on the inner element; does not work on all elements
+// in IE11/Edge (e.g., <pre>) as IE/Edge fails to properly attach the right background (i.e., "local" is
+// rendered as "scroll" )
+.scroll-shadows-horizontal-other(@bg-color: @scroll-shadows-bg-color, @bg-color-transparent: @scroll-shadows-bg-color-transparent) {
+  .scroll-shadows-horizontal(@bg-color);
+  > .scroll-shadows-cover {
+    background-attachment: local;
+    background-color: transparent;
+    background-image:
+      linear-gradient(to left, @bg-color-transparent 30%, @bg-color 70%), // left shadow cover
+      linear-gradient(to right, @bg-color-transparent 30%, @bg-color 70%);  // right shadow cover
+    background-position:  0 0, 100% 0;
+    background-repeat: no-repeat;
+    background-size: 20px 100%;
+  }
+}
+
+// use for tables
+.scroll-shadows-horizontal-table(@bg-color: @scroll-shadows-bg-color, @bg-color-transparent: @scroll-shadows-bg-color-transparent) {
+  border-left: 1px solid @table-border-color;
+  border-right: 1px solid @table-border-color;
+  .scroll-shadows-horizontal(@bg-color);
+  .table {
+    background-color: transparent;
+  }
+  td,
+  th {
+    background-attachment: local;
+    background-repeat: no-repeat;
+    background-size: 20px 100%;
+    &:first-child {
+      background-image: linear-gradient(to left, @bg-color-transparent 30%, @bg-color 70%); // left shadow cover
+      background-position:  0 0;
+    }
+    &:last-child {
+      background-image: linear-gradient(to right, @bg-color-transparent 30%, @bg-color 70%);  // right shadow cover
+      background-position:  100% 0;
+    }
+  }
+}

--- a/app/styles/_tables.less
+++ b/app/styles/_tables.less
@@ -108,13 +108,13 @@
         }
       }
     }
-    &.table-bordered-columns > {
-      tbody, thead {
-        > tr > {
-          td, th {
-            border-left: 1px solid @table-border-color;
-            border-right: 1px solid @table-border-color;
-          }
+  }
+  &.table-bordered-columns > {
+    tbody, thead {
+      > tr > {
+        td, th {
+          border-left: 1px solid @table-border-color;
+          border-right: 1px solid @table-border-color;
         }
       }
     }
@@ -217,30 +217,33 @@
 
 .table-responsive {
   margin-bottom: @line-height-computed;
-  @media(max-width: @screen-xs-max) {
+  &.scroll-shadows-horizontal {
+    .scroll-shadows-horizontal-table();
     .table.table-bordered {
-      > tbody, > thead {
-        > tr {
-          &:first-child {
-            > td, > th {
-              border-top: 0;
-            }
-          }
-          > td, > th {
-            &:first-child {
-              border-left: 0;
-            }
-            &:last-child {
-              border-right: 0;
-            }
-          }
+      border-left: 0;
+      border-right: 0;
+      td,
+      th {
+        &:first-child {
+          border-left: 0;
+        }
+        &:last-child {
+          border-right: 0;
         }
       }
     }
   }
-  @media(min-width: @screen-sm-min) {
-    .table {
-      margin-bottom: 0;
+  .table {
+    margin-bottom: 0;
+    &.table-bordered {
+      > tbody, > thead {
+        > tr:first-child {
+          > td,
+          > th {
+            border-top: 0;
+          }
+        }
+      }
     }
   }
 }

--- a/app/styles/_variables.less
+++ b/app/styles/_variables.less
@@ -81,6 +81,8 @@
 @pod-running-bg: #E4F5BC;
 @pod-pending-bg: #e8e8e8;
 @pod-warning-bg: #f9d67a;
+@scroll-shadows-bg-color: rgba(255, 255, 255, 1);
+@scroll-shadows-bg-color-transparent: rgba(255, 255, 255, 0);
 @sidebar-os-bg: #30363d;
 @sidebar-os-color: #dbdada;
 @sidebar-os-active-bg: #383f47;

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -38,6 +38,7 @@
 @import "_project-menu.less";
 @import "_responsive-utilities.less";
 @import "_scrollbars.less";
+@import "_scroll-shadows-horizontal.less";
 @import "_secrets.less";
 @import "_sidebar.less";
 @import "_substructure.less";

--- a/app/views/browse/config-map.html
+++ b/app/views/browse/config-map.html
@@ -53,7 +53,7 @@
               <div ng-if="!(configMap.data | hashSize)" class="empty-state-message text-center">
                 <h2>The config map has no items.</h2>
               </div>
-              <div ng-if="configMap.data | hashSize" class="table-responsive">
+              <div ng-if="configMap.data | hashSize" class="table-responsive scroll-shadows-horizontal">
                 <table class="table table-bordered table-bordered-columns config-map-table key-value-table">
                   <tbody>
                     <tr ng-repeat="(prop, value) in configMap.data">

--- a/app/views/directives/annotations.html
+++ b/app/views/directives/annotations.html
@@ -3,17 +3,17 @@
   <a href="" ng-click="toggleAnnotations()" ng-if="expandAnnotations">Hide Annotations</a>
 </p>
 <div ng-if="expandAnnotations">
-  <div ng-if="annotations" class="table-responsive">
+  <div ng-if="annotations" class="table-responsive scroll-shadows-horizontal">
     <table class="table table-bordered table-bordered-columns key-value-table">
       <tbody>
         <tr ng-repeat="(annotationKey, annotationValue) in annotations">
           <td class="key">{{annotationKey}}</td>
           <td class="value">
             <truncate-long-text
-                content="annotationValue | prettifyJSON"
-                limit="500"
-                newlineLimit="20"
-                expandable="true">
+              content="annotationValue | prettifyJSON"
+              limit="500"
+              newlineLimit="20"
+              expandable="true">
             </truncate-long-text>
           </td>
         </tr>

--- a/app/views/quota.html
+++ b/app/views/quota.html
@@ -63,7 +63,7 @@
                     </div>
                   </div>
 
-                  <div class="table-responsive">
+                  <div class="table-responsive scroll-shadows-horizontal">
                     <table class="table table-bordered">
                       <thead>
                         <th>Resource Type</th>
@@ -155,7 +155,7 @@
                     </div>
                   </div>
 
-                  <div class="table-responsive">
+                  <div class="table-responsive scroll-shadows-horizontal">
                     <table class="table table-bordered">
                       <thead>
                         <th>Resource Type</th>
@@ -210,7 +210,7 @@
                   <div ng-repeat="limitRange in limitRanges">
                     <h2 ng-if="limitRanges.length">{{limitRange.metadata.name}}</h2>
                     <div ng-if="$first" class="help-block mar-bottom-md">{{limitRangeHelp}}</div>
-                    <div class="table-responsive">
+                    <div class="table-responsive scroll-shadows-horizontal">
                       <table class="table table-bordered">
                         <thead>
                           <th>Resource Type</th>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2341,7 +2341,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"!(configMap.data | hashSize)\" class=\"empty-state-message text-center\">\n" +
     "<h2>The config map has no items.</h2>\n" +
     "</div>\n" +
-    "<div ng-if=\"configMap.data | hashSize\" class=\"table-responsive\">\n" +
+    "<div ng-if=\"configMap.data | hashSize\" class=\"table-responsive scroll-shadows-horizontal\">\n" +
     "<table class=\"table table-bordered table-bordered-columns config-map-table key-value-table\">\n" +
     "<tbody>\n" +
     "<tr ng-repeat=\"(prop, value) in configMap.data\">\n" +
@@ -5982,7 +5982,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a href=\"\" ng-click=\"toggleAnnotations()\" ng-if=\"expandAnnotations\">Hide Annotations</a>\n" +
     "</p>\n" +
     "<div ng-if=\"expandAnnotations\">\n" +
-    "<div ng-if=\"annotations\" class=\"table-responsive\">\n" +
+    "<div ng-if=\"annotations\" class=\"table-responsive scroll-shadows-horizontal\">\n" +
     "<table class=\"table table-bordered table-bordered-columns key-value-table\">\n" +
     "<tbody>\n" +
     "<tr ng-repeat=\"(annotationKey, annotationValue) in annotations\">\n" +
@@ -13572,7 +13572,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"table-responsive\">\n" +
+    "<div class=\"table-responsive scroll-shadows-horizontal\">\n" +
     "<table class=\"table table-bordered\">\n" +
     "<thead>\n" +
     "<th>Resource Type</th>\n" +
@@ -13655,7 +13655,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"table-responsive\">\n" +
+    "<div class=\"table-responsive scroll-shadows-horizontal\">\n" +
     "<table class=\"table table-bordered\">\n" +
     "<thead>\n" +
     "<th>Resource Type</th>\n" +
@@ -13701,7 +13701,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-repeat=\"limitRange in limitRanges\">\n" +
     "<h2 ng-if=\"limitRanges.length\">{{limitRange.metadata.name}}</h2>\n" +
     "<div ng-if=\"$first\" class=\"help-block mar-bottom-md\">{{limitRangeHelp}}</div>\n" +
-    "<div class=\"table-responsive\">\n" +
+    "<div class=\"table-responsive scroll-shadows-horizontal\">\n" +
     "<table class=\"table table-bordered\">\n" +
     "<thead>\n" +
     "<th>Resource Type</th>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5553,7 +5553,7 @@ body,html{margin:0;padding:0}
 .key-value-table>tbody>tr>td.value .truncated-content{white-space:pre}
 .table{background-color:#fff}
 .table.table-bordered>tbody>tr td,.table.table-bordered>tbody>tr th,.table.table-bordered>thead>tr td,.table.table-bordered>thead>tr th{border-left:0;border-right:0;padding-bottom:8px;padding-top:8px;vertical-align:middle}
-.table-filter-wrapper,.table.table-bordered.table-bordered-columns tbody>tr td,.table.table-bordered.table-bordered-columns tbody>tr th,.table.table-bordered.table-bordered-columns thead>tr td,.table.table-bordered.table-bordered-columns thead>tr th{border-left:1px solid #d1d1d1;border-right:1px solid #d1d1d1}
+.table-filter-wrapper,.table.table-bordered-columns tbody>tr td,.table.table-bordered-columns tbody>tr th,.table.table-bordered-columns thead>tr td,.table.table-bordered-columns thead>tr th{border-left:1px solid #d1d1d1;border-right:1px solid #d1d1d1}
 .table.table-layout-fixed{table-layout:fixed}
 .table.table-layout-fixed td{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .table>tbody+tbody{border-top-width:1px}
@@ -5573,17 +5573,23 @@ body,html{margin:0;padding:0}
 .table-mobile>tbody>tr>td{border:none;border-bottom:1px solid #dedede;min-height:37.67px;padding-left:35%;position:relative}
 .table-mobile>tbody>tr>td:last-child{border-bottom:none}
 .table-mobile>tbody>tr>td:before{content:attr(data-title);position:absolute;top:8px;left:6px;width:35%;padding-right:10px;white-space:nowrap}
-.table-responsive .table.table-bordered>tbody>tr:first-child>td,.table-responsive .table.table-bordered>tbody>tr:first-child>th,.table-responsive .table.table-bordered>thead>tr:first-child>td,.table-responsive .table.table-bordered>thead>tr:first-child>th{border-top:0}
-.table-responsive .table.table-bordered>tbody>tr>td:first-child,.table-responsive .table.table-bordered>tbody>tr>th:first-child,.table-responsive .table.table-bordered>thead>tr>td:first-child,.table-responsive .table.table-bordered>thead>tr>th:first-child{border-left:0}
-.table-responsive .table.table-bordered>tbody>tr>td:last-child,.table-responsive .table.table-bordered>tbody>tr>th:last-child,.table-responsive .table.table-bordered>thead>tr>td:last-child,.table-responsive .table.table-bordered>thead>tr>th:last-child{border-right:0}
 }
 .tooltip-inner,h1.contains-actions{overflow-wrap:break-word;min-width:0;word-wrap:break-word;word-break:break-word}
 .table-responsive{margin-bottom:21px}
+.table-responsive.scroll-shadows-horizontal{border-left:1px solid #d1d1d1;border-right:1px solid #d1d1d1;background-attachment:scroll;background-color:#fff;background-image:radial-gradient(ellipse at left,rgba(0,0,0,.25) 0%,rgba(0,0,0,0) 75%),radial-gradient(ellipse at right,rgba(0,0,0,.25) 0%,rgba(0,0,0,0) 75%);background-position:0 0,100% 0;background-repeat:no-repeat;background-size:8px 100%;-ms-overflow-style:auto;overflow-x:auto}
+.table-responsive.scroll-shadows-horizontal .table{background-color:transparent}
+.table-responsive.scroll-shadows-horizontal td,.table-responsive.scroll-shadows-horizontal th{background-attachment:local;background-repeat:no-repeat;background-size:20px 100%}
+.table-responsive.scroll-shadows-horizontal td:first-child,.table-responsive.scroll-shadows-horizontal th:first-child{background-image:linear-gradient(to left,rgba(255,255,255,0) 30%,#fff 70%);background-position:0 0}
+.table-responsive.scroll-shadows-horizontal td:last-child,.table-responsive.scroll-shadows-horizontal th:last-child{background-image:linear-gradient(to right,rgba(255,255,255,0) 30%,#fff 70%);background-position:100% 0}
+.table-responsive.scroll-shadows-horizontal .table.table-bordered{border-left:0;border-right:0}
+.table-responsive.scroll-shadows-horizontal .table.table-bordered td:first-child,.table-responsive.scroll-shadows-horizontal .table.table-bordered th:first-child{border-left:0}
+.table-responsive.scroll-shadows-horizontal .table.table-bordered td:last-child,.table-responsive.scroll-shadows-horizontal .table.table-bordered th:last-child{border-right:0}
+.table-responsive .table{margin-bottom:0}
+.table-responsive .table.table-bordered>tbody>tr:first-child>td,.table-responsive .table.table-bordered>tbody>tr:first-child>th,.table-responsive .table.table-bordered>thead>tr:first-child>td,.table-responsive .table.table-bordered>thead>tr:first-child>th{border-top:0}
 .table>tbody>tr.disabled>td,.table>tbody>tr.disabled>th,.table>tbody>tr>td.disabled,.table>tbody>tr>th.disabled,.table>tfoot>tr.disabled>td,.table>tfoot>tr.disabled>th,.table>tfoot>tr>td.disabled,.table>tfoot>tr>th.disabled,.table>thead>tr.disabled>td,.table>thead>tr.disabled>th,.table>thead>tr>td.disabled,.table>thead>tr>th.disabled{background-color:#f5f5f5}
 .table-hover>tbody>tr.disabled:hover>td,.table-hover>tbody>tr.disabled:hover>th,.table-hover>tbody>tr:hover>.disabled,.table-hover>tbody>tr>td.disabled:hover,.table-hover>tbody>tr>th.disabled:hover{background-color:#e8e8e8}
 td[role=presentation].arrow:after{content:"\2193"}
-@media (min-width:768px){.table-responsive .table{margin-bottom:0}
-td[role=presentation].arrow:after{content:"\2192"}
+@media (min-width:768px){td[role=presentation].arrow:after{content:"\2192"}
 }
 .tile{background:#fff;padding:20px;margin-bottom:20px;word-wrap:break-word;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;overflow-x:hidden}
 .tile h1,.tile h2,.tile h3{margin:10.5px 0px}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin-web-console/issues/1237

![screen shot 2017-05-15 at 3 20 35 pm](https://cloud.githubusercontent.com/assets/895728/26075136/341e2e12-3982-11e7-981a-4687a72e948c.PNG)
![screen shot 2017-05-15 at 3 20 42 pm](https://cloud.githubusercontent.com/assets/895728/26075135/341a69a8-3982-11e7-8a14-0fe5e94cdd1c.PNG)
![screen shot 2017-05-15 at 3 20 49 pm](https://cloud.githubusercontent.com/assets/895728/26075138/342672e8-3982-11e7-9ee2-e1971ff6493a.PNG)

Note:  this PR includes a mixin for adding inner scroll shadows to non-table elements, but the mixin hasn't been applied anywhere as I was unable to find a cross-browser compatible solution for the intended use case (copy-to-clipboard textareas).  But it seems like it could have utility for other elements, so I've included it here.