### PR TITLE
Bug Fix 1460167 - View Quota does not work on Overview page

### DIFF
--- a/app/scripts/services/resourceAlerts.js
+++ b/app/scripts/services/resourceAlerts.js
@@ -82,7 +82,7 @@ angular.module("openshiftConsole")
           type: 'warning',
           message: 'Quota limit has been reached.',
           links: [{
-            href: Navigate.quotaURL(),
+            href: Navigate.quotaURL(projectName),
             label: "View Quota"
           },{
             href: "",

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4019,7 +4019,7 @@ g.quotaExceeded = {
 type:"warning",
 message:"Quota limit has been reached.",
 links:[ {
-href:d.quotaURL(),
+href:d.quotaURL(f),
 label:"View Quota"
 }, {
 href:"",


### PR DESCRIPTION
The project name variable was not being passed in the Navigate.quotaURL call which made the "View Quota" link have an undefined link.  Added parameter to the call. @jwforres @spadgett 