### PR TITLE
Make it easier to discover enabling TLS for routes

### DIFF
--- a/app/views/browse/route.html
+++ b/app/views/browse/route.html
@@ -204,7 +204,12 @@
                       <pre class="clipped">{{route.spec.tls.destinationCACertificate}}</pre>
                     </div>
                   </dl>
-                  <div ng-if="!route.spec.tls"><em>TLS is not enabled for this route</em></div>
+                  <p ng-if="!route.spec.tls">
+                    TLS is not enabled.
+                    <span ng-if="'routes' | canI : 'update'">
+                      <a ng-href="{{route | editResourceURL}}" role="button">Edit</a> this route to enable secure network traffic.
+                    </span>
+                  </p>
                 </div>
                 <annotations annotations="route.metadata.annotations"></annotations>
               </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3535,7 +3535,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<pre class=\"clipped\">{{route.spec.tls.destinationCACertificate}}</pre>\n" +
     "</div>\n" +
     "</dl>\n" +
-    "<div ng-if=\"!route.spec.tls\"><em>TLS is not enabled for this route</em></div>\n" +
+    "<p ng-if=\"!route.spec.tls\">\n" +
+    "TLS is not enabled.\n" +
+    "<span ng-if=\"'routes' | canI : 'update'\">\n" +
+    "<a ng-href=\"{{route | editResourceURL}}\" role=\"button\">Edit</a> this route to enable secure network traffic.\n" +
+    "</span>\n" +
+    "</p>\n" +
     "</div>\n" +
     "<annotations annotations=\"route.metadata.annotations\"></annotations>\n" +
     "</div>\n" +


### PR DESCRIPTION
Add an "Edit this route to enable security" link under the TLS section if TLS is not enabled.

![openshift web console 2017-06-23 09-39-28](https://user-images.githubusercontent.com/1167259/27484619-e4646f0a-57f7-11e7-94df-f8913e1de057.png)

See #1760

cc @kargakis 