### PR TITLE
Update .length checks in controllers to use _.size()

### DIFF
--- a/app/scripts/controllers/buildConfig.js
+++ b/app/scripts/controllers/buildConfig.js
@@ -207,7 +207,7 @@ angular.module('openshiftConsole')
 
         // Sort now to avoid sorting on every digest loop.
         $scope.orderedBuilds = BuildsService.sortBuilds($scope.builds, true);
-        $scope.latestBuild = $scope.orderedBuilds.length ? $scope.orderedBuilds[0] : null;
+        $scope.latestBuild = _.first($scope.orderedBuilds);
       },
       // params object for filtering
       {
@@ -238,7 +238,7 @@ angular.module('openshiftConsole')
           $scope.$apply(function() {
             $scope.builds = labelSelector.select($scope.unfilteredBuilds);
             $scope.orderedBuilds = BuildsService.sortBuilds($scope.builds, true);
-            $scope.latestBuild = $scope.orderedBuilds.length ? $scope.orderedBuilds[0] : null;
+            $scope.latestBuild = _.first($scope.orderedBuilds);
             updateFilterWarning();
           });
         });

--- a/app/scripts/controllers/create/createFromImage.js
+++ b/app/scripts/controllers/create/createFromImage.js
@@ -201,7 +201,7 @@ angular.module("openshiftConsole")
                   scope.image = imageStreamTag.image;
                   scope.DCEnvVarsFromImage = ImagesService.getEnvironment(imageStreamTag);
                   var ports = ApplicationGenerator.parsePorts(imageStreamTag.image);
-                  if (ports.length === 0) {
+                  if (_.isEmpty(ports)) {
                     scope.routing.include = false;
                     scope.routing.portOptions = [];
                   } else {
@@ -286,7 +286,7 @@ angular.module("openshiftConsole")
               .then(function(result) {
                     var alerts = [];
                     var hasErrors = false;
-                    if (result.failure.length > 0) {
+                    if (!_.isEmpty(result.failure)) {
                       hasErrors = true;
                       result.failure.forEach(
                         function(failure) {
@@ -354,11 +354,11 @@ angular.module("openshiftConsole")
           // Now that all checks are completed, show any Alerts if we need to
           var quotaAlerts = result.quotaAlerts || [];
           var errorAlerts = _.filter(quotaAlerts, {type: 'error'});
-          if ($scope.nameTaken || errorAlerts.length) {
+          if ($scope.nameTaken || !_.isEmpty(errorAlerts)) {
             $scope.disableInputs = false;
             $scope.quotaAlerts = quotaAlerts;
           }
-          else if (quotaAlerts.length) {
+          else if (!_.isEmpty(quotaAlerts)) {
              launchConfirmationDialog(quotaAlerts);
              $scope.disableInputs = false;
           }

--- a/app/scripts/controllers/createFromURL.js
+++ b/app/scripts/controllers/createFromURL.js
@@ -89,7 +89,7 @@ angular.module('openshiftConsole')
     createDetails.namespace = createDetails.namespace || 'openshift';
 
     var validateName = function (name) {
-      return name.length < 25 && /^[a-z]([-a-z0-9]*[a-z0-9])?$/.test(name);
+      return _.size(name) < 25 && /^[a-z]([-a-z0-9]*[a-z0-9])?$/.test(name);
     };
 
     var getResources = function() {

--- a/app/scripts/controllers/edit/buildConfig.js
+++ b/app/scripts/controllers/edit/buildConfig.js
@@ -285,7 +285,7 @@ angular.module('openshiftConsole')
             if ($scope.sources.images) {
               $scope.sourceImages = $scope.buildConfig.spec.source.images;
               // If only one Image Source is present in the buildConfig make it editable, if more then one show them as readonly.
-              if ($scope.sourceImages.length === 1) {
+              if (_.size($scope.sourceImages) === 1) {
                 $scope.imageSourceTypes = angular.copy($scope.buildFromTypes);
                 setImageOptions($scope.imageOptions.fromSource, $scope.sourceImages[0].from);
                 $scope.imageSourcePaths = _.map($scope.sourceImages[0].paths, function(path) {
@@ -429,7 +429,7 @@ angular.module('openshiftConsole')
           kind: optionsModel.type,
           name: _.last(namespaceAndName)
         };
-        imageObject.namespace = (namespaceAndName.length !== 1) ? namespaceAndName[0] : $scope.buildConfig.metadata.namespace;
+        imageObject.namespace = (_.size(namespaceAndName) !== 1) ? _.first(namespaceAndName) : $scope.buildConfig.metadata.namespace;
         break;
       }
       return imageObject;

--- a/app/scripts/controllers/projects.js
+++ b/app/scripts/controllers/projects.js
@@ -157,7 +157,7 @@ angular.module('openshiftConsole')
         _.forEach(data.details.causes || [], function(cause) {
           if (cause.message) { messages.push(cause.message); }
         });
-        if (messages.length > 0) {
+        if (!_.isEmpty(messages)) {
           $scope.newProjectMessage = messages.join("\n");
         }
       }

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4822,7 +4822,7 @@ if (c.details) {
 var e = [];
 _.forEach(c.details.causes || [], function(a) {
 a.message && e.push(a.message);
-}), e.length > 0 && (a.newProjectMessage = e.join("\n"));
+}), _.isEmpty(e) || (a.newProjectMessage = e.join("\n"));
 }
 }), a.$on("$destroy", function() {
 h.unwatchAll(n);
@@ -5673,7 +5673,7 @@ delete a.unfilteredBuilds[j];
 }
 }
 } else a.unfilteredBuilds = f.validatedBuildsForBuildConfig(c.buildconfig, b.by("metadata.name"));
-a.builds = i.getLabelSelector().select(a.unfilteredBuilds), g(), i.addLabelSuggestionsFromResources(a.unfilteredBuilds, a.labelSuggestions), i.setLabelSuggestions(a.labelSuggestions), a.orderedBuilds = f.sortBuilds(a.builds, !0), a.latestBuild = a.orderedBuilds.length ? a.orderedBuilds[0] :null;
+a.builds = i.getLabelSelector().select(a.unfilteredBuilds), g(), i.addLabelSuggestionsFromResources(a.unfilteredBuilds, a.labelSuggestions), i.setLabelSuggestions(a.labelSuggestions), a.orderedBuilds = f.sortBuilds(a.builds, !0), a.latestBuild = _.first(a.orderedBuilds);
 }, {
 http:{
 params:{
@@ -5685,7 +5685,7 @@ omission:""
 }
 })), i.onActiveFiltersChanged(function(b) {
 a.$apply(function() {
-a.builds = b.select(a.unfilteredBuilds), a.orderedBuilds = f.sortBuilds(a.builds, !0), a.latestBuild = a.orderedBuilds.length ? a.orderedBuilds[0] :null, g();
+a.builds = b.select(a.unfilteredBuilds), a.orderedBuilds = f.sortBuilds(a.builds, !0), a.latestBuild = _.first(a.orderedBuilds), g();
 });
 }), a.startBuild = function() {
 f.startBuild(a.buildConfig.metadata.name, e).then(function(b) {
@@ -7283,7 +7283,7 @@ tag:""
 }
 }, e = "ImageStreamImage" === a.type ? (c.namespace || b.metadata.namespace) + "/" + c.name :"", f = "DockerImage" === a.type ? c.name :"", a.imageStreamTag = d, a.imageStreamImage = e, a.dockerImage = f;
 };
-c(a.imageOptions.from, a.buildStrategy.from), c(a.imageOptions.to, a.updatedBuildConfig.spec.output.to), a.sources.images && (a.sourceImages = a.buildConfig.spec.source.images, 1 === a.sourceImages.length ? (a.imageSourceTypes = angular.copy(a.buildFromTypes), c(a.imageOptions.fromSource, a.sourceImages[0].from), a.imageSourcePaths = _.map(a.sourceImages[0].paths, function(a) {
+c(a.imageOptions.from, a.buildStrategy.from), c(a.imageOptions.to, a.updatedBuildConfig.spec.output.to), a.sources.images && (a.sourceImages = a.buildConfig.spec.source.images, 1 === _.size(a.sourceImages) ? (a.imageSourceTypes = angular.copy(a.buildFromTypes), c(a.imageOptions.fromSource, a.sourceImages[0].from), a.imageSourcePaths = _.map(a.sourceImages[0].paths, function(a) {
 return {
 name:a.sourcePath,
 value:a.destinationDir
@@ -7391,7 +7391,7 @@ var d = b.imageStreamImage.split("/");
 c = {
 kind:b.type,
 name:_.last(d)
-}, c.namespace = 1 !== d.length ? d[0] :a.buildConfig.metadata.namespace;
+}, c.namespace = 1 !== _.size(d) ? _.first(d) :a.buildConfig.metadata.namespace;
 }
 return c;
 }, u = function() {
@@ -8215,7 +8215,7 @@ namespace:b.namespace
 }).then(function(a) {
 b.image = a.image, b.DCEnvVarsFromImage = o.getEnvironment(a);
 var c = i.parsePorts(a.image);
-0 === c.length ? (b.routing.include = !1, b.routing.portOptions = []) :(b.routing.portOptions = _.map(c, function(a) {
+_.isEmpty(c) ? (b.routing.include = !1, b.routing.portOptions = []) :(b.routing.portOptions = _.map(c, function(a) {
 var b = i.getServicePort(a);
 return {
 port:b.name,
@@ -8256,7 +8256,10 @@ p.clear(), p.add(b, e, d.project, function() {
 var b = c.defer();
 return f.batch(G, g).then(function(c) {
 var d = [], e = !1;
-c.failure.length > 0 ? (e = !0, c.failure.forEach(function(a) {
+_.isEmpty(c.failure) ? d.push({
+type:"success",
+message:"All resources for application " + a.name + " were created successfully."
+}) :(e = !0, c.failure.forEach(function(a) {
 d.push({
 type:"error",
 message:"Cannot create " + x(a.object.kind).toLowerCase() + ' "' + a.object.metadata.name + '". ',
@@ -8267,10 +8270,7 @@ d.push({
 type:"success",
 message:"Created " + x(a.kind).toLowerCase() + ' "' + a.metadata.name + '" successfully. '
 });
-})) :d.push({
-type:"success",
-message:"All resources for application " + a.name + " were created successfully."
-}), b.resolve({
+})), b.resolve({
 alerts:d,
 hasErrors:e
 });
@@ -8307,7 +8307,7 @@ b.result.then(H);
 var c = b.quotaAlerts || [], d = _.filter(c, {
 type:"error"
 });
-a.nameTaken || d.length ? (a.disableInputs = !1, a.quotaAlerts = c) :c.length ? (I(c), a.disableInputs = !1) :H();
+a.nameTaken || !_.isEmpty(d) ? (a.disableInputs = !1, a.quotaAlerts = c) :_.isEmpty(c) ? H() :(I(c), a.disableInputs = !1);
 };
 a.projectDisplayName = function() {
 return w(this.project) || this.projectName;
@@ -8637,7 +8637,7 @@ return _.contains(s, b) && _.isString(a);
 });
 t.namespace = t.namespace || "openshift";
 var u = function(a) {
-return a.length < 25 && /^[a-z]([-a-z0-9]*[a-z0-9])?$/.test(a);
+return _.size(a) < 25 && /^[a-z]([-a-z0-9]*[a-z0-9])?$/.test(a);
 }, v = function() {
 t.imageStream && f.get("imagestreams", t.imageStream, {
 namespace:t.namespace


### PR DESCRIPTION
re #1352 
Updating uses of `.length` in controllers to `_.size()` and/or `_.isEmpty()`. 

Opting for consistency by changing all the references (there are few), rather than being particular about only changing those associated w/an API object field.