### PR TITLE
Show a "View Events" link when a deployment is running

### DIFF
--- a/app/views/overview/_list-row-content.html
+++ b/app/views/overview/_list-row-content.html
@@ -47,7 +47,9 @@
         <ellipsis-pulser color="dark" size="sm" display="inline" msg="Deploying"></ellipsis-pulser>
       </span>
     </span>
+    <a ng-href="project/{{row.apiObject.metadata.namespace}}/browse/events">View Events</a>
     <span ng-if="'replicationcontrollers' | canI : 'update'">
+      <span class="action-divider">|</span>
       <a href="" ng-click="row.cancelDeployment()" role="button">Cancel</a>
     </span>
   </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -11568,7 +11568,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<ellipsis-pulser color=\"dark\" size=\"sm\" display=\"inline\" msg=\"Deploying\"></ellipsis-pulser>\n" +
     "</span>\n" +
     "</span>\n" +
+    "<a ng-href=\"project/{{row.apiObject.metadata.namespace}}/browse/events\">View Events</a>\n" +
     "<span ng-if=\"'replicationcontrollers' | canI : 'update'\">\n" +
+    "<span class=\"action-divider\">|</span>\n" +
     "<a href=\"\" ng-click=\"row.cancelDeployment()\" role=\"button\">Cancel</a>\n" +
     "</span>\n" +
     "</div>\n" +


### PR DESCRIPTION
Add a link to the events page from the overview when a deployment is in progress.

![screen shot 2017-06-07 at 10 13 38 am](https://user-images.githubusercontent.com/1167259/26883053-18d039a8-4b6a-11e7-87eb-683d15cbb0f2.png)

@jwforres @burrsutter Thoughts on this change?