### PR TITLE
Show optional parameters in template dialog

### DIFF
--- a/app/scripts/directives/templateopt.js
+++ b/app/scripts/directives/templateopt.js
@@ -25,17 +25,6 @@ angular.module('openshiftConsole')
         scope.focus = function(id) {
           angular.element('#' + id).focus();
         };
-
-        if (!scope.isDialog) {
-          scope.visibleParameters = scope.parameters;
-        } else {
-          scope.$watch('parameters', function(parameters) {
-            // Only show parameters that the user has to fill in a value when in a dialog.
-            scope.visibleParameters = _.reject(parameters, function(parameter) {
-              return !parameter.required || parameter.value || parameter.generate;
-            });
-          });
-        }
       }
     };
   });

--- a/app/views/_templateopt.html
+++ b/app/views/_templateopt.html
@@ -13,7 +13,7 @@
   <div ng-transclude></div>
   <div
       class="form-group options"
-      ng-repeat="parameter in visibleParameters"
+      ng-repeat="parameter in parameters"
       ng-show="expand"
       ng-init="paramID = 'param-' + $index">
     <label

--- a/app/views/directives/process-template.html
+++ b/app/views/directives/process-template.html
@@ -3,14 +3,7 @@
     <template-options is-dialog="$ctrl.isDialog" parameters="$ctrl.template.parameters" expand="true" can-toggle="false">
       <select-project ng-if="!$ctrl.project" selected-project="$ctrl.selectedProject" name-taken="$ctrl.projectNameTaken"></select-project>
     </template-options>
-    <!-- TODO: Also support advanced options for new projects. -->
-    <div ng-if="$ctrl.isDialog && $ctrl.selectedProject.metadata.uid" class="form-group">
-      <!-- TODO: Preserve entered form values. -->
-      To set optional parameters or labels, view
-      <a ng-href="{{$ctrl.template | createFromTemplateURL : $ctrl.selectedProject.metadata.name}}">advanced options</a>.
-    </div>
     <label-editor
-        ng-if="!$ctrl.isDialog"
         labels="$ctrl.labels"
         system-labels="$ctrl.systemLabels"
         expand="true"

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10533,11 +10533,7 @@ angular.isDefined(c.canToggle) || (a.canToggle = !0), a.isOnlyWhitespace = funct
 return /^\s+$/.test(a);
 }, a.focus = function(a) {
 angular.element("#" + a).focus();
-}, a.isDialog ? a.$watch("parameters", function(b) {
-a.visibleParameters = _.reject(b, function(a) {
-return !a.required || a.value || a.generate;
-});
-}) :a.visibleParameters = a.parameters;
+};
 }
 };
 }), angular.module("openshiftConsole").directive("tasks", function() {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -565,7 +565,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "<div ng-transclude></div>\n" +
-    "<div class=\"form-group options\" ng-repeat=\"parameter in visibleParameters\" ng-show=\"expand\" ng-init=\"paramID = 'param-' + $index\">\n" +
+    "<div class=\"form-group options\" ng-repeat=\"parameter in parameters\" ng-show=\"expand\" ng-init=\"paramID = 'param-' + $index\">\n" +
     "<label ng-attr-for=\"{{paramID}}\" ng-attr-title=\"{{parameter.name}}\" ng-class=\"{required: parameter.required}\">{{parameter.displayName || parameter.name}}</label>\n" +
     "<div class=\"parameter-input-wrapper\" ng-class=\"{\n" +
     "          'has-error': (paramForm[paramID].$error.required && paramForm[paramID].$touched && !cleared),\n" +
@@ -8701,13 +8701,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<template-options is-dialog=\"$ctrl.isDialog\" parameters=\"$ctrl.template.parameters\" expand=\"true\" can-toggle=\"false\">\n" +
     "<select-project ng-if=\"!$ctrl.project\" selected-project=\"$ctrl.selectedProject\" name-taken=\"$ctrl.projectNameTaken\"></select-project>\n" +
     "</template-options>\n" +
-    "\n" +
-    "<div ng-if=\"$ctrl.isDialog && $ctrl.selectedProject.metadata.uid\" class=\"form-group\">\n" +
-    "\n" +
-    "To set optional parameters or labels, view\n" +
-    "<a ng-href=\"{{$ctrl.template | createFromTemplateURL : $ctrl.selectedProject.metadata.name}}\">advanced options</a>.\n" +
-    "</div>\n" +
-    "<label-editor ng-if=\"!$ctrl.isDialog\" labels=\"$ctrl.labels\" system-labels=\"$ctrl.systemLabels\" expand=\"true\" can-toggle=\"false\" help-text=\"Each label is applied to each created resource.\">\n" +
+    "<label-editor labels=\"$ctrl.labels\" system-labels=\"$ctrl.systemLabels\" expand=\"true\" can-toggle=\"false\" help-text=\"Each label is applied to each created resource.\">\n" +
     "</label-editor>\n" +
     "<div ng-if=\"!$ctrl.isDialog\" class=\"buttons gutter-top-bottom\">\n" +
     "<button class=\"btn btn-primary btn-lg\" ng-click=\"$ctrl.createFromTemplate()\" ng-disabled=\"$ctrl.templateForm.$invalid || $ctrl.disableInputs\">Create</button>\n" +


### PR DESCRIPTION
Don't hide optional parameters behind a advanced options link in the
template dialog. This makes the dialog more consistent with what you see
when you enable the template broker.

Fixes #1731

cc @benjaminapetersen 