### PR TITLE
Fix delete binding modal to show secret names

### DIFF
--- a/app/scripts/directives/unbindService.js
+++ b/app/scripts/directives/unbindService.js
@@ -29,7 +29,7 @@
       DataService.delete({
         group: 'servicecatalog.k8s.io',
         resource: 'bindings'
-      }, ctrl.selectedBinding, context).then(_.noop, function(err) {
+      }, ctrl.selectedBinding.metadata.name, context).then(_.noop, function(err) {
         ctrl.error = err;
       });
     };
@@ -85,6 +85,12 @@
       context = {
         namespace: _.get(ctrl.target, 'metadata.namespace')
       };
+    };
+
+    // TODO: sort bindings by app in overview && eliminate this filter function
+    ctrl.firstAppForBindingName = function(binding) {
+      var sorted = binding && _.sortBy(ctrl.appsForBinding(binding.metadata.name), 'metadata.name');
+      return _.get(_.first(sorted), ['metadata', 'name']);
     };
 
     ctrl.appsForBinding = function(bindingName) {

--- a/app/views/directives/bind-service/delete-binding-result.html
+++ b/app/views/directives/bind-service/delete-binding-result.html
@@ -5,13 +5,12 @@
     </h3>
 
     <div
-      ng-if="ctrl.appsForBinding(ctrl.selectedBinding)"
-      ng-repeat="appForBinding in ctrl.appsForBinding(ctrl.selectedBinding)">
+      ng-if="ctrl.appsForBinding(ctrl.selectedBinding.metadata.name) | size"
+      ng-repeat="appForBinding in ctrl.appsForBinding(ctrl.selectedBinding.metadata.name)">
       {{appForBinding.metadata.name}} <small class="text-muted">&ndash; {{ appForBinding.kind | humanizeKind : true}}</small>
     </div>
-    <div ng-if="!(ctrl.appsForBinding(ctrl.selectedBinding))">
-      <!-- TODO: selected a secret name in the form, but see a binding name in the result. -->
-      {{ctrl.selectedBinding}} <small class="text-muted">&ndash; Binding</small>
+    <div ng-if="!(ctrl.appsForBinding(ctrl.selectedBinding.metadata.name)  | size)">
+      {{ctrl.selectedBinding.spec.secretName}} <small class="text-muted">&ndash; Secret</small>
     </div>
 
     <p class="mar-top-lg">

--- a/app/views/directives/bind-service/delete-binding-select-form.html
+++ b/app/views/directives/bind-service/delete-binding-select-form.html
@@ -3,18 +3,18 @@
 </h3>
 <form name="ctrl.bindingSelection" class="mar-bottom-lg">
   <fieldset ng-disabled="ctrl.isDisabled">
-    <div ng-repeat="binding in ctrl.bindings" class="radio">
+    <div ng-repeat="binding in ctrl.bindings | orderBy: ctrl.firstAppForBindingName" class="radio">
       <label>
           <input
             type="radio"
             ng-model="ctrl.selectedBinding"
-            value="{{binding.metadata.name}}">
+            ng-value="{{binding}}">
           <div
-            ng-if="ctrl.appsForBinding(binding.metadata.name)"
+            ng-if="ctrl.appsForBinding(binding.metadata.name) | size"
             ng-repeat="appForBinding in ctrl.appsForBinding(binding.metadata.name)">
             {{appForBinding.metadata.name}} <small class="text-muted">&ndash; {{ appForBinding.kind | humanizeKind : true}}</small>
           </div>
-          <div ng-if="!(ctrl.appsForBinding(binding.metadata.name))">
+          <div ng-if="!(ctrl.appsForBinding(binding.metadata.name)  | size)">
             {{binding.spec.secretName}} <small class="text-muted">&ndash; Secret</small>
           </div>
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12332,7 +12332,7 @@ var d, e, f = this, g = b("serviceInstanceDisplayName"), h = function() {
 c["delete"]({
 group:"servicecatalog.k8s.io",
 resource:"bindings"
-}, f.selectedBinding, e).then(_.noop, function(a) {
+}, f.selectedBinding.metadata.name, e).then(_.noop, function(a) {
 f.error = a;
 });
 }, i = function() {
@@ -12362,6 +12362,9 @@ onShow:l
 } ], e = {
 namespace:_.get(f.target, "metadata.namespace")
 };
+}, f.firstAppForBindingName = function(a) {
+var b = a && _.sortBy(f.appsForBinding(a.metadata.name), "metadata.name");
+return _.get(_.first(b), [ "metadata", "name" ]);
 }, f.appsForBinding = function(a) {
 return _.get(f.applicationsByBinding, a);
 }, f.closeWizard = function() {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5809,12 +5809,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<h3 class=\"mar-top-none\">\n" +
     "Binding for the following has been deleted:\n" +
     "</h3>\n" +
-    "<div ng-if=\"ctrl.appsForBinding(ctrl.selectedBinding)\" ng-repeat=\"appForBinding in ctrl.appsForBinding(ctrl.selectedBinding)\">\n" +
+    "<div ng-if=\"ctrl.appsForBinding(ctrl.selectedBinding.metadata.name) | size\" ng-repeat=\"appForBinding in ctrl.appsForBinding(ctrl.selectedBinding.metadata.name)\">\n" +
     "{{appForBinding.metadata.name}} <small class=\"text-muted\">&ndash; {{ appForBinding.kind | humanizeKind : true}}</small>\n" +
     "</div>\n" +
-    "<div ng-if=\"!(ctrl.appsForBinding(ctrl.selectedBinding))\">\n" +
-    "\n" +
-    "{{ctrl.selectedBinding}} <small class=\"text-muted\">&ndash; Binding</small>\n" +
+    "<div ng-if=\"!(ctrl.appsForBinding(ctrl.selectedBinding.metadata.name)  | size)\">\n" +
+    "{{ctrl.selectedBinding.spec.secretName}} <small class=\"text-muted\">&ndash; Secret</small>\n" +
     "</div>\n" +
     "<p class=\"mar-top-lg\">\n" +
     "<span class=\"pficon pficon-info\"></span> You will need to redeploy your pods for this to take effect.\n" +
@@ -5841,13 +5840,13 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</h3>\n" +
     "<form name=\"ctrl.bindingSelection\" class=\"mar-bottom-lg\">\n" +
     "<fieldset ng-disabled=\"ctrl.isDisabled\">\n" +
-    "<div ng-repeat=\"binding in ctrl.bindings\" class=\"radio\">\n" +
+    "<div ng-repeat=\"binding in ctrl.bindings | orderBy: ctrl.firstAppForBindingName\" class=\"radio\">\n" +
     "<label>\n" +
-    "<input type=\"radio\" ng-model=\"ctrl.selectedBinding\" value=\"{{binding.metadata.name}}\">\n" +
-    "<div ng-if=\"ctrl.appsForBinding(binding.metadata.name)\" ng-repeat=\"appForBinding in ctrl.appsForBinding(binding.metadata.name)\">\n" +
+    "<input type=\"radio\" ng-model=\"ctrl.selectedBinding\" ng-value=\"{{binding}}\">\n" +
+    "<div ng-if=\"ctrl.appsForBinding(binding.metadata.name) | size\" ng-repeat=\"appForBinding in ctrl.appsForBinding(binding.metadata.name)\">\n" +
     "{{appForBinding.metadata.name}} <small class=\"text-muted\">&ndash; {{ appForBinding.kind | humanizeKind : true}}</small>\n" +
     "</div>\n" +
-    "<div ng-if=\"!(ctrl.appsForBinding(binding.metadata.name))\">\n" +
+    "<div ng-if=\"!(ctrl.appsForBinding(binding.metadata.name)  | size)\">\n" +
     "{{binding.spec.secretName}} <small class=\"text-muted\">&ndash; Secret</small>\n" +
     "</div>\n" +
     "</label>\n" +


### PR DESCRIPTION
Now the results panel will show the secret instead of the binding.  

Aside, I am working on ordering the applications select form, probably ordering by the first app in the binding's associated app list.

![screen shot 2017-06-16 at 10 12 12 am](https://user-images.githubusercontent.com/280512/27230306-cac370e4-527c-11e7-9625-773b2f514a75.png)
![screen shot 2017-06-16 at 10 12 18 am](https://user-images.githubusercontent.com/280512/27230307-cac68e28-527c-11e7-93f7-aa8128158f87.png)
