### PR TITLE
Restructure markup order to correct tab focus order.

### DIFF
--- a/app/views/projects.html
+++ b/app/views/projects.html
@@ -66,6 +66,31 @@
                     </div>
                     <div class="list-group list-view-pf projects-list">
                       <div ng-repeat="project in projects" class="list-group-item project-info tile-click">
+                        <div class="list-view-pf-main-info">
+                          <div class="list-view-pf-description project-names">
+                            <div class="list-group-item-heading project-name-item">
+                              <h2 class="h1">
+                                <a class="tile-target" ng-href="project/{{project.metadata.name}}" title="{{project | displayName}}"><span ng-bind-html="project | displayName | highlightKeywords : keywords"></span></a>
+                                <span ng-if="project.status.phase != 'Active'"
+                                  data-toggle="tooltip"
+                                  title="This project has been marked for deletion."
+                                  class="pficon pficon-warning-triangle-o"></span>
+                              </h2>
+                              <small>
+                                <span ng-if="project | displayName : true"><span ng-bind-html="project.metadata.name | highlightKeywords : keywords"></span> &ndash;</span>
+                                created
+                                <span ng-if="project | annotation : 'openshift.io/requester'">by <span ng-bind-html="project | annotation : 'openshift.io/requester' | highlightKeywords : keywords"></span></span>
+                                <span am-time-ago="project.metadata.creationTimestamp"></span>
+                              </small>
+                            </div>
+                            <div class="list-view-pf-additional-info project-additional-info">
+                              <span class="list-group-item-text project-description">
+                                <truncate-long-text ng-if="!keywords.length" content="project | description" limit="265" newline-limit="10" use-word-boundary="true"></truncate-long-text>
+                                <span class="highlighted-content" ng-if="keywords.length" ng-bind-html="project | description | truncate : 1000 | highlightKeywords : keywords"></span>
+                              </span>
+                            </div>
+                          </div>
+                        </div>
                         <div row class="list-view-pf-actions list-pf-actions" ng-if="project.status.phase == 'Active'">
                           <div uib-dropdown>
                             <a href="" uib-dropdown-toggle class="actions-dropdown-kebab"><i class="fa fa-ellipsis-v" aria-hidden="true"></i><span class="sr-only">Actions</span></a>
@@ -93,31 +118,6 @@
                                 </delete-link>
                               </li>
                             </ul>
-                          </div>
-                        </div>
-                        <div class="list-view-pf-main-info">
-                          <div class="list-view-pf-description project-names">
-                            <div class="list-group-item-heading project-name-item">
-                              <h2 class="h1">
-                                <a class="tile-target" ng-href="project/{{project.metadata.name}}" title="{{project | displayName}}"><span ng-bind-html="project | displayName | highlightKeywords : keywords"></span></a>
-                                <span ng-if="project.status.phase != 'Active'"
-                                  data-toggle="tooltip"
-                                  title="This project has been marked for deletion."
-                                  class="pficon pficon-warning-triangle-o"></span>
-                              </h2>
-                              <small>
-                                <span ng-if="project | displayName : true"><span ng-bind-html="project.metadata.name | highlightKeywords : keywords"></span> &ndash;</span>
-                                created
-                                <span ng-if="project | annotation : 'openshift.io/requester'">by <span ng-bind-html="project | annotation : 'openshift.io/requester' | highlightKeywords : keywords"></span></span>
-                                <span am-time-ago="project.metadata.creationTimestamp"></span>
-                              </small>
-                            </div>
-                            <div class="list-view-pf-additional-info project-additional-info">
-                              <span class="list-group-item-text project-description">
-                                <truncate-long-text ng-if="!keywords.length" content="project | description" limit="265" newline-limit="10" use-word-boundary="true"></truncate-long-text>
-                                <span class="highlighted-content" ng-if="keywords.length" ng-bind-html="project | description | truncate : 1000 | highlightKeywords : keywords"></span>
-                              </span>
-                            </div>
                           </div>
                         </div>
                       </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -12297,27 +12297,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"list-group list-view-pf projects-list\">\n" +
     "<div ng-repeat=\"project in projects\" class=\"list-group-item project-info tile-click\">\n" +
-    "<div row class=\"list-view-pf-actions list-pf-actions\" ng-if=\"project.status.phase == 'Active'\">\n" +
-    "<div uib-dropdown>\n" +
-    "<a href=\"\" uib-dropdown-toggle class=\"actions-dropdown-kebab\"><i class=\"fa fa-ellipsis-v\" aria-hidden=\"true\"></i><span class=\"sr-only\">Actions</span></a>\n" +
-    "<ul class=\"dropdown-menu dropdown-menu-right\" uib-dropdown-menu role=\"menu\">\n" +
-    "<li role=\"menuitem\">\n" +
-    "<a ng-href=\"project/{{project.metadata.name}}/membership\">\n" +
-    "View Membership\n" +
-    "</a>\n" +
-    "</li>\n" +
-    "<li role=\"menuitem\">\n" +
-    "<a ng-href=\"project/{{project.metadata.name}}/edit?then=./\">\n" +
-    "Edit Project\n" +
-    "</a>\n" +
-    "</li>\n" +
-    "<li role=\"menuitem\">\n" +
-    "<delete-link kind=\"Project\" label=\"Delete Project\" resource-name=\"{{project.metadata.name}}\" project-name=\"{{project.metadata.name}}\" display-name=\"{{(project | displayName)}}\" type-name-to-confirm=\"true\" stay-on-current-page=\"true\" alerts=\"alerts\">\n" +
-    "</delete-link>\n" +
-    "</li>\n" +
-    "</ul>\n" +
-    "</div>\n" +
-    "</div>\n" +
     "<div class=\"list-view-pf-main-info\">\n" +
     "<div class=\"list-view-pf-description project-names\">\n" +
     "<div class=\"list-group-item-heading project-name-item\">\n" +
@@ -12338,6 +12317,27 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"highlighted-content\" ng-if=\"keywords.length\" ng-bind-html=\"project | description | truncate : 1000 | highlightKeywords : keywords\"></span>\n" +
     "</span>\n" +
     "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div row class=\"list-view-pf-actions list-pf-actions\" ng-if=\"project.status.phase == 'Active'\">\n" +
+    "<div uib-dropdown>\n" +
+    "<a href=\"\" uib-dropdown-toggle class=\"actions-dropdown-kebab\"><i class=\"fa fa-ellipsis-v\" aria-hidden=\"true\"></i><span class=\"sr-only\">Actions</span></a>\n" +
+    "<ul class=\"dropdown-menu dropdown-menu-right\" uib-dropdown-menu role=\"menu\">\n" +
+    "<li role=\"menuitem\">\n" +
+    "<a ng-href=\"project/{{project.metadata.name}}/membership\">\n" +
+    "View Membership\n" +
+    "</a>\n" +
+    "</li>\n" +
+    "<li role=\"menuitem\">\n" +
+    "<a ng-href=\"project/{{project.metadata.name}}/edit?then=./\">\n" +
+    "Edit Project\n" +
+    "</a>\n" +
+    "</li>\n" +
+    "<li role=\"menuitem\">\n" +
+    "<delete-link kind=\"Project\" label=\"Delete Project\" resource-name=\"{{project.metadata.name}}\" project-name=\"{{project.metadata.name}}\" display-name=\"{{(project | displayName)}}\" type-name-to-confirm=\"true\" stay-on-current-page=\"true\" alerts=\"alerts\">\n" +
+    "</delete-link>\n" +
+    "</li>\n" +
+    "</ul>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
Fixes https://github.com/openshift/origin-web-console/issues/1580

tested across supported browsers
*note default Firefox requires `accessibility.tabfocus` added to its' `about:config`