### PR TITLE
Fix inconsistent membership prompt messages

### DIFF
--- a/app/scripts/controllers/membership.js
+++ b/app/scripts/controllers/membership.js
@@ -122,6 +122,7 @@ angular
             }));
           }, function(err) {
             resetForm();
+            refreshRoleBindingList();
             showAlert('rolebindingCreateFail', 'error', messages.update.subject.error({
               roleName: role.metadata.name,
               subjectName: newSubject.name
@@ -141,6 +142,7 @@ angular
             }));
           }, function(err) {
             resetForm();
+            refreshRoleBindingList();
             showAlert('rolebindingUpdateFail', 'error', messages.update.subject.error({
               roleName: rb.roleRef.name,
               subjectName: newSubject.name

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5308,7 +5308,7 @@ roleName:b.metadata.name,
 subjectName:c.name
 }));
 }, function(d) {
-v(), u("rolebindingCreateFail", "error", t.update.subject.error({
+v(), x(), u("rolebindingCreateFail", "error", t.update.subject.error({
 roleName:b.metadata.name,
 subjectName:c.name
 }), t.errorReason({
@@ -5322,7 +5322,7 @@ roleName:b.roleRef.name,
 subjectName:c.name
 }));
 }, function(d) {
-v(), u("rolebindingUpdateFail", "error", t.update.subject.error({
+v(), x(), u("rolebindingUpdateFail", "error", t.update.subject.error({
 roleName:b.roleRef.name,
 subjectName:c.name
 }), t.errorReason({


### PR DESCRIPTION
Refreshes the binding list on a fail (as was already done with a success) to ensure consistency.