### PR TITLE
Update .length check in directives/popups to use _.size()

### DIFF
--- a/app/scripts/directives/popups.js
+++ b/app/scripts/directives/popups.js
@@ -95,7 +95,7 @@ angular.module('openshiftConsole')
       },
       link: function($scope) {
         var i, content = '', warnings = podWarningsFilter($scope.pod);
-        for (i = 0; i < warnings.length; i++) {
+        for (i = 0; i < _.size(warnings); i++) {
           if (content) {
             content += '<br>';
           }

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10726,7 +10726,7 @@ pod:"="
 },
 link:function(b) {
 var c, d = "", e = a(b.pod);
-for (c = 0; c < e.length; c++) d && (d += "<br>"), "error" === e[c].severity && (b.hasError = !0), d += e[c].message;
+for (c = 0; c < _.size(e); c++) d && (d += "<br>"), "error" === e[c].severity && (b.hasError = !0), d += e[c].message;
 b.content = d;
 },
 templateUrl:"views/directives/_warnings-popover.html"


### PR DESCRIPTION
re: 1352

`podWarningsFilter` can return null if there are no warnings, this could result in a runtime error in the `for` loop.

