### PR TITLE
Add link to controller on pod and replica set pages

### DIFF
--- a/app/scripts/controllers/pod.js
+++ b/app/scripts/controllers/pod.js
@@ -18,6 +18,7 @@ angular.module('openshiftConsole')
                                          FullscreenService,
                                          ImageStreamResolver,
                                          MetricsService,
+                                         OwnerReferencesService,
                                          PodsService,
                                          ProjectsService) {
     $scope.projectName = $routeParams.project;
@@ -238,6 +239,19 @@ angular.module('openshiftConsole')
       $scope.logCanRun = !(_.includes(['New', 'Pending', 'Unknown'], pod.status.phase));
       setContainerVars();
       updateEnv();
+
+      // Show owner ref if owned by a replication controller, replica set, or build.
+      // Deployment configs are handled specially in the view.
+      delete $scope.controllerRef;
+      if (!$scope.dcName) {
+        var controllerReferences = OwnerReferencesService.getControllerReferences(pod);
+        $scope.controllerRef = _.find(controllerReferences, function(ref) {
+          return ref.kind === 'ReplicationController' ||
+                 ref.kind === 'ReplicaSet' ||
+                 ref.kind === 'Build';
+        });
+      }
+
       if (action === "DELETED") {
         $scope.alerts["deleted"] = {
           type: "warning",

--- a/app/scripts/services/ownerReferences.js
+++ b/app/scripts/services/ownerReferences.js
@@ -6,8 +6,15 @@ angular.module("openshiftConsole")
       return _.get(apiObject, 'metadata.ownerReferences');
     };
 
+    // Find the owners of an API object.
+    var getControllerReferences = function(apiObject) {
+      var ownerReferences = getOwnerReferences(apiObject);
+      return _.filter(ownerReferences, 'controller');
+    };
+
     return {
       getOwnerReferences: getOwnerReferences,
+      getControllerReferences: getControllerReferences,
 
       groupByControllerUID: function(apiObjects) {
         var objectsByControllerUID = {};

--- a/app/views/browse/_pod-details.html
+++ b/app/views/browse/_pod-details.html
@@ -25,6 +25,12 @@
           <a ng-href="{{rcName | navigateResourceURL : 'ReplicationController' : pod.metadata.namespace}}"
             ><span ng-if="deploymentVersion">#{{deploymentVersion}}</span><span ng-if="!deploymentVersion">{{rcName}}</span></a></span>
         </dd>
+        <dt ng-if-start="!dcName && controllerRef">
+          {{controllerRef.kind | humanizeKind : true}}:
+        </dt>
+        <dd ng-if-end>
+          <a ng-href="{{controllerRef.name | navigateResourceURL : controllerRef.kind : pod.metadata.namespace}}">{{controllerRef.name}}</a>
+        </dd>
         <dt ng-if-start="pod.metadata.deletionTimestamp && pod.spec.terminationGracePeriodSeconds">Grace Period:</dt>
         <dd ng-if-end>
           <!-- Don't show "a few seconds" for small values. -->

--- a/app/views/browse/_replica-set-details.html
+++ b/app/views/browse/_replica-set-details.html
@@ -50,6 +50,10 @@
       <dd ng-if-end>
         <a ng-href="{{replicaSet | configURLForResource}}">{{deploymentConfigName}}</a>
       </dd>
+      <dt ng-if-start="deployment">Deployment:</dt>
+      <dd ng-if-end>
+        <a ng-href="{{deployment | navigateResourceURL}}">{{deployment.metadata.name}}</a>
+      </dd>
       <dt ng-if-start="replicaSet | annotation:'deploymentStatusReason'">Status Reason:</dt>
       <dd ng-if-end>
         {{replicaSet | annotation:'deploymentStatusReason'}}

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4063,9 +4063,13 @@ _.set(this, "selectedTab.networking", !0), b(this);
 }), angular.module("openshiftConsole").factory("OwnerReferencesService", function() {
 var a = function(a) {
 return _.get(a, "metadata.ownerReferences");
+}, b = function(b) {
+var c = a(b);
+return _.filter(c, "controller");
 };
 return {
 getOwnerReferences:a,
+getControllerReferences:b,
 groupByControllerUID:function(b) {
 var c = {};
 return _.each(b, function(b) {
@@ -4222,7 +4226,7 @@ b.pods = a.select(b.unfilteredPods), e();
 c.unwatchAll(h);
 });
 }));
-} ]), angular.module("openshiftConsole").controller("PodController", [ "$scope", "$filter", "$routeParams", "$timeout", "$uibModal", "Logger", "DataService", "EnvironmentService", "FullscreenService", "ImageStreamResolver", "MetricsService", "PodsService", "ProjectsService", function(a, b, c, d, e, f, g, h, i, j, k, l, m) {
+} ]), angular.module("openshiftConsole").controller("PodController", [ "$scope", "$filter", "$routeParams", "$timeout", "$uibModal", "Logger", "DataService", "EnvironmentService", "FullscreenService", "ImageStreamResolver", "MetricsService", "OwnerReferencesService", "PodsService", "ProjectsService", function(a, b, c, d, e, f, g, h, i, j, k, l, m, n) {
 a.projectName = c.project, a.pod = null, a.imageStreams = {}, a.imagesByDockerReference = {}, a.imageStreamImageRefByDockerReference = {}, a.builds = {}, a.alerts = {}, a.terminalDisconnectAlert = {}, a.renderOptions = a.renderOptions || {}, a.renderOptions.hideFilterWidget = !0, a.logOptions = {}, a.terminalTabWasSelected = !1, a.breadcrumbs = [ {
 title:"Pods",
 link:"project/" + c.project + "/browse/pods"
@@ -4232,11 +4236,11 @@ title:c.pod
 type:"warning",
 message:"This terminal has been disconnected. If you reconnect, your terminal history will be lost."
 }, a.noContainersYet = !0, a.selectedTab = {};
-var n = [], o = null;
+var o = [], p = null;
 k.isAvailable().then(function(b) {
 a.metricsAvailable = b;
 });
-var p = function() {
+var q = function() {
 if (a.pod) {
 var b = _.find(a.pod.status.containerStatuses, {
 name:a.logOptions.container
@@ -4253,7 +4257,7 @@ containerStartTime:_.get(c, [ d, "startedAt" ]),
 containerEndTime:_.get(c, [ d, "finishedAt" ])
 });
 }
-}, q = function() {
+}, r = function() {
 var a = $("<span>").css({
 position:"absolute",
 top:"-100px"
@@ -4262,36 +4266,36 @@ width:a.width() / 10,
 height:a.height()
 };
 return a.remove(), b;
-}, r = q(), s = $(window), t = function(b) {
-b || (b = 0), r.height && r.width && a.selectedTab.terminal && !(b > 10) && a.$apply(function() {
+}, s = r(), t = $(window), u = function(b) {
+b || (b = 0), s.height && s.width && a.selectedTab.terminal && !(b > 10) && a.$apply(function() {
 var c = $(".container-terminal-wrapper").get(0);
 if (!c) return void d(function() {
-t(b + 1);
+u(b + 1);
 }, 50);
 var e = c.getBoundingClientRect();
 if (0 === e.left && 0 === e.top && 0 === e.width && 0 === e.height) return void d(function() {
-t(b + 1);
+u(b + 1);
 }, 50);
-var f = s.width(), g = s.height(), h = f - e.left - 40, i = g - e.top - 50;
-a.terminalCols = Math.max(_.floor(h / r.width), 80), a.terminalRows = Math.max(_.floor(i / r.height), 24);
+var f = t.width(), g = t.height(), h = f - e.left - 40, i = g - e.top - 50;
+a.terminalCols = Math.max(_.floor(h / s.width), 80), a.terminalRows = Math.max(_.floor(i / s.height), 24);
 });
 };
 a.$watch("selectedTab.terminal", function(a) {
-a ? (r.height && r.width ? $(window).on("resize.terminalsize", _.debounce(t, 100)) :f.warn("Unable to calculate the bounding box for a character.  Terminal will not be able to resize."), d(t, 0)) :$(window).off("resize.terminalsize");
+a ? (s.height && s.width ? $(window).on("resize.terminalsize", _.debounce(u, 100)) :f.warn("Unable to calculate the bounding box for a character.  Terminal will not be able to resize."), d(u, 0)) :$(window).off("resize.terminalsize");
 }), a.onTerminalSelectChange = function(b) {
 _.each(a.containerTerminals, function(a) {
 a.isVisible = !1;
 }), b.isVisible = !0, b.isUsed = !0, a.selectedTerminalContainer = b;
 };
-var u = function(a) {
+var v = function(a) {
 var b = _.get(a, "state", {});
 return _.head(_.keys(b));
-}, v = function() {
+}, w = function() {
 var b = [];
 _.each(a.pod.spec.containers, function(c) {
 var d = _.find(a.pod.status.containerStatuses, {
 name:c.name
-}), e = u(d);
+}), e = v(d);
 b.push({
 containerName:c.name,
 isVisible:!1,
@@ -4301,34 +4305,40 @@ containerState:e
 });
 var c = _.head(b);
 return c.isVisible = !0, c.isUsed = !0, a.selectedTerminalContainer = c, b;
-}, w = function(b) {
-a.noContainersYet && (a.noContainersYet = 0 === a.containersRunning(b.status.containerStatuses));
 }, x = function(b) {
+a.noContainersYet && (a.noContainersYet = 0 === a.containersRunning(b.status.containerStatuses));
+}, y = function(b) {
 _.each(b, function(b) {
 var c = _.find(a.pod.status.containerStatuses, {
 name:b.containerName
-}), d = u(c);
+}), d = v(c);
 b.containerState = d;
 });
-}, y = function() {
+}, z = function() {
 var b = angular.copy(_.get(a, "pod.spec.containers", []));
 _.each(b, function(a) {
 a.env = a.env || [];
 }), a.containersEnv = b;
-}, z = b("annotation"), A = function(b, c) {
-a.loaded = !0, a.pod = b, a.dcName = z(b, "deploymentConfig"), a.rcName = z(b, "deployment"), a.deploymentVersion = z(b, "deploymentVersion"), a.logCanRun = !_.includes([ "New", "Pending", "Unknown" ], b.status.phase), p(), y(), "DELETED" === c && (a.alerts.deleted = {
+}, A = b("annotation"), B = function(b, c) {
+if (a.loaded = !0, a.pod = b, a.dcName = A(b, "deploymentConfig"), a.rcName = A(b, "deployment"), a.deploymentVersion = A(b, "deploymentVersion"), a.logCanRun = !_.includes([ "New", "Pending", "Unknown" ], b.status.phase), q(), z(), delete a.controllerRef, !a.dcName) {
+var d = l.getControllerReferences(b);
+a.controllerRef = _.find(d, function(a) {
+return "ReplicationController" === a.kind || "ReplicaSet" === a.kind || "Build" === a.kind;
+});
+}
+"DELETED" === c && (a.alerts.deleted = {
 type:"warning",
 message:"This pod has been deleted."
 });
 };
-m.get(c.project).then(_.spread(function(d, h) {
-o = h, a.project = d, a.projectContext = h, g.get("pods", c.pod, h, {
+n.get(c.project).then(_.spread(function(d, h) {
+p = h, a.project = d, a.projectContext = h, g.get("pods", c.pod, h, {
 errorNotification:!1
 }).then(function(b) {
-A(b);
+B(b);
 var d = {};
-d[b.metadata.name] = b, a.logOptions.container = c.container || b.spec.containers[0].name, a.containerTerminals = v(), w(b), j.fetchReferencedImageStreamImages(d, a.imagesByDockerReference, a.imageStreamImageRefByDockerReference, o), n.push(g.watchObject("pods", c.pod, h, function(b, c) {
-A(b, c), x(a.containerTerminals), w(b);
+d[b.metadata.name] = b, a.logOptions.container = c.container || b.spec.containers[0].name, a.containerTerminals = w(), x(b), j.fetchReferencedImageStreamImages(d, a.imagesByDockerReference, a.imageStreamImageRefByDockerReference, p), o.push(g.watchObject("pods", c.pod, h, function(b, c) {
+B(b, c), y(a.containerTerminals), x(b);
 }));
 }, function(c) {
 a.loaded = !0, a.alerts.load = {
@@ -4336,12 +4346,12 @@ type:"error",
 message:"The pod details could not be loaded.",
 details:b("getErrorDetails")(c)
 };
-}), a.$watch("logOptions.container", p), n.push(g.watch("imagestreams", h, function(b) {
+}), a.$watch("logOptions.container", q), o.push(g.watch("imagestreams", h, function(b) {
 a.imageStreams = b.by("metadata.name"), j.buildDockerRefMapForImageStreams(a.imageStreams, a.imageStreamImageRefByDockerReference), j.fetchReferencedImageStreamImages(a.pods, a.imagesByDockerReference, a.imageStreamImageRefByDockerReference, h), f.log("imagestreams (subscribe)", a.imageStreams);
-})), n.push(g.watch("builds", h, function(b) {
+})), o.push(g.watch("builds", h, function(b) {
 a.builds = b.by("metadata.name"), f.log("builds (subscribe)", a.builds);
 }));
-var k, m = function() {
+var k, l = function() {
 var c = a.debugPod;
 k && (g.unwatch(k), k = null), $(window).off("beforeunload.debugPod"), c && (g["delete"]("pods", c.metadata.name, h, {
 gracePeriodSeconds:0
@@ -4352,15 +4362,15 @@ message:"Could not delete pod " + c.metadata.name,
 details:b("getErrorDetails")(d)
 };
 }), a.debugPod = null);
-}, q = function() {
+}, n = function() {
 $(".terminal:visible").focus();
 };
 a.hasFullscreen = i.hasFullscreen(!0), a.fullscreenTerminal = function() {
-i.requestFullscreen("#container-terminal-wrapper"), setTimeout(q);
+i.requestFullscreen("#container-terminal-wrapper"), setTimeout(n);
 }, a.exitFullscreen = function() {
 i.exitFullscreen();
 }, a.debugTerminal = function(c) {
-var d = l.generateDebugPod(a.pod, c);
+var d = m.generateDebugPod(a.pod, c);
 return d ? void g.create("pods", null, d, h).then(function(b) {
 var f = _.find(a.pod.spec.containers, {
 name:c
@@ -4385,7 +4395,7 @@ return _.get(a, [ "imagesByDockerReference", f.image ]);
 },
 backdrop:"static"
 });
-i.result.then(m);
+i.result.then(l);
 }, function(d) {
 a.alerts["debug-container-error"] = {
 type:"error",
@@ -4402,7 +4412,7 @@ return a && a.forEach(function(a) {
 a.state && a.state.running && b++;
 }), b;
 }, a.$on("$destroy", function() {
-g.unwatchAll(n), m(), $(window).off("resize.terminalsize");
+g.unwatchAll(o), l(), $(window).off("resize.terminalsize");
 });
 }));
 } ]), angular.module("openshiftConsole").controller("OverviewController", [ "$scope", "$filter", "$routeParams", "AlertMessageService", "APIService", "AppsService", "BuildsService", "Constants", "DataService", "DeploymentsService", "HPAService", "HTMLService", "ImageStreamResolver", "KeywordService", "LabelFilter", "Logger", "MetricsService", "Navigate", "NotificationsService", "OwnerReferencesService", "PodsService", "ProjectsService", "BindingService", "ResourceAlertsService", "RoutesService", OverviewController ]), angular.module("openshiftConsole").controller("QuotaController", [ "$filter", "$routeParams", "$scope", "DataService", "ProjectsService", "Logger", function(a, b, c, d, e, f) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1308,6 +1308,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a ng-href=\"{{dcName | navigateResourceURL : 'DeploymentConfig' : pod.metadata.namespace}}\">{{dcName}}</a><span ng-if=\"rcName\">,\n" +
     "<a ng-href=\"{{rcName | navigateResourceURL : 'ReplicationController' : pod.metadata.namespace}}\"><span ng-if=\"deploymentVersion\">#{{deploymentVersion}}</span><span ng-if=\"!deploymentVersion\">{{rcName}}</span></a></span>\n" +
     "</dd>\n" +
+    "<dt ng-if-start=\"!dcName && controllerRef\">\n" +
+    "{{controllerRef.kind | humanizeKind : true}}:\n" +
+    "</dt>\n" +
+    "<dd ng-if-end>\n" +
+    "<a ng-href=\"{{controllerRef.name | navigateResourceURL : controllerRef.kind : pod.metadata.namespace}}\">{{controllerRef.name}}</a>\n" +
+    "</dd>\n" +
     "<dt ng-if-start=\"pod.metadata.deletionTimestamp && pod.spec.terminationGracePeriodSeconds\">Grace Period:</dt>\n" +
     "<dd ng-if-end>\n" +
     "\n" +
@@ -1441,6 +1447,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt ng-if-start=\"replicaSet | hasDeploymentConfig\">Deployment Config:</dt>\n" +
     "<dd ng-if-end>\n" +
     "<a ng-href=\"{{replicaSet | configURLForResource}}\">{{deploymentConfigName}}</a>\n" +
+    "</dd>\n" +
+    "<dt ng-if-start=\"deployment\">Deployment:</dt>\n" +
+    "<dd ng-if-end>\n" +
+    "<a ng-href=\"{{deployment | navigateResourceURL}}\">{{deployment.metadata.name}}</a>\n" +
     "</dd>\n" +
     "<dt ng-if-start=\"replicaSet | annotation:'deploymentStatusReason'\">Status Reason:</dt>\n" +
     "<dd ng-if-end>\n" +


### PR DESCRIPTION
Add the following links to the detail pages in the console using
controller references:

* pod -> replication controller (not part of deployment config)
* pod -> replica set
* pod -> build
* replica set -> deployment

We previously added a link to deployment configs using pod and
replication controller labels.