### PR TITLE
Other resources list update

### DIFF
--- a/app/scripts/constants.js
+++ b/app/scripts/constants.js
@@ -79,14 +79,7 @@ angular.extend(window.OPENSHIFT_CONSTANTS, {
   DISABLE_WILDCARD_ROUTES: true,
 
   // This blacklist hides certain kinds from the "Other Resources" page because they are unpersisted, disallowed for most end users, or not supported by openshift but exist in kubernetes
-  AVAILABLE_KINDS_BLACKLIST: [
-      // These are k8s kinds that are not supported in the current release of OpenShift
-      {kind: 'Binding', group: ''},
-      "Ingress",
-
-      // These are things like DCPs that aren't actually persisted resources
-      "DeploymentConfigRollback"
-  ],
+  AVAILABLE_KINDS_BLACKLIST: [],
 
   ENABLE_TECH_PREVIEW_FEATURE: {
     // Enable the new landing page and service catalog experience

--- a/app/scripts/controllers/otherResources.js
+++ b/app/scripts/controllers/otherResources.js
@@ -1,14 +1,18 @@
 'use strict';
 
-/**
- * @ngdoc function
- * @name openshiftConsole.controller:OtherResourcesController
- * @description
- * # ProjectController
- * Controller of the openshiftConsole
- */
 angular.module('openshiftConsole')
-  .controller('OtherResourcesController', function ($routeParams, $location, $scope, AlertMessageService, AuthorizationService, DataService, ProjectsService, $filter, LabelFilter, Logger, APIService ) {
+  .controller('OtherResourcesController', function (
+    $routeParams,
+    $location,
+    $scope,
+    AlertMessageService,
+    AuthorizationService,
+    DataService,
+    ProjectsService,
+    $filter,
+    LabelFilter,
+    Logger,
+    APIService) {
     $scope.projectName = $routeParams.project;
     $scope.labelSuggestions = {};
     $scope.alerts = $scope.alerts || {};
@@ -43,6 +47,19 @@ angular.module('openshiftConsole')
           return true;
       }
     });
+
+    var isListable = function(kind) {
+      if(!kind) {
+        return;
+      }
+      var rgv = APIService.kindToResourceGroupVersion(kind);
+      var apiInfo = APIService.apiInfo(rgv);
+      return apiInfo && apiInfo.verbs ?
+              _.contains(apiInfo.verbs, 'list') :
+              // if we don't have apiInfo, default to show the item
+              // this can happen if the api server is not current
+              true;
+    };
 
     $scope.getReturnURL = function() {
       var kind = _.get($scope, 'kindSelector.selected.kind');
@@ -93,6 +110,9 @@ angular.module('openshiftConsole')
             resource: APIService.kindToResource(kind.kind),
             group: kind.group || ''
           };
+          if(!isListable(kind)) {
+            return false;
+          }
           // exclude 'projectrequests', subresources, and REVIEW_RESOURCES from the list
           if (AuthorizationService.checkResource(resourceAndGroup.resource)) {
             return AuthorizationService.canI(resourceAndGroup, "list", $scope.projectName);

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1234,10 +1234,7 @@ DEFAULT_HPA_CPU_TARGET_PERCENT:80,
 DISABLE_OVERVIEW_METRICS:!1,
 DISABLE_CUSTOM_METRICS:!1,
 DISABLE_WILDCARD_ROUTES:!0,
-AVAILABLE_KINDS_BLACKLIST:[ {
-kind:"Binding",
-group:""
-}, "Ingress", "DeploymentConfigRollback" ],
+AVAILABLE_KINDS_BLACKLIST:[],
 ENABLE_TECH_PREVIEW_FEATURE:{
 service_catalog_landing_page:!1,
 template_service_broker:!1,
@@ -7016,7 +7013,14 @@ return !1;
 default:
 return !0;
 }
-}), c.getReturnURL = function() {
+});
+var n = function(a) {
+if (a) {
+var b = k.kindToResourceGroupVersion(a), c = k.apiInfo(b);
+return !c || !c.verbs || _.contains(c.verbs, "list");
+}
+};
+c.getReturnURL = function() {
 var b = _.get(c, "kindSelector.selected.kind");
 return b ? URI.expand("project/{projectName}/browse/other?kind={kind}&group={group}", {
 projectName:a.project,
@@ -7024,13 +7028,13 @@ kind:b,
 group:_.get(c, "kindSelector.selected.group", "")
 }).toString() :"";
 };
-var n;
+var o;
 c.isDuplicateKind = function(a) {
-return n || (n = _.countBy(c.kinds, "kind")), n[a] > 1;
+return o || (o = _.countBy(c.kinds, "kind")), o[a] > 1;
 }, d.getAlerts().forEach(function(a) {
 c.alerts[a.name] = a.data;
 }), d.clearAlerts();
-var o = function(a, b) {
+var p = function(a, b) {
 return _.some(c.kinds, function(c) {
 return c.kind === a && (!c.group && !b || c.group === b);
 });
@@ -7041,14 +7045,14 @@ var b = {
 resource:k.kindToResource(a.kind),
 group:a.group || ""
 };
-return !!e.checkResource(b.resource) && e.canI(b, "list", c.projectName);
-}), c.project = b, c.context = d, c.kindSelector.disabled = !1, a.kind && o(a.kind, a.group) && (_.set(c, "kindSelector.selected.kind", a.kind), _.set(c, "kindSelector.selected.group", a.group || ""));
+return !!n(a) && (!!e.checkResource(b.resource) && e.canI(b, "list", c.projectName));
+}), c.project = b, c.context = d, c.kindSelector.disabled = !1, a.kind && p(a.kind, a.group) && (_.set(c, "kindSelector.selected.kind", a.kind), _.set(c, "kindSelector.selected.group", a.group || ""));
 })), c.loadKind = m, c.$watch("kindSelector.selected", function() {
 c.alerts = {}, m();
 });
-var p = h("humanizeKind");
+var q = h("humanizeKind");
 c.matchKind = function(a, b) {
-return p(a).toLowerCase().indexOf(b.toLowerCase()) !== -1;
+return q(a).toLowerCase().indexOf(b.toLowerCase()) !== -1;
 }, i.onActiveFiltersChanged(function(a) {
 c.$apply(function() {
 c.resources = a.select(c.unfilteredResources), l();


### PR DESCRIPTION
Depends on [web-common PR 77](https://github.com/openshift/origin-web-common/pull/77)

These resources pass the 'list' verb test:
```
[
  "Endpoints",
  "PodTemplate",
  "ServiceAccount",
  "HorizontalPodAutoscaler",
  "DaemonSet",
  "Ingress",
  "NetworkPolicy",
  "ReplicationControllerDummy",
  "PodDisruptionBudget",
  "RoleBinding",
  "Role",
  "PodPreset",
  "Policy",
  "PolicyBinding",
  "RoleBindingRestriction",
  "RoleBinding",
  "Role",
  "Template",
  "EgressNetworkPolicy"
] 
```

these resources do not: 
```
[
  "LocalSubjectAccessReview",
  "LocalResourceAccessReview",
  "LocalSubjectAccessReview",
  "ResourceAccessReview",
  "SelfSubjectRulesReview",
  "SubjectAccessReview",
  "SubjectRulesReview",
  "PodSecurityPolicyReview",
  "PodSecurityPolicySelfSubjectReview",
  "PodSecurityPolicySubjectReview"
]
```
Moving the apiService updates to web-common to PR first, then will update & remove the [WIP]