### PR TITLE
Fix regression associating services to k8s deployments

### DIFF
--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -824,6 +824,8 @@ function OverviewController($scope,
       overview.monopods
     ];
     _.each(toUpdate, updateServicesForObjects);
+
+    updateRoutesByApp();
   };
 
   // Group routes by the services they route to (either as a primary service or
@@ -1181,9 +1183,9 @@ function OverviewController($scope,
       deploymentsByUID = deploymentData.by('metadata.uid');
       overview.deployments = _.sortBy(deploymentsByUID, 'metadata.name');
       groupReplicaSets();
-      updateServicesForObjects(overview.deploymentsByUID);
+      updateServicesForObjects(overview.deployments);
       updateServicesForObjects(overview.vanillaReplicaSets);
-      updateLabelSuggestions(overview.deploymentsByUID);
+      updateLabelSuggestions(overview.deployments);
       updateFilter();
       Logger.log("deployments (subscribe)", overview.deploymentsByUID);
     }));

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -261,7 +261,7 @@ Fa = _.mapValues(w.services, function(a) {
 return new LabelSelector(a.spec.selector);
 });
 var a = [ w.deploymentConfigs, w.vanillaReplicationControllers, w.deployments, w.vanillaReplicaSets, w.statefulSets, w.monopods ];
-_.each(a, Ga);
+_.each(a, Ga), W();
 }
 }, Ia = function() {
 var a = v.groupByService(w.routes, !0);
@@ -395,7 +395,7 @@ w.replicaSets = a.by("metadata.name"), Ea(), Ga(w.vanillaReplicaSets), Ga(w.mono
 group:"extensions",
 resource:"deployments"
 }, c, function(a) {
-z = a.by("metadata.uid"), w.deployments = _.sortBy(z, "metadata.name"), Ea(), Ga(w.deploymentsByUID), Ga(w.vanillaReplicaSets), wa(w.deploymentsByUID), fa(), o.log("deployments (subscribe)", w.deploymentsByUID);
+z = a.by("metadata.uid"), w.deployments = _.sortBy(z, "metadata.name"), Ea(), Ga(w.deployments), Ga(w.vanillaReplicaSets), wa(w.deployments), fa(), o.log("deployments (subscribe)", w.deploymentsByUID);
 })), Ya.push(h.watch("builds", c, function(a) {
 N.builds = a.by("metadata.name"), Ua(), o.log("builds (subscribe)", N.builds);
 })), Ya.push(h.watch({


### PR DESCRIPTION
Services are not properly associated with k8s deployments on the overview depending on the order that things load. Label suggestions for deployments are also not loading. (Caused by #1556.)

Additionally fixes a timing issue where the application route is not displayed if services load last.

Fixes #1566
