### PR TITLE
Sort bindingsByInstanceRef by first associated application

### DIFF
--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -1110,9 +1110,9 @@ function OverviewController($scope,
 
     // All objects that can be a target for bindings.
     var objectsByKind = [
+      overview.deployments,
       overview.deploymentConfigs,
       overview.vanillaReplicationControllers,
-      overview.deployments,
       overview.vanillaReplicaSets,
       overview.statefulSets
     ];
@@ -1158,6 +1158,15 @@ function OverviewController($scope,
         });
       });
     });
+
+    overview.bindingsByInstanceRef = _.reduce(overview.bindingsByInstanceRef, function(result, bindingList, key) {
+      result[key] = _.sortBy(bindingList, function(binding) {
+        var apps =  _.get(state.applicationsByBinding, [binding.metadata.name]);
+        var firstName = _.get(_.first(apps), ['metadata', 'name']);
+        return firstName;
+      });
+      return result;
+    }, {});
   };
 
   // TODO: code duplicated from directives/bindService.js

--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -1163,7 +1163,7 @@ function OverviewController($scope,
       result[key] = _.sortBy(bindingList, function(binding) {
         var apps =  _.get(state.applicationsByBinding, [binding.metadata.name]);
         var firstName = _.get(_.first(apps), ['metadata', 'name']);
-        return firstName;
+        return firstName || binding.metadata.name;
       });
       return result;
     }, {});

--- a/app/scripts/directives/unbindService.js
+++ b/app/scripts/directives/unbindService.js
@@ -91,12 +91,6 @@
       };
     };
 
-    // TODO: sort bindings by app in overview && eliminate this filter function
-    ctrl.firstAppForBindingName = function(binding) {
-      var sorted = binding && _.sortBy(ctrl.appsForBinding(binding.metadata.name), 'metadata.name');
-      return _.get(_.first(sorted), ['metadata', 'name']);
-    };
-
     ctrl.appsForBinding = function(bindingName) {
       return _.get(ctrl.applicationsByBinding, bindingName);
     };

--- a/app/views/directives/bind-service/delete-binding-select-form.html
+++ b/app/views/directives/bind-service/delete-binding-select-form.html
@@ -3,7 +3,7 @@
 </h3>
 <form name="ctrl.bindingSelection" class="mar-bottom-lg">
   <fieldset ng-disabled="ctrl.isDisabled">
-    <div ng-repeat="binding in ctrl.bindings | orderBy: ctrl.firstAppForBindingName" class="radio">
+    <div ng-repeat="binding in ctrl.bindings" class="radio">
       <label>
           <input
             type="radio"
@@ -17,7 +17,6 @@
           <div ng-if="!(ctrl.appsForBinding(binding.metadata.name)  | size)">
             {{binding.spec.secretName}} <small class="text-muted">&ndash; Secret</small>
           </div>
-
       </label>
     </div>
   </fieldset>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -369,7 +369,7 @@ Q.secrets = a.by("metadata.name");
 });
 }, 300), $a = function() {
 if (Q.bindingsByApplicationUID = {}, Q.applicationsByBinding = {}, Q.deleteableBindingsByApplicationUID = {}, !_.isEmpty(Q.bindings)) {
-var a = [ z.deploymentConfigs, z.vanillaReplicationControllers, z.deployments, z.vanillaReplicaSets, z.statefulSets ];
+var a = [ z.deployments, z.deploymentConfigs, z.vanillaReplicationControllers, z.vanillaReplicaSets, z.statefulSets ];
 if (!_.some(a, function(a) {
 return !a;
 })) {
@@ -384,7 +384,12 @@ Q.bindingsByApplicationUID[c] = [], Q.deleteableBindingsByApplicationUID[c] = []
 b.covers(d) && (Q.bindingsByApplicationUID[c].push(Q.bindings[e]), _.get(Q.bindings[e], "metadata.deletionTimestamp") || Q.deleteableBindingsByApplicationUID[c].push(Q.bindings[e]), Q.applicationsByBinding[e] = Q.applicationsByBinding[e] || [], Q.applicationsByBinding[e].push(a));
 });
 });
-});
+}), z.bindingsByInstanceRef = _.reduce(z.bindingsByInstanceRef, function(a, b, c) {
+return a[c] = _.sortBy(b, function(a) {
+var b = _.get(Q.applicationsByBinding, [ a.metadata.name ]), c = _.get(_.first(b), [ "metadata", "name" ]);
+return c;
+}), a;
+}, {});
 }
 }
 }, _a = function() {
@@ -12378,9 +12383,6 @@ onShow:l
 } ], e = {
 namespace:_.get(f.target, "metadata.namespace")
 };
-}, f.firstAppForBindingName = function(a) {
-var b = a && _.sortBy(f.appsForBinding(a.metadata.name), "metadata.name");
-return _.get(_.first(b), [ "metadata", "name" ]);
 }, f.appsForBinding = function(a) {
 return _.get(f.applicationsByBinding, a);
 }, f.closeWizard = function() {

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -387,7 +387,7 @@ b.covers(d) && (Q.bindingsByApplicationUID[c].push(Q.bindings[e]), _.get(Q.bindi
 }), z.bindingsByInstanceRef = _.reduce(z.bindingsByInstanceRef, function(a, b, c) {
 return a[c] = _.sortBy(b, function(a) {
 var b = _.get(Q.applicationsByBinding, [ a.metadata.name ]), c = _.get(_.first(b), [ "metadata", "name" ]);
-return c;
+return c || a.metadata.name;
 }), a;
 }, {});
 }

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5850,7 +5850,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</h3>\n" +
     "<form name=\"ctrl.bindingSelection\" class=\"mar-bottom-lg\">\n" +
     "<fieldset ng-disabled=\"ctrl.isDisabled\">\n" +
-    "<div ng-repeat=\"binding in ctrl.bindings | orderBy: ctrl.firstAppForBindingName\" class=\"radio\">\n" +
+    "<div ng-repeat=\"binding in ctrl.bindings\" class=\"radio\">\n" +
     "<label>\n" +
     "<input type=\"radio\" ng-model=\"ctrl.selectedBinding\" ng-value=\"{{binding}}\">\n" +
     "<div ng-if=\"ctrl.appsForBinding(binding.metadata.name) | size\" ng-repeat=\"appForBinding in ctrl.appsForBinding(binding.metadata.name)\">\n" +


### PR DESCRIPTION
Sort bindingsByInstanceRef by first associated application (from sorted applications)

Per @spadgett suggestion, sorting these in the overview controller so that they do not need to be resorted elsewhere.

![screen shot 2017-06-20 at 10 28 53 am](https://user-images.githubusercontent.com/280512/27338617-b5067042-55a3-11e7-90a0-40b631f83ac7.png)

![screen shot 2017-06-20 at 10 28 59 am](https://user-images.githubusercontent.com/280512/27338618-b50a888a-55a3-11e7-98f7-b3bb51a88c3f.png)


