### PR TITLE
Increase specificity of css overflow: hidden rule so it doesn't clip kebab dropdown menu in row collapsed state

### DIFF
--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -267,8 +267,10 @@
     &.deployment-in-progress {
       // So animation offsets are hidden when sliding in horizontally
       // Only use this style when a deployment is in progress so that chart
-      // tooltips aren't clipped.
-      overflow:hidden;
+      // tooltips aren't clipped and only when expanded(.active), so that kebab dropdown menu isn't clipped.
+      &.active {
+        overflow: hidden;
+      }
       .list-pf-expansion {
         @media (max-width: @screen-xs-max) {
           overflow: hidden; // Hidden when sliding in vertically

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4959,7 +4959,7 @@ h2+.list-view-pf{margin-top:20px}
 .overview .list-pf-expansion.in .pod-donut{text-align:center}
 .overview .list-pf-item{border-top-color:#dcdcdc}
 .overview .list-pf-item.active{border-top-color:#bbb}
-.overview .list-pf-item.deployment-in-progress{overflow:hidden}
+.overview .list-pf-item.deployment-in-progress.active{overflow:hidden}
 @media (max-width:767px){.overview .list-pf-item.deployment-in-progress .list-pf-expansion{overflow:hidden}
 .overview .list-pf-item>.list-pf-container>.list-pf-content{align-items:stretch;flex-direction:column;width:100%;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 }


### PR DESCRIPTION
Fixes Bug https://bugzilla.redhat.com/show_bug.cgi?id=1460153
<img width="320" alt="screen shot 2017-06-13 at 3 21 33 pm" src="https://user-images.githubusercontent.com/1874151/27101548-36842bb8-5050-11e7-88b9-fa65050dd258.png">

