### PR TITLE
Fixing bug where exit-fullscreen button wasn't visible in IE11

### DIFF
--- a/app/styles/_container-terminal.less
+++ b/app/styles/_container-terminal.less
@@ -1,44 +1,49 @@
-.terminal-font {
-  font-family: "Monospace Regular", "DejaVu Sans Mono", Menlo, Monaco, Consolas, monospace;
-  line-height: 1em;
-  font-size: 12px;
+// note this is mixin, so it needs to be at the top
+.fullscreen() {
+  background: #000;
+  height: 100%;
+  width: 100%;
+  .fullscreen-toggle {
+    .exit-fullscreen {
+      display: block;
+    }
+    .go-fullscreen {
+      display: none;
+    }
+  }
 }
 
-// Control what fonts are used in the container terminal since we need the terminal-font class for row/col character calculations
-kubernetes-container-terminal .terminal {
-  .terminal-font();
-}
-
-.pod-container-terminal {
-  margin-top: 15px;
-  margin-bottom: 15px;
-  kubernetes-container-terminal .terminal-wrapper {
-    max-width: 100%;
-    overflow-x: auto;
+// note this is mixin, so it needs to be at the top
+.style-terminal-action() {
+  color: @gray-light;
+  cursor: pointer;
+  font-size: 18px;
+  padding: 5px;
+  &:hover, &:active, &:focus {
+    color: #fff;
+    text-decoration: none;
   }
 }
 
 .container-terminal-wrapper {
-  .style-terminal-action() {
-    color: @gray-light;
-    cursor: pointer;
-    font-size: 18px;
-    &:hover, &:active, &:focus {
-      color: #fff;
-      text-decoration: none;
+  position: relative;
+  @media(min-width: @screen-sm-min) {
+    // Show the expand to fullscreen action when hovering over the terminal.
+    &:hover {
+      .fullscreen-toggle {
+        display: block;
+      }
     }
   }
-  position: relative;
-  .terminal-actions .btn {
-    .btn-link();
-    .style-terminal-action();
-    background: none;
+  &.disconnected .fullscreen-toggle {
+    display: none;
   }
   .fullscreen-toggle {
     display: none;
+    line-height: 1;
     position: absolute;
-    top: 7px;
-    right: 15px;
+    right: 5px;
+    top: 0;
     z-index: 1;
     a {
       .style-terminal-action();
@@ -46,40 +51,46 @@ kubernetes-container-terminal .terminal {
     .exit-fullscreen {
       display: none;
     }
-  }
-  &.disconnected .go-fullscreen {
-    display: none;
-  }
-  .fullscreen() {
-    width: 100%;
-    height: 100%;
     .go-fullscreen {
-      display: none;
-    }
-    .exit-fullscreen {
-      display: inline;
+      display: block;
     }
   }
-  &:-webkit-full-screen {
-    .fullscreen();
+  .terminal-actions .btn {
+    background: none;
+    .btn-link();
+    .style-terminal-action();
   }
+  // so that &-:ms-fullscreen works correctly, these need to come after .fullscreen-toggle
   &:-moz-full-screen {
     .fullscreen();
   }
-  &:-ms-full-screen {
+  &:-ms-fullscreen {
+    .fullscreen();
+  }
+  &:-webkit-full-screen {
     .fullscreen();
   }
   &:-fullscreen {
     .fullscreen();
   }
-  @media(min-width: @screen-sm-min) {
-    // Fill the extra right border we get when we cant quite fit the last col so it lines up with the Actions dropdown button
-    background-color: #000;
-    // Show the expand to fullscreen action when hovering over the terminal.
-    &:hover {
-      .fullscreen-toggle {
-        display: inline-block;
-      }
+}
+
+kubernetes-container-terminal {
+  // Control what fonts are used in the container terminal since we need the terminal-font class for row/col character calculations
+  .terminal {
+    .terminal-font();
+  }
+  .terminal-actions {
+    top: 0;
+    right: 30px;
+    .spinner {
+      top: 5px;
     }
   }
+}
+
+.terminal-font {
+  font-family: "Monospace Regular", "DejaVu Sans Mono", Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1em;
 }

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5739,36 +5739,36 @@ alerts+.chromeless .log-loading-msg{margin-top:130px}
 .projects-instructions-link{white-space:pre}
 .projects-list{border-top:0;box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09);margin-bottom:20px}
 .projects-list .project-info:hover{background-color:#def3ff}
-.terminal-font,kubernetes-container-terminal .terminal{font-family:"Monospace Regular","DejaVu Sans Mono",Menlo,Monaco,Consolas,monospace;line-height:1em;font-size:12px}
-.pod-container-terminal{margin-top:15px;margin-bottom:15px}
-.pod-container-terminal kubernetes-container-terminal .terminal-wrapper{max-width:100%;overflow-x:auto}
 .container-terminal-wrapper{position:relative}
-.container-terminal-wrapper .terminal-actions .btn{font-weight:400;border-radius:0;color:#9c9c9c;cursor:pointer;font-size:18px;background:0 0}
+@media (min-width:768px){.container-terminal-wrapper:hover .fullscreen-toggle{display:block}
+}
+.container-terminal-wrapper .fullscreen-toggle .exit-fullscreen,.container-terminal-wrapper.disconnected .fullscreen-toggle{display:none}
+.container-terminal-wrapper .fullscreen-toggle{display:none;line-height:1;position:absolute;right:5px;top:0;z-index:1}
+.container-terminal-wrapper .fullscreen-toggle a{color:#9c9c9c;cursor:pointer;font-size:18px;padding:5px}
+.container-terminal-wrapper .fullscreen-toggle a:active,.container-terminal-wrapper .fullscreen-toggle a:focus,.container-terminal-wrapper .fullscreen-toggle a:hover{color:#fff;text-decoration:none}
+.container-terminal-wrapper .fullscreen-toggle .go-fullscreen{display:block}
+.container-terminal-wrapper .terminal-actions .btn{background:0 0;font-weight:400;border-radius:0;color:#9c9c9c;cursor:pointer;font-size:18px;padding:5px}
+.terminal-font,kubernetes-container-terminal .terminal{font-family:"Monospace Regular","DejaVu Sans Mono",Menlo,Monaco,Consolas,monospace;font-size:12px;line-height:1em}
 .container-terminal-wrapper .terminal-actions .btn,.container-terminal-wrapper .terminal-actions .btn.active,.container-terminal-wrapper .terminal-actions .btn:active,.container-terminal-wrapper .terminal-actions .btn[disabled],fieldset[disabled] .container-terminal-wrapper .terminal-actions .btn{background-color:transparent;-webkit-box-shadow:none;box-shadow:none}
 .container-terminal-wrapper .terminal-actions .btn,.container-terminal-wrapper .terminal-actions .btn:active,.container-terminal-wrapper .terminal-actions .btn:focus,.container-terminal-wrapper .terminal-actions .btn:hover{border-color:transparent}
 .container-terminal-wrapper .terminal-actions .btn:focus,.container-terminal-wrapper .terminal-actions .btn:hover{background-color:transparent}
 .container-terminal-wrapper .terminal-actions .btn[disabled]:focus,.container-terminal-wrapper .terminal-actions .btn[disabled]:hover,fieldset[disabled] .container-terminal-wrapper .terminal-actions .btn:focus,fieldset[disabled] .container-terminal-wrapper .terminal-actions .btn:hover{color:#9c9c9c;text-decoration:none}
 .container-terminal-wrapper .terminal-actions .btn,.container-terminal-wrapper .terminal-actions .btn:active{-webkit-box-shadow:none;box-shadow:none}
 .container-terminal-wrapper .terminal-actions .btn:active,.container-terminal-wrapper .terminal-actions .btn:focus,.container-terminal-wrapper .terminal-actions .btn:hover{color:#fff;text-decoration:none}
-.container-terminal-wrapper .fullscreen-toggle{display:none;position:absolute;top:7px;right:15px;z-index:1}
-.container-terminal-wrapper .fullscreen-toggle a{color:#9c9c9c;cursor:pointer;font-size:18px}
-.container-terminal-wrapper .fullscreen-toggle a:active,.container-terminal-wrapper .fullscreen-toggle a:focus,.container-terminal-wrapper .fullscreen-toggle a:hover{color:#fff;text-decoration:none}
-.container-terminal-wrapper .fullscreen-toggle .exit-fullscreen,.container-terminal-wrapper.disconnected .go-fullscreen{display:none}
-.container-terminal-wrapper:-webkit-full-screen{width:100%;height:100%}
-.container-terminal-wrapper:-webkit-full-screen .go-fullscreen{display:none}
-.container-terminal-wrapper:-webkit-full-screen .exit-fullscreen{display:inline}
-.container-terminal-wrapper:-moz-full-screen{width:100%;height:100%}
-.container-terminal-wrapper:-moz-full-screen .go-fullscreen{display:none}
-.container-terminal-wrapper:-moz-full-screen .exit-fullscreen{display:inline}
-.container-terminal-wrapper:-ms-full-screen{width:100%;height:100%}
-.container-terminal-wrapper:-ms-full-screen .go-fullscreen{display:none}
-.container-terminal-wrapper:-ms-full-screen .exit-fullscreen{display:inline}
-.container-terminal-wrapper:-fullscreen{width:100%;height:100%}
-.container-terminal-wrapper:-fullscreen .go-fullscreen{display:none}
-.container-terminal-wrapper:-fullscreen .exit-fullscreen{display:inline}
-@media (min-width:768px){.container-terminal-wrapper{background-color:#000}
-.container-terminal-wrapper:hover .fullscreen-toggle{display:inline-block}
-}
+.container-terminal-wrapper:-moz-full-screen{background:#000;height:100%;width:100%}
+.container-terminal-wrapper:-moz-full-screen .fullscreen-toggle .exit-fullscreen{display:block}
+.container-terminal-wrapper:-moz-full-screen .fullscreen-toggle .go-fullscreen{display:none}
+.container-terminal-wrapper:-ms-fullscreen{background:#000;height:100%;width:100%}
+.container-terminal-wrapper:-ms-fullscreen .fullscreen-toggle .exit-fullscreen{display:block}
+.container-terminal-wrapper:-ms-fullscreen .fullscreen-toggle .go-fullscreen{display:none}
+.container-terminal-wrapper:-webkit-full-screen{background:#000;height:100%;width:100%}
+.container-terminal-wrapper:-webkit-full-screen .fullscreen-toggle .exit-fullscreen{display:block}
+.container-terminal-wrapper:-webkit-full-screen .fullscreen-toggle .go-fullscreen{display:none}
+.container-terminal-wrapper:-fullscreen{background:#000;height:100%;width:100%}
+.container-terminal-wrapper:-fullscreen .fullscreen-toggle .exit-fullscreen{display:block}
+.container-terminal-wrapper:-fullscreen .fullscreen-toggle .go-fullscreen{display:none}
+kubernetes-container-terminal .terminal-actions{top:0;right:30px}
+kubernetes-container-terminal .terminal-actions .spinner{top:5px}
 .key-value-editor.as-sortable-dragging .as-sortable-item-delete,.key-value-editor.as-sortable-dragging .input-group-addon,.key-value-editor.as-sortable-dragging input{opacity:.65}
 .key-value-editor .as-sortable-DISABLED-item-delete:hover,.key-value-editor .as-sortable-item-delete:hover,.key-value-editor .as-sortable-item-handle:hover,.key-value-editor.as-sortable-dragging .as-sortable-item-handle{opacity:1}
 .key-value-editor .as-sortable-DISABLED-item-delete,.key-value-editor .as-sortable-item-delete,.key-value-editor .as-sortable-item-handle{display:inline-block;font-size:15px;opacity:.65;padding:6px;vertical-align:middle}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1427076

Plus additional styling tweaks to improve appearance of loading spinner
and refresh button as well as the fullscreen buttons.

IE11 in fullscreen now shows the exit fullscreen button
![screen shot 2017-05-24 at 5 20 11 pm](https://cloud.githubusercontent.com/assets/895728/26426300/06347bfc-40a6-11e7-93fb-b94017b3cdf4.PNG)
