### PR TITLE
Bug 1455105 - Correct quota / HPA donut warnings

### DIFF
--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -1130,7 +1130,7 @@ function OverviewController($scope,
   var watches = [];
   ProjectsService.get($routeParams.project).then(_.spread(function(project, context) {
     // Project must be set on `$scope` for the projects dropdown.
-    $scope.project = project;
+    state.project = $scope.project = project;
     state.context = context;
 
     var updateReferencedImageStreams = function() {

--- a/app/scripts/controllers/replicaSet.js
+++ b/app/scripts/controllers/replicaSet.js
@@ -202,7 +202,7 @@ angular.module('openshiftConsole')
           displayError('Could not load secrets', getErrorDetails(e));
         });
 
-        var allHPA = {}, limitRanges = {};
+        var allHPA = {};
         var updateHPA = function() {
           $scope.hpaForRS = HPAService.filterHPA(allHPA, kind, $routeParams.replicaSet);
           if ($scope.deploymentConfigName && $scope.isActive) {
@@ -237,7 +237,7 @@ angular.module('openshiftConsole')
         };
 
         var updateHPAWarnings = function() {
-            HPAService.getHPAWarnings($scope.replicaSet, $scope.autoscalers, limitRanges, project)
+            HPAService.getHPAWarnings($scope.replicaSet, $scope.autoscalers, $scope.limitRanges, project)
                       .then(function(warnings) {
               $scope.hpaWarnings = warnings;
             });
@@ -529,9 +529,19 @@ angular.module('openshiftConsole')
         // List limit ranges in this project to determine if there is a default
         // CPU request for autoscaling.
         DataService.list("limitranges", context).then(function(resp) {
-          limitRanges = resp.by("metadata.name");
+          $scope.limitRanges = resp.by("metadata.name");
           updateHPAWarnings();
         });
+
+        // Watch quotas and cluster quotas to warn about problems in the deployment donut.
+        var QUOTA_POLL_INTERVAL = 60 * 1000;
+        watches.push(DataService.watch('resourcequotas', context, function(quotaData) {
+          $scope.quotas = quotaData.by("metadata.name");
+        }, {poll: true, pollInterval: QUOTA_POLL_INTERVAL}));
+
+        watches.push(DataService.watch('appliedclusterresourcequotas', context, function(clusterQuotaData) {
+          $scope.clusterQuotas = clusterQuotaData.by("metadata.name");
+        }, {poll: true, pollInterval: QUOTA_POLL_INTERVAL}));
 
         var deploymentIsLatest = $filter('deploymentIsLatest');
 

--- a/app/scripts/controllers/statefulSet.js
+++ b/app/scripts/controllers/statefulSet.js
@@ -80,6 +80,16 @@ angular
               var pods = podData.by('metadata.name');
               $scope.podsForStatefulSet = PodsService.filterForOwner(pods, statefulSet);
             }));
+
+            // Watch quotas and cluster quotas to warn about problems in the deployment donut.
+            var QUOTA_POLL_INTERVAL = 60 * 1000;
+            watches.push(DataService.watch('resourcequotas', context, function(quotaData) {
+              $scope.quotas = quotaData.by("metadata.name");
+            }, {poll: true, pollInterval: QUOTA_POLL_INTERVAL}));
+
+            watches.push(DataService.watch('appliedclusterresourcequotas', context, function(clusterQuotaData) {
+              $scope.clusterQuotas = clusterQuotaData.by("metadata.name");
+            }, {poll: true, pollInterval: QUOTA_POLL_INTERVAL}));
           });
       }));
 

--- a/app/views/browse/_replica-set-details.html
+++ b/app/views/browse/_replica-set-details.html
@@ -7,6 +7,10 @@
         pods="podsForDeployment"
         hpa="autoscalers"
         scalable="isScalable()"
+        limit-ranges="limitRanges"
+        project="project"
+        quotas="quotas"
+        cluster-quotas="clusterQuotas"
         alerts="alerts">
     </deployment-donut>
   </div>

--- a/app/views/browse/stateful-set.html
+++ b/app/views/browse/stateful-set.html
@@ -79,6 +79,8 @@
                         rc="statefulSet"
                         pods="podsForStatefulSet"
                         scalable="isScalable()"
+                        quotas="quotas"
+                        cluster-quotas="clusterQuotas"
                         alerts="alerts">
                       </deployment-donut>
                     </div>

--- a/app/views/overview/_list-row-expanded.html
+++ b/app/views/overview/_list-row-expanded.html
@@ -51,17 +51,18 @@
             'stacked-template': row.state.breakpoint !== 'lg'
         }">
           <div ng-if="row.previous" class="previous-donut">
-              <deployment-donut
-                rc="row.previous"
-                deployment-config="row.apiObject"
-                pods="row.getPods(row.previous)"
-                hpa="row.hpa"
-                limit-ranges="row.state.limitRanges"
-                quotas="row.state.quotas"
-                cluster-quotas="row.state.clusterQuotas"
-                scalable="false"
-                alerts="row.state.alerts">
-              </deployment-donut>
+            <deployment-donut
+              rc="row.previous"
+              deployment-config="row.apiObject"
+              pods="row.getPods(row.previous)"
+              hpa="row.hpa"
+              limit-ranges="row.state.limitRanges"
+              project="row.state.project"
+              quotas="row.state.quotas"
+              cluster-quotas="row.state.clusterQuotas"
+              scalable="false"
+              alerts="row.state.alerts">
+            </deployment-donut>
             <div ng-if="row.previous" class="deployment-connector">
               <div class="deployment-connector-arrow" aria-hidden="true">
               </div>
@@ -81,6 +82,7 @@
                 pods="row.getPods(row.current)"
                 hpa="row.hpa"
                 limit-ranges="row.state.limitRanges"
+                project="row.state.project"
                 quotas="row.state.quotas"
                 cluster-quotas="row.state.clusterQuotas"
                 scalable="row.isScalable()"

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -385,7 +385,7 @@ return c === d && (c = _.get(a, "metadata.name", ""), d = _.get(b, "metadata.nam
 }));
 }, $a = [];
 u.get(c.project).then(_.spread(function(b, c) {
-a.project = b, P.context = c;
+P.project = a.project = b, P.context = c;
 var d = function() {
 x.pods && m.fetchReferencedImageStreamImages(x.pods, P.imagesByDockerReference, P.imageStreamImageRefByDockerReference, c);
 };
@@ -6382,7 +6382,7 @@ J = F(b.by("metadata.name")), a.valueFromObjects = J.concat(I);
 }, function(a) {
 403 !== a.code && H("Could not load secrets", G(a));
 });
-var m = {}, q = {}, s = function() {
+var m = {}, q = function() {
 if (a.hpaForRS = j.filterHPA(m, t, c.replicaSet), a.deploymentConfigName && a.isActive) {
 var b = j.filterHPA(m, "DeploymentConfig", a.deploymentConfigName);
 a.autoscalers = a.hpaForRS.concat(b);
@@ -6390,19 +6390,19 @@ a.autoscalers = a.hpaForRS.concat(b);
 var d = j.filterHPA(m, "Deployment", a.deployment.metadata.name);
 a.autoscalers = a.hpaForRS.concat(d);
 } else a.autoscalers = a.hpaForRS;
-}, C = function() {
+}, s = function() {
 y.push(g.watch(a.resource, i, function(b) {
 var c, d = [];
 angular.forEach(b.by("metadata.name"), function(b) {
 var c = v(b, "deploymentConfig") || "";
 c === a.deploymentConfigName && d.push(b);
-}), c = h.getActiveDeployment(d), a.isActive = c && c.metadata.uid === a.replicaSet.metadata.uid, s();
+}), c = h.getActiveDeployment(d), a.isActive = c && c.metadata.uid === a.replicaSet.metadata.uid, q();
 }));
-}, K = function() {
-j.getHPAWarnings(a.replicaSet, a.autoscalers, q, d).then(function(b) {
+}, C = function() {
+j.getHPAWarnings(a.replicaSet, a.autoscalers, a.limitRanges, d).then(function(b) {
 a.hpaWarnings = b;
 });
-}, L = function(d) {
+}, K = function(d) {
 var e = v(d, "deploymentConfig");
 if (e) {
 u = !0, a.deploymentConfigName = e;
@@ -6419,10 +6419,10 @@ details:"Reason: " + b("getErrorDetails")(c)
 });
 });
 }
-}, M = function() {
+}, L = function() {
 a.isActive = h.isActiveReplicaSet(a.replicaSet, a.deployment);
-}, N = b("hasDeployment"), O = !1, P = function() {
-N(a.replicaSet) && g.list({
+}, M = b("hasDeployment"), N = !1, O = function() {
+M(a.replicaSet) && g.list({
 group:"extensions",
 resource:"deployments"
 }, i).then(function(b) {
@@ -6445,20 +6445,20 @@ title:a.deployment.metadata.name,
 link:o.resourceURL(a.deployment)
 },
 humanizedKind:"Deployments"
-}), M(), void s());
+}), L(), void q());
 })), void y.push(g.watch({
 group:"extensions",
 resource:"replicasets"
 }, i, function(b) {
 var c = new LabelSelector(a.deployment.spec.selector);
-O = !1;
+N = !1;
 var d = 0;
 _.each(b.by("metadata.name"), function(a) {
-if (a.status.replicas && c.covers(new LabelSelector(a.spec.selector))) return d++, d > 1 ? (O = !0, !1) :void 0;
+if (a.status.replicas && c.covers(new LabelSelector(a.spec.selector))) return d++, d > 1 ? (N = !0, !1) :void 0;
 });
 }))) :void (a.deploymentMissing = !0);
 });
-}, Q = function() {
+}, P = function() {
 if (!_.isEmpty(x)) {
 var b = _.get(a, "replicaSet.spec.template");
 b && k.fetchReferencedImageStreamImages([ b ], a.imagesByDockerReference, x, i);
@@ -6467,13 +6467,13 @@ b && k.fetchReferencedImageStreamImages([ b ], a.imagesByDockerReference, x, i);
 g.get(a.resource, c.replicaSet, i).then(function(b) {
 switch (a.loaded = !0, a.replicaSet = b, B(b), t) {
 case "ReplicationController":
-L(b);
+K(b);
 break;
 
 case "ReplicaSet":
-P();
+O();
 }
-K(), a.breadcrumbs = f.getBreadcrumbs({
+C(), a.breadcrumbs = f.getBreadcrumbs({
 object:b
 }), y.push(g.watchObject(a.resource, c.replicaSet, i, function(b, c) {
 "DELETED" === c && (a.alerts.deleted = {
@@ -6483,8 +6483,8 @@ message:"This " + w + " has been deleted."
 var d = a.replicaSet;
 a.replicaSet = b, z ? z["finally"](function() {
 D(b, d);
-}) :D(b, d), B(b), K(), Q();
-})), a.deploymentConfigName && C(), y.push(g.watch("pods", i, function(b) {
+}) :D(b, d), B(b), C(), P();
+})), a.deploymentConfigName && s(), y.push(g.watch("pods", i, function(b) {
 var c = b.by("metadata.name");
 a.podsForDeployment = p.filterForOwner(c, a.replicaSet);
 }));
@@ -6506,7 +6506,7 @@ a.causes = b("deploymentCauses")(a);
 });
 })), y.push(g.watch("imagestreams", i, function(a) {
 var b = a.by("metadata.name");
-k.buildDockerRefMapForImageStreams(b, x), Q(), l.log("imagestreams (subscribe)", b);
+k.buildDockerRefMapForImageStreams(b, x), P(), l.log("imagestreams (subscribe)", b);
 })), y.push(g.watch("builds", i, function(b) {
 a.builds = b.by("metadata.name"), l.log("builds (subscribe)", a.builds);
 })), y.push(g.watch({
@@ -6514,13 +6514,25 @@ group:"autoscaling",
 resource:"horizontalpodautoscalers",
 version:"v1"
 }, i, function(a) {
-m = a.by("metadata.name"), s(), K();
+m = a.by("metadata.name"), q(), C();
 }, {
 poll:E,
 pollInterval:6e4
-})), g.list("limitranges", i).then(function(a) {
-q = a.by("metadata.name"), K();
+})), g.list("limitranges", i).then(function(b) {
+a.limitRanges = b.by("metadata.name"), C();
 });
+var Q = 6e4;
+y.push(g.watch("resourcequotas", i, function(b) {
+a.quotas = b.by("metadata.name");
+}, {
+poll:!0,
+pollInterval:Q
+})), y.push(g.watch("appliedclusterresourcequotas", i, function(b) {
+a.clusterQuotas = b.by("metadata.name");
+}, {
+poll:!0,
+pollInterval:Q
+}));
 var R = b("deploymentIsLatest");
 a.showRollbackAction = function() {
 return "Complete" === A(a.replicaSet) && !R(a.replicaSet, a.deploymentConfig) && !a.replicaSet.metadata.deletionTimestamp && e.canI("deploymentconfigrollbacks", "create");
@@ -6542,7 +6554,7 @@ h.scale(e, c).then(_.noop, d);
 };
 var S = b("hasDeploymentConfig");
 a.isScalable = function() {
-return !!_.isEmpty(a.autoscalers) && (!S(a.replicaSet) && !N(a.replicaSet) || (!(!a.deploymentConfigMissing && !a.deploymentMissing) || !(!a.deploymentConfig && !a.deployment) && (a.isActive && !O)));
+return !!_.isEmpty(a.autoscalers) && (!S(a.replicaSet) && !M(a.replicaSet) || (!(!a.deploymentConfigMissing && !a.deploymentMissing) || !(!a.deploymentConfig && !a.deployment) && (a.isActive && !N)));
 }, a.removeVolume = function(c) {
 var d = "This will remove the volume from the " + b("humanizeKind")(a.replicaSet.kind) + ".";
 c.persistentVolumeClaim ? d += " It will not delete the persistent volume claim." :c.secret ? d += " It will not delete the secret." :c.configMap && (d += " It will not delete the config map.");
@@ -6635,6 +6647,18 @@ statefulSet:k(a)
 })), m.push(f.watch("pods", c, function(a) {
 var c = a.by("metadata.name");
 b.podsForStatefulSet = j.filterForOwner(c, d);
+}));
+var e = 6e4;
+m.push(f.watch("resourcequotas", c, function(a) {
+b.quotas = a.by("metadata.name");
+}, {
+poll:!0,
+pollInterval:e
+})), m.push(f.watch("appliedclusterresourcequotas", c, function(a) {
+b.clusterQuotas = a.by("metadata.name");
+}, {
+poll:!0,
+pollInterval:e
 }));
 });
 })), b.$on("$destroy", function() {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1336,7 +1336,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   $templateCache.put('views/browse/_replica-set-details.html',
     "<div class=\"row\" style=\"max-width: 650px\">\n" +
     "<div class=\"col-sm-4 col-sm-push-8 browse-deployment-donut\">\n" +
-    "<deployment-donut rc=\"replicaSet\" deployment=\"deployment\" deployment-config=\"deploymentConfig\" pods=\"podsForDeployment\" hpa=\"autoscalers\" scalable=\"isScalable()\" alerts=\"alerts\">\n" +
+    "<deployment-donut rc=\"replicaSet\" deployment=\"deployment\" deployment-config=\"deploymentConfig\" pods=\"podsForDeployment\" hpa=\"autoscalers\" scalable=\"isScalable()\" limit-ranges=\"limitRanges\" project=\"project\" quotas=\"quotas\" cluster-quotas=\"clusterQuotas\" alerts=\"alerts\">\n" +
     "</deployment-donut>\n" +
     "</div>\n" +
     "<div class=\"col-sm-8 col-sm-pull-4\">\n" +
@@ -3894,7 +3894,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"row\" style=\"max-width: 650px\">\n" +
     "<div class=\"col-sm-4 col-sm-push-8 browse-deployment-donut\">\n" +
     "\n" +
-    "<deployment-donut rc=\"statefulSet\" pods=\"podsForStatefulSet\" scalable=\"isScalable()\" alerts=\"alerts\">\n" +
+    "<deployment-donut rc=\"statefulSet\" pods=\"podsForStatefulSet\" scalable=\"isScalable()\" quotas=\"quotas\" cluster-quotas=\"clusterQuotas\" alerts=\"alerts\">\n" +
     "</deployment-donut>\n" +
     "</div>\n" +
     "<div class=\"col-sm-8 col-sm-pull-4\">\n" +
@@ -11666,7 +11666,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "            'stacked-template': row.state.breakpoint !== 'lg'\n" +
     "        }\">\n" +
     "<div ng-if=\"row.previous\" class=\"previous-donut\">\n" +
-    "<deployment-donut rc=\"row.previous\" deployment-config=\"row.apiObject\" pods=\"row.getPods(row.previous)\" hpa=\"row.hpa\" limit-ranges=\"row.state.limitRanges\" quotas=\"row.state.quotas\" cluster-quotas=\"row.state.clusterQuotas\" scalable=\"false\" alerts=\"row.state.alerts\">\n" +
+    "<deployment-donut rc=\"row.previous\" deployment-config=\"row.apiObject\" pods=\"row.getPods(row.previous)\" hpa=\"row.hpa\" limit-ranges=\"row.state.limitRanges\" project=\"row.state.project\" quotas=\"row.state.quotas\" cluster-quotas=\"row.state.clusterQuotas\" scalable=\"false\" alerts=\"row.state.alerts\">\n" +
     "</deployment-donut>\n" +
     "<div ng-if=\"row.previous\" class=\"deployment-connector\">\n" +
     "<div class=\"deployment-connector-arrow\" aria-hidden=\"true\">\n" +
@@ -11680,7 +11680,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</a>\n" +
     "</div>\n" +
     "<div ng-if=\"row.apiObject.kind !== 'Pod'\">\n" +
-    "<deployment-donut rc=\"row.current\" deployment-config=\"row.apiObject\" pods=\"row.getPods(row.current)\" hpa=\"row.hpa\" limit-ranges=\"row.state.limitRanges\" quotas=\"row.state.quotas\" cluster-quotas=\"row.state.clusterQuotas\" scalable=\"row.isScalable()\" alerts=\"row.state.alerts\">\n" +
+    "<deployment-donut rc=\"row.current\" deployment-config=\"row.apiObject\" pods=\"row.getPods(row.current)\" hpa=\"row.hpa\" limit-ranges=\"row.state.limitRanges\" project=\"row.state.project\" quotas=\"row.state.quotas\" cluster-quotas=\"row.state.clusterQuotas\" scalable=\"row.isScalable()\" alerts=\"row.state.alerts\">\n" +
     "</deployment-donut>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
Consistently show the same quota and HPA warnings everywhere we show the
pod donut. Fixes an issue where we would incorrectly show an HPA warning
when cluster resource overrides were enabled on the deployment page.
Also adds quota warnings to the donut on other pages, not just the overview.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1455105