### PR TITLE
Show average pod metrics for all containers on overview

### DIFF
--- a/app/scripts/directives/deploymentMetrics.js
+++ b/app/scripts/directives/deploymentMetrics.js
@@ -338,10 +338,13 @@ angular.module('openshiftConsole')
           }
           var config = {
             pods: scope.pods,
-            containerName: scope.options.selectedContainer.name,
             namespace: pod.metadata.namespace,
             bucketDuration: getBucketDuration()
           };
+
+          if (!compact) {
+            config.containerName = scope.options.selectedContainer.name;
+          }
 
           // Leave the end time off to use the server's current time as the
           // end time. This prevents an issue where the donut chart shows 0

--- a/app/scripts/directives/metricsSummary.js
+++ b/app/scripts/directives/metricsSummary.js
@@ -94,7 +94,6 @@
 
       var config = {
         pods: metricsSummary.pods,
-        containerName: _.head(pod.spec.containers).name,
         namespace: pod.metadata.namespace,
         start: '-1mn',
         bucketDuration: '1mn'

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2361,33 +2361,38 @@ _.set(b, [ d.descriptor, f ], h);
 };
 return _.each(a.data.counter, c), _.each(a.data.gauge, c), b;
 });
-}, s = _.template("descriptor_name:network/tx_rate|network/rx_rate,type:pod,pod_id:<%= uid %>"), t = _.template("descriptor_name:memory/usage|cpu/usage_rate,type:pod_container,pod_id:<%= uid %>,container_name:<%= containerName %>"), u = function(a) {
+}, s = _.template("descriptor_name:network/tx_rate|network/rx_rate,type:pod,pod_id:<%= uid %>"), t = _.template("descriptor_name:memory/usage|cpu/usage_rate,type:pod_container,pod_id:<%= uid %>,container_name:<%= containerName %>"), u = _.template("descriptor_name:network/tx_rate|network/rx_rate|memory/usage|cpu/usage_rate,type:pod,pod_id:<%= uid %>"), v = function(a) {
 return i().then(function(b) {
 var d = {
 bucketDuration:a.bucketDuration,
 start:a.start
 };
 a.end && (d.end = a.end);
-var e = [], f = h(_.map(a.pods, "metadata.uid")), g = _.assign({
+var e = [], f = [], g = h(_.map(a.pods, "metadata.uid"));
+return a.containerName ? (e.push(_.assign({
 tags:t({
-uid:f,
+uid:g,
 containerName:a.containerName
 })
-}, d);
-e.push(r(b, g, a));
-var i = _.assign({
+}, d)), e.push(_.assign({
 tags:s({
-uid:f
+uid:g
 })
-}, d);
-return e.push(r(b, i, a)), c.all(e).then(function(a) {
+}, d))) :e.push(_.assign({
+tags:u({
+uid:g
+})
+}, d)), _.each(e, function(c) {
+var d = r(b, c, a);
+f.push(d);
+}), c.all(f).then(function(a) {
 var b = {};
 return _.each(a, function(a) {
 _.assign(b, a);
 }), b;
 });
 });
-}, v = function(a) {
+}, w = function(a) {
 var c = a.metadata.namespace, d = a.metadata.uid;
 return f().then(function(a) {
 if (!a) return null;
@@ -2461,8 +2466,8 @@ usage:_.head(g(b.data))
 });
 });
 },
-getPodMetrics:u,
-getCustomMetrics:v
+getPodMetrics:v,
+getCustomMetrics:w
 };
 } ]), angular.module("openshiftConsole").factory("MetricsCharts", [ "$timeout", "ConversionService", function(a, b) {
 var c = function(a, c) {
@@ -11075,11 +11080,10 @@ var a = _.find(b.pods, "metadata.namespace");
 if (a) {
 var c = {
 pods:b.pods,
-containerName:b.options.selectedContainer.name,
 namespace:a.metadata.namespace,
 bucketDuration:n()
 };
-return y ? c.start = y :c.start = l(), c;
+return w || (c.containerName = b.options.selectedContainer.name), y ? c.start = y :c.start = l(), c;
 }
 }
 function p(a) {
@@ -12824,7 +12828,6 @@ var a = _.find(f.pods, "metadata.namespace");
 if (!a) return null;
 var b = {
 pods:f.pods,
-containerName:_.head(a.spec.containers).name,
 namespace:a.metadata.namespace,
 start:"-1mn",
 bucketDuration:"1mn"


### PR DESCRIPTION
Currently, the overview only shows the average metrics for the first container in each pod. Instead, include usage for all containers (but still average by pod).

Fixes #1668

cc @smarterclayton 