### PR TITLE
Update .length check in directives/deploymentDonut to use _.isEmpty()

### DIFF
--- a/app/scripts/directives/deploymentDonut.js
+++ b/app/scripts/directives/deploymentDonut.js
@@ -63,7 +63,7 @@ angular.module('openshiftConsole')
             var filteredQuotas = QuotaService.filterQuotasForResource($scope.rc, $scope.quotas);
             var filteredClusterQuotas = QuotaService.filterQuotasForResource($scope.rc, $scope.clusterQuotas);
             var checkQuota = function(quota) {
-              return !!(QuotaService.getResourceLimitAlerts($scope.rc, quota).length);
+              return !_.isEmpty(QuotaService.getResourceLimitAlerts($scope.rc, quota));
             };
             $scope.showQuotaWarning = _.some(filteredQuotas, checkQuota) || _.some(filteredClusterQuotas, checkQuota);
           }

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12155,7 +12155,7 @@ b.$watchGroup([ "limitRanges", "hpa", "project" ], h), b.$watch("rc.spec.templat
 var j = function() {
 if (_.get(b.rc, "spec.replicas", 1) > _.get(b.rc, "status.replicas", 0)) {
 var a = g.filterQuotasForResource(b.rc, b.quotas), c = g.filterQuotasForResource(b.rc, b.clusterQuotas), d = function(a) {
-return !!g.getResourceLimitAlerts(b.rc, a).length;
+return !_.isEmpty(g.getResourceLimitAlerts(b.rc, a));
 };
 b.showQuotaWarning = _.some(a, d) || _.some(c, d);
 } else b.showQuotaWarning = !1;


### PR DESCRIPTION
re #1352 

This is not essential.  `QuotaService.getResourceLimitAlerts` makes an arbitrary array anyway, just kept it because `!![].length` seems less clear than `_.isEmpty([])`.

