### PR TITLE
Show owner reference links on browse pages

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -356,10 +356,12 @@
         <script src="scripts/directives/buildHooks.js"></script>
         <script src="scripts/directives/pauseRolloutsCheckbox.js"></script>
         <script src="scripts/directives/keyValueEditor.js"></script>
+        <script src="scripts/directives/ownerReferences.js"></script>
         <script src="scripts/filters/date.js"></script>
         <script src="scripts/filters/resources.js"></script>
         <script src="scripts/filters/canI.js"></script>
         <script src="scripts/filters/util.js"></script>
+        <script src="scripts/filters/navigate.js"></script>
         <script src="scripts/directives/affix.js"></script>
         <script src="scripts/services/logLinks.js"></script>
 

--- a/app/scripts/directives/ownerReferences.js
+++ b/app/scripts/directives/ownerReferences.js
@@ -1,0 +1,16 @@
+'use strict';
+
+(function() {
+  angular.module('openshiftConsole').component('ownerReferences', {
+    controller: [
+      OwnerReferences
+    ],
+    controllerAs: 'ctrl',
+    bindings: {
+      apiObject: '<'
+    },
+    templateUrl: 'views/directives/owner-references.html'
+  });
+
+  function OwnerReferences() {}
+}());

--- a/app/scripts/filters/navigate.js
+++ b/app/scripts/filters/navigate.js
@@ -1,0 +1,36 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  // Resource is either a resource object, or a name.  If resource is a name, kind and namespace must be specified
+  // Note that builds and deployments can only have their URL built correctly (including their config in the URL)
+  // if resource is an object
+  .filter('navigateResourceURL', function(Navigate) {
+    return function(resource, kind, namespace, apiVersion) {
+      return Navigate.resourceURL(resource, kind, namespace, null, {apiVersion: apiVersion});
+    };
+  })
+  .filter('configURLForResource', function(Navigate) {
+    return function(resource, /* optional */ action) {
+      return Navigate.configURLForResource(resource, action);
+    };
+  })
+  .filter('editResourceURL', function(Navigate) {
+    return function(resource, kind, namespace) {
+      var url = Navigate.resourceURL(resource, kind, namespace, "edit");
+      return url;
+    };
+  })
+  .filter('editYamlURL', function(Navigate) {
+    return function(object, /* optional */ returnURL) {
+      return Navigate.yamlURL(object, returnURL);
+    };
+  })
+  .filter('urlForOwnerRef', function(Navigate) {
+    return function(ownerReference, namespace) {
+      if (!ownerReference) {
+        return null;
+      }
+
+      return Navigate.resourceURL(ownerReference.name, ownerReference.kind, namespace);
+    };
+  });

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -1355,4 +1355,7 @@ angular.module('openshiftConsole')
       var alternateBackends = _.get(route, 'spec.alternateBackends', []);
       return !_.isEmpty(alternateBackends);
     };
+  })
+  .filter('ownerReferences', function(OwnerReferencesService) {
+    return OwnerReferencesService.getOwnerReferences;
   });

--- a/app/scripts/filters/util.js
+++ b/app/scripts/filters/util.js
@@ -348,30 +348,6 @@ angular.module('openshiftConsole')
           .replace(/^./, function(str){ return str.toUpperCase(); });
     };
   })
-  // Resource is either a resource object, or a name.  If resource is a name, kind and namespace must be specified
-  // Note that builds and deployments can only have their URL built correctly (including their config in the URL)
-  // if resource is an object
-  .filter('navigateResourceURL', function(Navigate) {
-    return function(resource, kind, namespace, apiVersion) {
-      return Navigate.resourceURL(resource, kind, namespace, null, {apiVersion: apiVersion});
-    };
-  })
-  .filter('configURLForResource', function(Navigate) {
-    return function(resource, /* optional */ action) {
-      return Navigate.configURLForResource(resource, action);
-    };
-  })
-  .filter('editResourceURL', function(Navigate) {
-    return function(resource, kind, namespace) {
-      var url = Navigate.resourceURL(resource, kind, namespace, "edit");
-      return url;
-    };
-  })
-  .filter('editYamlURL', function(Navigate) {
-    return function(object, /* optional */ returnURL) {
-      return Navigate.yamlURL(object, returnURL);
-    };
-  })
   .filter('join', function() {
     return function(array, separator) {
       if (!separator) {

--- a/app/views/browse/_pod-details.html
+++ b/app/views/browse/_pod-details.html
@@ -25,6 +25,7 @@
           <a ng-href="{{rcName | navigateResourceURL : 'ReplicationController' : pod.metadata.namespace}}"
             ><span ng-if="deploymentVersion">#{{deploymentVersion}}</span><span ng-if="!deploymentVersion">{{rcName}}</span></a></span>
         </dd>
+        <owner-references ng-if="!dcName" api-object="pod"></owner-references>
         <dt ng-if-start="pod.metadata.deletionTimestamp && pod.spec.terminationGracePeriodSeconds">Grace Period:</dt>
         <dd ng-if-end>
           <!-- Don't show "a few seconds" for small values. -->

--- a/app/views/browse/_replica-set-details.html
+++ b/app/views/browse/_replica-set-details.html
@@ -47,6 +47,7 @@
       <dd ng-if-end>
         <a ng-href="{{replicaSet | configURLForResource}}">{{deploymentConfigName}}</a>
       </dd>
+      <owner-references ng-if="!(replicaSet | hasDeploymentConfig)" api-object="replicaSet"></owner-references>
       <dt ng-if-start="replicaSet | annotation:'deploymentStatusReason'">Status Reason:</dt>
       <dd ng-if-end>
         {{replicaSet | annotation:'deploymentStatusReason'}}

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -237,6 +237,7 @@
                             -->
                             <h3 class="hidden visible-lg visible-xl">Details</h3>
                             <dl class="dl-horizontal left">
+                              <owner-references api-object="buildConfig"></owner-references>
                               <div>
                                 <dt>Build Strategy:</dt>
                                 <dd>{{buildConfig.spec.strategy.type | startCase}}</dd>

--- a/app/views/browse/route.html
+++ b/app/views/browse/route.html
@@ -95,6 +95,7 @@
 
                 <h4 class="mar-top-xl">Details</h4>
                 <dl class="dl-horizontal left">
+                  <owner-references api-object="route"></owner-references>
                   <dt ng-if-start="route.spec.wildcardPolicy && route.spec.wildcardPolicy !== 'None' && route.spec.wildcardPolicy !== 'Subdomain'">Wildcard Policy:</dt>
                   <dd ng-if-end>{{route.spec.wildcardPolicy}}</dd>
                   <dt>Path:</dt>

--- a/app/views/browse/service.html
+++ b/app/views/browse/service.html
@@ -53,6 +53,7 @@
                   <uib-tab-heading>Details</uib-tab-heading>
                   <div class="resource-details">
                     <dl class="dl-horizontal left">
+                      <owner-references api-object="service"></owner-references>
                       <dt>Selectors:</dt>
                       <dd>
                         <span ng-if="!service.spec.selector"><em>none</em></span>

--- a/app/views/browse/stateful-set.html
+++ b/app/views/browse/stateful-set.html
@@ -90,6 +90,7 @@
                           <status-icon status="statefulSet | deploymentStatus"></status-icon>
                           {{statefulSet | deploymentStatus}}
                         </dd>
+                        <owner-references api-object="statefulSet"></owner-references>
                         <dt>Replicas:</dt>
                         <dd>
                           <!-- TODO: swap back in 1.6

--- a/app/views/directives/owner-references.html
+++ b/app/views/directives/owner-references.html
@@ -1,0 +1,11 @@
+<dt ng-repeat-start="ownerReference in (ctrl.apiObject | ownerReferences) track by ownerReference.uid">
+  {{ownerReference.kind | humanizeKind : true}}:
+</dt>
+<dd ng-repeat-end>
+  <span ng-if="url = (ownerReference | urlForOwnerRef : ctrl.apiObject.metadata.namespace)">
+    <a ng-href="{{url}}">{{ownerReference.name}}</a>
+  </span>
+  <span ng-if="!url">
+    {{ownerReference.name}}
+  </span>
+</dd>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -13362,6 +13362,16 @@ e.findReferenceValueForEntries(b.entries, b.valueFromSelectorOptions);
 } ]
 };
 } ]);
+}(), function() {
+function a() {}
+angular.module("openshiftConsole").component("ownerReferences", {
+controller:[ a ],
+controllerAs:"ctrl",
+bindings:{
+apiObject:"<"
+},
+templateUrl:"views/directives/owner-references.html"
+});
 }(), angular.module("openshiftConsole").filter("duration", function() {
 return function(a, b, c, d) {
 function e(a, b, d) {
@@ -14121,7 +14131,9 @@ return function(a) {
 var b = _.get(a, "spec.alternateBackends", []);
 return !_.isEmpty(b);
 };
-}), angular.module("openshiftConsole").filter("canIDoAny", [ "canIFilter", function(a) {
+}).filter("ownerReferences", [ "OwnerReferencesService", function(a) {
+return a.getOwnerReferences;
+} ]), angular.module("openshiftConsole").filter("canIDoAny", [ "canIFilter", function(a) {
 var b = {
 buildConfigs:[ {
 group:"",
@@ -14439,26 +14451,7 @@ return a.replace(/([a-z])([A-Z])/g, "$1 $2").replace(/\b([A-Z]+)([A-Z])([a-z])/,
 return a.toUpperCase();
 });
 };
-}).filter("navigateResourceURL", [ "Navigate", function(a) {
-return function(b, c, d, e) {
-return a.resourceURL(b, c, d, null, {
-apiVersion:e
-});
-};
-} ]).filter("configURLForResource", [ "Navigate", function(a) {
-return function(b, c) {
-return a.configURLForResource(b, c);
-};
-} ]).filter("editResourceURL", [ "Navigate", function(a) {
-return function(b, c, d) {
-var e = a.resourceURL(b, c, d, "edit");
-return e;
-};
-} ]).filter("editYamlURL", [ "Navigate", function(a) {
-return function(b, c) {
-return a.yamlURL(b, c);
-};
-} ]).filter("join", function() {
+}).filter("join", function() {
 return function(a, b) {
 return b || (b = ","), a.join(b);
 };
@@ -14536,6 +14529,29 @@ return a.linkify(b, c, d);
 } ]).filter("enableTechPreviewFeature", [ "Constants", function(a) {
 return function(b) {
 return _.get(a, [ "ENABLE_TECH_PREVIEW_FEATURE", b ], !1);
+};
+} ]), angular.module("openshiftConsole").filter("navigateResourceURL", [ "Navigate", function(a) {
+return function(b, c, d, e) {
+return a.resourceURL(b, c, d, null, {
+apiVersion:e
+});
+};
+} ]).filter("configURLForResource", [ "Navigate", function(a) {
+return function(b, c) {
+return a.configURLForResource(b, c);
+};
+} ]).filter("editResourceURL", [ "Navigate", function(a) {
+return function(b, c, d) {
+var e = a.resourceURL(b, c, d, "edit");
+return e;
+};
+} ]).filter("editYamlURL", [ "Navigate", function(a) {
+return function(b, c) {
+return a.yamlURL(b, c);
+};
+} ]).filter("urlForOwnerRef", [ "Navigate", function(a) {
+return function(b, c) {
+return b ? a.resourceURL(b.name, b.kind, c) :null;
 };
 } ]), angular.module("openshiftConsole").directive("affix", [ "$window", function(a) {
 return {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1231,6 +1231,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a ng-href=\"{{dcName | navigateResourceURL : 'DeploymentConfig' : pod.metadata.namespace}}\">{{dcName}}</a><span ng-if=\"rcName\">,\n" +
     "<a ng-href=\"{{rcName | navigateResourceURL : 'ReplicationController' : pod.metadata.namespace}}\"><span ng-if=\"deploymentVersion\">#{{deploymentVersion}}</span><span ng-if=\"!deploymentVersion\">{{rcName}}</span></a></span>\n" +
     "</dd>\n" +
+    "<owner-references ng-if=\"!dcName\" api-object=\"pod\"></owner-references>\n" +
     "<dt ng-if-start=\"pod.metadata.deletionTimestamp && pod.spec.terminationGracePeriodSeconds\">Grace Period:</dt>\n" +
     "<dd ng-if-end>\n" +
     "\n" +
@@ -1382,6 +1383,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dd ng-if-end>\n" +
     "<a ng-href=\"{{replicaSet | configURLForResource}}\">{{deploymentConfigName}}</a>\n" +
     "</dd>\n" +
+    "<owner-references ng-if=\"!(replicaSet | hasDeploymentConfig)\" api-object=\"replicaSet\"></owner-references>\n" +
     "<dt ng-if-start=\"replicaSet | annotation:'deploymentStatusReason'\">Status Reason:</dt>\n" +
     "<dd ng-if-end>\n" +
     "{{replicaSet | annotation:'deploymentStatusReason'}}\n" +
@@ -1759,6 +1761,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "\n" +
     "<h3 class=\"hidden visible-lg visible-xl\">Details</h3>\n" +
     "<dl class=\"dl-horizontal left\">\n" +
+    "<owner-references api-object=\"buildConfig\"></owner-references>\n" +
     "<div>\n" +
     "<dt>Build Strategy:</dt>\n" +
     "<dd>{{buildConfig.spec.strategy.type | startCase}}</dd>\n" +
@@ -3418,6 +3421,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<h4 class=\"mar-top-xl\">Details</h4>\n" +
     "<dl class=\"dl-horizontal left\">\n" +
+    "<owner-references api-object=\"route\"></owner-references>\n" +
     "<dt ng-if-start=\"route.spec.wildcardPolicy && route.spec.wildcardPolicy !== 'None' && route.spec.wildcardPolicy !== 'Subdomain'\">Wildcard Policy:</dt>\n" +
     "<dd ng-if-end>{{route.spec.wildcardPolicy}}</dd>\n" +
     "<dt>Path:</dt>\n" +
@@ -3777,6 +3781,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<uib-tab-heading>Details</uib-tab-heading>\n" +
     "<div class=\"resource-details\">\n" +
     "<dl class=\"dl-horizontal left\">\n" +
+    "<owner-references api-object=\"service\"></owner-references>\n" +
     "<dt>Selectors:</dt>\n" +
     "<dd>\n" +
     "<span ng-if=\"!service.spec.selector\"><em>none</em></span>\n" +
@@ -3903,6 +3908,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<status-icon status=\"statefulSet | deploymentStatus\"></status-icon>\n" +
     "{{statefulSet | deploymentStatus}}\n" +
     "</dd>\n" +
+    "<owner-references api-object=\"statefulSet\"></owner-references>\n" +
     "<dt>Replicas:</dt>\n" +
     "<dd>\n" +
     "\n" +
@@ -8488,6 +8494,21 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a href=\"\" ng-if=\"'secrets' | canI : 'create'\" role=\"button\" ng-click=\"openCreateSecretModal()\">Create New Secret</a>\n" +
     "</div>\n" +
     "</ng-form>"
+  );
+
+
+  $templateCache.put('views/directives/owner-references.html',
+    "<dt ng-repeat-start=\"ownerReference in (ctrl.apiObject | ownerReferences) track by ownerReference.uid\">\n" +
+    "{{ownerReference.kind | humanizeKind : true}}:\n" +
+    "</dt>\n" +
+    "<dd ng-repeat-end>\n" +
+    "<span ng-if=\"url = (ownerReference | urlForOwnerRef : ctrl.apiObject.metadata.namespace)\">\n" +
+    "<a ng-href=\"{{url}}\">{{ownerReference.name}}</a>\n" +
+    "</span>\n" +
+    "<span ng-if=\"!url\">\n" +
+    "{{ownerReference.name}}\n" +
+    "</span>\n" +
+    "</dd>"
   );
 
 


### PR DESCRIPTION
Add links to an object's owners on various browse pages. For instance, here is a replica set owned by a deployment:

![openshift web console 2017-05-23 12-52-37](https://cloud.githubusercontent.com/assets/1167259/26365956/3cc9f506-3fb7-11e7-938b-7795e030bec7.png)

@jwforres Thoughts on this change?

For now, I intentionally left out some relationships we already had special handling for like

build -> bc
pod -> rc -> dc