### PR TITLE
Prevent cancel from submitting edit dc form

### DIFF
--- a/app/views/edit/deployment-config.html
+++ b/app/views/edit/deployment-config.html
@@ -17,7 +17,7 @@
                 Edit Deployment Config {{deploymentConfig.metadata.name}}
               </h1>
               <fieldset ng-disabled="disableInputs">
-                <form class="edit-form" name="form" novalidate ng-submit="save()">
+                <form class="edit-form" name="form" novalidate>
                   <confirm-on-exit dirty="form.$dirty && !confirm.doneEditing"></confirm-on-exit>
                   <div class="row">
                     <div class="col-lg-12">
@@ -376,7 +376,7 @@
                       </pause-rollouts-checkbox>
 
                       <div class="buttons gutter-top-bottom">
-                        <button type="submit" class="btn btn-primary btn-lg" ng-disabled="form.$invalid || form.$pristine || disableInputs">
+                        <button ng-click="save()" class="btn btn-primary btn-lg" ng-disabled="form.$invalid || form.$pristine || disableInputs">
                           Save
                         </button>
                         <button ng-click="cancel()" class="btn btn-default btn-lg">Cancel</button>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -9361,7 +9361,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Edit Deployment Config {{deploymentConfig.metadata.name}}\n" +
     "</h1>\n" +
     "<fieldset ng-disabled=\"disableInputs\">\n" +
-    "<form class=\"edit-form\" name=\"form\" novalidate ng-submit=\"save()\">\n" +
+    "<form class=\"edit-form\" name=\"form\" novalidate>\n" +
     "<confirm-on-exit dirty=\"form.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-lg-12\">\n" +
@@ -9594,7 +9594,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<pause-rollouts-checkbox deployment=\"updatedDeploymentConfig\" always-visible=\"true\">\n" +
     "</pause-rollouts-checkbox>\n" +
     "<div class=\"buttons gutter-top-bottom\">\n" +
-    "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-disabled=\"form.$invalid || form.$pristine || disableInputs\">\n" +
+    "<button ng-click=\"save()\" class=\"btn btn-primary btn-lg\" ng-disabled=\"form.$invalid || form.$pristine || disableInputs\">\n" +
     "Save\n" +
     "</button>\n" +
     "<button ng-click=\"cancel()\" class=\"btn btn-default btn-lg\">Cancel</button>\n" +


### PR DESCRIPTION
The form element has an `ng-submit`, which causes the form to be submitted when the cancel button is clicked. Cancel was recently changed from a link to a button element in #1646, which caused the regression.