### PR TITLE
Change create project redirect for new experience

### DIFF
--- a/app/scripts/controllers/createProject.js
+++ b/app/scripts/controllers/createProject.js
@@ -9,7 +9,24 @@
  */
 angular.module('openshiftConsole')
   .controller('CreateProjectController',
-              function($scope, AuthService) {
+              function($scope,
+                       $location,
+                       $window,
+                       AuthService,
+                       Constants) {
+    var landingPageEnabled = _.get(Constants, 'ENABLE_TECH_PREVIEW_FEATURE.service_catalog_landing_page');
+
     $scope.alerts = {};
+    $scope.onProjectCreated = function(encodedProjectName) {
+      if (landingPageEnabled) {
+        // If the new experience is enabled, return to project list.
+        $window.history.back();
+      } else {
+        // If the next experience is not enabled, go to the catalog.
+        $location.path("project/" + encodedProjectName + "/create");
+      }
+    };
+
+    // Make sure we're logged in.
     AuthService.withUser();
   });

--- a/app/views/create-project.html
+++ b/app/views/create-project.html
@@ -12,7 +12,7 @@
             <div class="col-md-12">
               <h1>Create Project</h1>
               <alerts alerts="alerts"></alerts>
-              <create-project alerts="alerts"></create-project>
+              <create-project alerts="alerts" redirect-action="onProjectCreated"></create-project>
             </div>
           </div>
         </div><!-- /middle-content -->

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8111,8 +8111,11 @@ a.canCreateProject = !0;
 }, function() {
 a.canCreateProject = !1;
 });
-} ]), angular.module("openshiftConsole").controller("CreateProjectController", [ "$scope", "AuthService", function(a, b) {
-a.alerts = {}, b.withUser();
+} ]), angular.module("openshiftConsole").controller("CreateProjectController", [ "$scope", "$location", "$window", "AuthService", "Constants", function(a, b, c, d, e) {
+var f = _.get(e, "ENABLE_TECH_PREVIEW_FEATURE.service_catalog_landing_page");
+a.alerts = {}, a.onProjectCreated = function(a) {
+f ? c.history.back() :b.path("project/" + a + "/create");
+}, d.withUser();
 } ]), angular.module("openshiftConsole").controller("EditProjectController", [ "$scope", "$routeParams", "$filter", "$location", "DataService", "ProjectsService", "Navigate", function(a, b, c, d, e, f, g) {
 a.alerts = {};
 var h = c("annotation"), i = c("annotationName");

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4674,7 +4674,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"col-md-12\">\n" +
     "<h1>Create Project</h1>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
-    "<create-project alerts=\"alerts\"></create-project>\n" +
+    "<create-project alerts=\"alerts\" redirect-action=\"onProjectCreated\"></create-project>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
Don't redirect users to the old catalog after creating a project when the new experience is enabled. Instead go back to the project list.

Closes #1485