### PR TITLE
Global tech preview indicator for service catalog

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -495,6 +495,15 @@ angular
       // content (e.g. using :before pseudo-elements).
       $('body').addClass('ios');
     }
+  })
+  .run(function($rootScope){
+    // if the service catalog landing page is enabled,
+    // set global variable for use in views
+    // and add class to body
+    if (_.get(window, 'OPENSHIFT_CONSTANTS.ENABLE_TECH_PREVIEW_FEATURE.service_catalog_landing_page')) {
+      $rootScope.globalTechPreviewIndicator = true;
+      $('body').addClass('tech-preview');
+    }
   });
 
 hawtioPluginLoader.addModule('openshiftConsole');

--- a/app/styles/_catalog.less
+++ b/app/styles/_catalog.less
@@ -45,7 +45,11 @@
 }
 
 @media(min-width: @screen-sm-min) {
-  .catalog-search, .landing-side-bar {
+  .catalog-search,
+  .landing-side-bar {
     top: @navbar-os-header-height-desktop + 1; // add 1 for the bottom border
+    .tech-preview & {
+      top: @navbar-os-header-height-desktop + 1 + @tech-preview-banner-height; // add 1 for the bottom border
+    }
   }
 }

--- a/app/styles/_log.less
+++ b/app/styles/_log.less
@@ -123,6 +123,9 @@
       @media (min-width: @screen-sm-min) {
         right: @log-scroll-top-offset-right-sm;
         top: (@log-scroll-offset-top + @navbar-os-header-height-desktop);
+        .tech-preview & {
+          top: (@log-scroll-offset-top + @navbar-os-header-height-desktop + @tech-preview-banner-height);
+        }
       }
       @media (min-width: @screen-md-min) {
         right: @log-scroll-top-offset-right-lg;

--- a/app/styles/_navbar-alt.less
+++ b/app/styles/_navbar-alt.less
@@ -27,6 +27,9 @@
     top: 0;
     z-index: @zindex-navbar-fixed;
   }
+  .layout-pf-alt-fixed .tech-preview & {
+    top: @tech-preview-banner-height;
+  }
   .navbar-toggle {
     float: none;
     margin: 0;
@@ -348,5 +351,19 @@
         }
       }
     }
+  }
+}
+
+
+.tech-preview-banner {
+  background: @brand-warning;
+  color: @color-pf-white;
+  font-size: 12px;
+  text-align: center;
+  text-transform: uppercase;
+  width: 100%;
+  z-index: @zindex-navbar-fixed;
+  @media (min-width: @screen-sm-min) {
+    position: fixed;
   }
 }

--- a/app/styles/_substructure.less
+++ b/app/styles/_substructure.less
@@ -11,10 +11,14 @@ html,body {
 }
 .console-os {
   background-color: @body-bg;
+  &.tech-preview .top-header {
+    height: @navbar-os-header-height-mobile + @tech-preview-banner-height;
+  }
   .top-header {
     display: flex;
-    position:relative;
+    position: relative;
     height: @navbar-os-header-height-mobile;
+
   }
   .wrap {
     display: flex;
@@ -106,11 +110,20 @@ html,body {
     /* width: inherit; used if parent is using width: can't use 100% or auto */
   }
   .console-os {
+    &.tech-preview {
+      .top-header {
+        height: @navbar-os-header-height-desktop + @tech-preview-banner-height;
+      }
+      .wrap {
+        margin-top: -(@navbar-os-header-height-desktop + @tech-preview-banner-height); /* top offset height */
+        padding-top: @navbar-os-header-height-desktop + @tech-preview-banner-height; /* top offset height */
+      }
+    }
     .wrap {
       flex-direction: row;
-      margin-top:-@navbar-os-header-height-desktop; /* top offset height */
-      overflow:hidden;
-      padding-top:@navbar-os-header-height-desktop; /* top offset height */
+      margin-top: -@navbar-os-header-height-desktop; /* top offset height */
+      overflow: hidden;
+      padding-top: @navbar-os-header-height-desktop; /* top offset height */
       &.no-sidebar {
         .sidebar-left {
           display: none !important;

--- a/app/styles/_variables.less
+++ b/app/styles/_variables.less
@@ -105,6 +105,7 @@
 @scrollbar-width: 15px;
 @status-bg-color: #E6ECF1;
 @status-border-color: #BFCEDB;
+@tech-preview-banner-height: 20px;
 @tileHeadingIconFontSize: 33px;
 @tooltip-bg: #111;
 

--- a/app/views/directives/header/_tech-preview-banner.html
+++ b/app/views/directives/header/_tech-preview-banner.html
@@ -1,0 +1,1 @@
+Technology preview is enabled

--- a/app/views/directives/header/default-header.html
+++ b/app/views/directives/header/default-header.html
@@ -1,3 +1,4 @@
+<ng-include ng-if="globalTechPreviewIndicator" src="'views/directives/header/_tech-preview-banner.html'" class="tech-preview-banner"></ng-include>
 <nav class="navbar navbar-pf-alt" role="navigation">
   <div row>
     <div class="navbar-header">

--- a/app/views/directives/header/project-header.html
+++ b/app/views/directives/header/project-header.html
@@ -1,3 +1,4 @@
+<ng-include ng-if="globalTechPreviewIndicator" src="'views/directives/header/_tech-preview-banner.html'" class="tech-preview-banner"></ng-include>
 <nav class="navbar navbar-pf-alt" role="navigation">
   <div class="navbar-header hidden-xs">
     <a class="navbar-home" href="./"><span class="fa-fw pficon pficon-home" aria-hidden="true"></span>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1166,6 +1166,8 @@ return h ? b(e, null) || d :a(e, null, f, g) || d;
 }, 1e3);
 } ]).run([ "IS_IOS", function(a) {
 a && $("body").addClass("ios");
+} ]).run([ "$rootScope", function(a) {
+_.get(window, "OPENSHIFT_CONSTANTS.ENABLE_TECH_PREVIEW_FEATURE.service_catalog_landing_page") && (a.globalTechPreviewIndicator = !0, $("body").addClass("tech-preview"));
 } ]), hawtioPluginLoader.addModule("openshiftConsole"), angular.module("openshiftConsole").factory("APIDiscovery", [ "LOGGING_URL", "METRICS_URL", "$q", function(a, b, c) {
 return {
 getLoggingURL:function() {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7021,7 +7021,13 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/directives/header/_tech-preview-banner.html',
+    "Technology preview is enabled"
+  );
+
+
   $templateCache.put('views/directives/header/default-header.html',
+    "<ng-include ng-if=\"globalTechPreviewIndicator\" src=\"'views/directives/header/_tech-preview-banner.html'\" class=\"tech-preview-banner\"></ng-include>\n" +
     "<nav class=\"navbar navbar-pf-alt\" role=\"navigation\">\n" +
     "<div row>\n" +
     "<div class=\"navbar-header\">\n" +
@@ -7048,6 +7054,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/directives/header/project-header.html',
+    "<ng-include ng-if=\"globalTechPreviewIndicator\" src=\"'views/directives/header/_tech-preview-banner.html'\" class=\"tech-preview-banner\"></ng-include>\n" +
     "<nav class=\"navbar navbar-pf-alt\" role=\"navigation\">\n" +
     "<div class=\"navbar-header hidden-xs\">\n" +
     "<a class=\"navbar-home\" href=\"./\"><span class=\"fa-fw pficon pficon-home\" aria-hidden=\"true\"></span>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4255,6 +4255,7 @@ copy-to-clipboard .input-group.limit-width{max-width:300px}
 }
 .landing .nav-tabs,.landing h1{margin-bottom:0!important;margin-top:0!important}
 @media (min-width:768px){.catalog-search,.landing-side-bar{top:61px}
+.tech-preview .catalog-search,.tech-preview .landing-side-bar{top:81px}
 }
 .collapse{display:none}
 .collapse.in{display:block}
@@ -4704,6 +4705,7 @@ h2+.list-view-pf{margin-top:20px}
 #header-logo{background-image:url(../images/logo-origin-thin.svg);background-repeat:no-repeat;background-position:center left;background-size:initial;height:46px;width:230px}
 .navbar-pf-alt{background:#1c2127;border-bottom:1px solid #050505;border-left:1px solid transparent;border-right:1px solid transparent;border-top:0;min-height:inherit}
 .layout-pf-alt-fixed .navbar-pf-alt{left:0;position:fixed;right:0;top:0;z-index:1030}
+.layout-pf-alt-fixed .tech-preview .navbar-pf-alt{top:20px}
 .navbar-pf-alt .navbar-toggle{margin:0;padding:9px 14px}
 @media (max-width:479px){.navbar-pf-alt .navbar-toggle{padding-left:8px;padding-right:8px}
 }
@@ -4771,6 +4773,7 @@ h2+.list-view-pf{margin-top:20px}
 @media (min-width:768px){.navbar-pf-alt .navbar-header{height:60px;width:143px}
 .navbar-pf-alt .navbar-header .navbar-brand{padding:0;margin-left:30px;margin-right:75px;margin-top:0}
 .navbar-flex-btn.toggle-menu{display:none}
+.tech-preview-banner{position:fixed}
 }
 @media (min-width:1200px){.navbar-pf-alt .navbar-header{width:143px}
 }
@@ -4779,6 +4782,7 @@ h2+.list-view-pf{margin-top:20px}
 .navbar-pf-alt .navbar-header .navbar-home .pficon{display:inline-block;width:25px;margin-right:10px}
 .navbar-pf-alt .navbar-header .navbar-home .visible-xlg-inline-block{margin-left:3px}
 }
+.tech-preview-banner{background:#ec7a08;color:#fff;font-size:12px;text-align:center;text-transform:uppercase;width:100%;z-index:1030}
 @font-face{font-family:openshift-logos-icon;src:url(../styles/fonts/openshift-logos-icon.ttf) format('truetype'),url(../styles/fonts/openshift-logos-icon.woff) format('woff'),url(../styles/fonts/openshift-logos-icon.svg#openshift-logos-icon) format('svg');font-weight:400;font-style:normal}
 .font-icon{font-family:openshift-logos-icon!important;speak:none;font-style:normal;font-weight:400;font-variant:normal;text-transform:none;line-height:1;-webkit-font-smoothing:antialiased}
 .icon-mediawiki:before{content:"\f158"}
@@ -5325,6 +5329,7 @@ dl.secret-data pre{margin-bottom:0}
 body,html{margin:0;padding:0}
 .layout-pf-alt.layout-pf-alt-fixed body{padding-top:0}
 .console-os{background-color:#fff}
+.console-os.tech-preview .top-header{height:66px}
 .console-os .top-header{display:flex;position:relative;height:46px}
 .console-os .wrap{display:flex;flex-direction:column;height:100vh;margin-top:-46px;padding-top:46px;position:relative;width:100%;-webkit-backface-visibility:hidden;-moz-backface-visibility:hidden;backface-visibility:hidden}
 .console-os .wrap.no-sidebar h1{margin:10px 0 20px}
@@ -5344,6 +5349,8 @@ body,html{margin:0;padding:0}
 .header-toolbar{background-color:#fff;border-bottom:1px solid #e4e4e4}
 .surface-shaded{background-color:#f2f2f2}
 @media (min-width:768px){.layout-pf-alt-fixed .nav-pf-vertical-alt{position:fixed;bottom:0;overflow:visible}
+.console-os.tech-preview .top-header{height:80px}
+.console-os.tech-preview .wrap{margin-top:-80px;padding-top:80px}
 .console-os .wrap{flex-direction:row;margin-top:-60px;overflow:hidden;padding-top:60px}
 .console-os .wrap.no-sidebar .sidebar-left{display:none!important}
 .console-os .wrap.show-sidebar-right .sidebar-right{display:block}
@@ -5608,6 +5615,7 @@ alerts+.chromeless .log-loading-msg{margin-top:130px}
 .log-view .log-scroll-top{position:absolute;right:25px;top:10px}
 .log-view .log-scroll-top.affix{position:fixed;right:45px}
 @media (min-width:768px){.log-view .log-scroll-top.affix{right:60px;top:70px}
+.tech-preview .log-view .log-scroll-top.affix{top:90px}
 }
 @media (min-width:992px){.log-view .log-scroll-top.affix{right:70px}
 }


### PR DESCRIPTION
Fixes #1699

Following the design direction set by the page-level "Technology Preview" badge, how about an orange bar above the navbar?  Exact message wording to be determined.

![screen shot 2017-06-15 at 10 27 00 am](https://user-images.githubusercontent.com/895728/27186092-4f729db0-51b5-11e7-869e-6521092ca4c0.PNG)
![screen shot 2017-06-15 at 10 26 23 am](https://user-images.githubusercontent.com/895728/27186094-4f76e46a-51b5-11e7-8ccc-5684fea9d002.PNG)

![screen shot 2017-06-15 at 10 29 02 am](https://user-images.githubusercontent.com/895728/27186202-93fbf698-51b5-11e7-896c-58baa0b2fdd3.PNG)
![screen shot 2017-06-15 at 10 29 39 am](https://user-images.githubusercontent.com/895728/27186200-91cc5cf0-51b5-11e7-9af0-330a49a4a479.PNG)



