### PR TITLE
Bug 1460122 - Only use confirm-on-exit on some forms

### DIFF
--- a/app/scripts/controllers/addConfigVolume.js
+++ b/app/scripts/controllers/addConfigVolume.js
@@ -81,7 +81,6 @@ angular.module('openshiftConsole')
     };
 
     var navigateBack = function() {
-      _.set($scope, 'confirm.doneEditing', true);
       $window.history.back();
     };
 

--- a/app/scripts/controllers/attachPVC.js
+++ b/app/scripts/controllers/attachPVC.js
@@ -101,7 +101,6 @@ angular.module('openshiftConsole')
         };
 
         var navigateBack = function() {
-          _.set($scope, 'confirm.doneEditing', true);
           $window.history.back();
         };
 

--- a/app/scripts/controllers/create/createFromImage.js
+++ b/app/scripts/controllers/create/createFromImage.js
@@ -323,7 +323,6 @@ angular.module("openshiftConsole")
                   };
               }
             );
-          _.set($scope, 'confirm.doneEditing', true);
           Navigate.toNextSteps($scope.name, $scope.projectName, {
             usingSampleRepo: $scope.usingSampleRepo(),
             breadcrumbTitle: breadcrumbTitle

--- a/app/scripts/controllers/createPersistentVolumeClaim.js
+++ b/app/scripts/controllers/createPersistentVolumeClaim.js
@@ -56,7 +56,6 @@ angular.module('openshiftConsole')
             var claim = generatePersistentVolumeClaim();
             DataService.create('persistentvolumeclaims', null, claim, context)
               .then(function() { // Success
-                _.set($scope, 'confirm.doneEditing', true);
                 // Return to the previous page
                 $window.history.back();
               },

--- a/app/scripts/controllers/createRoute.js
+++ b/app/scripts/controllers/createRoute.js
@@ -51,7 +51,6 @@ angular.module('openshiftConsole')
     };
 
     var navigateBack = function() {
-      _.set($scope, 'confirm.doneEditing', true);
       $window.history.back();
     };
 

--- a/app/scripts/controllers/edit/autoscaler.js
+++ b/app/scripts/controllers/edit/autoscaler.js
@@ -113,7 +113,6 @@ angular.module('openshiftConsole')
             group: 'autoscaling'
           }, null, hpa, context)
             .then(function() { // Success
-              _.set($scope, 'confirm.doneEditing', true);
               // Return to the previous page
               $window.history.back();
             }, function(result) { // Failure
@@ -136,7 +135,6 @@ angular.module('openshiftConsole')
             group: 'autoscaling'
           }, hpa.metadata.name, hpa, context)
             .then(function() { // Success
-              _.set($scope, 'confirm.doneEditing', true);
               // Return to the previous page
               $window.history.back();
             }, function(result) { // Failure

--- a/app/scripts/controllers/edit/buildConfig.js
+++ b/app/scripts/controllers/edit/buildConfig.js
@@ -211,8 +211,6 @@ angular.module('openshiftConsole')
     var buildStrategy = $filter('buildStrategy');
 
     var navigateBack = function() {
-      _.set($scope, 'confirm.doneEditing', true);
-
       var buildConfigURL;
       if ($scope.buildConfig) {
         buildConfigURL = Navigate.resourceURL($scope.buildConfig);

--- a/app/scripts/controllers/edit/deploymentConfig.js
+++ b/app/scripts/controllers/edit/deploymentConfig.js
@@ -316,10 +316,6 @@ angular.module('openshiftConsole')
       return updatedTriggers;
     };
 
-    var doneEditing = function() {
-      _.set($scope, 'confirm.doneEditing', true);
-    };
-
     var hideErrorNotifications = function() {
       NotificationsService.hideNotification("edit-deployment-config-error");
     };
@@ -380,7 +376,6 @@ angular.module('openshiftConsole')
             type: "success",
             message: "Deployment config " + $scope.updatedDeploymentConfig.metadata.name + " was successfully updated."
           });
-          doneEditing();
           var returnURL = Navigate.resourceURL($scope.updatedDeploymentConfig);
           $location.url(returnURL);
         },
@@ -398,7 +393,6 @@ angular.module('openshiftConsole')
 
     $scope.cancel = function() {
       hideErrorNotifications();
-      doneEditing();
       $window.history.back();
     };
 

--- a/app/scripts/controllers/edit/healthChecks.js
+++ b/app/scripts/controllers/edit/healthChecks.js
@@ -64,7 +64,6 @@ angular.module('openshiftConsole')
     };
 
     var navigateBack = function() {
-      _.set($scope, 'confirm.doneEditing', true);
       $location.url($scope.resourceURL);
     };
 

--- a/app/scripts/controllers/edit/project.js
+++ b/app/scripts/controllers/edit/project.js
@@ -61,7 +61,6 @@ angular.module('openshiftConsole')
             ProjectsService
               .update($routeParams.project, mergeEditable(project, $scope.editableFields))
               .then(function() {
-                _.set($scope, 'confirm.doneEditing', true);
                 if ($routeParams.then) {
                   $location.path($routeParams.then);
                 }

--- a/app/scripts/controllers/edit/route.js
+++ b/app/scripts/controllers/edit/route.js
@@ -46,8 +46,6 @@ angular.module('openshiftConsole')
     };
 
     var navigateBack = function() {
-      _.set($scope, 'confirm.doneEditing', true);
-      $scope.doneEditing = true;
       $location.path($scope.routeURL);
     };
 

--- a/app/scripts/controllers/setLimits.js
+++ b/app/scripts/controllers/setLimits.js
@@ -71,7 +71,6 @@ angular.module('openshiftConsole')
     };
 
     var navigateBack = function() {
-      _.set($scope, 'confirm.doneEditing', true);
       $location.url($scope.resourceURL);
     };
 

--- a/app/scripts/directives/createSecret.js
+++ b/app/scripts/directives/createSecret.js
@@ -213,7 +213,6 @@ angular.module("openshiftConsole")
           hideErrorNotifications();
           var newSecret = constructSecretObject($scope.newSecret.data, $scope.newSecret.authType);
           DataService.create('secrets', null, newSecret, $scope).then(function(secret) { // Success
-            _.set($scope, 'confirm.doneEditing', true);
             // In order to link:
             // - the SA has to be defined
             // - defined SA has to be present in the obtained SA list
@@ -244,7 +243,6 @@ angular.module("openshiftConsole")
         };
 
         $scope.cancel = function() {
-          _.set($scope, 'confirm.doneEditing', true);
           hideErrorNotifications();
           $scope.onCancel();
         };

--- a/app/scripts/directives/deployImage.js
+++ b/app/scripts/directives/deployImage.js
@@ -250,7 +250,6 @@ angular.module("openshiftConsole")
               return d.promise;
             });
 
-            _.set($scope, 'confirm.doneEditing', true);
             Navigate.toNextSteps($scope.app.name, $scope.project);
           };
 

--- a/app/scripts/directives/fromFile.js
+++ b/app/scripts/directives/fromFile.js
@@ -264,8 +264,6 @@ angular.module("openshiftConsole")
         // When redirecting to newFromTemplate page, use the cached Template if user doesn't adds it into the
         // namespace by the create process or if the template is being updated.
         function redirect() {
-          _.set($scope, 'confirm.doneEditing', true);
-
           var path;
           if ($scope.resourceKind === "Template" && $scope.templateOptions.process && !$scope.errorOccured) {
             var namespace = ($scope.templateOptions.add || $scope.updateResources.length > 0) ? $scope.projectName : "";

--- a/app/scripts/directives/processTemplate.js
+++ b/app/scripts/directives/processTemplate.js
@@ -121,7 +121,6 @@ function ProcessTemplate($filter,
       return d.promise;
     });
 
-    _.set(ctrl, 'confirm.doneEditing', true);
     if (ctrl.isDialog) {
       $scope.$emit('templateInstantiated', {
         project: ctrl.selectedProject,

--- a/app/views/add-config-volume.html
+++ b/app/views/add-config-volume.html
@@ -38,7 +38,6 @@
                       Add values from a config map or secret as volume. This will make the data available as files for {{kind | humanizeKind}} {{name}}.
                     </div>
                     <form name="forms.addConfigVolumeForm" class="mar-top-lg">
-                      <confirm-on-exit dirty="forms.addConfigVolumeForm.$dirty && !confirm.doneEditing"></confirm-on-exit>
                       <fieldset ng-disabled="disableInputs">
                         <div class="form-group">
                           <label class="required">Source</label>

--- a/app/views/attach-pvc.html
+++ b/app/views/attach-pvc.html
@@ -41,7 +41,6 @@
                     Add an existing persistent volume claim to the template of {{kind | humanizeKind}} {{name}}.
                   </div>
                   <form name="attachPVCForm" class="mar-top-lg">
-                    <confirm-on-exit dirty="attachPVCForm.$dirty && !confirm.doneEditing"></confirm-on-exit>
                     <fieldset ng-disabled="disableInputs">
                       <div class="form-group">
                         <label for="persistentVolumeClaim" class="required">Storage</label>

--- a/app/views/browse/deployment.html
+++ b/app/views/browse/deployment.html
@@ -253,6 +253,11 @@
                 <uib-tab heading="Environment" active="selectedTab.environment" ng-if="deployment">
                   <uib-tab-heading>Environment</uib-tab-heading>
                   <ng-form name="forms.deploymentEnvVars">
+                    <confirm-on-exit
+                      ng-if="{ group: 'extensions', resource: 'deployments' } | canI : 'update'"
+                      dirty="forms.deploymentEnvVars.$dirty">
+                    </confirm-on-exit>
+
                     <div ng-repeat="container in updatedDeployment.spec.template.spec.containers">
                       <h3>Container {{container.name}} Environment Variables</h3>
                       <key-value-editor

--- a/app/views/create-persistent-volume-claim.html
+++ b/app/views/create-persistent-volume-claim.html
@@ -20,7 +20,6 @@
                     <a href="{{'persistent_volumes' | helpLink}}" target="_blank"><span class="learn-more-inline">Learn More&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a>
                   </div>
                   <form name="createPersistentVolumeClaimForm" class="mar-top-lg">
-                    <confirm-on-exit dirty="createPersistentVolumeClaimForm.$dirty && !confirm.doneEditing"></confirm-on-exit>
                     <fieldset ng-disabled="disableInputs">
                       <osc-persistent-volume-claim model="claim" project-name="projectName"></osc-persistent-volume-claim>
                       <div class="button-group gutter-bottom">
@@ -29,10 +28,7 @@
                                 ng-click="createPersistentVolumeClaim()"
                                 ng-disabled="createPersistentVolumeClaimForm.$invalid || disableInputs"
                                 value="">Create</button>
-                        <a class="btn btn-default btn-lg"
-                           href=""
-                           ng-click="confirm.doneEditing = true"
-                           back>Cancel</a>
+                        <a class="btn btn-default btn-lg" href="" back>Cancel</a>
                       </div>
                     </fieldset>
                   </form>

--- a/app/views/create-route.html
+++ b/app/views/create-route.html
@@ -18,7 +18,6 @@
                     Routing is a way to make your application publicly visible.
                   </div>
                   <form name="createRouteForm" class="mar-top-xl osc-form">
-                    <confirm-on-exit dirty="createRouteForm.$dirty && !confirm.doneEditing"></confirm-on-exit>
                     <div ng-if="!services">Loading...</div>
                     <div ng-if="services">
                       <fieldset ng-disabled="disableInputs">

--- a/app/views/create/fromimage.html
+++ b/app/views/create/fromimage.html
@@ -26,7 +26,6 @@
                         <osc-image-summary resource="image" name="displayName || imageName" tag="imageTag"></osc-image-summary>
                         <div class="clearfix visible-xs-block"></div>
                         <form class="" ng-show="imageStream" novalidate name="form" ng-submit="createApp()">
-                          <confirm-on-exit dirty="form.$dirty && !confirm.doneEditing"></confirm-on-exit>
                           <div style="margin-bottom: 15px;">
                             <div class="form-group">
                              <label for="appname" class="required">Name</label>
@@ -419,9 +418,7 @@
                                 class="btn btn-primary btn-lg"
                                 ng-disabled="form.$invalid || nameTaken || cpuProblems.length || memoryProblems.length || disableInputs"
                                 >Create</button>
-                            <a class="btn btn-default btn-lg"
-                              ng-click="confirm.doneEditing = true"
-                              ng-href="{{projectName | projectOverviewURL}}">Cancel</a>
+                            <a class="btn btn-default btn-lg" ng-href="{{projectName | projectOverviewURL}}">Cancel</a>
                           </div>
                         </form>
                       </fieldset>

--- a/app/views/directives/create-secret.html
+++ b/app/views/directives/create-secret.html
@@ -1,5 +1,4 @@
 <ng-form name="secretForm" class="create-secret-form">
-  <confirm-on-exit dirty="secretForm.$dirty && !confirm.doneEditing"></confirm-on-exit>
   <div for="secretType" ng-if="!type" class="form-group mar-top-lg">
     <label>Secret Type</label>
     <ui-select required ng-model="newSecret.type" search-enabled="false" ng-change="newSecret.authType = secretAuthTypeMap[newSecret.type].authTypes[0].id">

--- a/app/views/directives/deploy-image.html
+++ b/app/views/directives/deploy-image.html
@@ -109,7 +109,6 @@
   <div class="row" ng-if-end>
     <div class="col-sm-12">
       <form name="form" class="osc-form">
-        <confirm-on-exit dirty="form.$dirty && !confirm.doneEditing"></confirm-on-exit>
         <div class="form-group">
          <label for="name" class="required">Name</label>
          <div ng-class="{'has-error': form.name.$invalid || nameTaken}">
@@ -190,10 +189,7 @@
               ng-click="create()"
               value=""
               ng-disabled="form.$invalid || nameTaken || disableInputs">Create</button>
-          <a class="btn btn-default btn-lg"
-              ng-click="confirm.doneEditing = true"
-              href="#"
-              back>Cancel</a>
+          <a class="btn btn-default btn-lg" href="#" back>Cancel</a>
         </div>
       </form>
     </div>

--- a/app/views/directives/from-file.html
+++ b/app/views/directives/from-file.html
@@ -6,7 +6,6 @@
 <div class="row">
   <div class="col-sm-12 pod-bottom-xl">
     <form name="form">
-      <confirm-on-exit dirty="form.$dirty && !confirm.doneEditing"></confirm-on-exit>
       <div class="form-group" id="from-file">
         <osc-file-input
           model="editorContent"
@@ -35,7 +34,6 @@
           Create
         </button>
         <a class="btn btn-default btn-lg"
-          ng-click="confirm.doneEditing = true"
           ng-href="{{projectName | projectOverviewURL}}">
           Cancel
         </a>

--- a/app/views/directives/process-template.html
+++ b/app/views/directives/process-template.html
@@ -1,6 +1,5 @@
 <fieldset ng-disabled="disableInputs">
   <ng-form name="$ctrl.templateForm">
-    <confirm-on-exit dirty="$ctrl.templateForm.$dirty && !$ctrl.confirm.doneEditing"></confirm-on-exit>
     <template-options is-dialog="$ctrl.isDialog" parameters="$ctrl.template.parameters" expand="true" can-toggle="false">
       <select-project ng-if="!$ctrl.project" selected-project="$ctrl.selectedProject" name-taken="$ctrl.projectNameTaken"></select-project>
     </template-options>
@@ -8,8 +7,7 @@
     <div ng-if="$ctrl.isDialog && $ctrl.selectedProject.metadata.uid" class="form-group">
       <!-- TODO: Preserve entered form values. -->
       To set optional parameters or labels, view
-      <a ng-click="$ctrl.confirm.doneEditing = true"
-         ng-href="{{$ctrl.template | createFromTemplateURL : $ctrl.selectedProject.metadata.name}}">advanced options</a>.
+      <a ng-href="{{$ctrl.template | createFromTemplateURL : $ctrl.selectedProject.metadata.name}}">advanced options</a>.
     </div>
     <label-editor
         ng-if="!$ctrl.isDialog"
@@ -22,9 +20,7 @@
     <alerts alerts="$ctrl.precheckAlerts"></alerts>
     <div ng-if="!$ctrl.isDialog" class="buttons gutter-top-bottom">
       <button class="btn btn-primary btn-lg" ng-click="$ctrl.createFromTemplate()" ng-disabled="$ctrl.templateForm.$invalid || $ctrl.disableInputs">Create</button>
-      <a class="btn btn-default btn-lg"
-         ng-href="{{$ctrl.project | projectOverviewURL}}"
-         ng-click="$ctrl.confirm.doneEditing = true">Cancel</a>
+      <a class="btn btn-default btn-lg" ng-href="{{$ctrl.project | projectOverviewURL}}">Cancel</a>
     </div>
   </ng-form>
 </fieldset>

--- a/app/views/edit/autoscaler.html
+++ b/app/views/edit/autoscaler.html
@@ -17,7 +17,6 @@
                   Loading...
                 </div>
                 <form name="form" ng-submit="save()" class="osc-form" ng-show="targetKind && targetName">
-                  <confirm-on-exit dirty="form.$dirty && !confirm.doneEditing"></confirm-on-exit>
                   <h1>
                     Autoscale {{targetKind | humanizeKind : true}} {{targetName}}
                   </h1>
@@ -68,10 +67,7 @@
                           ng-disabled="form.$invalid || form.$pristine">
                         Save
                       </button>
-                      <a href=""
-                        ng-click="confirm.doneEditing = true"
-                        class="btn btn-default btn-lg"
-                        back>Cancel</a>
+                      <a href="" class="btn btn-default btn-lg" back>Cancel</a>
                     </div>
                   </fieldset>
                 </form>

--- a/app/views/edit/build-config.html
+++ b/app/views/edit/build-config.html
@@ -18,7 +18,6 @@
             </h1>
             <fieldset ng-disabled="disableInputs">
               <form class="edit-form" name="form" novalidate ng-submit="save()">
-                <confirm-on-exit dirty="form.$dirty && !confirm.doneEditing"></confirm-on-exit>
                 <div class="row">
                   <div class="col-lg-12">
                     <div ng-if="buildConfig.spec.source.type !== 'None'" class="section">

--- a/app/views/edit/config-map.html
+++ b/app/views/edit/config-map.html
@@ -22,7 +22,6 @@
                   <div class="mar-top-xl">
                     <div ng-if="!loaded">Loading...</div>
                     <form ng-if="loaded" name="forms.editConfigMapForm">
-                      <confirm-on-exit dirty="forms.editConfigMapForm.$dirty && !confirm.doneEditing"></confirm-on-exit>
                       <div ng-if="resourceChanged && !resourceDeleted && !updatingNow" class="alert alert-warning">
                         <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
                         <span class="sr-only">Warning:</span>
@@ -42,7 +41,7 @@
                               ng-click="updateConfigMap()"
                               ng-disabled="forms.editConfigMapForm.$invalid || forms.editConfigMapForm.$pristine || disableInputs || resourceChanged || resourceDeleted"
                               value="">Save</button>
-                          <a class="btn btn-default btn-lg" href="#" ng-click="confirm.doneEditing = true" back>Cancel</a>
+                          <a class="btn btn-default btn-lg" href="#" back>Cancel</a>
                         </div>
                       </fieldset>
                     </form>

--- a/app/views/edit/deployment-config.html
+++ b/app/views/edit/deployment-config.html
@@ -18,7 +18,6 @@
               </h1>
               <fieldset ng-disabled="disableInputs">
                 <form class="edit-form" name="form" novalidate>
-                  <confirm-on-exit dirty="form.$dirty && !confirm.doneEditing"></confirm-on-exit>
                   <div class="row">
                     <div class="col-lg-12">
                       <div class="section">

--- a/app/views/edit/health-checks.html
+++ b/app/views/edit/health-checks.html
@@ -14,7 +14,6 @@
               <div class="col-md-12">
                 <div ng-show="!containers.length" class="mar-top-md">Loading...</div>
                 <form ng-show="containers.length" name="form" class="health-checks-form">
-                  <confirm-on-exit dirty="form.$dirty && !confirm.doneEditing"></confirm-on-exit>
                   <h1>Health Checks: {{name}}</h1>
                   <div class="help-block">
                     Container health is periodically checked using readiness and liveness probes.

--- a/app/views/edit/project.html
+++ b/app/views/edit/project.html
@@ -14,7 +14,6 @@
               <div class="help-block mar-bottom-lg">Update the display name and description of your project. The project's unique name cannot be modified.</div>
               <alerts alerts="alerts"></alerts>
               <form name="editProjectForm">
-                <confirm-on-exit dirty="editProjectForm && !confirm.doneEditing"></confirm-on-exit>
                 <fieldset ng-disabled="disableInputs">
                   <div class="form-group">
                     <label for="displayName">Display Name</label>
@@ -41,10 +40,7 @@
                         ng-click="update()"
                         ng-disabled="editProjectForm.$invalid || disableInputs"
                         value="">Save</button>
-                    <a class="btn btn-default btn-lg"
-                      href="#"
-                      ng-click="confirm.doneEditing = true"
-                      back>Cancel</a>
+                    <a class="btn btn-default btn-lg" href="#" back>Cancel</a>
                   </div>
                 </fieldset>
               </form>

--- a/app/views/edit/route.html
+++ b/app/views/edit/route.html
@@ -18,7 +18,6 @@
               </div>
               <form name="form">
                 <fieldset ng-disabled="disableInputs" ng-if="!loading">
-                  <confirm-on-exit dirty="form.$dirty && !confirm.doneEditing"></confirm-on-exit>
                   <osc-routing
                       model="routing"
                       services="services"

--- a/app/views/set-limits.html
+++ b/app/views/set-limits.html
@@ -14,7 +14,6 @@
               <div class="col-md-12">
                 <div ng-show="!containers.length">Loading...</div>
                 <form ng-if="containers.length" name="form" class="set-limits-form">
-                  <confirm-on-exit dirty="form.$dirty && !confirm.doneEditing"></confirm-on-exit>
                   <h1>Resource Limits: {{name}}</h1>
                   <div class="help-block">
                     Resource limits control how much <span ng-if="!hideCPU">CPU and</span> memory a container will consume on a node.

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -562,7 +562,7 @@ alerts:c,
 hasErrors:d
 });
 }), a.promise;
-}), _.set(o, "confirm.doneEditing", !0), o.isDialog ? c.$emit("templateInstantiated", {
+}), o.isDialog ? c.$emit("templateInstantiated", {
 project:o.selectedProject,
 template:o.template
 }) :f.toNextSteps(o.templateDisplayName, o.selectedProject.metadata.name);
@@ -6559,7 +6559,7 @@ message:a,
 details:b
 });
 }, s = function() {
-_.set(e, "confirm.doneEditing", !0), b.url(e.resourceURL);
+b.url(e.resourceURL);
 }, t = function() {
 l.hideNotification("set-compute-limits-error");
 };
@@ -6711,7 +6711,6 @@ delete a.updatedBuildConfig.spec.postCommit.script;
 };
 a.secrets = {};
 var q = [], r = b("buildStrategy"), s = function() {
-_.set(a, "confirm.doneEditing", !0);
 var b;
 a.buildConfig ? (b = i.resourceURL(a.buildConfig), c.path(b)) :e.history.back();
 }, t = function() {
@@ -7166,8 +7165,6 @@ e.image = c.image;
 type:"ConfigChange"
 }), b;
 }, A = function() {
-_.set(a, "confirm.doneEditing", !0);
-}, B = function() {
 l.hideNotification("edit-deployment-config-error");
 };
 a.save = function() {
@@ -7184,11 +7181,11 @@ var f = a.strategyData[a.strategyParamsPropertyName].maxUnavailable, g = Number(
 }
 "Custom" !== a.strategyData.type && _.each([ "pre", "mid", "post" ], function(b) {
 _.has(a.strategyData, [ a.strategyParamsPropertyName, b, "execNewPod", "env" ]) && (a.strategyData[a.strategyParamsPropertyName][b].execNewPod.env = o.compactEntries(a.strategyData[a.strategyParamsPropertyName][b].execNewPod.env));
-}), _.has(a, "strategyData.customParams.environment") && (a.strategyData.customParams.environment = o.compactEntries(a.strategyData.customParams.environment)), a.updatedDeploymentConfig.spec.template.spec.imagePullSecrets = _.filter(a.secrets.pullSecrets, "name"), a.updatedDeploymentConfig.spec.strategy = a.strategyData, a.updatedDeploymentConfig.spec.triggers = z(), B(), i.update("deploymentconfigs", a.updatedDeploymentConfig.metadata.name, a.updatedDeploymentConfig, a.context).then(function() {
+}), _.has(a, "strategyData.customParams.environment") && (a.strategyData.customParams.environment = o.compactEntries(a.strategyData.customParams.environment)), a.updatedDeploymentConfig.spec.template.spec.imagePullSecrets = _.filter(a.secrets.pullSecrets, "name"), a.updatedDeploymentConfig.spec.strategy = a.strategyData, a.updatedDeploymentConfig.spec.triggers = z(), A(), i.update("deploymentconfigs", a.updatedDeploymentConfig.metadata.name, a.updatedDeploymentConfig, a.context).then(function() {
 l.addNotification({
 type:"success",
 message:"Deployment config " + a.updatedDeploymentConfig.metadata.name + " was successfully updated."
-}), A();
+});
 var b = k.resourceURL(a.updatedDeploymentConfig);
 c.url(b);
 }, function(c) {
@@ -7200,7 +7197,7 @@ details:b("getErrorDetails")(c)
 });
 });
 }, a.cancel = function() {
-B(), A(), f.history.back();
+A(), f.history.back();
 }, a.$on("$destroy", function() {
 i.unwatchAll(s);
 });
@@ -7252,7 +7249,7 @@ h.create({
 resource:"horizontalpodautoscalers",
 group:"autoscaling"
 }, null, b, j).then(function() {
-_.set(a, "confirm.doneEditing", !0), d.history.back();
+d.history.back();
 }, function(b) {
 a.disableInputs = !1, p("An error occurred creating the horizontal pod autoscaler.", b);
 });
@@ -7261,7 +7258,7 @@ a.disableInputs = !0, b = angular.copy(b), b.metadata.labels = m.mapEntries(m.co
 resource:"horizontalpodautoscalers",
 group:"autoscaling"
 }, b.metadata.name, b, j).then(function() {
-_.set(a, "confirm.doneEditing", !0), d.history.back();
+d.history.back();
 }, function(c) {
 a.disableInputs = !1, p('An error occurred updating horizontal pod autoscaler "' + b.metadata.name + '".', c);
 });
@@ -7328,7 +7325,7 @@ message:a,
 details:b
 });
 }, p = function() {
-_.set(d, "confirm.doneEditing", !0), b.url(d.resourceURL);
+b.url(d.resourceURL);
 }, q = function() {
 j.hideNotification("add-health-check-error");
 };
@@ -7382,7 +7379,7 @@ title:"Edit"
 var l = function() {
 i.hideNotification("edit-route-error");
 }, m = function() {
-_.set(d, "confirm.doneEditing", !0), d.doneEditing = !0, b.path(d.routeURL);
+b.path(d.routeURL);
 };
 d.cancel = function() {
 l(), m();
@@ -7749,7 +7746,7 @@ type:"error",
 message:"An error occurred creating the application.",
 details:"Status: " + b.status + ". " + b.data
 };
-}), _.set(a, "confirm.doneEditing", !0), h.toNextSteps(a.name, a.projectName, {
+}), h.toNextSteps(a.name, a.projectName, {
 usingSampleRepo:a.usingSampleRepo(),
 breadcrumbTitle:z
 });
@@ -8180,7 +8177,7 @@ a.actions.canSubmit = b;
 },
 update:function() {
 a.disableInputs = !0, g.update(b.project, k(e, a.editableFields)).then(function() {
-_.set(a, "confirm.doneEditing", !0), b.then ? d.path(b.then) :h.toProjectOverview(e.metadata.name);
+b.then ? d.path(b.then) :h.toProjectOverview(e.metadata.name);
 }, function(b) {
 a.disableInputs = !1, a.editableFields = f(e), a.alerts.update = {
 type:"error",
@@ -8208,7 +8205,7 @@ title:"Create Route"
 var l = function() {
 i.hideNotification("create-route-error");
 }, m = function() {
-_.set(c, "confirm.doneEditing", !0), d.history.back();
+d.history.back();
 };
 c.cancel = function() {
 l(), m();
@@ -8287,7 +8284,7 @@ details:b
 }, t = function() {
 k.hideNotification("attach-pvc-error");
 }, u = function() {
-_.set(c, "confirm.doneEditing", !0), d.history.back();
+d.history.back();
 }, v = function(a) {
 return c.attach.allContainers || c.attach.containers[a.name];
 }, w = function() {
@@ -8374,7 +8371,7 @@ d.$watch("attach.source", r);
 var s = function() {
 d.forms.addConfigVolumeForm.$setDirty();
 }, t = function() {
-_.set(d, "confirm.doneEditing", !0), e.history.back();
+e.history.back();
 }, u = function(a, b) {
 k.addNotification({
 id:"add-config-volume-error",
@@ -8584,7 +8581,7 @@ if (c.createPersistentVolumeClaimForm.$valid) {
 c.disableInputs = !0;
 var b = k();
 g.create("persistentvolumeclaims", null, b, i).then(function() {
-_.set(c, "confirm.doneEditing", !0), d.history.back();
+d.history.back();
 }, function(b) {
 c.disableInputs = !1, c.alerts["create-persistent-volume-claim"] = {
 type:"error",
@@ -8761,7 +8758,7 @@ f.nameTaken = !1;
 h();
 var e = g(f.newSecret.data, f.newSecret.authType);
 c.create("secrets", null, e, f).then(function(a) {
-_.set(f, "confirm.doneEditing", !0), f.newSecret.linkSecret && f.serviceAccountsNames.contains(f.newSecret.pickedServiceAccountToLink) && b.canI("serviceaccounts", "update") ? i(a) :(d.addNotification({
+f.newSecret.linkSecret && f.serviceAccountsNames.contains(f.newSecret.pickedServiceAccountToLink) && b.canI("serviceaccounts", "update") ? i(a) :(d.addNotification({
 type:"success",
 message:"Secret " + e.metadata.name + " was created."
 }), f.onCreate({
@@ -8777,7 +8774,7 @@ details:a("getErrorDetails")(b)
 });
 });
 }, f.cancel = function() {
-_.set(f, "confirm.doneEditing", !0), h(), f.onCancel();
+h(), f.onCancel();
 };
 }
 };
@@ -9149,7 +9146,6 @@ c > 0 && d.push(w()), b > 0 && d.push(v()), a.all(d).then(s);
 } else u();
 }
 function s() {
-_.set(m, "confirm.doneEditing", !0);
 var a;
 if ("Template" === m.resourceKind && m.templateOptions.process && !m.errorOccured) {
 var b = m.templateOptions.add || m.updateResources.length > 0 ? m.projectName :"";
@@ -13088,7 +13084,7 @@ alerts:d,
 hasErrors:e
 });
 }), a.promise;
-}), _.set(c, "confirm.doneEditing", !0), h.toNextSteps(c.app.name, c.project);
+}), h.toNextSteps(c.app.name, c.project);
 }, A = function(a) {
 var b = d.open({
 animation:!0,

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -768,7 +768,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Add values from a config map or secret as volume. This will make the data available as files for {{kind | humanizeKind}} {{name}}.\n" +
     "</div>\n" +
     "<form name=\"forms.addConfigVolumeForm\" class=\"mar-top-lg\">\n" +
-    "<confirm-on-exit dirty=\"forms.addConfigVolumeForm.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<fieldset ng-disabled=\"disableInputs\">\n" +
     "<div class=\"form-group\">\n" +
     "<label class=\"required\">Source</label>\n" +
@@ -938,7 +937,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Add an existing persistent volume claim to the template of {{kind | humanizeKind}} {{name}}.\n" +
     "</div>\n" +
     "<form name=\"attachPVCForm\" class=\"mar-top-lg\">\n" +
-    "<confirm-on-exit dirty=\"attachPVCForm.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<fieldset ng-disabled=\"disableInputs\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"persistentVolumeClaim\" class=\"required\">Storage</label>\n" +
@@ -2768,6 +2766,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<uib-tab heading=\"Environment\" active=\"selectedTab.environment\" ng-if=\"deployment\">\n" +
     "<uib-tab-heading>Environment</uib-tab-heading>\n" +
     "<ng-form name=\"forms.deploymentEnvVars\">\n" +
+    "<confirm-on-exit ng-if=\"{ group: 'extensions', resource: 'deployments' } | canI : 'update'\" dirty=\"forms.deploymentEnvVars.$dirty\">\n" +
+    "</confirm-on-exit>\n" +
     "<div ng-repeat=\"container in updatedDeployment.spec.template.spec.containers\">\n" +
     "<h3>Container {{container.name}} Environment Variables</h3>\n" +
     "<key-value-editor ng-if=\"!({ group: 'extensions', resource: 'deployments' } | canI : 'update')\" entries=\"container.env\" key-placeholder=\"Name\" value-placeholder=\"Value\" cannot-add cannot-sort cannot-delete is-readonly show-header></key-value-editor>\n" +
@@ -4649,12 +4649,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a href=\"{{'persistent_volumes' | helpLink}}\" target=\"_blank\"><span class=\"learn-more-inline\">Learn More&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></span></a>\n" +
     "</div>\n" +
     "<form name=\"createPersistentVolumeClaimForm\" class=\"mar-top-lg\">\n" +
-    "<confirm-on-exit dirty=\"createPersistentVolumeClaimForm.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<fieldset ng-disabled=\"disableInputs\">\n" +
     "<osc-persistent-volume-claim model=\"claim\" project-name=\"projectName\"></osc-persistent-volume-claim>\n" +
     "<div class=\"button-group gutter-bottom\">\n" +
     "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-click=\"createPersistentVolumeClaim()\" ng-disabled=\"createPersistentVolumeClaimForm.$invalid || disableInputs\" value=\"\">Create</button>\n" +
-    "<a class=\"btn btn-default btn-lg\" href=\"\" ng-click=\"confirm.doneEditing = true\" back>Cancel</a>\n" +
+    "<a class=\"btn btn-default btn-lg\" href=\"\" back>Cancel</a>\n" +
     "</div>\n" +
     "</fieldset>\n" +
     "</form>\n" +
@@ -4717,7 +4716,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Routing is a way to make your application publicly visible.\n" +
     "</div>\n" +
     "<form name=\"createRouteForm\" class=\"mar-top-xl osc-form\">\n" +
-    "<confirm-on-exit dirty=\"createRouteForm.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<div ng-if=\"!services\">Loading...</div>\n" +
     "<div ng-if=\"services\">\n" +
     "<fieldset ng-disabled=\"disableInputs\">\n" +
@@ -4892,7 +4890,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<osc-image-summary resource=\"image\" name=\"displayName || imageName\" tag=\"imageTag\"></osc-image-summary>\n" +
     "<div class=\"clearfix visible-xs-block\"></div>\n" +
     "<form class=\"\" ng-show=\"imageStream\" novalidate name=\"form\" ng-submit=\"createApp()\">\n" +
-    "<confirm-on-exit dirty=\"form.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<div style=\"margin-bottom: 15px\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"appname\" class=\"required\">Name</label>\n" +
@@ -5128,7 +5125,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"buttons gutter-bottom\" ng-class=\"{'gutter-top': !alerts.length}\">\n" +
     "\n" +
     "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-disabled=\"form.$invalid || nameTaken || cpuProblems.length || memoryProblems.length || disableInputs\">Create</button>\n" +
-    "<a class=\"btn btn-default btn-lg\" ng-click=\"confirm.doneEditing = true\" ng-href=\"{{projectName | projectOverviewURL}}\">Cancel</a>\n" +
+    "<a class=\"btn btn-default btn-lg\" ng-href=\"{{projectName | projectOverviewURL}}\">Cancel</a>\n" +
     "</div>\n" +
     "</form>\n" +
     "</fieldset>\n" +
@@ -5902,7 +5899,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/directives/create-secret.html',
     "<ng-form name=\"secretForm\" class=\"create-secret-form\">\n" +
-    "<confirm-on-exit dirty=\"secretForm.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<div for=\"secretType\" ng-if=\"!type\" class=\"form-group mar-top-lg\">\n" +
     "<label>Secret Type</label>\n" +
     "<ui-select required ng-model=\"newSecret.type\" search-enabled=\"false\" ng-change=\"newSecret.authType = secretAuthTypeMap[newSecret.type].authTypes[0].id\">\n" +
@@ -6237,7 +6233,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"row\" ng-if-end>\n" +
     "<div class=\"col-sm-12\">\n" +
     "<form name=\"form\" class=\"osc-form\">\n" +
-    "<confirm-on-exit dirty=\"form.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"name\" class=\"required\">Name</label>\n" +
     "<div ng-class=\"{'has-error': form.name.$invalid || nameTaken}\">\n" +
@@ -6272,7 +6267,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"button-group gutter-bottom\" ng-class=\"{'gutter-top': !alerts.length}\">\n" +
     "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-click=\"create()\" value=\"\" ng-disabled=\"form.$invalid || nameTaken || disableInputs\">Create</button>\n" +
-    "<a class=\"btn btn-default btn-lg\" ng-click=\"confirm.doneEditing = true\" href=\"#\" back>Cancel</a>\n" +
+    "<a class=\"btn btn-default btn-lg\" href=\"#\" back>Cancel</a>\n" +
     "</div>\n" +
     "</form>\n" +
     "</div>\n" +
@@ -6833,7 +6828,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"row\">\n" +
     "<div class=\"col-sm-12 pod-bottom-xl\">\n" +
     "<form name=\"form\">\n" +
-    "<confirm-on-exit dirty=\"form.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<div class=\"form-group\" id=\"from-file\">\n" +
     "<osc-file-input model=\"editorContent\" drop-zone-id=\"from-file\" help-text=\"Upload file by dragging & dropping, selecting it, or pasting from the clipboard.\" ng-disabled=\"false\"></osc-file-input>\n" +
     "<div ui-ace=\"{\n" +
@@ -6852,7 +6846,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<button type=\"submit\" ng-click=\"create()\" ng-disabled=\"editorErrorAnnotation || !editorContent\" class=\"btn btn-primary btn-lg\">\n" +
     "Create\n" +
     "</button>\n" +
-    "<a class=\"btn btn-default btn-lg\" ng-click=\"confirm.doneEditing = true\" ng-href=\"{{projectName | projectOverviewURL}}\">\n" +
+    "<a class=\"btn btn-default btn-lg\" ng-href=\"{{projectName | projectOverviewURL}}\">\n" +
     "Cancel\n" +
     "</a>\n" +
     "</div>\n" +
@@ -8569,7 +8563,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   $templateCache.put('views/directives/process-template.html',
     "<fieldset ng-disabled=\"disableInputs\">\n" +
     "<ng-form name=\"$ctrl.templateForm\">\n" +
-    "<confirm-on-exit dirty=\"$ctrl.templateForm.$dirty && !$ctrl.confirm.doneEditing\"></confirm-on-exit>\n" +
     "<template-options is-dialog=\"$ctrl.isDialog\" parameters=\"$ctrl.template.parameters\" expand=\"true\" can-toggle=\"false\">\n" +
     "<select-project ng-if=\"!$ctrl.project\" selected-project=\"$ctrl.selectedProject\" name-taken=\"$ctrl.projectNameTaken\"></select-project>\n" +
     "</template-options>\n" +
@@ -8577,14 +8570,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"$ctrl.isDialog && $ctrl.selectedProject.metadata.uid\" class=\"form-group\">\n" +
     "\n" +
     "To set optional parameters or labels, view\n" +
-    "<a ng-click=\"$ctrl.confirm.doneEditing = true\" ng-href=\"{{$ctrl.template | createFromTemplateURL : $ctrl.selectedProject.metadata.name}}\">advanced options</a>.\n" +
+    "<a ng-href=\"{{$ctrl.template | createFromTemplateURL : $ctrl.selectedProject.metadata.name}}\">advanced options</a>.\n" +
     "</div>\n" +
     "<label-editor ng-if=\"!$ctrl.isDialog\" labels=\"$ctrl.labels\" system-labels=\"$ctrl.systemLabels\" expand=\"true\" can-toggle=\"false\" help-text=\"Each label is applied to each created resource.\">\n" +
     "</label-editor>\n" +
     "<alerts alerts=\"$ctrl.precheckAlerts\"></alerts>\n" +
     "<div ng-if=\"!$ctrl.isDialog\" class=\"buttons gutter-top-bottom\">\n" +
     "<button class=\"btn btn-primary btn-lg\" ng-click=\"$ctrl.createFromTemplate()\" ng-disabled=\"$ctrl.templateForm.$invalid || $ctrl.disableInputs\">Create</button>\n" +
-    "<a class=\"btn btn-default btn-lg\" ng-href=\"{{$ctrl.project | projectOverviewURL}}\" ng-click=\"$ctrl.confirm.doneEditing = true\">Cancel</a>\n" +
+    "<a class=\"btn btn-default btn-lg\" ng-href=\"{{$ctrl.project | projectOverviewURL}}\">Cancel</a>\n" +
     "</div>\n" +
     "</ng-form>\n" +
     "</fieldset>"
@@ -8793,7 +8786,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Loading...\n" +
     "</div>\n" +
     "<form name=\"form\" ng-submit=\"save()\" class=\"osc-form\" ng-show=\"targetKind && targetName\">\n" +
-    "<confirm-on-exit dirty=\"form.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<h1>\n" +
     "Autoscale {{targetKind | humanizeKind : true}} {{targetName}}\n" +
     "</h1>\n" +
@@ -8828,7 +8820,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-disabled=\"form.$invalid || form.$pristine\">\n" +
     "Save\n" +
     "</button>\n" +
-    "<a href=\"\" ng-click=\"confirm.doneEditing = true\" class=\"btn btn-default btn-lg\" back>Cancel</a>\n" +
+    "<a href=\"\" class=\"btn btn-default btn-lg\" back>Cancel</a>\n" +
     "</div>\n" +
     "</fieldset>\n" +
     "</form>\n" +
@@ -8864,7 +8856,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</h1>\n" +
     "<fieldset ng-disabled=\"disableInputs\">\n" +
     "<form class=\"edit-form\" name=\"form\" novalidate ng-submit=\"save()\">\n" +
-    "<confirm-on-exit dirty=\"form.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-lg-12\">\n" +
     "<div ng-if=\"buildConfig.spec.source.type !== 'None'\" class=\"section\">\n" +
@@ -9312,7 +9303,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"mar-top-xl\">\n" +
     "<div ng-if=\"!loaded\">Loading...</div>\n" +
     "<form ng-if=\"loaded\" name=\"forms.editConfigMapForm\">\n" +
-    "<confirm-on-exit dirty=\"forms.editConfigMapForm.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<div ng-if=\"resourceChanged && !resourceDeleted && !updatingNow\" class=\"alert alert-warning\">\n" +
     "<span class=\"pficon pficon-warning-triangle-o\" aria-hidden=\"true\"></span>\n" +
     "<span class=\"sr-only\">Warning:</span>\n" +
@@ -9327,7 +9317,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<edit-config-map model=\"configMap\"></edit-config-map>\n" +
     "<div class=\"button-group gutter-top gutter-bottom\">\n" +
     "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-click=\"updateConfigMap()\" ng-disabled=\"forms.editConfigMapForm.$invalid || forms.editConfigMapForm.$pristine || disableInputs || resourceChanged || resourceDeleted\" value=\"\">Save</button>\n" +
-    "<a class=\"btn btn-default btn-lg\" href=\"#\" ng-click=\"confirm.doneEditing = true\" back>Cancel</a>\n" +
+    "<a class=\"btn btn-default btn-lg\" href=\"#\" back>Cancel</a>\n" +
     "</div>\n" +
     "</fieldset>\n" +
     "</form>\n" +
@@ -9365,7 +9355,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</h1>\n" +
     "<fieldset ng-disabled=\"disableInputs\">\n" +
     "<form class=\"edit-form\" name=\"form\" novalidate>\n" +
-    "<confirm-on-exit dirty=\"form.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-lg-12\">\n" +
     "<div class=\"section\">\n" +
@@ -9633,7 +9622,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"col-md-12\">\n" +
     "<div ng-show=\"!containers.length\" class=\"mar-top-md\">Loading...</div>\n" +
     "<form ng-show=\"containers.length\" name=\"form\" class=\"health-checks-form\">\n" +
-    "<confirm-on-exit dirty=\"form.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<h1>Health Checks: {{name}}</h1>\n" +
     "<div class=\"help-block\">\n" +
     "Container health is periodically checked using readiness and liveness probes.\n" +
@@ -9763,7 +9751,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"help-block mar-bottom-lg\">Update the display name and description of your project. The project's unique name cannot be modified.</div>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<form name=\"editProjectForm\">\n" +
-    "<confirm-on-exit dirty=\"editProjectForm && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<fieldset ng-disabled=\"disableInputs\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"displayName\">Display Name</label>\n" +
@@ -9775,7 +9762,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"button-group\">\n" +
     "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-click=\"update()\" ng-disabled=\"editProjectForm.$invalid || disableInputs\" value=\"\">Save</button>\n" +
-    "<a class=\"btn btn-default btn-lg\" href=\"#\" ng-click=\"confirm.doneEditing = true\" back>Cancel</a>\n" +
+    "<a class=\"btn btn-default btn-lg\" href=\"#\" back>Cancel</a>\n" +
     "</div>\n" +
     "</fieldset>\n" +
     "</form>\n" +
@@ -9810,7 +9797,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<form name=\"form\">\n" +
     "<fieldset ng-disabled=\"disableInputs\" ng-if=\"!loading\">\n" +
-    "<confirm-on-exit dirty=\"form.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<osc-routing model=\"routing\" services=\"services\" show-name-input=\"false\" host-read-only=\"true\">\n" +
     "</osc-routing>\n" +
     "<div class=\"button-group gutter-top gutter-bottom\">\n" +
@@ -12869,7 +12855,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"col-md-12\">\n" +
     "<div ng-show=\"!containers.length\">Loading...</div>\n" +
     "<form ng-if=\"containers.length\" name=\"form\" class=\"set-limits-form\">\n" +
-    "<confirm-on-exit dirty=\"form.$dirty && !confirm.doneEditing\"></confirm-on-exit>\n" +
     "<h1>Resource Limits: {{name}}</h1>\n" +
     "<div class=\"help-block\">\n" +
     "Resource limits control how much <span ng-if=\"!hideCPU\">CPU and</span> memory a container will consume on a node.\n" +


### PR DESCRIPTION
Use confirm-on-exit only on forms where the left navigation is visible or where you might have typed a lot of content, such as Edit YAML.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1460122