### PR TITLE
Let users add labels when creating a config map

### DIFF
--- a/app/scripts/controllers/createConfigMap.js
+++ b/app/scripts/controllers/createConfigMap.js
@@ -9,15 +9,16 @@
  */
 angular.module('openshiftConsole')
   .controller('CreateConfigMapController',
-              function ($filter,
-                        $routeParams,
-                        $scope,
-                        $window,
-                        AuthorizationService,
-                        DataService,
-                        Navigate,
-                        NotificationsService,
-                        ProjectsService) {
+              function($filter,
+                       $routeParams,
+                       $scope,
+                       $window,
+                       AuthorizationService,
+                       DataService,
+                       Navigate,
+                       NotificationsService,
+                       ProjectsService,
+                       keyValueEditorUtils) {
     $scope.projectName = $routeParams.project;
 
     // TODO: Update BreadcrumbsService to handle create pages.
@@ -65,11 +66,13 @@ angular.module('openshiftConsole')
           },
           data: {}
         };
+        $scope.labels = [];
 
         $scope.createConfigMap = function() {
           if ($scope.createConfigMapForm.$valid) {
             hideErrorNotifications();
             $scope.disableInputs = true;
+            $scope.configMap.metadata.labels = keyValueEditorUtils.mapEntries(keyValueEditorUtils.compactEntries($scope.labels));
             DataService.create('configmaps', null, $scope.configMap, context)
               .then(function() { // Success
                 NotificationsService.addNotification({

--- a/app/views/create-config-map.html
+++ b/app/views/create-config-map.html
@@ -18,9 +18,15 @@
                     Config maps hold key-value pairs that can be used in pods to read application
                     configuration.
                   </div>
-                  <form name="createConfigMapForm" class="mar-top-xl">
+                  <form name="createConfigMapForm" class="mar-top-xl osc-form">
                     <fieldset ng-disabled="disableInputs">
                       <edit-config-map model="configMap" show-name-input="true"></edit-config-map>
+                      <label-editor
+                        labels="labels"
+                        expand="true"
+                        can-toggle="false"
+                        help-text="Labels for this config map.">
+                      </label-editor>
                       <div class="button-group gutter-top gutter-bottom">
                         <button type="submit"
                             class="btn btn-primary btn-lg"

--- a/app/views/directives/edit-config-map.html
+++ b/app/views/directives/edit-config-map.html
@@ -116,7 +116,5 @@
         </span>
       </div>
     </div>
-    <div>
-    </div>
   </fieldset>
 </ng-form>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -6176,7 +6176,7 @@ a.loaded = !0, a.error = b;
 d.unwatchAll(f);
 });
 }));
-} ]), angular.module("openshiftConsole").controller("CreateConfigMapController", [ "$filter", "$routeParams", "$scope", "$window", "AuthorizationService", "DataService", "Navigate", "NotificationsService", "ProjectsService", function(a, b, c, d, e, f, g, h, i) {
+} ]), angular.module("openshiftConsole").controller("CreateConfigMapController", [ "$filter", "$routeParams", "$scope", "$window", "AuthorizationService", "DataService", "Navigate", "NotificationsService", "ProjectsService", "keyValueEditorUtils", function(a, b, c, d, e, f, g, h, i, j) {
 c.projectName = b.project, c.breadcrumbs = [ {
 title:c.projectName,
 link:"project/" + c.projectName
@@ -6186,14 +6186,14 @@ link:"project/" + c.projectName + "/browse/config-maps"
 }, {
 title:"Create Config Map"
 } ];
-var j = function() {
+var k = function() {
 h.hideNotification("create-config-map-error");
 };
-c.$on("$destroy", j);
-var k = function() {
+c.$on("$destroy", k);
+var l = function() {
 d.history.back();
 };
-c.cancel = k, i.get(b.project).then(_.spread(function(d, i) {
+c.cancel = l, i.get(b.project).then(_.spread(function(d, i) {
 return c.project = d, c.breadcrumbs[0].title = a("displayName")(d), e.canI("configmaps", "create", b.project) ? (c.configMap = {
 apiVersion:"v1",
 kind:"ConfigMap",
@@ -6201,12 +6201,12 @@ metadata:{
 namespace:b.project
 },
 data:{}
-}, void (c.createConfigMap = function() {
-c.createConfigMapForm.$valid && (j(), c.disableInputs = !0, f.create("configmaps", null, c.configMap, i).then(function() {
+}, c.labels = [], void (c.createConfigMap = function() {
+c.createConfigMapForm.$valid && (k(), c.disableInputs = !0, c.configMap.metadata.labels = j.mapEntries(j.compactEntries(c.labels)), f.create("configmaps", null, c.configMap, i).then(function() {
 h.addNotification({
 type:"success",
 message:"Config map " + c.configMap.metadata.name + " successfully created."
-}), k();
+}), l();
 }, function(b) {
 c.disableInputs = !1, h.addNotification({
 id:"create-config-map-error",

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4518,9 +4518,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"help-block\">\n" +
     "Config maps hold key-value pairs that can be used in pods to read application configuration.\n" +
     "</div>\n" +
-    "<form name=\"createConfigMapForm\" class=\"mar-top-xl\">\n" +
+    "<form name=\"createConfigMapForm\" class=\"mar-top-xl osc-form\">\n" +
     "<fieldset ng-disabled=\"disableInputs\">\n" +
     "<edit-config-map model=\"configMap\" show-name-input=\"true\"></edit-config-map>\n" +
+    "<label-editor labels=\"labels\" expand=\"true\" can-toggle=\"false\" help-text=\"Labels for this config map.\">\n" +
+    "</label-editor>\n" +
     "<div class=\"button-group gutter-top gutter-bottom\">\n" +
     "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-click=\"createConfigMap()\" ng-disabled=\"createConfigMapForm.$invalid || disableInputs\" value=\"\">Create</button>\n" +
     "<a class=\"btn btn-default btn-lg\" href=\"\" ng-click=\"cancel()\" role=\"button\">Cancel</a>\n" +
@@ -6572,8 +6574,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a href=\"\" ng-click=\"addItem()\">Add Item</a>\n" +
     "</span>\n" +
     "</div>\n" +
-    "</div>\n" +
-    "<div>\n" +
     "</div>\n" +
     "</fieldset>\n" +
     "</ng-form>"


### PR DESCRIPTION
Fixes #1185

@jwforres It looks like none of our editors let you change labels, so I only added it to the config map create form for now.

![screen shot 2017-07-05 at 12 12 14 pm](https://user-images.githubusercontent.com/1167259/27873791-4d872874-617b-11e7-801c-9fcdd483237d.png)
