### PR TITLE
Enable sorting by keys in YAML editor

### DIFF
--- a/app/scripts/controllers/edit/yaml.js
+++ b/app/scripts/controllers/edit/yaml.js
@@ -96,20 +96,7 @@ angular.module('openshiftConsole')
               return _.get(resource, 'metadata.resourceVersion');
             };
 
-            // Hack to make `apiVersion` and `kind` appear at the top.
-            //
-            // Since these properties are inserted by DataService for list operations,
-            // they're inserted last. yamljs serializes using Object.keys() ordering
-            // with no option to control order. Most browsers return keys in insertion
-            // order, however, so if we add apiVersion and kind first, they appear at
-            // the top of the serialized YAML. The rest of the properties are in the
-            // order returned from the API that we want (metadata, spec, status).
-            resource = angular.extend({
-              apiVersion: resource.apiVersion,
-              kind: resource.kind
-            }, resource);
-
-            _.set($scope, 'editor.model', jsyaml.safeDump(resource));
+            _.set($scope, 'editor.model', jsyaml.safeDump(resource, {'sortKeys': true}));
 
             $scope.save = function() {
               $scope.modified = false;

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7479,10 +7479,9 @@ a.resource = g;
 var j = function(a) {
 return _.get(a, "metadata.resourceVersion");
 };
-g = angular.extend({
-apiVersion:g.apiVersion,
-kind:g.kind
-}, g), _.set(a, "editor.model", jsyaml.safeDump(g)), a.save = function() {
+_.set(a, "editor.model", jsyaml.safeDump(g, {
+sortKeys:!0
+})), a.save = function() {
 a.modified = !1;
 var c;
 try {


### PR DESCRIPTION
Show YAML in editor window in a sorted and consistent order every time. Mirrors CLI tool output ("oc edit" and "oc get" etc)