### PR TITLE
Bug Fix 1451013 - Show Events on PVC detail page

### DIFF
--- a/app/scripts/controllers/persistentVolumeClaim.js
+++ b/app/scripts/controllers/persistentVolumeClaim.js
@@ -41,6 +41,7 @@ angular.module('openshiftConsole')
     .get($routeParams.project)
     .then(_.spread(function(project, context) {
       $scope.project = project;
+      $scope.projectContext = context;
       DataService
         .get("persistentvolumeclaims", $routeParams.pvc, context)
         .then(function(pvc) {

--- a/app/views/browse/persistent-volume-claim.html
+++ b/app/views/browse/persistent-volume-claim.html
@@ -51,32 +51,41 @@
         <div class="container-fluid">
           <div class="row" ng-if="pvc" >
             <div class="col-md-12">
-              <div class="resource-details">
-                <dl class="dl-horizontal left">
-                  <dt>Status:</dt>
-                  <dd>
-                    <status-icon status="pvc.status.phase" disable-animation></status-icon>
-                    {{pvc.status.phase}}
-                    <span ng-if="pvc.spec.volumeName">to volume <strong>{{pvc.spec.volumeName}}</strong></span>
-                  </dd>
-                  <dt ng-if="pvc.spec.volumeName">Capacity:</dt>
-                  <dd ng-if="pvc.spec.volumeName">
-                    <span ng-if="pvc.status.capacity['storage']">
-                      allocated {{pvc.status.capacity['storage'] | usageWithUnits: 'storage'}}
-                    </span>
-                    <span ng-if="!pvc.status.capacity['storage']">allocated unknown size</span>
-                  </dd>
-                  <dt>Requested Capacity:</dt>
-                  <dd>
-                    <span ng-if="pvc.spec.resources.requests['storage']">
-                      {{pvc.spec.resources.requests['storage'] | usageWithUnits: 'storage'}}
-                    </span>
-                    <span ng-if="!pvc.spec.resources.requests['storage']"><em>none</em></span>
-                  </dd>
-                  <dt>Access Modes:</dt>
-                  <dd>{{pvc.spec.accessModes | accessModes:'long' | join}}</dd>
-                </dl>
-              </div>
+              <uib-tabset>
+                <uib-tab heading="Details" active="selectedTab.details">
+                  <uib-tab-heading>Details</uib-tab-heading>
+                    <div class="resource-details">
+                    <dl class="dl-horizontal left">
+                      <dt>Status:</dt>
+                      <dd>
+                        <status-icon status="pvc.status.phase" disable-animation></status-icon>
+                        {{pvc.status.phase}}
+                        <span ng-if="pvc.spec.volumeName">to volume <strong>{{pvc.spec.volumeName}}</strong></span>
+                      </dd>
+                      <dt ng-if="pvc.spec.volumeName">Capacity:</dt>
+                      <dd ng-if="pvc.spec.volumeName">
+                        <span ng-if="pvc.status.capacity['storage']">
+                          allocated {{pvc.status.capacity['storage'] | usageWithUnits: 'storage'}}
+                        </span>
+                        <span ng-if="!pvc.status.capacity['storage']">allocated unknown size</span>
+                      </dd>
+                      <dt>Requested Capacity:</dt>
+                      <dd>
+                        <span ng-if="pvc.spec.resources.requests['storage']">
+                          {{pvc.spec.resources.requests['storage'] | usageWithUnits: 'storage'}}
+                        </span>
+                        <span ng-if="!pvc.spec.resources.requests['storage']"><em>none</em></span>
+                      </dd>
+                      <dt>Access Modes:</dt>
+                      <dd>{{pvc.spec.accessModes | accessModes:'long' | join}}</dd>
+                    </dl>
+                  </div>
+                </uib-tab>
+                <uib-tab active="selectedTab.events" ng-if="'events' | canI : 'watch'">
+                  <uib-tab-heading>Events</uib-tab-heading>
+                  <events resource-kind="PersistentVolumeClaim" resource-name="{{pvc.metadata.name}}" project-context="projectContext" ng-if="selectedTab.events"></events>
+                </uib-tab>
+              </uib-tabset>
             </div><!-- /col-* -->
           </div>
         </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7629,7 +7629,7 @@ message:"This persistent volume claim has been deleted."
 });
 };
 d.get(b.project).then(_.spread(function(d, h) {
-a.project = d, c.get("persistentvolumeclaims", b.pvc, h).then(function(a) {
+a.project = d, a.projectContext = h, c.get("persistentvolumeclaims", b.pvc, h).then(function(a) {
 g(a), f.push(c.watchObject("persistentvolumeclaims", b.pvc, h, g));
 }, function(b) {
 a.loaded = !0, a.alerts.load = {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3232,6 +3232,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\" ng-if=\"pvc\">\n" +
     "<div class=\"col-md-12\">\n" +
+    "<uib-tabset>\n" +
+    "<uib-tab heading=\"Details\" active=\"selectedTab.details\">\n" +
+    "<uib-tab-heading>Details</uib-tab-heading>\n" +
     "<div class=\"resource-details\">\n" +
     "<dl class=\"dl-horizontal left\">\n" +
     "<dt>Status:</dt>\n" +
@@ -3258,6 +3261,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dd>{{pvc.spec.accessModes | accessModes:'long' | join}}</dd>\n" +
     "</dl>\n" +
     "</div>\n" +
+    "</uib-tab>\n" +
+    "<uib-tab active=\"selectedTab.events\" ng-if=\"'events' | canI : 'watch'\">\n" +
+    "<uib-tab-heading>Events</uib-tab-heading>\n" +
+    "<events resource-kind=\"PersistentVolumeClaim\" resource-name=\"{{pvc.metadata.name}}\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
+    "</uib-tab>\n" +
+    "</uib-tabset>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
In order to explain to users why a PersistentVolumeClaim is not binding, I have added the events information section to the detail page for that specific PVC.