### PR TITLE
Bug 1459848 - Fix template confirm-on-exit prompt

### DIFF
--- a/app/scripts/directives/processTemplate.js
+++ b/app/scripts/directives/processTemplate.js
@@ -121,7 +121,7 @@ function ProcessTemplate($filter,
       return d.promise;
     });
 
-    _.set($scope, 'confirm.doneEditing', true);
+    _.set(ctrl, 'confirm.doneEditing', true);
     if (ctrl.isDialog) {
       $scope.$emit('templateInstantiated', {
         project: ctrl.selectedProject,

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -562,7 +562,7 @@ alerts:c,
 hasErrors:d
 });
 }), a.promise;
-}), _.set(c, "confirm.doneEditing", !0), o.isDialog ? c.$emit("templateInstantiated", {
+}), _.set(o, "confirm.doneEditing", !0), o.isDialog ? c.$emit("templateInstantiated", {
 project:o.selectedProject,
 template:o.template
 }) :f.toNextSteps(o.templateDisplayName, o.selectedProject.metadata.name);


### PR DESCRIPTION
Correctly set `confirm.doneEditing` when the "Create" button is clicked.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1459848