### PR TITLE
Removed temp fixes which were fixed in latest PatternFly release 

### DIFF
--- a/app/styles/_forms.less
+++ b/app/styles/_forms.less
@@ -99,12 +99,3 @@ copy-to-clipboard .input-group.limit-width {
   margin-left: 0;
   margin-right: 10px;
 }
-
-// Add vendor prefixes for placeholder text, since they where removed from PatternFly
-// https://github.com/patternfly/patternfly/issues/597
-.placeholder(@color: @input-color-placeholder) {
-  &:-moz-placeholder            { color: @color; font-style: italic; } // Firefox 4-18
-  &::-moz-placeholder           { color: @color; font-style: italic; opacity: 1; } // Firefox 19+
-  &:-ms-input-placeholder       { color: @color; font-style: italic; } // Internet Explorer 10+
-  &::-webkit-input-placeholder  { color: @color; font-style: italic; } // Safari and Chrome
-}

--- a/app/styles/_patternfly-additions.less
+++ b/app/styles/_patternfly-additions.less
@@ -9,8 +9,3 @@
   font-size: @donut-font-size-big * .75;  // ~ 22.5px;
   font-weight: 300;
 }
-
-// TODO: fixed in latest patternfly
-.wizard-pf-steps-indicator .wizard-pf-step-number {
-  left: ~"calc(50% - 13px)";
-}

--- a/bower.json
+++ b/bower.json
@@ -46,7 +46,6 @@
     "angular-moment": "1.0.0",
     "angular-utf8-base64": "0.0.5",
     "file-saver": "1.3.3",
-    "bootstrap-switch": "3.3.3",
     "origin-web-common": "0.0.20",
     "origin-web-catalog": "0.0.14"
   },

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -272,7 +272,8 @@ div.hopscotch-bubble .hopscotch-bubble-arrow-container.left,div.hopscotch-bubble
 .dialog-btn:first-of-type{margin-right:0}
 .truncation-block{margin-right:10px}
 .truncation-collapse-link{margin-left:10px;white-space:nowrap}
-.pretty-json{font-family:Menlo,Monaco,Consolas,monospace;white-space:pre-wrap}
+.pre-wrap,.pretty-json,pre code{white-space:pre-wrap}
+.pretty-json{font-family:Menlo,Monaco,Consolas,monospace}
 label.required:before{content:'*';position:absolute;left:10px}
 @media (min-width:768px){.form-horizontal label.required:before{position:relative;left:-3px}
 }
@@ -718,7 +719,7 @@ dd{margin-left:0}
 @media (min-width:415px){.dl-horizontal dt{float:left;width:160px;clear:left;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .dl-horizontal dd{margin-left:180px}
 }
-.btn-group-vertical>.btn-group:after,.btn-toolbar:after,.clearfix:after,.container-fluid:after,.container:after,.dl-horizontal dd:after,.form-horizontal .form-group:after,.list-view-pf .list-group-item:after,.modal-footer:after,.modal-header:after,.nav:after,.navbar-collapse:after,.navbar-header:after,.navbar:after,.pager:after,.panel-body:after,.row:after{clear:both}
+.btn-group-vertical>.btn-group:after,.btn-toolbar:after,.clearfix:after,.container-fluid:after,.container:after,.dl-horizontal dd:after,.dropdown-menu>li>a,.form-horizontal .form-group:after,.list-view-pf .list-group-item:after,.modal-footer:after,.modal-header:after,.nav:after,.navbar-collapse:after,.navbar-header:after,.navbar:after,.pager:after,.panel-body:after,.row:after,ul.messenger.messenger-theme-flat .messenger-message:after{clear:both}
 abbr[data-original-title],abbr[title]{cursor:help;border-bottom:1px dotted #9c9c9c}
 .initialism{font-size:90%;text-transform:uppercase}
 blockquote{padding:10.5px 21px;margin:0 0 21px;font-size:16.25px;border-left:5px solid #f1f1f1}
@@ -737,7 +738,7 @@ kbd kbd{padding:0;font-size:100%;box-shadow:none}
 div.code,pre{padding:10px;margin:0 0 10.5px;font-size:12px;line-height:1.66666667;word-break:break-all;word-wrap:break-word;background-color:#fafafa;border:1px solid #ccc;border-radius:1px}
 .container,.container-fluid{margin-right:auto;margin-left:auto}
 pre code,table{background-color:transparent}
-pre code{padding:0;font-size:inherit;color:inherit;white-space:pre-wrap;border-radius:0}
+pre code{padding:0;font-size:inherit;color:inherit;border-radius:0}
 .container,.container-fluid{padding-left:20px;padding-right:20px}
 .pre-scrollable{overflow-y:scroll}
 @media (min-width:768px){.container{width:760px}
@@ -1143,7 +1144,7 @@ tbody.collapse.in{display:table-row-group}
 .btn-group>.btn-group:first-child:not(:last-child)>.btn:last-child,.btn-group>.btn-group:first-child:not(:last-child)>.dropdown-toggle,.btn-group>.btn:first-child:not(:last-child):not(.dropdown-toggle){border-bottom-right-radius:0;border-top-right-radius:0}
 .btn-group>.btn-group:last-child:not(:first-child)>.btn:first-child,.btn-group>.btn:last-child:not(:first-child),.btn-group>.dropdown-toggle:not(:first-child){border-bottom-left-radius:0;border-top-left-radius:0}
 .btn-group-vertical>.btn:not(:first-child):not(:last-child),.btn-group>.btn-group:not(:first-child):not(:last-child)>.btn,.btn-group>.btn:not(:first-child):not(:last-child):not(.dropdown-toggle){border-radius:0}
-.dropdown-menu>li>a{display:block;clear:both;font-weight:400;color:#363636}
+.dropdown-menu>li>a{display:block;font-weight:400;color:#363636}
 .dropdown-menu>li>a:focus,.dropdown-menu>li>a:hover{text-decoration:none;color:#4d5258;background-color:#def3ff}
 .dropdown-menu>.active>a,.dropdown-menu>.active>a:focus,.dropdown-menu>.active>a:hover{color:#fff;text-decoration:none;outline:0}
 .dropdown-menu>.disabled>a,.dropdown-menu>.disabled>a:focus,.dropdown-menu>.disabled>a:hover{color:#9c9c9c}
@@ -4067,7 +4068,7 @@ table.dataTable th:active{outline:0}
 .wizard-pf-steps-indicator li:only-of-type:before{background-color:transparent}
 .wizard-pf-steps-indicator li a{color:#030303;font-size:16px;cursor:pointer;margin-left:1em;margin-right:1em;text-decoration:none}
 .wizard-pf-steps-indicator li a:hover .wizard-pf-step-number{background-color:#bbb;border-color:#bbb;color:#fff}
-.wizard-pf-steps-indicator .wizard-pf-step-number{background-color:#fff;border-radius:50%;border:2px solid #bbb;color:#bbb;font-size:13px;font-weight:700;height:25px;line-height:22px;position:absolute;top:27px;width:25px}
+.wizard-pf-steps-indicator .wizard-pf-step-number{background-color:#fff;border-radius:50%;border:2px solid #bbb;color:#bbb;font-size:13px;font-weight:700;height:25px;left:calc(50% - 13px);line-height:22px;position:absolute;top:27px;width:25px}
 .wizard-pf-steps-indicator .active .wizard-pf-step-number{cursor:default;background-color:#39a5dc;border-color:#39a5dc;color:#fff}
 .wizard-pf-steps-indicator .viewed-pf .wizard-pf-step-number{background-color:#fff;border-color:#39a5dc;color:#030303}
 .wizard-pf-main{height:100%;margin-left:253px;overflow:auto;padding:3em;vertical-align:top}
@@ -4097,7 +4098,6 @@ table.dataTable th:active{outline:0}
 .wizard-pf-footer{border-top:1px solid #d1d1d1;bottom:0;left:0;margin-top:0;padding-bottom:17px;position:absolute;right:0}
 .wizard-pf-footer .btn-cancel{margin-right:25px}
 .wizard-pf-row{bottom:58px;position:absolute;overflow:hidden;top:172px;width:100%}
-.pre-wrap{white-space:pre-wrap}
 .visible-xlg-inline-block{display:none!important}
 @media (max-width:767px){.td-long-string{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 }
@@ -4690,7 +4690,6 @@ h2+.list-view-pf{margin-top:20px}
 ul.messenger.messenger-theme-flat{margin:0;padding:0;opacity:1;-webkit-transition:all .2s ease .2s;-o-transition:all .2s ease .2s;transition:all .2s ease .2s}
 ul.messenger.messenger-theme-flat>li{list-style:none;margin:0;padding:0}
 ul.messenger.messenger-theme-flat .messenger-message:after,ul.messenger.messenger-theme-flat .messenger-message:before{content:" ";display:table}
-ul.messenger.messenger-theme-flat .messenger-message:after{clear:both}
 ul.messenger.messenger-theme-flat .messenger-message.messenger-hidden{display:none}
 ul.messenger.messenger-theme-flat .messenger-message .messenger-actions{float:right}
 ul.messenger.messenger-theme-flat .messenger-message .messenger-actions a{cursor:pointer;text-decoration:underline}
@@ -5956,7 +5955,6 @@ alerts+.chromeless .log-loading-msg{margin-top:130px}
 .appended-icon{display:inline-block;white-space:nowrap}
 .block{display:block}
 .donut-title-med-pf{font-size:22.5px;font-weight:300}
-.wizard-pf-steps-indicator .wizard-pf-step-number{left:calc(50% - 13px)}
 .col-md-12>.alerts:first-child{margin-top:20px}
 .empty-state-message .projects-instructions code{display:inline-block}
 .project-additional-info.list-view-pf-additional-info,.project-info .list-view-pf-main-info{display:block}


### PR DESCRIPTION
Fixes #1306 Remove bootstrap-switch dependency

Fixes #1261 Remove ::placeholder vendor prefixes once updated in PatternFly

- Removes alignment of wizard step indicator number which was fixed in base PatternFly