### PR TITLE
Don't mark YAML editor as immediately changed

### DIFF
--- a/app/scripts/controllers/edit/yaml.js
+++ b/app/scripts/controllers/edit/yaml.js
@@ -61,7 +61,12 @@ angular.module('openshiftConsole')
       var session = editor.getSession();
       session.setOption('tabSize', 2);
       session.setOption('useSoftTabs', true);
-      session.on('change', onChange);
+
+      // Wait for the editor to initialize before adding the on change handler
+      // so it's not immediately marked as modified.
+      setTimeout(function() {
+        session.on('change', onChange);
+      });
     };
 
     var watches = [];

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7465,7 +7465,9 @@ a.modified = !0;
 }, 1e3);
 a.aceLoaded = function(a) {
 var b = a.getSession();
-b.setOption("tabSize", 2), b.setOption("useSoftTabs", !0), b.on("change", o);
+b.setOption("tabSize", 2), b.setOption("useSoftTabs", !0), setTimeout(function() {
+b.on("change", o);
+});
 };
 var p = [];
 l.get(d.project).then(_.spread(function(c, e) {


### PR DESCRIPTION
This fixes two issues:

* Don't enable the save button before the user modifies the YAML. The intent in the code is for the button to only enable after the user types something.
* Don't prompt about unsaved changes when the user navigates away immediately.