### PR TITLE
Bug 1462067 - Don't set propagationPolicy when deleting pod immediately

### DIFF
--- a/app/scripts/directives/deleteLink.js
+++ b/app/scripts/directives/deleteLink.js
@@ -145,6 +145,7 @@ angular.module("openshiftConsole")
             var deleteOptions = {};
             if (scope.options.deleteImmediately) {
               deleteOptions.gracePeriodSeconds = 0;
+              deleteOptions.propagationPolicy = null;
             }
 
             // TODO - remove once this is resolved https://github.com/kubernetes-incubator/service-catalog/issues/942

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8868,7 +8868,7 @@ b.result.then(function() {
 var a = d.kind, b = d.resourceName, e = d.typeDisplayName || c("humanizeKind")(a), h = e + " '" + (d.displayName ? d.displayName :b) + "'", k = "Project" === d.kind ? {} :{
 namespace:d.projectName
 }, l = {};
-d.options.deleteImmediately && (l.gracePeriodSeconds = 0), "servicecatalog.k8s.io" === d.group && (l.propagationPolicy = null), g["delete"]({
+d.options.deleteImmediately && (l.gracePeriodSeconds = 0, l.propagationPolicy = null), "servicecatalog.k8s.io" === d.group && (l.propagationPolicy = null), g["delete"]({
 resource:f.kindToResource(a),
 group:d.group
 }, b, k, l).then(function() {


### PR DESCRIPTION
This change removes the propagation policy from delete options when force deleting a pod from the web console. It makes the web console DELETE request consistent with `oc delete --now --force` (only when delete immediately is checked).

@jwforres WIP because I haven't been able to verify against a pod that is really stuck in terminating. I'm concerned we might have a GC bug with propagation policy foreground and grace period 0.

@derekwaynecarr Do you know how I can purposely get a pod stuck in Terminating state to test this fix?

cc @deads2k 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1462067