### PR TITLE
Bug 1460142 - Use $routeChangeStart for confirm-on-exit

### DIFF
--- a/app/scripts/directives/confirmOnExit.js
+++ b/app/scripts/directives/confirmOnExit.js
@@ -29,7 +29,11 @@ angular.module("openshiftConsole")
         };
         $(window).on('beforeunload', confirmBeforeUnload);
 
-        var removeLocationChangeListener = $scope.$on('$locationChangeStart', function(event) {
+        // Use $routeChangeStart instead of $locationChangeStart. Otherwise the
+        // user is incorrectly prompted when switching tabs with
+        // `persist-tab-state` on since this changes the URL, but doesn not
+        // leave the page.
+        var removeRouteChangeListener = $scope.$on('$routeChangeStart', function(event) {
           if (!$scope.dirty) {
             return;
           }
@@ -61,8 +65,8 @@ angular.module("openshiftConsole")
 
         $scope.$on('$destroy', function() {
           $(window).off('beforeunload', confirmBeforeUnload);
-          if (removeLocationChangeListener) {
-            removeLocationChangeListener();
+          if (removeRouteChangeListener) {
+            removeRouteChangeListener();
           }
         });
       }

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -13619,7 +13619,7 @@ return b.message || "You have unsaved changes. Leave this page anyway?";
 if (b.dirty) return c();
 };
 $(window).on("beforeunload", d);
-var e = b.$on("$locationChangeStart", function(d) {
+var e = b.$on("$routeChangeStart", function(d) {
 if (b.dirty) {
 var e = new Date().getTime(), f = confirm(c());
 if (!f) {


### PR DESCRIPTION
Listen for `$routeChangeStart` instead of `$locationChangeStart` in the
`confirm-on-exit` directive. This prevents us from incorrectly prompting
when the user switches tab with `persist-tab-state` on.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1460142