### PR TITLE
Update .length check in directives/podDonut to use _.size()

### DIFF
--- a/app/scripts/directives/podDonut.js
+++ b/app/scripts/directives/podDonut.js
@@ -154,7 +154,7 @@ angular.module('openshiftConsole')
 
         function isReady(pod) {
           var numReady = numContainersReadyFilter(pod);
-          var total = pod.spec.containers.length;
+          var total = _.size(pod.spec.containers);
 
           return numReady === total;
         }

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -11965,7 +11965,7 @@ c.columns.push([ a, b[a] || 0 ]);
 }), _.isEmpty(b) ? c.columns.push([ "Empty", 1 ]) :c.unload = "Empty", m ? m.load(c) :(n.data.columns = c.columns, m = c3.generate(n)), a.podStatusData = c.columns;
 }
 function j(a) {
-var b = e(a), c = a.spec.containers.length;
+var b = e(a), c = _.size(a.spec.containers);
 return b === c;
 }
 function k(a) {


### PR DESCRIPTION
re #1352 

So in the above issue:

>  the items field in List objects guarantees []

I'm not sure if `pod.spec.containers` = List object (seems plausible).  If so, we can skip this PR.