### PR TITLE
Removing scroll-shadows-horizontal from quota table-responsives

### DIFF
--- a/app/views/quota.html
+++ b/app/views/quota.html
@@ -63,7 +63,7 @@
                     </div>
                   </div>
 
-                  <div class="table-responsive scroll-shadows-horizontal">
+                  <div class="table-responsive">
                     <table class="table table-bordered">
                       <thead>
                         <th>Resource Type</th>
@@ -155,7 +155,7 @@
                     </div>
                   </div>
 
-                  <div class="table-responsive scroll-shadows-horizontal">
+                  <div class="table-responsive">
                     <table class="table table-bordered">
                       <thead>
                         <th>Resource Type</th>
@@ -210,7 +210,7 @@
                   <div ng-repeat="limitRange in limitRanges">
                     <h2 ng-if="limitRanges.length">{{limitRange.metadata.name}}</h2>
                     <div ng-if="$first" class="help-block mar-bottom-md">{{limitRangeHelp}}</div>
-                    <div class="table-responsive scroll-shadows-horizontal">
+                    <div class="table-responsive">
                       <table class="table table-bordered">
                         <thead>
                           <th>Resource Type</th>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -12425,7 +12425,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"table-responsive scroll-shadows-horizontal\">\n" +
+    "<div class=\"table-responsive\">\n" +
     "<table class=\"table table-bordered\">\n" +
     "<thead>\n" +
     "<th>Resource Type</th>\n" +
@@ -12508,7 +12508,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"table-responsive scroll-shadows-horizontal\">\n" +
+    "<div class=\"table-responsive\">\n" +
     "<table class=\"table table-bordered\">\n" +
     "<thead>\n" +
     "<th>Resource Type</th>\n" +
@@ -12554,7 +12554,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-repeat=\"limitRange in limitRanges\">\n" +
     "<h2 ng-if=\"limitRanges.length\">{{limitRange.metadata.name}}</h2>\n" +
     "<div ng-if=\"$first\" class=\"help-block mar-bottom-md\">{{limitRangeHelp}}</div>\n" +
-    "<div class=\"table-responsive scroll-shadows-horizontal\">\n" +
+    "<div class=\"table-responsive\">\n" +
     "<table class=\"table table-bordered\">\n" +
     "<thead>\n" +
     "<th>Resource Type</th>\n" +


### PR DESCRIPTION
as scroll-shadows-horizontal is not compatible with table-responsives that have a header or colored background rows.

Fixes #1610

My bad for assuming and not testing!