### PR TITLE
[WIP] Don't show in-page alerts for create project

### DIFF
--- a/app/scripts/controllers/createProject.js
+++ b/app/scripts/controllers/createProject.js
@@ -16,7 +16,6 @@ angular.module('openshiftConsole')
                        Constants) {
     var landingPageEnabled = _.get(Constants, 'ENABLE_TECH_PREVIEW_FEATURE.service_catalog_landing_page');
 
-    $scope.alerts = {};
     $scope.onProjectCreated = function(encodedProjectName) {
       if (landingPageEnabled) {
         // If the new experience is enabled, return to project list.

--- a/app/views/create-project.html
+++ b/app/views/create-project.html
@@ -11,8 +11,7 @@
           <div class="container surface-shaded gutter-top">
             <div class="col-md-12">
               <h1>Create Project</h1>
-              <alerts alerts="alerts"></alerts>
-              <create-project alerts="alerts" redirect-action="onProjectCreated"></create-project>
+              <create-project alerts="{}" redirect-action="onProjectCreated"></create-project>
             </div>
           </div>
         </div><!-- /middle-content -->

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8131,7 +8131,7 @@ a.canCreateProject = !1;
 });
 } ]), angular.module("openshiftConsole").controller("CreateProjectController", [ "$scope", "$location", "$window", "AuthService", "Constants", function(a, b, c, d, e) {
 var f = _.get(e, "ENABLE_TECH_PREVIEW_FEATURE.service_catalog_landing_page");
-a.alerts = {}, a.onProjectCreated = function(a) {
+a.onProjectCreated = function(a) {
 f ? c.history.back() :b.path("project/" + a + "/create");
 }, d.withUser();
 } ]), angular.module("openshiftConsole").controller("EditProjectController", [ "$scope", "$routeParams", "$filter", "$location", "DataService", "ProjectsService", "Navigate", function(a, b, c, d, e, f, g) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4678,8 +4678,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container surface-shaded gutter-top\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<h1>Create Project</h1>\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
-    "<create-project alerts=\"alerts\" redirect-action=\"onProjectCreated\"></create-project>\n" +
+    "<create-project alerts=\"{}\" redirect-action=\"onProjectCreated\"></create-project>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
Fixes an issue where both an in-page alert and toast notification can appear when there is an error creating a project.