### PR TITLE
Don't modify cached template

### DIFF
--- a/app/scripts/directives/processTemplate.js
+++ b/app/scripts/directives/processTemplate.js
@@ -70,6 +70,8 @@ function ProcessTemplate($filter,
 
   ctrl.$onInit = function() {
     ctrl.labels = [];
+    // Make a copy of the template to avoid modifying the original if it's cached.
+    ctrl.template = angular.copy(ctrl.template);
     ctrl.templateDisplayName = displayName(ctrl.template);
     ctrl.selectedProject = ctrl.project;
     setTemplateParams();

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -636,7 +636,7 @@ value:o.template.metadata.name
 }
 var n, o = this, p = a("displayName"), q = a("humanize");
 o.$onInit = function() {
-o.labels = [], o.templateDisplayName = p(o.template), o.selectedProject = o.project, m();
+o.labels = [], o.template = angular.copy(o.template), o.templateDisplayName = p(o.template), o.selectedProject = o.project, m();
 };
 var r, s = function() {
 var a = {


### PR DESCRIPTION
Make a copy of the template in the process-template directive before
editing parameters. This fixes a problem in the new experience where you
open the same template more than once and the previous values you
entered are used.