### PR TITLE
Bug 1461346 - Filter events by UID

### DIFF
--- a/app/scripts/controllers/build.js
+++ b/app/scripts/controllers/build.js
@@ -58,6 +58,8 @@ angular.module('openshiftConsole')
       title: $routeParams.build
     });
 
+    var buildPod;
+    var annotation = $filter('annotation');
     var watches = [];
 
     var setLogVars = function(build) {
@@ -72,45 +74,6 @@ angular.module('openshiftConsole')
       }
     };
 
-    var buildResolved = function(build, action) {
-      $scope.loaded = true;
-      $scope.build = build;
-      setLogVars(build);
-
-      var buildNumber = $filter("annotation")(build, "buildNumber");
-      if (buildNumber) {
-        $scope.breadcrumbs[2].title = "#" + buildNumber;
-      }
-      if (action === "DELETED") {
-        $scope.alerts["deleted"] = {
-          type: "warning",
-          message: "This build has been deleted."
-        };
-      }
-    };
-
-    var buildRejected = function(e) {
-      $scope.loaded = true;
-      $scope.alerts["load"] = {
-        type: "error",
-        message: "The build details could not be loaded.",
-        details: $filter('getErrorDetails')(e)
-      };
-    };
-
-    var buildConfigResolved = function(buildConfig, action) {
-      if (action === "DELETED") {
-        $scope.alerts["deleted"] = {
-          type: "warning",
-          message: "Build configuration " + $scope.buildConfigName + " has been deleted."
-        };
-        $scope.buildConfigDeleted = true;
-      }
-      $scope.buildConfig = buildConfig;
-      $scope.buildConfigPaused = BuildsService.isPaused($scope.buildConfig);
-      updateCanBuild();
-    };
-
 
     ProjectsService
       .get($routeParams.project)
@@ -122,6 +85,67 @@ angular.module('openshiftConsole')
         // context into the log-viewer directive.
         $scope.projectContext = context;
         $scope.logOptions = {};
+
+        var updateEventObjects = function() {
+          if (buildPod) {
+            $scope.eventObjects = [$scope.build, buildPod];
+          } else {
+            $scope.eventObjects = [$scope.build];
+          }
+        };
+
+        var buildResolved = function(build, action) {
+          $scope.loaded = true;
+          $scope.build = build;
+          setLogVars(build);
+          updateEventObjects();
+
+          var buildNumber = annotation(build, "buildNumber");
+          if (buildNumber) {
+            $scope.breadcrumbs[2].title = "#" + buildNumber;
+          }
+          if (action === "DELETED") {
+            $scope.alerts["deleted"] = {
+              type: "warning",
+              message: "This build has been deleted."
+            };
+          }
+
+          var buildPodName;
+          if (!buildPod) {
+            buildPodName = annotation(build, 'buildPod');
+            if (buildPodName) {
+              // Don't show an error if we can't get the build pod. Often it will have been deleted.
+              DataService.get("pods", buildPodName, context, { errorNotification: false }).then(function(response) {
+                buildPod = response;
+                updateEventObjects();
+              });
+            }
+          }
+        };
+
+        var buildRejected = function(e) {
+          $scope.loaded = true;
+          $scope.alerts["load"] = {
+            type: "error",
+            message: "The build details could not be loaded.",
+            details: $filter('getErrorDetails')(e)
+          };
+        };
+
+        var buildConfigResolved = function(buildConfig, action) {
+          if (action === "DELETED") {
+            $scope.alerts["deleted"] = {
+              type: "warning",
+              message: "Build configuration " + $scope.buildConfigName + " has been deleted."
+            };
+            $scope.buildConfigDeleted = true;
+          }
+          $scope.buildConfig = buildConfig;
+          $scope.buildConfigPaused = BuildsService.isPaused($scope.buildConfig);
+          updateCanBuild();
+        };
+
         DataService
           .get("builds", $routeParams.build, context, { errorNotification: false })
           .then(function(build) {

--- a/app/scripts/directives/events.js
+++ b/app/scripts/directives/events.js
@@ -5,28 +5,26 @@ angular.module('openshiftConsole')
     return {
       restrict: 'E',
       scope: {
-        resourceKind: "@?",
-        resourceName: "@?",
+        apiObjects: "=?",
         projectContext: "="
       },
       templateUrl: 'views/directives/events.html',
-      controller: function($scope){
+      controller: function($scope) {
+        var allEvents;
+        var uids = {};
+        var watches = [];
+
         $scope.filter = {
           text: ''
         };
 
         var filterForResource = function(events) {
-          // If there is a kind, but no name, assume that the name hasn't been
-          // set yet and none of the events should match. This is the case with
-          // build resources and that have a build pod annotation, which isn't
-          // set until the build starts running.
-          if (!$scope.resourceKind) {
+          if (_.isEmpty(uids)) {
             return events;
           }
 
           return _.filter(events, function(event) {
-            return event.involvedObject.kind === $scope.resourceKind &&
-                   event.involvedObject.name === $scope.resourceName;
+            return uids[event.involvedObject.uid];
           });
         };
 
@@ -69,7 +67,7 @@ angular.module('openshiftConsole')
 
         $scope.$watch('filter.text', _.debounce(function() {
           updateKeywords();
-          $scope.$apply(filterForKeyword);
+          $scope.$evalAsync(filterForKeyword);
         }, 50, { maxWait: 250 }));
 
         var update = function() {
@@ -80,56 +78,83 @@ angular.module('openshiftConsole')
 
         // Invoke update when first called, debouncing subsequent calls.
         var debounceUpdate = _.debounce(function() {
-          $scope.$evalAsync(update);
+          if (!allEvents) {
+            return;
+          }
+
+          $scope.$evalAsync(function() {
+            // Assign `$scope.events` here instead of the watch callback to
+            // avoid the "Filter hiding all events" message from flickering
+            // briefly before the debounced filter and update calls.
+            $scope.events = filterForResource(allEvents);
+            update();
+          });
         }, 250, {
           leading: true,
-          trailing: false,
+          trailing: true,
           maxWait: 1000
         });
 
-        // Set up the sort configuration for `pf-sort`.
-        $scope.sortConfig = {
-          fields: [{
-            id: 'lastTimestamp',
-            title: 'Time',
-            sortType: 'alpha'
-          }, {
-            id: 'type',
-            title: 'Severity',
-            sortType: 'alpha'
-          }, {
-            id: 'reason',
-            title: 'Reason',
-            sortType: 'alpha'
-          }, {
-            id: 'message',
-            title: 'Message',
-            sortType: 'alpha'
-          }, {
-            id: 'count',
-            title: 'Count',
-            sortType: 'numeric'
-          }],
-          isAscending: true,
-          onSortChange: update
-        };
-
-        // Conditionally add kind and name to sort fields if not passed to the directive.
-        if (!$scope.resourceKind || !$scope.resourceName) {
-          $scope.sortConfig.fields.splice(1, 0, {
-            id: 'involvedObject.name',
-            title: 'Name',
-            sortType: 'alpha'
-          }, {
-            id: 'involvedObject.kind',
-            title: 'Kind',
-            sortType: 'alpha'
+        $scope.$watch('apiObjects', function(apiObjects) {
+          // Create a map of UIDs to for quick lookup (key UID, value `true`).
+          uids = {};
+          _.each(apiObjects, function(apiObject) {
+            var uid = _.get(apiObject, 'metadata.uid');
+            if (uid) {
+              uids[apiObject.metadata.uid] = true;
+            }
           });
-        }
+          $scope.showKindAndName = _.size(uids) !== 1;
 
-        var watches = [];
+          if (allEvents) {
+            debounceUpdate();
+          }
+        });
+
+        $scope.$watch('showKindAndName', function(showKindAndName) {
+          // Set up the sort configuration for `pf-sort`.
+          $scope.sortConfig = {
+            fields: [{
+              id: 'lastTimestamp',
+              title: 'Time',
+              sortType: 'alpha'
+            }, {
+              id: 'type',
+              title: 'Severity',
+              sortType: 'alpha'
+            }, {
+              id: 'reason',
+              title: 'Reason',
+              sortType: 'alpha'
+            }, {
+              id: 'message',
+              title: 'Message',
+              sortType: 'alpha'
+            }, {
+              id: 'count',
+              title: 'Count',
+              sortType: 'numeric'
+            }],
+            isAscending: true,
+            onSortChange: update
+          };
+
+          // Conditionally add kind and name to sort fields if not passed to the directive.
+          if (showKindAndName) {
+            $scope.sortConfig.fields.splice(1, 0, {
+              id: 'involvedObject.name',
+              title: 'Name',
+              sortType: 'alpha'
+            }, {
+              id: 'involvedObject.kind',
+              title: 'Kind',
+              sortType: 'alpha'
+            });
+          }
+        });
+
         watches.push(DataService.watch("events", $scope.projectContext, function(events) {
-          $scope.events = filterForResource(events.by('metadata.name'));
+          allEvents = events.by("metadata.name");
           debounceUpdate();
           Logger.log("events (subscribe)", $scope.filteredEvents);
         }));
@@ -137,7 +162,6 @@ angular.module('openshiftConsole')
         $scope.$on('$destroy', function(){
           DataService.unwatchAll(watches);
         });
-
       },
     };
   });

--- a/app/views/browse/build.html
+++ b/app/views/browse/build.html
@@ -142,7 +142,7 @@
                     </uib-tab>
                     <uib-tab active="selectedTab.events" ng-if="('events' | canI : 'watch')">
                       <uib-tab-heading>Events</uib-tab-heading>
-                      <events resource-kind="Pod" resource-name="{{build | annotation : 'buildPod'}}" project-context="projectContext" ng-if="selectedTab.events"></events>
+                      <events api-objects="eventObjects" project-context="projectContext" ng-if="selectedTab.events"></events>
                     </uib-tab>
                   </uib-tabset>
 

--- a/app/views/browse/deployment-config.html
+++ b/app/views/browse/deployment-config.html
@@ -382,7 +382,7 @@
                   </uib-tab>
                   <uib-tab active="selectedTab.events" ng-if="'events' | canI : 'watch'">
                     <uib-tab-heading>Events</uib-tab-heading>
-                    <events resource-kind="DeploymentConfig" resource-name="{{deploymentConfig.metadata.name}}" project-context="projectContext" ng-if="selectedTab.events"></events>
+                    <events api-objects="[ deploymentConfig ]" project-context="projectContext" ng-if="selectedTab.events"></events>
                   </uib-tab>
                 </uib-tabset>
               </div><!-- /col-* -->

--- a/app/views/browse/deployment.html
+++ b/app/views/browse/deployment.html
@@ -298,7 +298,7 @@
                 </uib-tab>
                 <uib-tab active="selectedTab.events" ng-if="'events' | canI : 'watch'">
                   <uib-tab-heading>Events</uib-tab-heading>
-                  <events resource-kind="Deployment" resource-name="{{deployment.metadata.name}}" project-context="projectContext" ng-if="selectedTab.events"></events>
+                  <events api-objects="[ deployment ]" project-context="projectContext" ng-if="selectedTab.events"></events>
                 </uib-tab>
               </uib-tabset>
             </div><!-- /col-* -->

--- a/app/views/browse/persistent-volume-claim.html
+++ b/app/views/browse/persistent-volume-claim.html
@@ -83,7 +83,7 @@
                 </uib-tab>
                 <uib-tab active="selectedTab.events" ng-if="'events' | canI : 'watch'">
                   <uib-tab-heading>Events</uib-tab-heading>
-                  <events resource-kind="PersistentVolumeClaim" resource-name="{{pvc.metadata.name}}" project-context="projectContext" ng-if="selectedTab.events"></events>
+                  <events api-objects="[ pvc ] " project-context="projectContext" ng-if="selectedTab.events"></events>
                 </uib-tab>
               </uib-tabset>
             </div><!-- /col-* -->

--- a/app/views/browse/pod.html
+++ b/app/views/browse/pod.html
@@ -220,7 +220,7 @@
 
                   <uib-tab active="selectedTab.events" ng-if="'events' | canI : 'watch'">
                     <uib-tab-heading>Events</uib-tab-heading>
-                    <events resource-kind="Pod" resource-name="{{pod.metadata.name}}" project-context="projectContext" ng-if="selectedTab.events"></events>
+                    <events api-objects="[ pod ]" project-context="projectContext" ng-if="selectedTab.events"></events>
                   </uib-tab>
                 </uib-tabset>
               </div><!-- /col-* -->

--- a/app/views/browse/replica-set.html
+++ b/app/views/browse/replica-set.html
@@ -150,7 +150,7 @@
                   </uib-tab>
                   <uib-tab active="selectedTab.events" ng-if="'events' | canI : 'watch'">
                     <uib-tab-heading>Events</uib-tab-heading>
-                    <events resource-kind="{{kind}}" resource-name="{{replicaSet.metadata.name}}" project-context="projectContext" ng-if="selectedTab.events"></events>
+                    <events api-objects="[ replicaSet ]" project-context="projectContext" ng-if="selectedTab.events"></events>
                   </uib-tab>
                 </uib-tabset>
               </div><!-- /col-* -->

--- a/app/views/browse/service.html
+++ b/app/views/browse/service.html
@@ -107,7 +107,7 @@
                 </uib-tab>
                 <uib-tab active="selectedTab.events" ng-if="'events' | canI : 'watch'">
                   <uib-tab-heading>Events</uib-tab-heading>
-                  <events resource-kind="Service" resource-name="{{service.metadata.name}}" project-context="projectContext" ng-if="selectedTab.events"></events>
+                  <events api-objects="[ service ]" project-context="projectContext" ng-if="selectedTab.events"></events>
                 </uib-tab>
               </uib-tabset>
             </div><!-- /col-* -->

--- a/app/views/browse/stateful-set.html
+++ b/app/views/browse/stateful-set.html
@@ -186,11 +186,7 @@
                 <uib-tab active="selectedTab.events">
                   <uib-tab-heading>Events</uib-tab-heading>
                   <div class="resource-events">
-                      <events
-                        resource-kind="StatefulSet"
-                        resource-name="{{statefulSet.metadata.name}}"
-                        project-context="projectContext"
-                        ng-if="selectedTab.events"></events>
+                    <events api-objects="[ statefulSet ]" project-context="projectContext" ng-if="selectedTab.events"></events>
                   </div>
                 </uib-tab>
 

--- a/app/views/directives/events.html
+++ b/app/views/directives/events.html
@@ -37,11 +37,11 @@
       <tr>
         <th id="time">Time</th>
         <!-- Only show Name and Kind columns if not passed to the directive. -->
-        <th id="kind-name" ng-if="!resourceKind || !resourceName">
+        <th id="kind-name" ng-if="showKindAndName">
           <span class="hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline">Kind and Name</span>
           <span class="visible-lg-inline">Name</span>
         </th>
-        <th id="kind" ng-if="!resourceKind || !resourceName" class="hidden-sm hidden-md">
+        <th id="kind" ng-if="showKindAndName" class="hidden-sm hidden-md">
           <span class="visible-lg-inline">Kind</span>
         </th>
         <th id="severity" class="hidden-xs hidden-sm hidden-md"><span class="sr-only">Severity</span></th>
@@ -51,14 +51,14 @@
     </thead>
     <tbody ng-if="(filteredEvents | hashSize) === 0">
       <tr>
-        <td class="hidden-lg" colspan="{{!resourceKind || !resourceName ? 3 : 2}}">
+        <td class="hidden-lg" colspan="{{showKindAndName ? 3 : 2}}">
           <span ng-if="(events | hashSize) === 0"><em>No events to show.</em></span>
           <span ng-if="(events | hashSize) > 0">
             All events hidden by filter.
             <a href="" ng-click="filter.text = ''" role="button">Clear Filter</a>
           </span>
         </td>
-          <td class="hidden-xs hidden-sm hidden-md" colspan="{{!resourceKind || !resourceName ? 6 : 4}}">
+          <td class="hidden-xs hidden-sm hidden-md" colspan="{{showKindAndName ? 6 : 4}}">
           <span ng-if="(events | hashSize) === 0"><em>No events to show.</em></span>
           <span ng-if="(events | hashSize) > 0">
             All events hidden by filter.
@@ -70,7 +70,7 @@
     <tbody ng-if="(filteredEvents | hashSize) > 0">
       <tr ng-repeat="event in filteredEvents">
         <td data-title="Time" class="nowrap">{{event.lastTimestamp | date:'mediumTime'}}</td>
-        <td ng-if="!resourceKind || !resourceName" data-title="Name">
+        <td ng-if="showKindAndName" data-title="Name">
           <div class="hidden-xs-block visible-sm-block visible-md-block hidden-lg-block">
             <span ng-bind-html="event.involvedObject.kind | humanizeKind : true | highlightKeywords : filterExpressions"></span>
           </div>
@@ -81,7 +81,7 @@
             <span ng-if="!resourceURL" ng-bind-html="event.involvedObject.name | highlightKeywords : filterExpressions"></span>
           </span>
         </td>
-        <td ng-if="!resourceKind || !resourceName" class="hidden-sm hidden-md" data-title="Kind">
+        <td ng-if="showKindAndName" class="hidden-sm hidden-md" data-title="Kind">
           <span ng-bind-html="event.involvedObject.kind | humanizeKind : true | highlightKeywords : filterExpressions"></span>
         </td>
         <td data-title="Severity" class="hidden-xs hidden-sm hidden-md text-center severity-icon-td">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5078,35 +5078,45 @@ link:"project/" + c.project + "/browse/builds/" + c.buildconfig
 })), a.breadcrumbs.push({
 title:c.build
 });
-var i = [], j = function(b) {
+var i, j = b("annotation"), k = [], l = function(b) {
 a.logCanRun = !_.includes([ "New", "Pending", "Error" ], b.status.phase);
-}, k = function() {
+}, m = function() {
 a.buildConfig ? a.canBuild = d.canBuild(a.buildConfig) :a.canBuild = !1;
-}, l = function(c, d) {
-a.loaded = !0, a.build = c, j(c);
-var e = b("annotation")(c, "buildNumber");
-e && (a.breadcrumbs[2].title = "#" + e), "DELETED" === d && (a.alerts.deleted = {
+};
+h.get(c.project).then(_.spread(function(g, h) {
+a.project = g, a.projectContext = h, a.logOptions = {};
+var n = function() {
+i ? a.eventObjects = [ a.build, i ] :a.eventObjects = [ a.build ];
+}, o = function(b, c) {
+a.loaded = !0, a.build = b, l(b), n();
+var d = j(b, "buildNumber");
+d && (a.breadcrumbs[2].title = "#" + d), "DELETED" === c && (a.alerts.deleted = {
 type:"warning",
 message:"This build has been deleted."
 });
-}, m = function(c) {
+var f;
+i || (f = j(b, "buildPod"), f && e.get("pods", f, h, {
+errorNotification:!1
+}).then(function(a) {
+i = a, n();
+}));
+}, p = function(c) {
 a.loaded = !0, a.alerts.load = {
 type:"error",
 message:"The build details could not be loaded.",
 details:b("getErrorDetails")(c)
 };
-}, n = function(b, c) {
+}, q = function(b, c) {
 "DELETED" === c && (a.alerts.deleted = {
 type:"warning",
 message:"Build configuration " + a.buildConfigName + " has been deleted."
-}, a.buildConfigDeleted = !0), a.buildConfig = b, a.buildConfigPaused = d.isPaused(a.buildConfig), k();
+}, a.buildConfigDeleted = !0), a.buildConfig = b, a.buildConfigPaused = d.isPaused(a.buildConfig), m();
 };
-h.get(c.project).then(_.spread(function(b, g) {
-a.project = b, a.projectContext = g, a.logOptions = {}, e.get("builds", c.build, g, {
+e.get("builds", c.build, h, {
 errorNotification:!1
 }).then(function(a) {
-l(a), i.push(e.watchObject("builds", c.build, g, l)), i.push(e.watchObject("buildconfigs", c.buildconfig, g, n));
-}, m), a.toggleSecret = function() {
+o(a), k.push(e.watchObject("builds", c.build, h, o)), k.push(e.watchObject("buildconfigs", c.buildconfig, h, q));
+}, p), a.toggleSecret = function() {
 a.showSecret = !0;
 }, a.cancelBuild = function() {
 d.cancelBuild(a.build, a.buildConfigName);
@@ -5115,7 +5125,7 @@ a.build && a.canBuild && d.cloneBuild(a.build, a.buildConfigName);
 }, a.showJenkinsfileExamples = function() {
 f.showJenkinsfileExamples();
 }, a.$on("$destroy", function() {
-e.unwatchAll(i);
+e.unwatchAll(k);
 });
 }));
 } ]), angular.module("openshiftConsole").controller("ImageController", [ "$scope", "$routeParams", "DataService", "ProjectsService", "$filter", "ImageStreamsService", "imageLayers", function(a, b, c, d, e, f, g) {
@@ -8894,47 +8904,55 @@ c[a.key] = a.value;
 return {
 restrict:"E",
 scope:{
-resourceKind:"@?",
-resourceName:"@?",
+apiObjects:"=?",
 projectContext:"="
 },
 templateUrl:"views/directives/events.html",
 controller:[ "$scope", function(a) {
+var b, e = {}, g = [];
 a.filter = {
 text:""
 };
-var b = function(b) {
-return a.resourceKind ? _.filter(b, function(b) {
-return b.involvedObject.kind === a.resourceKind && b.involvedObject.name === a.resourceName;
-}) :b;
-}, e = [], g = _.get(a, "sortConfig.currentField.id"), h = {
+var h = function(a) {
+return _.isEmpty(e) ? a :_.filter(a, function(a) {
+return e[a.involvedObject.uid];
+});
+}, i = [], j = _.get(a, "sortConfig.currentField.id"), k = {
 lastTimestamp:!0
-}, i = function() {
+}, l = function() {
 var b = _.get(a, "sortConfig.currentField.id", "lastTimestamp");
-g !== b && (g = b, a.sortConfig.isAscending = !h[g]);
+j !== b && (j = b, a.sortConfig.isAscending = !k[j]);
 var c = a.sortConfig.isAscending ? "asc" :"desc";
-e = _.sortByOrder(a.events, [ b ], [ c ]);
-}, j = [], k = function() {
-a.filterExpressions = j = d.generateKeywords(_.get(a, "filter.text"));
-}, l = [ "reason", "message", "type" ];
-a.resourceKind && a.resourceName || l.splice(0, 0, "involvedObject.name", "involvedObject.kind");
-var m = function() {
-a.filteredEvents = d.filterForKeywords(e, l, j);
+i = _.sortByOrder(a.events, [ b ], [ c ]);
+}, m = [], n = function() {
+a.filterExpressions = m = d.generateKeywords(_.get(a, "filter.text"));
+}, o = [ "reason", "message", "type" ];
+a.resourceKind && a.resourceName || o.splice(0, 0, "involvedObject.name", "involvedObject.kind");
+var p = function() {
+a.filteredEvents = d.filterForKeywords(i, o, m);
 };
 a.$watch("filter.text", _.debounce(function() {
-k(), a.$apply(m);
+n(), a.$evalAsync(p);
 }, 50, {
 maxWait:250
 }));
-var n = function() {
-i(), m();
-}, o = _.debounce(function() {
-a.$evalAsync(n);
+var q = function() {
+l(), p();
+}, r = _.debounce(function() {
+b && a.$evalAsync(function() {
+a.events = h(b), q();
+});
 }, 250, {
 leading:!0,
-trailing:!1,
+trailing:!0,
 maxWait:1e3
 });
+a.$watch("apiObjects", function(c) {
+e = {}, _.each(c, function(a) {
+var b = _.get(a, "metadata.uid");
+b && (e[a.metadata.uid] = !0);
+}), a.showKindAndName = 1 !== _.size(e), b && r();
+}), a.$watch("showKindAndName", function(b) {
 a.sortConfig = {
 fields:[ {
 id:"lastTimestamp",
@@ -8958,8 +8976,8 @@ title:"Count",
 sortType:"numeric"
 } ],
 isAscending:!0,
-onSortChange:n
-}, a.resourceKind && a.resourceName || a.sortConfig.fields.splice(1, 0, {
+onSortChange:q
+}, b && a.sortConfig.fields.splice(1, 0, {
 id:"involvedObject.name",
 title:"Name",
 sortType:"alpha"
@@ -8968,11 +8986,10 @@ id:"involvedObject.kind",
 title:"Kind",
 sortType:"alpha"
 });
-var p = [];
-p.push(c.watch("events", a.projectContext, function(c) {
-a.events = b(c.by("metadata.name")), o(), f.log("events (subscribe)", a.filteredEvents);
+}), g.push(c.watch("events", a.projectContext, function(c) {
+b = c.by("metadata.name"), r(), f.log("events (subscribe)", a.filteredEvents);
 })), a.$on("$destroy", function() {
-c.unwatchAll(p);
+c.unwatchAll(g);
 });
 } ]
 };

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2136,7 +2136,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</uib-tab>\n" +
     "<uib-tab active=\"selectedTab.events\" ng-if=\"('events' | canI : 'watch')\">\n" +
     "<uib-tab-heading>Events</uib-tab-heading>\n" +
-    "<events resource-kind=\"Pod\" resource-name=\"{{build | annotation : 'buildPod'}}\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
+    "<events api-objects=\"eventObjects\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
     "</uib-tab>\n" +
     "</uib-tabset>\n" +
     "</div>\n" +
@@ -2600,7 +2600,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</uib-tab>\n" +
     "<uib-tab active=\"selectedTab.events\" ng-if=\"'events' | canI : 'watch'\">\n" +
     "<uib-tab-heading>Events</uib-tab-heading>\n" +
-    "<events resource-kind=\"DeploymentConfig\" resource-name=\"{{deploymentConfig.metadata.name}}\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
+    "<events api-objects=\"[ deploymentConfig ]\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
     "</uib-tab>\n" +
     "</uib-tabset>\n" +
     "</div>\n" +
@@ -2836,7 +2836,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</uib-tab>\n" +
     "<uib-tab active=\"selectedTab.events\" ng-if=\"'events' | canI : 'watch'\">\n" +
     "<uib-tab-heading>Events</uib-tab-heading>\n" +
-    "<events resource-kind=\"Deployment\" resource-name=\"{{deployment.metadata.name}}\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
+    "<events api-objects=\"[ deployment ]\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
     "</uib-tab>\n" +
     "</uib-tabset>\n" +
     "</div>\n" +
@@ -3040,7 +3040,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</uib-tab>\n" +
     "<uib-tab active=\"selectedTab.events\" ng-if=\"'events' | canI : 'watch'\">\n" +
     "<uib-tab-heading>Events</uib-tab-heading>\n" +
-    "<events resource-kind=\"PersistentVolumeClaim\" resource-name=\"{{pvc.metadata.name}}\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
+    "<events api-objects=\"[ pvc ] \" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
     "</uib-tab>\n" +
     "</uib-tabset>\n" +
     "</div>\n" +
@@ -3202,7 +3202,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</uib-tab>\n" +
     "<uib-tab active=\"selectedTab.events\" ng-if=\"'events' | canI : 'watch'\">\n" +
     "<uib-tab-heading>Events</uib-tab-heading>\n" +
-    "<events resource-kind=\"Pod\" resource-name=\"{{pod.metadata.name}}\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
+    "<events api-objects=\"[ pod ]\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
     "</uib-tab>\n" +
     "</uib-tabset>\n" +
     "</div>\n" +
@@ -3305,7 +3305,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</uib-tab>\n" +
     "<uib-tab active=\"selectedTab.events\" ng-if=\"'events' | canI : 'watch'\">\n" +
     "<uib-tab-heading>Events</uib-tab-heading>\n" +
-    "<events resource-kind=\"{{kind}}\" resource-name=\"{{replicaSet.metadata.name}}\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
+    "<events api-objects=\"[ replicaSet ]\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
     "</uib-tab>\n" +
     "</uib-tabset>\n" +
     "</div>\n" +
@@ -3816,7 +3816,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</uib-tab>\n" +
     "<uib-tab active=\"selectedTab.events\" ng-if=\"'events' | canI : 'watch'\">\n" +
     "<uib-tab-heading>Events</uib-tab-heading>\n" +
-    "<events resource-kind=\"Service\" resource-name=\"{{service.metadata.name}}\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
+    "<events api-objects=\"[ service ]\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
     "</uib-tab>\n" +
     "</uib-tabset>\n" +
     "</div>\n" +
@@ -3945,7 +3945,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<uib-tab active=\"selectedTab.events\">\n" +
     "<uib-tab-heading>Events</uib-tab-heading>\n" +
     "<div class=\"resource-events\">\n" +
-    "<events resource-kind=\"StatefulSet\" resource-name=\"{{statefulSet.metadata.name}}\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
+    "<events api-objects=\"[ statefulSet ]\" project-context=\"projectContext\" ng-if=\"selectedTab.events\"></events>\n" +
     "</div>\n" +
     "</uib-tab>\n" +
     "</uib-tabset>\n" +
@@ -6799,11 +6799,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tr>\n" +
     "<th id=\"time\">Time</th>\n" +
     "\n" +
-    "<th id=\"kind-name\" ng-if=\"!resourceKind || !resourceName\">\n" +
+    "<th id=\"kind-name\" ng-if=\"showKindAndName\">\n" +
     "<span class=\"hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline\">Kind and Name</span>\n" +
     "<span class=\"visible-lg-inline\">Name</span>\n" +
     "</th>\n" +
-    "<th id=\"kind\" ng-if=\"!resourceKind || !resourceName\" class=\"hidden-sm hidden-md\">\n" +
+    "<th id=\"kind\" ng-if=\"showKindAndName\" class=\"hidden-sm hidden-md\">\n" +
     "<span class=\"visible-lg-inline\">Kind</span>\n" +
     "</th>\n" +
     "<th id=\"severity\" class=\"hidden-xs hidden-sm hidden-md\"><span class=\"sr-only\">Severity</span></th>\n" +
@@ -6813,14 +6813,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</thead>\n" +
     "<tbody ng-if=\"(filteredEvents | hashSize) === 0\">\n" +
     "<tr>\n" +
-    "<td class=\"hidden-lg\" colspan=\"{{!resourceKind || !resourceName ? 3 : 2}}\">\n" +
+    "<td class=\"hidden-lg\" colspan=\"{{showKindAndName ? 3 : 2}}\">\n" +
     "<span ng-if=\"(events | hashSize) === 0\"><em>No events to show.</em></span>\n" +
     "<span ng-if=\"(events | hashSize) > 0\">\n" +
     "All events hidden by filter.\n" +
     "<a href=\"\" ng-click=\"filter.text = ''\" role=\"button\">Clear Filter</a>\n" +
     "</span>\n" +
     "</td>\n" +
-    "<td class=\"hidden-xs hidden-sm hidden-md\" colspan=\"{{!resourceKind || !resourceName ? 6 : 4}}\">\n" +
+    "<td class=\"hidden-xs hidden-sm hidden-md\" colspan=\"{{showKindAndName ? 6 : 4}}\">\n" +
     "<span ng-if=\"(events | hashSize) === 0\"><em>No events to show.</em></span>\n" +
     "<span ng-if=\"(events | hashSize) > 0\">\n" +
     "All events hidden by filter.\n" +
@@ -6832,7 +6832,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tbody ng-if=\"(filteredEvents | hashSize) > 0\">\n" +
     "<tr ng-repeat=\"event in filteredEvents\">\n" +
     "<td data-title=\"Time\" class=\"nowrap\">{{event.lastTimestamp | date:'mediumTime'}}</td>\n" +
-    "<td ng-if=\"!resourceKind || !resourceName\" data-title=\"Name\">\n" +
+    "<td ng-if=\"showKindAndName\" data-title=\"Name\">\n" +
     "<div class=\"hidden-xs-block visible-sm-block visible-md-block hidden-lg-block\">\n" +
     "<span ng-bind-html=\"event.involvedObject.kind | humanizeKind : true | highlightKeywords : filterExpressions\"></span>\n" +
     "</div>\n" +
@@ -6841,7 +6841,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"!resourceURL\" ng-bind-html=\"event.involvedObject.name | highlightKeywords : filterExpressions\"></span>\n" +
     "</span>\n" +
     "</td>\n" +
-    "<td ng-if=\"!resourceKind || !resourceName\" class=\"hidden-sm hidden-md\" data-title=\"Kind\">\n" +
+    "<td ng-if=\"showKindAndName\" class=\"hidden-sm hidden-md\" data-title=\"Kind\">\n" +
     "<span ng-bind-html=\"event.involvedObject.kind | humanizeKind : true | highlightKeywords : filterExpressions\"></span>\n" +
     "</td>\n" +
     "<td data-title=\"Severity\" class=\"hidden-xs hidden-sm hidden-md text-center severity-icon-td\">\n" +


### PR DESCRIPTION
Use the API object UID rather than kind and name to filter events. This
prevents events for showing for a previous object with the same name.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1461346