### PR TITLE
Fix delete binding result message

### DIFF
--- a/app/scripts/directives/unbindService.js
+++ b/app/scripts/directives/unbindService.js
@@ -26,11 +26,16 @@
     var serviceInstanceDisplayName = $filter('serviceInstanceDisplayName');
 
     var unbindService = function() {
+      var bindingName = ctrl.selectedBinding.metadata.name;
+      // Make sure to get the unbound apps now. Otherwise they don't appear on
+      // the result page since deleting the binding will remove them from the
+      // map that is passed in.
+      ctrl.unboundApps = ctrl.appsForBinding(bindingName);
       DataService.delete({
         group: 'servicecatalog.k8s.io',
         resource: 'bindings'
       },
-      ctrl.selectedBinding.metadata.name,
+      bindingName,
       context,
       { propagationPolicy: null })
       .then(_.noop, function(err) {

--- a/app/views/directives/bind-service/delete-binding-result.html
+++ b/app/views/directives/bind-service/delete-binding-result.html
@@ -5,16 +5,18 @@
     </h3>
 
     <div
-      ng-if="ctrl.appsForBinding(ctrl.selectedBinding.metadata.name) | size"
-      ng-repeat="appForBinding in ctrl.appsForBinding(ctrl.selectedBinding.metadata.name)">
+      ng-if="ctrl.unboundApps | size"
+      ng-repeat="appForBinding in ctrl.unboundApps track by (appForBinding | uid)">
       {{appForBinding.metadata.name}} <small class="text-muted">&ndash; {{ appForBinding.kind | humanizeKind : true}}</small>
     </div>
-    <div ng-if="!(ctrl.appsForBinding(ctrl.selectedBinding.metadata.name)  | size)">
+    <div ng-if="!(ctrl.unboundApps | size)">
       {{ctrl.selectedBinding.spec.secretName}} <small class="text-muted">&ndash; Secret</small>
     </div>
 
-    <p class="mar-top-lg">
-      <span class="pficon pficon-info"></span> You will need to redeploy your pods for this to take effect.
+    <!-- Only show the redeploy pods message if previously bound to an app. -->
+    <p ng-if="ctrl.unboundApps | size" class="mar-top-lg">
+      <span class="pficon pficon-info" aria-hidden="true"></span>
+      You will need to redeploy your pods for this to take effect.
     </p>
   </div>
   <div ng-if="ctrl.error">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12348,10 +12348,11 @@ templateUrl:"views/directives/bind-service.html"
 }(), function() {
 function a(a, b, c) {
 var d, e, f = this, g = b("serviceInstanceDisplayName"), h = function() {
-c["delete"]({
+var a = f.selectedBinding.metadata.name;
+f.unboundApps = f.appsForBinding(a), c["delete"]({
 group:"servicecatalog.k8s.io",
 resource:"bindings"
-}, f.selectedBinding.metadata.name, e, {
+}, a, e, {
 propagationPolicy:null
 }).then(_.noop, function(a) {
 f.error = a;

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5819,14 +5819,16 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<h3 class=\"mar-top-none\">\n" +
     "Binding for the following has been deleted:\n" +
     "</h3>\n" +
-    "<div ng-if=\"ctrl.appsForBinding(ctrl.selectedBinding.metadata.name) | size\" ng-repeat=\"appForBinding in ctrl.appsForBinding(ctrl.selectedBinding.metadata.name)\">\n" +
+    "<div ng-if=\"ctrl.unboundApps | size\" ng-repeat=\"appForBinding in ctrl.unboundApps track by (appForBinding | uid)\">\n" +
     "{{appForBinding.metadata.name}} <small class=\"text-muted\">&ndash; {{ appForBinding.kind | humanizeKind : true}}</small>\n" +
     "</div>\n" +
-    "<div ng-if=\"!(ctrl.appsForBinding(ctrl.selectedBinding.metadata.name)  | size)\">\n" +
+    "<div ng-if=\"!(ctrl.unboundApps | size)\">\n" +
     "{{ctrl.selectedBinding.spec.secretName}} <small class=\"text-muted\">&ndash; Secret</small>\n" +
     "</div>\n" +
-    "<p class=\"mar-top-lg\">\n" +
-    "<span class=\"pficon pficon-info\"></span> You will need to redeploy your pods for this to take effect.\n" +
+    "\n" +
+    "<p ng-if=\"ctrl.unboundApps | size\" class=\"mar-top-lg\">\n" +
+    "<span class=\"pficon pficon-info\" aria-hidden=\"true\"></span>\n" +
+    "You will need to redeploy your pods for this to take effect.\n" +
     "</p>\n" +
     "</div>\n" +
     "<div ng-if=\"ctrl.error\">\n" +


### PR DESCRIPTION
Fix a timing issue where the app names changed to the secret name on the delete binding results step. This happened because deleting the binding updated the `bindingsByApplication` map that was passed in.

Also changes the results step to only show the redeploy pods message if the service was bound to an app.