### PR TITLE
Improve YAML editor validation and feedback

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -366,6 +366,7 @@
         <script src="scripts/directives/pauseRolloutsCheckbox.js"></script>
         <script src="scripts/directives/keyValueEditor.js"></script>
         <script src="scripts/directives/confirmOnExit.js"></script>
+        <script src="scripts/directives/uiAceYaml.js"></script>
         <script src="scripts/filters/date.js"></script>
         <script src="scripts/filters/resources.js"></script>
         <script src="scripts/filters/canI.js"></script>

--- a/app/scripts/directives/oscFileInput.js
+++ b/app/scripts/directives/oscFileInput.js
@@ -9,6 +9,8 @@ angular.module('openshiftConsole')
         required: "=",
         disabled: "=ngDisabled",
         showTextArea: '=',
+        // Hide the clear value link.
+        hideClear: '=?',
         helpText: "@?",
         dropZoneId: "@?"
       },

--- a/app/scripts/directives/uiAceYaml.js
+++ b/app/scripts/directives/uiAceYaml.js
@@ -1,0 +1,124 @@
+'use strict';
+
+(function() {
+  angular.module('openshiftConsole').component('uiAceYaml', {
+    controller: [
+      '$scope',
+      UIAceYAML
+    ],
+    controllerAs: '$ctrl',
+    bindings: {
+      resource: '=',
+      ngRequired: '<?',
+      showFileInput: '<?'
+    },
+    templateUrl: 'views/directives/ui-ace-yaml.html'
+  });
+
+  function UIAceYAML($scope) {
+    var ctrl = this;
+    var aceEditor;
+
+    var parseYAML = function(strict) {
+      // https://github.com/nodeca/js-yaml#safeload-string---options-
+      return jsyaml.safeLoad(ctrl.model, {
+        // If `strict` is false, allow duplicate keys in the YAML for
+        // compability with `oc create` using the js-yaml `json` option. This
+        // also lets us parse JSON as YAML, where duplicate keys are allowed.
+        json: !strict
+      });
+    };
+
+    var clearAnnotations = function() {
+      aceEditor.getSession().clearAnnotations();
+      $scope.$evalAsync(function() {
+        ctrl.annotations = {};
+      });
+    };
+
+    var setAnnotation = function(e, severity) {
+      var session = aceEditor.getSession();
+      var length = session.getLength();
+      var row = _.get(e, 'mark.line', 0);
+      var col = _.get(e, 'mark.column', 0);
+      var message = e.message || 'Could not parse content.';
+
+      // If the error line is reported as being after the last line, use the
+      // last line. This can happen when the error is at the very end of the
+      // document and the user doesn't have a final newline.
+      if (row >= length) {
+        row = length - 1;
+      }
+
+      var annotation = {
+        row: row,
+        column: col,
+        text: message,
+        type: severity
+      };
+      session.setAnnotations([ annotation ]);
+
+      $scope.$evalAsync(function() {
+        ctrl.annotations = {};
+        ctrl.annotations[severity] = [ annotation ];
+      });
+    };
+
+    var setValid = function(valid) {
+      $scope.$evalAsync(function() {
+        ctrl.form.$setValidity('yamlValid', valid);
+      });
+    };
+
+    var updated = function() {
+      // Check for errors, then check for warnings.
+      try {
+        ctrl.resource = parseYAML(false);
+        setValid(true);
+        // Check for warnings.
+        try {
+          parseYAML(true);
+          clearAnnotations();
+        } catch (e) {
+          setAnnotation(e, 'warning');
+        }
+      } catch (e) {
+        setAnnotation(e, 'error');
+        setValid(false);
+      }
+    };
+
+    $scope.$watch(function() {
+      return ctrl.fileUpload;
+    }, function(content, previous) {
+      if (content === previous) {
+        return;
+      }
+
+      ctrl.model = content;
+    });
+
+    ctrl.$onInit = function() {
+      if (ctrl.resource) {
+        ctrl.model = jsyaml.safeDump(ctrl.resource, {
+          sortKeys: true
+        });
+      }
+    };
+
+    ctrl.aceChanged = updated;
+    ctrl.aceLoaded = function(editor) {
+      // Keep a reference to use later in event callbacks.
+      aceEditor = editor;
+
+      var session = editor.getSession();
+      session.setOption('tabSize', 2);
+      session.setOption('useSoftTabs', true);
+      editor.setDragDelay = 0;
+    };
+
+    ctrl.gotoLine = function(line) {
+      aceEditor.gotoLine(line);
+    };
+  }
+})();

--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -976,30 +976,6 @@ a.disabled-link {
   }
 }
 
-// Disable numeric highlighting in YAML and Dockerfile modes because of bugs
-.editor.yaml-mode .ace_constant.ace_numeric, .ace_editor.dockerfile-mode .ace_constant.ace_numeric {
-  color: inherit;
-}
-
-.edit-yaml {
-  h1 {
-    line-height: 1.3;
-  }
-  .editor {
-    font-family: @font-family-monospace;
-    line-height: 1.5;
-    width: 100%;
-    min-height: 140px;
-    height: 50vh;
-    .ace_gutter {
-      color: #8b8d8f;
-    }
-    @media (min-height: 700px) {
-      height: 60vh;
-    }
-  }
-}
-
 .debug-pod-action {
   margin-top: 5px;
 }
@@ -1042,18 +1018,6 @@ a.disabled-link {
     margin-top: 0;
     padding-top: 0;
   }
-}
-
-.ace-inline {
-  height: 300px;
-}
-
-.ace-inline-small {
-  height: 200px;
-}
-
-#from-file .editor {
-  height: 350px;
 }
 
 .edit-form {
@@ -1225,14 +1189,6 @@ pre.clipped {
     .label-pair {
       width: 100%;
     }
-  }
-}
-
-.ace-bordered {
-  border: 1px solid #8b8d8f;
-  &.ace-read-only {
-    border-color: #d1d1d1;
-    background-color: #fafafa;
   }
 }
 

--- a/app/styles/_editor.less
+++ b/app/styles/_editor.less
@@ -1,0 +1,56 @@
+//
+// Ace editor styles
+// --------------------------------------------------
+
+.ace-bordered {
+  border: 1px solid #8b8d8f;
+  &.ace-read-only {
+    border-color: #d1d1d1;
+    background-color: #fafafa;
+  }
+}
+
+.ace-inline {
+  height: 300px;
+}
+
+.ace-inline-small {
+  height: 200px;
+}
+
+// Disable numeric highlighting in YAML and Dockerfile modes because of bugs
+.editor.yaml-mode .ace_constant.ace_numeric,
+.ace_editor.dockerfile-mode .ace_constant.ace_numeric {
+  color: inherit;
+}
+
+.edit-yaml {
+  h1 {
+    line-height: 1.3;
+  }
+  .editor {
+    font-family: @font-family-monospace;
+    line-height: 1.5;
+    width: 100%;
+    min-height: 140px;
+    height: 50vh;
+    .ace_gutter {
+      color: #8b8d8f;
+    }
+    @media (min-height: 700px) {
+      height: 60vh;
+    }
+  }
+}
+
+.edit-yaml-errors {
+  .small();
+  // Always occupy the same height so the editor doesn't move when we show an error.
+  height: 2em;
+  text-align: right;
+}
+
+#from-file .editor {
+  height: 350px;
+}
+

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -60,3 +60,4 @@
 @import "_application-launcher";
 @import "_wizard.less";
 @import "_builds.less";
+@import "_editor.less";

--- a/app/views/directives/from-file.html
+++ b/app/views/directives/from-file.html
@@ -5,30 +5,13 @@
 <parse-error error="error" ng-show="error"></parse-error>
 <div class="row">
   <div class="col-sm-12 pod-bottom-xl">
-    <form name="form">
-      <div class="form-group" id="from-file">
-        <osc-file-input
-          model="editorContent"
-          drop-zone-id="from-file"
-          help-text="Upload file by dragging & dropping, selecting it, or pasting from the clipboard."
-          ng-disabled="false"></osc-file-input>
-        <div ui-ace="{
-          mode: 'yaml',
-          theme: 'eclipse',
-          onLoad: aceLoaded,
-          onChange: aceChanged,
-          rendererOptions: {
-            fadeFoldWidgets: true,
-            showPrintMargin: false
-          }
-        }" ng-model="editorContent" class="editor ace-bordered yaml-mode" id="add-component-editor" required></div>
-      </div>
-
+    <form name="form" id="from-file">
+      <ui-ace-yaml resource="resource" ng-required="true" show-file-input="true"></ui-ace-yaml>
       <div ng-if="!isDialog" class="buttons gutter-bottom">
         <button
           type="submit"
           ng-click="create()"
-          ng-disabled="editorErrorAnnotation || !editorContent"
+          ng-disabled="form.$invalid"
           class="btn btn-primary btn-lg">
           Create
         </button>

--- a/app/views/directives/osc-file-input.html
+++ b/app/views/directives/osc-file-input.html
@@ -36,5 +36,5 @@
       ng-attr-aria-describedby="{{helpText ? helpID : undefined}}">
   </textarea>
 
-  <a href="" ng-show="(model || fileName) && !disabled" ng-click="cleanInputValues()">Clear Value</a>
+  <a href="" ng-show="(model || fileName) && !disabled && !hideClear" ng-click="cleanInputValues()">Clear Value</a>
 </div>

--- a/app/views/directives/ui-ace-yaml.html
+++ b/app/views/directives/ui-ace-yaml.html
@@ -1,0 +1,44 @@
+<ng-form name="$ctrl.form">
+  <div class="form-group" id="yaml-file">
+    <osc-file-input
+      ng-if="$ctrl.showFileInput"
+      model="$ctrl.fileUpload"
+      drop-zone-id="yaml-file"
+      help-text="Upload a file by dragging & dropping, selecting it, or pasting from the clipboard."
+      ng-disabled="false"
+      hide-clear="true"></osc-file-input>
+
+    <div class="edit-yaml-errors">
+      <!--
+        Since the YAML parser quits after the first error, don't give a count.
+        Just show an indicator and link to the first problem line.
+      -->
+      <div ng-if="firstError = $ctrl.annotations.error[0]">
+        <a href="" ng-click="$ctrl.gotoLine(firstError.row)">
+          <span class="pficon pficon-error-circle-o" aria-hidden="true"></span>
+          Error
+        </a>
+      </div>
+      <div ng-if="firstWarning = $ctrl.annotations.warning[0]">
+        <a href="" ng-click="$ctrl.gotoLine(firstWarning.row)">
+          <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
+          Warning
+        </a>
+      </div>
+    </div>
+
+    <div ui-ace="{
+      mode: 'yaml',
+      theme: 'eclipse',
+      onLoad: $ctrl.aceLoaded,
+      onChange: $ctrl.aceChanged,
+      rendererOptions: {
+        showPrintMargin: false
+      }
+    }"
+    ng-model="$ctrl.model"
+    class="editor ace-bordered yaml-mode"
+    ng-required="$ctrl.ngRequired"
+    id="ace-yaml-editor"></div>
+  </div>
+</ng-form>

--- a/app/views/edit/yaml.html
+++ b/app/views/edit/yaml.html
@@ -11,48 +11,42 @@
           <div class="container surface-shaded">
             <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
             <alerts alerts="alerts"></alerts>
-            <div ng-if="!resource" class="pad-top-md">Loading...</div>
-            <div ng-if="resource" class="pad-top-md">
-              <h1 class="truncate">Edit <span class="hidden-xs">{{resource.kind | humanizeKind : true}}</span> {{resource.metadata.name}}</h1>
+            <div ng-if="!updated.resource" class="pad-top-md">Loading...</div>
+            <div ng-if="updated.resource" class="pad-top-md">
+              <h1 class="truncate">Edit <span class="hidden-xs">{{updated.resource.kind | humanizeKind : true}}</span> {{updated.resource.metadata.name}}</h1>
               <parse-error error="error" ng-if="error"></parse-error>
 
               <div ng-if="resourceChanged && !resourceDeleted && !updatingNow" class="alert alert-warning">
                 <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
                 <span class="sr-only">Warning:</span>
-                {{resource.kind | humanizeKind | upperFirst}} <strong>{{resource.metadata.name}}</strong> has
+                {{updated.resource.kind | humanizeKind | upperFirst}} <strong>{{updated.resource.metadata.name}}</strong> has
                 changed since you started editing it. You'll need to copy any changes you've made and edit the
-                {{resource.kind | humanizeKind}} again.
+                {{updated.resource.kind | humanizeKind}} again.
               </div>
 
               <div ng-if="resourceDeleted" class="alert alert-warning">
                 <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
                 <span class="sr-only">Warning:</span>
-                {{resource.kind | humanizeKind | upperFirst}} <strong>{{resource.metadata.name}}</strong> has
+                {{updated.resource.kind | humanizeKind | upperFirst}} <strong>{{updated.resource.metadata.name}}</strong> has
                 been deleted since you started editing it.
               </div>
 
               <confirm-on-exit dirty="modified"></confirm-on-exit>
 
-              <!-- Editor -->
-              <div ui-ace="{
-                mode: 'yaml',
-                theme: 'eclipse',
-                onLoad: aceLoaded,
-                rendererOptions: {
-                  showPrintMargin: false
-                }
-              }" ng-model="editor.model" class="editor ace-bordered yaml-mode"></div>
+              <form name="editor.form">
+                <ui-ace-yaml resource="updated.resource" ng-required="true"></ui-ace-yaml>
 
-              <div class="button-group mar-top-xl">
-                <button class="btn btn-lg btn-primary"
-                        type="button"
-                        ng-click="save()"
-                        ng-disabled="!modified || resourceChanged || resourceDeleted || updatingNow">Save</button>
-                <button class="btn btn-lg btn-default"
-                        type="button"
-                        ng-disabled="updatingNow"
-                        ng-click="cancel()">Cancel</button>
-              </div>
+                <div class="button-group mar-top-xl">
+                  <button class="btn btn-lg btn-primary"
+                          type="button"
+                          ng-click="save()"
+                          ng-disabled="editor.form.$pristine || editor.form.$invalid || resourceChanged || resourceDeleted || updatingNow">Save</button>
+                  <button class="btn btn-lg btn-default"
+                          type="button"
+                          ng-disabled="updatingNow"
+                          ng-click="cancel()">Cancel</button>
+                </div>
+              </form>
             </div>
           </div>
         </div><!-- /middle-content -->

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12,7 +12,7 @@ group: "servicecatalog.k8s.io",
 resource: "bindings"
 });
 e.projectName = n.project;
-var E, N, D = t("annotation"), I = t("buildConfigForBuild"), B = t("deploymentIsInProgress"), A = t("imageObjectRef"), L = t("isJenkinsPipelineStrategy"), U = t("isNewerResource"), O = t("label"), x = t("podTemplate"), F = {}, M = {}, V = {}, q = R.state = {
+var E, N, D = t("annotation"), I = t("buildConfigForBuild"), A = t("deploymentIsInProgress"), B = t("imageObjectRef"), L = t("isJenkinsPipelineStrategy"), U = t("isNewerResource"), O = t("label"), x = t("podTemplate"), F = {}, M = {}, V = {}, q = R.state = {
 alerts: {},
 builds: {},
 clusterQuotas: {},
@@ -218,7 +218,7 @@ return "Succeeded" !== e.status.phase && "Failed" !== e.status.phase && (!O(e, "
 }, Pe = function() {
 q.podsByOwnerUID = C.groupByOwnerUID(R.pods), R.monopods = _.filter(q.podsByOwnerUID[""], Re);
 }, Te = function(e) {
-return !!_.get(e, "status.replicas") || (!D(e, "deploymentConfig") || B(e));
+return !!_.get(e, "status.replicas") || (!D(e, "deploymentConfig") || A(e));
 }, Ee = function(e) {
 return D(e, "deploymentConfig");
 }, Ne = function() {
@@ -253,20 +253,20 @@ return De(e, n);
 R.replicaSetsByDeploymentUID[t] = r, R.currentByDeploymentUID[t] = _.head(r);
 }
 }), R.vanillaReplicaSets = _.sortBy(R.replicaSetsByDeploymentUID[""], "metadata.name"), Se());
-}, $e = {}, Be = function(e) {
+}, $e = {}, Ae = function(e) {
 e && q.allServices && _.each(e, function(e) {
 var t = [], n = K(e), a = x(e);
 _.each($e, function(e, n) {
 e.matches(a) && t.push(q.allServices[n]);
 }), q.servicesByObjectUID[n] = _.sortBy(t, "metadata.name");
 });
-}, Ae = function() {
+}, Be = function() {
 if (q.allServices) {
 $e = _.mapValues(q.allServices, function(e) {
 return new LabelSelector(e.spec.selector);
 });
 var e = [ R.deploymentConfigs, R.vanillaReplicationControllers, R.deployments, R.vanillaReplicaSets, R.statefulSets, R.monopods ];
-_.each(e, Be), Z();
+_.each(e, Ae), Z();
 }
 }, Le = function() {
 var e = j.groupByService(R.routes, !0);
@@ -315,7 +315,7 @@ var t = [], n = _.get(e, "spec.triggers");
 _.each(n, function(n) {
 var a = _.get(n, "imageChangeParams.from");
 if (a) {
-var r = A(a, e.metadata.namespace), o = xe[r];
+var r = B(a, e.metadata.namespace), o = xe[r];
 _.isEmpty(o) || (t = t.concat(o));
 }
 }), t = _.sortBy(t, "metadata.name"), qe(t, e), Ve(e);
@@ -403,33 +403,33 @@ var r = function() {
 R.pods && m.fetchReferencedImageStreamImages(R.pods, q.imagesByDockerReference, q.imageStreamImageRefByDockerReference, a);
 };
 Xe.push(c.watch("pods", a, function(e) {
-R.pods = e.by("metadata.name"), Pe(), r(), we(), Be(R.monopods), ge(R.monopods), ke(R.monopods), se(), f.log("pods (subscribe)", R.pods);
+R.pods = e.by("metadata.name"), Pe(), r(), we(), Ae(R.monopods), ge(R.monopods), ke(R.monopods), se(), f.log("pods (subscribe)", R.pods);
 })), Xe.push(c.watch("replicationcontrollers", a, function(e) {
-R.replicationControllers = e.by("metadata.name"), Ne(), Be(R.vanillaReplicationControllers), Be(R.monopods), ge(R.vanillaReplicationControllers), ke(R.vanillaReplicationControllers), Ye(), se(), f.log("replicationcontrollers (subscribe)", R.replicationControllers);
+R.replicationControllers = e.by("metadata.name"), Ne(), Ae(R.vanillaReplicationControllers), Ae(R.monopods), ge(R.vanillaReplicationControllers), ke(R.vanillaReplicationControllers), Ye(), se(), f.log("replicationcontrollers (subscribe)", R.replicationControllers);
 })), Xe.push(c.watch("deploymentconfigs", a, function(e) {
-R.deploymentConfigs = e.by("metadata.name"), Ne(), Be(R.deploymentConfigs), Be(R.vanillaReplicationControllers), ke(R.deploymentConfigs), Se(), Ke(), We(), Ye(), se(), f.log("deploymentconfigs (subscribe)", R.deploymentConfigs);
+R.deploymentConfigs = e.by("metadata.name"), Ne(), Ae(R.deploymentConfigs), Ae(R.vanillaReplicationControllers), ke(R.deploymentConfigs), Se(), Ke(), We(), Ye(), se(), f.log("deploymentconfigs (subscribe)", R.deploymentConfigs);
 })), Xe.push(c.watch({
 group: "extensions",
 resource: "replicasets"
 }, a, function(e) {
-R.replicaSets = e.by("metadata.name"), Ie(), Be(R.vanillaReplicaSets), Be(R.monopods), ge(R.vanillaReplicaSets), ke(R.vanillaReplicaSets), Ye(), se(), f.log("replicasets (subscribe)", R.replicaSets);
+R.replicaSets = e.by("metadata.name"), Ie(), Ae(R.vanillaReplicaSets), Ae(R.monopods), ge(R.vanillaReplicaSets), ke(R.vanillaReplicaSets), Ye(), se(), f.log("replicasets (subscribe)", R.replicaSets);
 })), Xe.push(c.watch({
 group: "apps",
 resource: "deployments"
 }, a, function(e) {
-E = e.by("metadata.uid"), R.deployments = _.sortBy(E, "metadata.name"), Ie(), Be(R.deployments), Be(R.vanillaReplicaSets), ke(R.deployments), Ye(), se(), f.log("deployments (subscribe)", R.deploymentsByUID);
+E = e.by("metadata.uid"), R.deployments = _.sortBy(E, "metadata.name"), Ie(), Ae(R.deployments), Ae(R.vanillaReplicaSets), ke(R.deployments), Ye(), se(), f.log("deployments (subscribe)", R.deploymentsByUID);
 })), Xe.push(c.watch("builds", a, function(e) {
 q.builds = e.by("metadata.name"), Ge(), f.log("builds (subscribe)", q.builds);
 })), Xe.push(c.watch({
 group: "apps",
 resource: "statefulsets"
 }, a, function(e) {
-R.statefulSets = e.by("metadata.name"), Be(R.statefulSets), Be(R.monopods), ge(R.statefulSets), ke(R.statefulSets), Ye(), se(), f.log("statefulsets (subscribe)", R.statefulSets);
+R.statefulSets = e.by("metadata.name"), Ae(R.statefulSets), Ae(R.monopods), ge(R.statefulSets), ke(R.statefulSets), Ye(), se(), f.log("statefulsets (subscribe)", R.statefulSets);
 }, {
 poll: P,
 pollInterval: 6e4
 })), Xe.push(c.watch("services", a, function(e) {
-q.allServices = e.by("metadata.name"), Ae(), f.log("services (subscribe)", q.allServices);
+q.allServices = e.by("metadata.name"), Be(), f.log("services (subscribe)", q.allServices);
 }, {
 poll: P,
 pollInterval: 6e4
@@ -4583,7 +4583,7 @@ n.filteredStatefulSets = s.filterForKeywords(_.values(n.statefulSets), S, w);
 b = _.filter(n.pods, function(e) {
 return !n.filters.hideOlderResources || "Succeeded" !== e.status.phase && "Failed" !== e.status.phase;
 }), n.filteredPods = s.filterForKeywords(b, S, w);
-}, N = a("isIncompleteBuild"), D = a("buildConfigForBuild"), I = a("isRecentBuild"), B = function() {
+}, N = a("isIncompleteBuild"), D = a("buildConfigForBuild"), I = a("isRecentBuild"), A = function() {
 moment().subtract(5, "m");
 h = _.filter(n.builds, function(e) {
 if (!n.filters.hideOlderResources) return !0;
@@ -4591,9 +4591,9 @@ if (N(e)) return !0;
 var t = D(e);
 return t ? n.latestBuildByConfig[t].metadata.name === e.metadata.name : I(e);
 }), n.filteredBuilds = s.filterForKeywords(h, S, w);
-}, A = a("deploymentStatus"), L = a("deploymentIsInProgress"), U = function() {
+}, B = a("deploymentStatus"), L = a("deploymentIsInProgress"), U = function() {
 v = _.filter(n.replicationControllers, function(e) {
-return !n.filters.hideOlderResources || (L(e) || "Active" === A(e));
+return !n.filters.hideOlderResources || (L(e) || "Active" === B(e));
 }), n.filteredReplicationControllers = s.filterForKeywords(v, S, w);
 }, O = function() {
 y = _.filter(n.replicaSets, function(e) {
@@ -4653,7 +4653,7 @@ n.statefulSets = e.by("metadata.name"), n.statefulSetsLoaded = !0, T(), c.log("s
 }), o.watch("replicationcontrollers", a, function(e) {
 n.replicationControllers = C(e.by("metadata.name"), !0), n.replicationControllersLoaded = !0, _.each(n.replicationControllers, R), U(), c.log("replicationcontrollers", n.replicationControllers);
 }), o.watch("builds", a, function(e) {
-n.builds = C(e.by("metadata.name"), !0), n.latestBuildByConfig = r.latestBuildByConfig(n.builds), n.buildsLoaded = !0, _.each(n.builds, P), B(), c.log("builds", n.builds);
+n.builds = C(e.by("metadata.name"), !0), n.latestBuildByConfig = r.latestBuildByConfig(n.builds), n.buildsLoaded = !0, _.each(n.builds, P), A(), c.log("builds", n.builds);
 }), o.watch({
 group: "extensions",
 resource: "replicasets"
@@ -4662,7 +4662,7 @@ n.replicaSets = C(e.by("metadata.name"), !0), n.replicaSetsLoaded = !0, O(), c.l
 }), n.$on("$destroy", function() {
 o.unwatchAll(g);
 }), n.$watch("filters.hideOlderResources", function() {
-E(), B(), U(), O(), T();
+E(), A(), U(), O(), T();
 var e = t.search();
 e.hideOlderResources = n.filters.hideOlderResources ? "true" : "false", t.replace().search(e);
 }), n.$watch("kindSelector.selected.kind", function() {
@@ -5632,7 +5632,7 @@ details: t("getErrorDetails")(n)
 }
 }, $ = function() {
 e.isActive = i.isActiveReplicaSet(e.replicaSet, e.deployment);
-}, B = function(t) {
+}, A = function(t) {
 return _.some(t, function(t) {
 if (_.get(t, "status.replicas") && _.get(t, "metadata.uid") !== _.get(e.replicaSet, "metadata.uid")) {
 var n = p.getControllerReferences(t);
@@ -5641,7 +5641,7 @@ uid: e.deployment.metadata.uid
 });
 }
 });
-}, A = !1, L = function() {
+}, B = !1, L = function() {
 var t = p.getControllerReferences(e.replicaSet), a = _.find(t, {
 kind: "Deployment"
 });
@@ -5671,7 +5671,7 @@ group: "extensions",
 resource: "replicasets"
 }, f, function(e) {
 var t = e.by("metadata.name");
-A = B(t);
+B = A(t);
 }));
 });
 }, U = function() {
@@ -5767,7 +5767,7 @@ details: t("getErrorDetails")(n)
 };
 var x = t("hasDeploymentConfig");
 e.isScalable = function() {
-return !!_.isEmpty(e.autoscalers) && (!x(e.replicaSet) && !w(e.replicaSet) || (!(!e.deploymentConfigMissing && !e.deploymentMissing) || !(!e.deploymentConfig && !e.deployment) && (e.isActive && !A)));
+return !!_.isEmpty(e.autoscalers) && (!x(e.replicaSet) && !w(e.replicaSet) || (!(!e.deploymentConfigMissing && !e.deploymentMissing) || !(!e.deploymentConfig && !e.deployment) && (e.isActive && !B)));
 }, e.removeVolume = function(n) {
 var a = "This will remove the volume from the " + t("humanizeKind")(e.replicaSet.kind) + ".";
 n.persistentVolumeClaim ? a += " It will not delete the persistent volume claim." : n.secret ? a += " It will not delete the secret." : n.configMap && (a += " It will not delete the config map.");
@@ -7292,18 +7292,11 @@ title: "Edit YAML"
 } ];
 var p = function() {
 e.modified = !1, a.returnURL ? n.url(a.returnURL) : r.history.back();
-}, g = _.throttle(function() {
-e.$eval(function() {
-e.modified = !0;
-});
-}, 1e3);
-e.aceLoaded = function(e) {
-var t = e.getSession();
-t.setOption("tabSize", 2), t.setOption("useSoftTabs", !0), setTimeout(function() {
-t.on("change", g);
-});
 };
-var f = [];
+e.$watch("resource", function(t, n) {
+t !== n && (e.modified = !0);
+});
+var g = [];
 d.get(a.project).then(_.spread(function(n, r) {
 var s = {
 resource: o.kindToResource(a.kind),
@@ -7312,25 +7305,17 @@ group: a.group
 i.canI(s, "update", a.project) ? (c.get(s, e.name, r, {
 errorNotification: !1
 }).then(function(n) {
-var i = angular.copy(n);
-e.resource = i;
+var i = n;
+_.set(e, "updated.resource", angular.copy(n));
 var l = function(e) {
 return _.get(e, "metadata.resourceVersion");
 };
-_.set(e, "editor.model", jsyaml.safeDump(i, {
-sortKeys: !0
-})), e.save = function() {
-e.modified = !1;
-var n;
-try {
-n = jsyaml.safeLoad(e.editor.model);
-} catch (t) {
-return void (e.error = t);
-}
-if (n.kind === i.kind) {
+e.save = function() {
+var n = e.updated.resource;
+if (e.modified = !1, n.kind === i.kind) {
 var r = o.objectToResourceGroupVersion(i), s = o.objectToResourceGroupVersion(n);
-s ? s.group === r.group ? o.apiInfo(s) ? (e.updatingNow = !0, c.update(s, e.resource.metadata.name, n, {
-namespace: e.resource.metadata.namespace
+s ? s.group === r.group ? o.apiInfo(s) ? (e.updatingNow = !0, c.update(r, i.metadata.name, i, {
+namespace: i.metadata.namespace
 }).then(function(t) {
 var r = _.get(n, "metadata.resourceVersion");
 if (_.get(t, "metadata.resourceVersion") === r) return e.alerts["no-changes-applied"] = {
@@ -7358,7 +7343,7 @@ message: "Cannot change resource kind (original: " + i.kind + ", modified: " + (
 };
 }, e.cancel = function() {
 p();
-}, f.push(c.watchObject(s, e.name, r, function(t, n) {
+}, g.push(c.watchObject(s, e.name, r, function(t, n) {
 e.resourceChanged = l(t) !== l(i), e.resourceDeleted = "DELETED" === n;
 }, {
 errorNotification: !1
@@ -7366,7 +7351,7 @@ errorNotification: !1
 }, function(e) {
 l.toErrorPage("Could not load " + m(a.kind) + " '" + a.name + "'. " + t("getErrorDetails")(e));
 }), e.$on("$destroy", function() {
-c.unwatchAll(f);
+c.unwatchAll(g);
 })) : l.toErrorPage("You do not have authority to update " + m(a.kind) + " " + a.name + ".", "access_denied");
 }));
 } else l.toErrorPage("Kind or name parameter missing.");
@@ -7555,7 +7540,7 @@ g.toErrorPage("Cannot create from source: the specified image could not be retri
 g.toErrorPage("Cannot create from source: the specified image could not be retrieved.");
 });
 }(e);
-var B, A = function() {
+var A, B = function() {
 var t = {
 started: "Creating application " + e.name + " in project " + e.projectDisplayName(),
 success: "Created application " + e.name + " in project " + e.projectDisplayName(),
@@ -7563,7 +7548,7 @@ failure: "Failed to create " + e.name + " in project " + e.projectDisplayName()
 }, n = {};
 C.clear(), C.add(t, n, r.project, function() {
 var t = a.defer();
-return c.batch(B, i).then(function(n) {
+return c.batch(A, i).then(function(n) {
 var a = [], r = !1;
 _.isEmpty(n.failure) ? a.push({
 type: "success",
@@ -7604,13 +7589,13 @@ cancelButtonText: "Cancel"
 };
 }
 }
-}).result.then(A);
+}).result.then(B);
 }, U = function(t) {
 I(), D = t.quotaAlerts || [], e.nameTaken || _.some(D, {
 type: "error"
 }) ? (e.disableInputs = !1, _.each(D, function(e) {
 e.id = _.uniqueId("create-builder-alert-"), f.addNotification(e);
-})) : _.isEmpty(D) ? A() : (L(D), e.disableInputs = !1);
+})) : _.isEmpty(D) ? B() : (L(D), e.disableInputs = !1);
 };
 e.projectDisplayName = function() {
 return k(this.project) || this.projectName;
@@ -7619,10 +7604,10 @@ e.disableInputs = !0, I(), e.buildConfig.envVars = w.compactEntries(e.buildConfi
 var t = w.mapEntries(w.compactEntries(e.userDefinedLabels)), n = w.mapEntries(w.compactEntries(e.systemLabels));
 e.labels = _.extend(n, t);
 var a = s.generate(e);
-B = [], angular.forEach(a, function(e) {
-null !== e && (m.debug("Generated resource definition:", e), B.push(e));
+A = [], angular.forEach(a, function(e) {
+null !== e && (m.debug("Generated resource definition:", e), A.push(e));
 });
-var r = s.ifResourcesDontExist(B, e.projectName), o = v.getLatestQuotaAlerts(B, i), c = function(t) {
+var r = s.ifResourcesDontExist(A, e.projectName), o = v.getLatestQuotaAlerts(A, i), c = function(t) {
 return e.nameTaken = t.nameTaken, o;
 };
 r.then(c, c).then(U, U);
@@ -8968,7 +8953,7 @@ templateUrl: "views/modals/confirm-replace.html",
 controller: "ConfirmReplaceModalController",
 scope: m
 }).result.then(function() {
-l.getLatestQuotaAlerts(m.createResources, m.context).then(I);
+l.getLatestQuotaAlerts(m.createResources, m.context).then(E);
 });
 }
 function v() {
@@ -8980,10 +8965,10 @@ t > 0 && a.push(w()), e > 0 && a.push(S()), n.all(a).then(y);
 }
 function y() {
 var e, n;
-D(), "Template" === m.resourceKind && m.templateOptions.process && !m.errorOccured ? m.isDialog ? m.$emit("fileImportedFromYAMLOrJSON", {
+T(), "Template" === m.resourceKind && m.templateOptions.process && !m.errorOccured ? m.isDialog ? m.$emit("fileImportedFromYAMLOrJSON", {
 project: m.project,
-template: T
-}) : (n = m.templateOptions.add || m.updateResources.length > 0 ? m.project.metadata.name : "", e = s.createFromTemplateURL(T, m.project.metadata.name, {
+template: m.resource
+}) : (n = m.templateOptions.add || m.updateResources.length > 0 ? m.project.metadata.name : "", e = s.createFromTemplateURL(m.resource, m.project.metadata.name, {
 namespace: n
 }), t.url(e)) : m.isDialog ? m.$emit("fileImportedFromYAMLOrJSON", {
 project: m.project
@@ -9040,9 +9025,9 @@ details: e("getErrorDetails")(n)
 }
 function S() {
 var e = {
-started: "Creating resources in project " + $(m.project),
-success: "Creating resources in project " + $(m.project),
-failure: "Failed to create some resources in project " + $(m.project)
+started: "Creating resources in project " + N(m.project),
+success: "Creating resources in project " + N(m.project),
+failure: "Failed to create some resources in project " + N(m.project)
 }, t = {};
 d.add(e, t, m.project.metadata.name, function() {
 var e = n.defer();
@@ -9075,9 +9060,9 @@ hasErrors: a
 }
 function w() {
 var e = {
-started: "Updating resources in project " + $(m.project),
-success: "Updated resources in project " + $(m.project),
-failure: "Failed to update some resources in project " + $(m.project)
+started: "Updating resources in project " + N(m.project),
+success: "Updated resources in project " + N(m.project),
+failure: "Failed to update some resources in project " + N(m.project)
 }, t = {};
 d.add(e, t, m.project.metadata.name, function() {
 var e = n.defer();
@@ -9121,23 +9106,7 @@ var k, j = e("humanizeKind");
 d.clear(), m.aceLoaded = function(e) {
 (k = e.getSession()).setOption("tabSize", 2), k.setOption("useSoftTabs", !0), e.setDragDelay = 0, e.$blockScrolling = 1 / 0;
 };
-var R = function() {
-var e = k.getAnnotations();
-m.editorErrorAnnotation = _.some(e, {
-type: "error"
-});
-}, P = _.debounce(function() {
-try {
-JSON.parse(m.editorContent), k.setMode("ace/mode/json");
-} catch (e) {
-try {
-jsyaml.safeLoad(m.editorContent), k.setMode("ace/mode/yaml");
-} catch (e) {}
-}
-m.$apply(R);
-}, 300);
-m.aceChanged = P;
-var T, E = function(e) {
+var R = function(e) {
 a.open({
 animation: !0,
 templateUrl: "views/modals/confirm.html",
@@ -9154,32 +9123,22 @@ cancelButtonText: "Cancel"
 }
 }
 }).result.then(v);
-}, N = {}, D = function() {
-c.hideNotification("from-file-error"), _.each(N, function(e) {
+}, P = {}, T = function() {
+c.hideNotification("from-file-error"), _.each(P, function(e) {
 !e.id || "error" !== e.type && "warning" !== e.type || c.hideNotification(e.id);
 });
-}, I = function(e) {
-D(), N = u.getSecurityAlerts(m.createResources, m.project.metadata.name);
+}, E = function(e) {
+T(), P = u.getSecurityAlerts(m.createResources, m.project.metadata.name);
 var t = e.quotaAlerts || [];
-N = N.concat(t), _.filter(N, {
+P = P.concat(t), _.filter(P, {
 type: "error"
-}).length ? (_.each(N, function(e) {
+}).length ? (_.each(P, function(e) {
 e.id = _.uniqueId("from-file-alert-"), c.addNotification(e);
-}), m.disableInputs = !1) : N.length ? (E(N), m.disableInputs = !1) : v();
+}), m.disableInputs = !1) : P.length ? (R(P), m.disableInputs = !1) : v();
 };
 m.create = function() {
-delete m.error;
-try {
-T = JSON.parse(m.editorContent);
-} catch (e) {
-try {
-T = jsyaml.safeLoad(m.editorContent);
-} catch (e) {
-return void (m.error = e);
-}
-}
-if (p(T) && (m.resourceKind = T.kind, m.resourceKind.endsWith("List") ? m.isList = !0 : m.isList = !1, g(T))) {
-m.isList ? (m.resourceList = T.items, m.resourceName = "") : (m.resourceList = [ T ], m.resourceName = T.metadata.name, "Template" === m.resourceKind && (m.templateOptions = {
+if (delete m.error, p(m.resource) && (m.resourceKind = m.resource.kind, m.resourceKind.endsWith("List") ? m.isList = !0 : m.isList = !1, g(m.resource))) {
+m.isList ? (m.resourceList = m.resource.items, m.resourceName = "") : (m.resourceList = [ m.resource ], m.resourceName = m.resource.metadata.name, "Template" === m.resourceKind && (m.templateOptions = {
 process: !0,
 add: !1
 })), m.updateResources = [], m.createResources = [];
@@ -9188,14 +9147,14 @@ m.errorOccured = !1, _.forEach(m.resourceList, function(t) {
 if (!g(t)) return m.errorOccured = !0, !1;
 e.push(b(t));
 }), n.all(e).then(function() {
-m.errorOccured || (1 === m.createResources.length && "Template" === m.resourceList[0].kind ? f() : _.isEmpty(m.updateResources) ? l.getLatestQuotaAlerts(m.createResources, m.context).then(I) : (m.updateTemplate = 1 === m.updateResources.length && "Template" === m.updateResources[0].kind, m.updateTemplate ? f() : h()));
+m.errorOccured || (1 === m.createResources.length && "Template" === m.resourceList[0].kind ? f() : _.isEmpty(m.updateResources) ? l.getLatestQuotaAlerts(m.createResources, m.context).then(E) : (m.updateTemplate = 1 === m.updateResources.length && "Template" === m.updateResources[0].kind, m.updateTemplate ? f() : h()));
 });
 }
 }, m.cancel = function() {
-D(), s.toProjectOverview(m.project.metadata.name);
+T(), s.toProjectOverview(m.project.metadata.name);
 };
-var $ = e("displayName");
-m.$on("importFileFromYAMLOrJSON", m.create), m.$on("$destroy", D);
+var N = e("displayName");
+m.$on("importFileFromYAMLOrJSON", m.create), m.$on("$destroy", T);
 } ]
 };
 } ]), angular.module("openshiftConsole").directive("oscFileInput", [ "Logger", function(e) {
@@ -9206,6 +9165,7 @@ model: "=",
 required: "=",
 disabled: "=ngDisabled",
 showTextArea: "=",
+hideClear: "=?",
 helpText: "@?",
 dropZoneId: "@?"
 },
@@ -10607,7 +10567,7 @@ Used: t.available > 0 ? "#0088ce" : "#ec7a08",
 Available: "#d1d1d1"
 }
 };
-T[t.id] ? T[t.id].load(r) : ((n = A(e)).data = r, a(function() {
+T[t.id] ? T[t.id].load(r) : ((n = B(e)).data = r, a(function() {
 $ || (T[t.id] = c3.generate(n));
 }));
 }
@@ -10758,12 +10718,12 @@ m.metricsURL = e;
 }), m.options = {
 rangeOptions: c.getTimeRangeOptions()
 }, m.options.timeRange = _.head(m.options.rangeOptions);
-var B = e("upperFirst"), A = function(e) {
+var A = e("upperFirst"), B = function(e) {
 var t = "#" + e.chartPrefix + m.uniqueID + "-donut";
 return {
 bindto: t,
 onrendered: function() {
-i.updateDonutCenterText(t, e.datasets[0].used, B(e.units) + " Used");
+i.updateDonutCenterText(t, e.datasets[0].used, A(e.units) + " Used");
 },
 donut: {
 label: {
@@ -11105,17 +11065,17 @@ n > 10 ? e() : (n++, E().is(":visible") && (N(), e()));
 N(!0), w(), P(), k(), T(), R();
 }, 100);
 p.on("resize", I);
-var B, A = function() {
+var A, B = function() {
 j = !0, d.scrollBottom(h);
 }, L = document.createDocumentFragment(), U = _.debounce(function() {
-l.appendChild(L), L = document.createDocumentFragment(), t.autoScrollActive && A(), t.showScrollLinks || k();
+l.appendChild(L), L = document.createDocumentFragment(), t.autoScrollActive && B(), t.showScrollLinks || k();
 }, 100, {
 maxWait: 300
 }), O = function(e) {
 var t = r.defer();
-return B ? (B.onClose(function() {
+return A ? (A.onClose(function() {
 t.resolve();
-}), B.stop()) : t.resolve(), e || (U.cancel(), l && (l.innerHTML = ""), L = document.createDocumentFragment()), t.promise;
+}), A.stop()) : t.resolve(), e || (U.cancel(), l && (l.innerHTML = ""), L = document.createDocumentFragment()), t.promise;
 }, x = function() {
 O().then(function() {
 t.$evalAsync(function() {
@@ -11135,7 +11095,7 @@ limitBytes: 10485760
 }, t.options), n = 0, a = function(e) {
 n++, L.appendChild(f(n, e)), U();
 };
-(B = c.createStream(b, C, t.context, e)).onMessage(function(r, o, i) {
+(A = c.createStream(b, C, t.context, e)).onMessage(function(r, o, i) {
 t.$evalAsync(function() {
 t.empty = !1, "logs" !== t.state && (t.state = "logs", D());
 }), r && (e.limitBytes && i >= e.limitBytes && (t.$evalAsync(function() {
@@ -11143,18 +11103,18 @@ t.limitReached = !0, t.loading = !1;
 }), O(!0)), a(r), !t.largeLog && n >= e.tailLines && t.$evalAsync(function() {
 t.largeLog = !0;
 }));
-}), B.onClose(function() {
-B = null, t.$evalAsync(function() {
+}), A.onClose(function() {
+A = null, t.$evalAsync(function() {
 t.loading = !1, t.autoScrollActive = !1, 0 !== n || t.emptyStateMessage || (t.state = "empty", t.emptyStateMessage = "The logs are no longer available or could not be loaded.");
 });
-}), B.onError(function() {
-B = null, t.$evalAsync(function() {
+}), A.onError(function() {
+A = null, t.$evalAsync(function() {
 angular.extend(t, {
 loading: !1,
 autoScrollActive: !1
 }), 0 === n ? (t.state = "empty", t.emptyStateMessage = "The logs are no longer available or could not be loaded.") : t.errorWhileRunning = !0;
 });
-}), B.start();
+}), A.start();
 }
 });
 });
@@ -11195,7 +11155,7 @@ onScrollTop: function() {
 t.autoScrollActive = !1, d.scrollTop(h), $("#" + t.logViewerID + "-affixedFollow").affix("checkPosition");
 },
 toggleAutoScroll: function() {
-t.autoScrollActive = !t.autoScrollActive, t.autoScrollActive && A();
+t.autoScrollActive = !t.autoScrollActive, t.autoScrollActive && B();
 },
 goChromeless: d.chromelessLink,
 restartLogs: x
@@ -13455,7 +13415,70 @@ $(window).off("beforeunload", a), r && r();
 }
 }
 };
-} ]), angular.module("openshiftConsole").filter("duration", function() {
+} ]), function() {
+angular.module("openshiftConsole").component("uiAceYaml", {
+controller: [ "$scope", function(e) {
+var t, n = this, a = function(e) {
+return jsyaml.safeLoad(n.model, {
+json: !e
+});
+}, r = function() {
+t.getSession().clearAnnotations(), e.$evalAsync(function() {
+n.annotations = {};
+});
+}, o = function(a, r) {
+var o = t.getSession(), i = o.getLength(), s = _.get(a, "mark.line", 0), c = _.get(a, "mark.column", 0), l = a.message || "Could not parse content.";
+s >= i && (s = i - 1);
+var u = {
+row: s,
+column: c,
+text: l,
+type: r
+};
+o.setAnnotations([ u ]), e.$evalAsync(function() {
+n.annotations = {}, n.annotations[r] = [ u ];
+});
+}, i = function(t) {
+e.$evalAsync(function() {
+n.form.$setValidity("yamlValid", t);
+});
+};
+e.$watch(function() {
+return n.fileUpload;
+}, function(e, t) {
+e !== t && (n.model = e);
+}), n.$onInit = function() {
+n.resource && (n.model = jsyaml.safeDump(n.resource, {
+sortKeys: !0
+}));
+}, n.aceChanged = function() {
+try {
+n.resource = a(!1), i(!0);
+try {
+a(!0), r();
+} catch (e) {
+o(e, "warning");
+}
+} catch (e) {
+o(e, "error"), i(!1);
+}
+}, n.aceLoaded = function(e) {
+t = e;
+var n = e.getSession();
+n.setOption("tabSize", 2), n.setOption("useSoftTabs", !0), e.setDragDelay = 0;
+}, n.gotoLine = function(e) {
+t.gotoLine(e);
+};
+} ],
+controllerAs: "$ctrl",
+bindings: {
+resource: "=",
+ngRequired: "<?",
+showFileInput: "<?"
+},
+templateUrl: "views/directives/ui-ace-yaml.html"
+});
+}(), angular.module("openshiftConsole").filter("duration", function() {
 return function(e, t, n, a) {
 function r(e, t, a) {
 0 !== e && (1 !== e ? s.push(e + " " + a) : n ? s.push(t) : s.push("1 " + t));

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7016,22 +7016,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<parse-error error=\"error\" ng-show=\"error\"></parse-error>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-sm-12 pod-bottom-xl\">\n" +
-    "<form name=\"form\">\n" +
-    "<div class=\"form-group\" id=\"from-file\">\n" +
-    "<osc-file-input model=\"editorContent\" drop-zone-id=\"from-file\" help-text=\"Upload file by dragging & dropping, selecting it, or pasting from the clipboard.\" ng-disabled=\"false\"></osc-file-input>\n" +
-    "<div ui-ace=\"{\n" +
-    "          mode: 'yaml',\n" +
-    "          theme: 'eclipse',\n" +
-    "          onLoad: aceLoaded,\n" +
-    "          onChange: aceChanged,\n" +
-    "          rendererOptions: {\n" +
-    "            fadeFoldWidgets: true,\n" +
-    "            showPrintMargin: false\n" +
-    "          }\n" +
-    "        }\" ng-model=\"editorContent\" class=\"editor ace-bordered yaml-mode\" id=\"add-component-editor\" required></div>\n" +
-    "</div>\n" +
+    "<form name=\"form\" id=\"from-file\">\n" +
+    "<ui-ace-yaml resource=\"resource\" ng-required=\"true\" show-file-input=\"true\"></ui-ace-yaml>\n" +
     "<div ng-if=\"!isDialog\" class=\"buttons gutter-bottom\">\n" +
-    "<button type=\"submit\" ng-click=\"create()\" ng-disabled=\"editorErrorAnnotation || !editorContent\" class=\"btn btn-primary btn-lg\">\n" +
+    "<button type=\"submit\" ng-click=\"create()\" ng-disabled=\"form.$invalid\" class=\"btn btn-primary btn-lg\">\n" +
     "Create\n" +
     "</button>\n" +
     "<a class=\"btn btn-default btn-lg\" href=\"\" role=\"button\" ng-click=\"cancel()\">\n" +
@@ -7818,7 +7806,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<textarea class=\"form-control\" rows=\"5\" ng-show=\"showTextArea || !supportsFileUpload\" ng-model=\"model\" ng-required=\"required\" ng-disabled=\"disabled\" autocorrect=\"off\" autocapitalize=\"none\" spellcheck=\"false\" ng-attr-aria-describedby=\"{{helpText ? helpID : undefined}}\">\n" +
     "  </textarea>\n" +
-    "<a href=\"\" ng-show=\"(model || fileName) && !disabled\" ng-click=\"cleanInputValues()\">Clear Value</a>\n" +
+    "<a href=\"\" ng-show=\"(model || fileName) && !disabled && !hideClear\" ng-click=\"cleanInputValues()\">Clear Value</a>\n" +
     "</div>"
   );
 
@@ -8966,6 +8954,39 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/directives/ui-ace-yaml.html',
+    "<ng-form name=\"$ctrl.form\">\n" +
+    "<div class=\"form-group\" id=\"yaml-file\">\n" +
+    "<osc-file-input ng-if=\"$ctrl.showFileInput\" model=\"$ctrl.fileUpload\" drop-zone-id=\"yaml-file\" help-text=\"Upload a file by dragging & dropping, selecting it, or pasting from the clipboard.\" ng-disabled=\"false\" hide-clear=\"true\"></osc-file-input>\n" +
+    "<div class=\"edit-yaml-errors\">\n" +
+    "\n" +
+    "<div ng-if=\"firstError = $ctrl.annotations.error[0]\">\n" +
+    "<a href=\"\" ng-click=\"$ctrl.gotoLine(firstError.row)\">\n" +
+    "<span class=\"pficon pficon-error-circle-o\" aria-hidden=\"true\"></span>\n" +
+    "Error\n" +
+    "</a>\n" +
+    "</div>\n" +
+    "<div ng-if=\"firstWarning = $ctrl.annotations.warning[0]\">\n" +
+    "<a href=\"\" ng-click=\"$ctrl.gotoLine(firstWarning.row)\">\n" +
+    "<span class=\"pficon pficon-warning-triangle-o\" aria-hidden=\"true\"></span>\n" +
+    "Warning\n" +
+    "</a>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div ui-ace=\"{\n" +
+    "      mode: 'yaml',\n" +
+    "      theme: 'eclipse',\n" +
+    "      onLoad: $ctrl.aceLoaded,\n" +
+    "      onChange: $ctrl.aceChanged,\n" +
+    "      rendererOptions: {\n" +
+    "        showPrintMargin: false\n" +
+    "      }\n" +
+    "    }\" ng-model=\"$ctrl.model\" class=\"editor ace-bordered yaml-mode\" ng-required=\"$ctrl.ngRequired\" id=\"ace-yaml-editor\"></div>\n" +
+    "</div>\n" +
+    "</ng-form>"
+  );
+
+
   $templateCache.put('views/directives/unbind-service.html',
     "<div class=\"bind-service-wizard unbind-service\">\n" +
     "<div pf-wizard hide-header=\"true\" hide-sidebar=\"true\" hide-back-button=\"true\" step-class=\"bind-service-wizard-step\" wizard-ready=\"ctrl.wizardReady\" next-title=\"ctrl.nextTitle\" on-finish=\"ctrl.closeWizard()\" on-cancel=\"ctrl.closeWizard()\" wizard-done=\"ctrl.wizardComplete\" class=\"pf-wizard-no-back\">\n" +
@@ -10070,34 +10091,28 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container surface-shaded\">\n" +
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
-    "<div ng-if=\"!resource\" class=\"pad-top-md\">Loading...</div>\n" +
-    "<div ng-if=\"resource\" class=\"pad-top-md\">\n" +
-    "<h1 class=\"truncate\">Edit <span class=\"hidden-xs\">{{resource.kind | humanizeKind : true}}</span> {{resource.metadata.name}}</h1>\n" +
+    "<div ng-if=\"!updated.resource\" class=\"pad-top-md\">Loading...</div>\n" +
+    "<div ng-if=\"updated.resource\" class=\"pad-top-md\">\n" +
+    "<h1 class=\"truncate\">Edit <span class=\"hidden-xs\">{{updated.resource.kind | humanizeKind : true}}</span> {{updated.resource.metadata.name}}</h1>\n" +
     "<parse-error error=\"error\" ng-if=\"error\"></parse-error>\n" +
     "<div ng-if=\"resourceChanged && !resourceDeleted && !updatingNow\" class=\"alert alert-warning\">\n" +
     "<span class=\"pficon pficon-warning-triangle-o\" aria-hidden=\"true\"></span>\n" +
     "<span class=\"sr-only\">Warning:</span>\n" +
-    "{{resource.kind | humanizeKind | upperFirst}} <strong>{{resource.metadata.name}}</strong> has changed since you started editing it. You'll need to copy any changes you've made and edit the {{resource.kind | humanizeKind}} again.\n" +
+    "{{updated.resource.kind | humanizeKind | upperFirst}} <strong>{{updated.resource.metadata.name}}</strong> has changed since you started editing it. You'll need to copy any changes you've made and edit the {{updated.resource.kind | humanizeKind}} again.\n" +
     "</div>\n" +
     "<div ng-if=\"resourceDeleted\" class=\"alert alert-warning\">\n" +
     "<span class=\"pficon pficon-warning-triangle-o\" aria-hidden=\"true\"></span>\n" +
     "<span class=\"sr-only\">Warning:</span>\n" +
-    "{{resource.kind | humanizeKind | upperFirst}} <strong>{{resource.metadata.name}}</strong> has been deleted since you started editing it.\n" +
+    "{{updated.resource.kind | humanizeKind | upperFirst}} <strong>{{updated.resource.metadata.name}}</strong> has been deleted since you started editing it.\n" +
     "</div>\n" +
     "<confirm-on-exit dirty=\"modified\"></confirm-on-exit>\n" +
-    "\n" +
-    "<div ui-ace=\"{\n" +
-    "                mode: 'yaml',\n" +
-    "                theme: 'eclipse',\n" +
-    "                onLoad: aceLoaded,\n" +
-    "                rendererOptions: {\n" +
-    "                  showPrintMargin: false\n" +
-    "                }\n" +
-    "              }\" ng-model=\"editor.model\" class=\"editor ace-bordered yaml-mode\"></div>\n" +
+    "<form name=\"editor.form\">\n" +
+    "<ui-ace-yaml resource=\"updated.resource\" ng-required=\"true\"></ui-ace-yaml>\n" +
     "<div class=\"button-group mar-top-xl\">\n" +
-    "<button class=\"btn btn-lg btn-primary\" type=\"button\" ng-click=\"save()\" ng-disabled=\"!modified || resourceChanged || resourceDeleted || updatingNow\">Save</button>\n" +
+    "<button class=\"btn btn-lg btn-primary\" type=\"button\" ng-click=\"save()\" ng-disabled=\"editor.form.$pristine || editor.form.$invalid || resourceChanged || resourceDeleted || updatingNow\">Save</button>\n" +
     "<button class=\"btn btn-lg btn-default\" type=\"button\" ng-disabled=\"updatingNow\" ng-click=\"cancel()\">Cancel</button>\n" +
     "</div>\n" +
+    "</form>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -955,6 +955,7 @@ select[multiple].input-group-sm>.form-control,select[multiple].input-group-sm>.i
 .embed-responsive,.modal,.modal-open,.progress{overflow:hidden}
 @media (max-device-width:480px) and (orientation:landscape){.navbar-fixed-bottom .navbar-collapse,.navbar-fixed-top .navbar-collapse{max-height:200px}
 }
+.membership .ui-select-bootstrap>.ui-select-choices,.typeahead-long{max-height:300px}
 .container-fluid>.navbar-collapse,.container-fluid>.navbar-header,.container>.navbar-collapse,.container>.navbar-header{margin-right:-20px;margin-left:-20px}
 .navbar-static-top{z-index:1000;border-width:0 0 1px}
 .navbar-fixed-bottom,.navbar-fixed-top{position:fixed;right:0;left:0;z-index:1030}
@@ -2351,7 +2352,7 @@ td>.progress:first-child:last-child{margin-bottom:0;margin-top:3px}
 .form-inline .combobox-container .input-group-addon,.form-search .combobox-container .input-group-addon{width:auto}
 }
 .combobox-container:not(.combobox-selected) .glyphicon-remove,.combobox-selected .caret{display:none}
-.typeahead-long{max-height:300px;overflow-y:auto}
+.typeahead-long{overflow-y:auto}
 .control-group.error .combobox-container .add-on{color:#B94A48;border-color:#B94A48}
 .control-group.error .combobox-container .caret{border-top-color:#B94A48}
 .control-group.warning .combobox-container .add-on{color:#C09853;border-color:#C09853}
@@ -4290,7 +4291,7 @@ body.overlay-open,body.overlay-open .landing,body.overlay-open .landing-side-bar
 .btn-remove{color:#333;display:inline-block;font-size:15px;line-height:1;opacity:.65;padding:5px 7px;vertical-align:middle}
 .btn-remove:focus,.btn-remove:hover{color:inherit;opacity:1;text-decoration:none}
 .static-form-value-large{font-family:inherit;font-weight:500;line-height:1.1;color:inherit;margin-bottom:10.5px;font-size:16px;margin-top:3px}
-.edit-yaml .editor,.environment-variables.table.table-bordered>tbody>tr>td:last-child .env-var-value,.hash,.osc-file-input textarea,.template-message .resource-description{font-family:Menlo,Monaco,Consolas,monospace}
+.environment-variables.table.table-bordered>tbody>tr>td:last-child .env-var-value,.hash,.osc-file-input textarea,.template-message .resource-description{font-family:Menlo,Monaco,Consolas,monospace}
 .static-form-value-large .small,.static-form-value-large small{font-weight:400;line-height:1;color:#9c9c9c;font-size:65%}
 .breadcrumb strong,.pod-template-block .pod-template .pod-template-key,.weight-slider-values .service-name{font-weight:600}
 .clear-env-changes-link{vertical-align:-2px}
@@ -4299,7 +4300,6 @@ copy-to-clipboard .input-group.limit-width{max-width:300px}
 .jenkinsfile-examples .copy-to-clipboard{margin-top:3px}
 .copy-to-clipboard-multiline{display:block;overflow-x:auto}
 .copy-to-clipboard-multiline a{box-shadow:none;position:absolute;right:0;top:0}
-.card-pf,.tile{box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09)}
 .collapsing,.wizard-pf-footer.wizard-pf-position-override{position:relative}
 .copy-to-clipboard-multiline pre{background-color:#fff;word-break:normal;word-wrap:normal}
 .input-group-addon.wildcard-prefix{padding-left:10px}
@@ -4316,6 +4316,7 @@ copy-to-clipboard .input-group.limit-width{max-width:300px}
 .osc-file-input textarea{margin:5px 0}
 .health-checks-form .pause-rollouts-checkbox,.set-limits-form .pause-rollouts-checkbox{margin-top:21px}
 .checkbox-inline,.checkbox-inline+.checkbox-inline,.radio-inline,.radio-inline+.radio-inline{margin-left:0;margin-right:10px}
+.card-pf{box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09)}
 .card-pf .image-icon{font-size:28px;line-height:1;margin-right:15px;opacity:.38}
 .card-pf-badge{color:#999;font-size:11px;text-transform:uppercase}
 .card-pf-body{margin-bottom:0}
@@ -4636,12 +4637,6 @@ a.disabled-link:active,a.disabled-link:focus,a.disabled-link:hover{color:#bbb;te
 .modal-resource-action h1{font-size:21px;font-weight:500;margin-bottom:20px;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .modal-resource-action p{font-size:15px}
 .modal-resource-action .help-block{margin-top:0px;margin-bottom:10px}
-.ace_editor.dockerfile-mode .ace_constant.ace_numeric,.editor.yaml-mode .ace_constant.ace_numeric{color:inherit}
-.edit-yaml h1{line-height:1.3}
-.edit-yaml .editor{line-height:1.5;width:100%;min-height:140px;height:50vh}
-.edit-yaml .editor .ace_gutter{color:#8b8d8f}
-@media (min-height:700px){.edit-yaml .editor{height:60vh}
-}
 .debug-pod-action{margin-top:5px}
 .modal-debug-terminal .modal-header{padding:0 18px 5px}
 .modal-debug-terminal .modal-header h2{margin-bottom:5px}
@@ -4652,9 +4647,6 @@ a.disabled-link:active,a.disabled-link:focus,a.disabled-link:hover{color:#bbb;te
 .modal-debug-terminal .modal-footer{padding-top:0}
 .jenkinsfile-examples-modal .jenkinsfile-examples p:last-child{margin-bottom:0;padding-bottom:0}
 .jenkinsfile-examples-modal .modal-footer{margin-top:0;padding-top:0}
-.ace-inline{height:300px}
-.ace-inline-small{height:200px}
-#from-file .editor{height:350px}
 .edit-form .with-divider{border-top:1px solid rgba(0,0,0,.15);padding-top:21px;padding-bottom:10px;margin-top:10px}
 .edit-form .labels .form-group{width:44%}
 .edit-form .labels .form-group .form-control{width:100%}
@@ -4692,8 +4684,6 @@ pre.clipped.scroll{max-height:150px;overflow:auto;width:100%}
 @media (max-width:768px){.k8s-label,.k8s-label .label-pair{width:100%}
 .k8s-label .label{display:block;min-width:50px}
 }
-.ace-bordered{border:1px solid #8b8d8f}
-.ace-bordered.ace-read-only{border-color:#d1d1d1;background-color:#fafafa}
 .action-divider{color:#9c9c9c}
 .surface-shaded .table{background-color:transparent}
 .environment-variables.table.table-bordered>tbody>tr>td:first-child{font-weight:700;padding-right:10px;vertical-align:top}
@@ -5332,7 +5322,7 @@ dl.secret-data pre{margin-bottom:0}
 .events-sidebar .events-sidebar-collapse a{text-decoration:none}
 .events-sidebar .sidebar-header.right-header{align-items:center;display:flex;justify-content:space-between;margin-top:17.5px}
 .events-sidebar .sidebar-header.right-header h2{font-family:inherit;font-weight:500;line-height:1.1;color:inherit;margin-top:10.5px;margin-bottom:10.5px;font-size:14px;display:inline-block}
-.config-map-table .key,.config-map-table .truncated-content,.log-view{font-family:Menlo,Monaco,Consolas,monospace}
+.config-map-table .key,.config-map-table .truncated-content,.edit-yaml .editor,.log-view{font-family:Menlo,Monaco,Consolas,monospace}
 .events-sidebar .sidebar-header.right-header h2 .small,.events-sidebar .sidebar-header.right-header h2 small{font-weight:400;line-height:1;color:#9c9c9c;font-size:75%}
 .events-sidebar .sidebar-header.right-header .warning-count{white-space:nowrap;margin-left:2px}
 .events-sidebar .sidebar-header.right-header .warning-count .pficon{vertical-align:-1px}
@@ -5475,7 +5465,7 @@ body,html{margin:0;padding:0}
 td[role=presentation].arrow:after{content:"\2193"}
 @media (min-width:768px){td[role=presentation].arrow:after{content:"\2192"}
 }
-.tile{background:#fff;padding:20px;margin-bottom:20px;word-wrap:break-word;overflow-x:hidden}
+.tile{background:#fff;padding:20px;box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09);margin-bottom:20px;word-wrap:break-word;overflow-x:hidden}
 .tile h1,.tile h2,.tile h3{margin:10.5px 0px}
 .tile-click:hover .image-icon{opacity:.75}
 .tile-click .image-icon{font-size:48px;line-height:1;margin-bottom:15px;opacity:.38}
@@ -5549,12 +5539,12 @@ a.subtle-link:active,a.subtle-link:focus,a.subtle-link:hover{color:#00659c;borde
 .mar-auto-sm{margin:0 auto}
 .pad-sm{padding:5px 7.5px}
 .mar-sm{margin:5px 7.5px}
+.key-value-editor .key-value-editor-header,.mar-bottom-sm{margin-bottom:5px}
 .pad-top-sm{padding-top:5px}
 .mar-top-sm{margin-top:5px}
 .pad-right-sm{padding-right:5px}
 .mar-right-sm{margin-right:5px}
 .pad-bottom-sm{padding-bottom:5px}
-.mar-bottom-sm{margin-bottom:5px}
 .pad-left-sm{padding-left:5px}
 .mar-left-sm{margin-left:5px}
 .mar-auto-md{margin:0 auto}
@@ -5777,7 +5767,6 @@ kubernetes-container-terminal .terminal-actions .spinner{top:5px}
 @media (min-width:992px){.key-value-editor .key-value-editor-input .ui-select{float:left;width:50%}
 .key-value-editor .key-value-editor-input .ui-select+.ui-select{padding-top:0;padding-left:5px}
 }
-.key-value-editor .key-value-editor-header{margin-bottom:5px}
 .membership h1 .learn-more-inline{white-space:nowrap;margin-right:10px;margin-left:0px;display:inline-block}
 .membership .content-pane .col-heading .col-add-role h3,.membership .content-pane .form-new-role .col-roles{display:none}
 .membership .content-pane{width:100%}
@@ -5797,7 +5786,6 @@ kubernetes-container-terminal .terminal-actions .spinner{top:5px}
 .membership .content-pane .select-role small{color:#999;display:inline-block;line-height:1.4;white-space:pre-line}
 .membership .content-pane .select-role .active small{color:#c0e0f0}
 .membership .content-pane .col-add-role,.membership .content-pane .col-heading,.membership .content-pane .col-name,.membership .content-pane .col-roles,.membership .content-pane .item-row,.membership .content-pane [flex-collapse-fix],.membership .content-pane [flex]{flex-shrink:0;flex-basis:auto}
-.membership .ui-select-bootstrap>.ui-select-choices{max-height:300px}
 @media (min-width:480px){.membership .content-pane .col-heading .col-add-role h3,.membership .content-pane .form-new-role .col-roles{display:block}
 .membership .content-pane .col-add-role{padding:0;min-width:245px}
 .membership .content-pane .col-heading,.membership .content-pane .item-row{border-bottom:none;margin-bottom:none}
@@ -5832,3 +5820,15 @@ kubernetes-container-terminal .terminal-actions .spinner{top:5px}
 .pf-wizard-no-back .wizard-pf-footer .btn-cancel{margin-right:0}
 .wizard-pf-steps-indicator .wizard-pf-step-number{font-size:12px}
 .build-triggers .copy-to-clipboard{margin-bottom:10px}
+.ace-bordered{border:1px solid #8b8d8f}
+.ace-bordered.ace-read-only{border-color:#d1d1d1;background-color:#fafafa}
+.ace-inline{height:300px}
+.ace-inline-small{height:200px}
+.ace_editor.dockerfile-mode .ace_constant.ace_numeric,.editor.yaml-mode .ace_constant.ace_numeric{color:inherit}
+.edit-yaml h1{line-height:1.3}
+.edit-yaml .editor{line-height:1.5;width:100%;min-height:140px;height:50vh}
+.edit-yaml .editor .ace_gutter{color:#8b8d8f}
+@media (min-height:700px){.edit-yaml .editor{height:60vh}
+}
+.edit-yaml-errors{font-size:84%;height:2em;text-align:right}
+#from-file .editor{height:350px}

--- a/test/integration/page-objects/catalog.js
+++ b/test/integration/page-objects/catalog.js
@@ -46,12 +46,12 @@ class CatalogPage extends Page {
   }
   setImportValue(str) {
     return browser.executeScript((value) => {
-      window.ace.edit('add-component-editor').setValue(value);
+      window.ace.edit('ace-yaml-editor').setValue(value);
     }, str);
   }
   getImportValue() {
     return browser.executeScript(() => {
-      return window.ace.edit('add-component-editor').getValue();
+      return window.ace.edit('ace-yaml-editor').getValue();
     });
   }
   submitTemplate() {


### PR DESCRIPTION
- Create a common YAML editor component.
- Show errors and warnings as Ace editor annotations by the line number.
- For compatibility with `oc create`, accept YAML with duplicate keys
  when importing YAML. Duplicate keys when importing YAML are considered
  a warning.

<img width="394" alt="screen shot 2017-07-05 at 5 59 49 pm" src="https://user-images.githubusercontent.com/1167259/27889182-b46810a2-61b8-11e7-8834-5714ae9cb737.png">

Replaces #1797

@jwforres