### PR TITLE
Tighten up documentation paragraph in about page

### DIFF
--- a/app/views/about.html
+++ b/app/views/about.html
@@ -29,7 +29,7 @@
                         <dd>{{version.master.kubernetes || 'unknown'}}</dd>
                       </dl>
 
-                      <p>The <a target="_blank" href="{{'welcome' | helpLink}}">documentation</a> contains information and guides to help you learn about OpenShift and start exploring its features. From getting started with creating your first application, to trying out more advanced build and deployment techniques, it provides what you need to set up and manage your OpenShift environment as an application developer.</p>
+                      <p>The <a target="_blank" ng-href="{{'welcome' | helpLink}}">documentation</a> helps you learn about OpenShift and start exploring its features. From getting started with creating your first application to trying out more advanced build and deployment techniques, it provides guidance on setting up and managing your OpenShift environment as an application developer.</p>
 
                       <p>With the OpenShift command line interface (CLI), you can create applications and manage OpenShift projects from a terminal. To get started using the CLI, visit <a href="command-line">Command Line Tools</a>.
                       </p>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -880,7 +880,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt>Kubernetes Master:</dt>\n" +
     "<dd>{{version.master.kubernetes || 'unknown'}}</dd>\n" +
     "</dl>\n" +
-    "<p>The <a target=\"_blank\" href=\"{{'welcome' | helpLink}}\">documentation</a> contains information and guides to help you learn about OpenShift and start exploring its features. From getting started with creating your first application, to trying out more advanced build and deployment techniques, it provides what you need to set up and manage your OpenShift environment as an application developer.</p>\n" +
+    "<p>The <a target=\"_blank\" ng-href=\"{{'welcome' | helpLink}}\">documentation</a> helps you learn about OpenShift and start exploring its features. From getting started with creating your first application to trying out more advanced build and deployment techniques, it provides guidance on setting up and managing your OpenShift environment as an application developer.</p>\n" +
     "<p>With the OpenShift command line interface (CLI), you can create applications and manage OpenShift projects from a terminal. To get started using the CLI, visit <a href=\"command-line\">Command Line Tools</a>.\n" +
     "</p>\n" +
     "</div>\n" +


### PR DESCRIPTION
Slightly changes wording on the About page regarding documentation, [as suggested here](https://github.com/openshift/online/pull/1235#issuecomment-303805345)

cc @ahardin-rh 