### PR TITLE
Watch for changes to the tab query parameter

### DIFF
--- a/app/scripts/controllers/replicaSet.js
+++ b/app/scripts/controllers/replicaSet.js
@@ -64,7 +64,6 @@ angular.module('openshiftConsole')
     $scope.renderOptions = $scope.renderOptions || {};
     $scope.renderOptions.hideFilterWidget = true;
     $scope.forms = {};
-
     $scope.logOptions = {};
 
     var watches = [];

--- a/app/scripts/directives/util.js
+++ b/app/scripts/directives/util.js
@@ -182,9 +182,15 @@ angular.module('openshiftConsole')
       scope: false,
       link: function(scope) {
         scope.selectedTab = scope.selectedTab || {};
-        if ($routeParams.tab) {
-          scope.selectedTab[$routeParams.tab] = true;
-        }
+        scope.$watch(function() {
+          return $routeParams.tab;
+        }, function(tab) {
+          if (!tab) {
+            return;
+          }
+
+          scope.selectedTab[tab] = true;
+        });
 
         scope.$watch('selectedTab', function() {
           var selected = _.keys(_.pick(scope.selectedTab, function(active) {return active;}));

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10360,7 +10360,11 @@ return {
 restrict:"A",
 scope:!1,
 link:function(c) {
-c.selectedTab = c.selectedTab || {}, a.tab && (c.selectedTab[a.tab] = !0), c.$watch("selectedTab", function() {
+c.selectedTab = c.selectedTab || {}, c.$watch(function() {
+return a.tab;
+}, function(a) {
+a && (c.selectedTab[a] = !0);
+}), c.$watch("selectedTab", function() {
 var a = _.keys(_.pick(c.selectedTab, function(a) {
 return a;
 }));


### PR DESCRIPTION
In the `persist-tab-state` directive, watch for changes to the `tab`
query parameter so we can update the selected tab. This lets links to
the same page, but a different tab, work (like the check events link in
the `deployment-donut` quota warning).

Fixes #1748