### PR TITLE
Let users save env changes with enter

### DIFF
--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -463,7 +463,7 @@
                       cannot-sort
                       cannot-delete
                       show-header></key-value-editor>
-                    <ng-form name="forms.bcEnvVars" class="mar-bottom-xl block">
+                    <form name="forms.bcEnvVars" class="mar-bottom-xl block">
                       <div ng-if="'buildconfigs' | canI : 'update'">
                         <confirm-on-exit dirty="forms.bcEnvVars.$dirty"></confirm-on-exit>
                         <key-value-editor
@@ -496,7 +496,7 @@
                         cannot-sort
                         cannot-delete
                         show-header></key-value-editor>
-                    </ng-form>
+                    </form>
                   </uib-tab>
                 </uib-tabset>
               </div><!-- /col-* -->

--- a/app/views/browse/deployment-config.html
+++ b/app/views/browse/deployment-config.html
@@ -336,7 +336,7 @@
                   </uib-tab>
                   <uib-tab heading="Environment" active="selectedTab.environment" ng-if="deploymentConfig">
                     <uib-tab-heading>Environment</uib-tab-heading>
-                    <ng-form name="forms.dcEnvVars" class="mar-bottom-xl block">
+                    <form name="forms.dcEnvVars" class="mar-bottom-xl block">
                       <confirm-on-exit
                         ng-if="'deploymentconfigs' | canI : 'update'"
                         dirty="forms.dcEnvVars.$dirty">
@@ -378,7 +378,7 @@
                         ng-click="clearEnvVarUpdates()"
                         class="mar-left-sm"
                         style="vertical-align: -2px;">Clear Changes</a>
-                    </ng-form>
+                    </form>
                   </uib-tab>
                   <uib-tab active="selectedTab.events" ng-if="'events' | canI : 'watch'">
                     <uib-tab-heading>Events</uib-tab-heading>

--- a/app/views/browse/deployment.html
+++ b/app/views/browse/deployment.html
@@ -252,7 +252,7 @@
                 </uib-tab>
                 <uib-tab heading="Environment" active="selectedTab.environment" ng-if="deployment">
                   <uib-tab-heading>Environment</uib-tab-heading>
-                  <ng-form name="forms.deploymentEnvVars">
+                  <form name="forms.deploymentEnvVars">
                     <confirm-on-exit
                       ng-if="{ group: 'extensions', resource: 'deployments' } | canI : 'update'"
                       dirty="forms.deploymentEnvVars.$dirty">
@@ -294,7 +294,7 @@
                       ng-click="clearEnvVarUpdates()"
                       class="mar-left-sm"
                       style="vertical-align: -2px;">Clear Changes</a>
-                  </ng-form>
+                  </form>
                 </uib-tab>
                 <uib-tab active="selectedTab.events" ng-if="'events' | canI : 'watch'">
                   <uib-tab-heading>Events</uib-tab-heading>

--- a/app/views/browse/replica-set.html
+++ b/app/views/browse/replica-set.html
@@ -79,7 +79,7 @@
                         <em ng-if="!container.env.length">The container specification has no environment variables set.</em>
                       </div>
                     </div>
-                    <ng-form ng-if="!(replicaSet | hasDeployment) && !(replicaSet | hasDeploymentConfig)" name="forms.envForm">
+                    <form ng-if="!(replicaSet | hasDeployment) && !(replicaSet | hasDeploymentConfig)" name="forms.envForm">
                       <confirm-on-exit dirty="forms.envForm.$dirty"></confirm-on-exit>
                       <div ng-repeat="container in updatedReplicaSet.spec.template.spec.containers">
                         <div ng-if="resource | canI : 'update'">
@@ -119,7 +119,7 @@
                           <em ng-if="!container.env.length">The container specification has no environment variables set.</em>
                         </div>
                       </div>
-                    </ng-form>
+                    </form>
                   </uib-tab>
                   <uib-tab ng-if="metricsAvailable" heading="Metrics" active="selectedTab.metrics">
                     <!-- Use ng-if to remove the metrics directive when the tab is not active so

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2040,7 +2040,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a href=\"\" ng-click=\"expand.imageEnv = false\" ng-if=\"expand.imageEnv\">Hide Image Environment Variables</a>\n" +
     "</p>\n" +
     "<key-value-editor ng-if=\"expand.imageEnv\" entries=\"BCEnvVarsFromImage\" key-placeholder=\"Name\" value-placeholder=\"Value\" is-readonly cannot-add cannot-sort cannot-delete show-header></key-value-editor>\n" +
-    "<ng-form name=\"forms.bcEnvVars\" class=\"mar-bottom-xl block\">\n" +
+    "<form name=\"forms.bcEnvVars\" class=\"mar-bottom-xl block\">\n" +
     "<div ng-if=\"'buildconfigs' | canI : 'update'\">\n" +
     "<confirm-on-exit dirty=\"forms.bcEnvVars.$dirty\"></confirm-on-exit>\n" +
     "<key-value-editor entries=\"envVars\" key-placeholder=\"Name\" value-placeholder=\"Value\" key-validator=\"[A-Za-z_][A-Za-z0-9_]*\" key-validator-error=\"Please enter a valid key\" key-validator-error-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" add-row-link=\"Add Environment Variable\" show-header></key-value-editor>\n" +
@@ -2048,7 +2048,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a ng-if=\"!forms.bcEnvVars.$pristine\" href=\"\" ng-click=\"clearEnvVarUpdates()\" class=\"mar-left-sm\" style=\"vertical-align: -2px\">Clear Changes</a>\n" +
     "</div>\n" +
     "<key-value-editor ng-if=\"!('buildconfigs' | canI : 'update')\" entries=\"envVars\" key-placeholder=\"Name\" value-placeholder=\"Value\" is-readonly cannot-add cannot-sort cannot-delete show-header></key-value-editor>\n" +
-    "</ng-form>\n" +
+    "</form>\n" +
     "</uib-tab>\n" +
     "</uib-tabset>\n" +
     "</div>\n" +
@@ -2607,7 +2607,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</uib-tab>\n" +
     "<uib-tab heading=\"Environment\" active=\"selectedTab.environment\" ng-if=\"deploymentConfig\">\n" +
     "<uib-tab-heading>Environment</uib-tab-heading>\n" +
-    "<ng-form name=\"forms.dcEnvVars\" class=\"mar-bottom-xl block\">\n" +
+    "<form name=\"forms.dcEnvVars\" class=\"mar-bottom-xl block\">\n" +
     "<confirm-on-exit ng-if=\"'deploymentconfigs' | canI : 'update'\" dirty=\"forms.dcEnvVars.$dirty\">\n" +
     "</confirm-on-exit>\n" +
     "<div ng-repeat=\"container in updatedDeploymentConfig.spec.template.spec.containers\">\n" +
@@ -2617,7 +2617,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<button class=\"btn btn-default\" ng-if=\"'deploymentconfigs' | canI : 'update'\" ng-click=\"saveEnvVars()\" ng-disabled=\"forms.dcEnvVars.$pristine || forms.dcEnvVars.$invalid\">Save</button>\n" +
     "<a ng-if=\"!forms.dcEnvVars.$pristine\" href=\"\" ng-click=\"clearEnvVarUpdates()\" class=\"mar-left-sm\" style=\"vertical-align: -2px\">Clear Changes</a>\n" +
-    "</ng-form>\n" +
+    "</form>\n" +
     "</uib-tab>\n" +
     "<uib-tab active=\"selectedTab.events\" ng-if=\"'events' | canI : 'watch'\">\n" +
     "<uib-tab-heading>Events</uib-tab-heading>\n" +
@@ -2843,7 +2843,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</uib-tab>\n" +
     "<uib-tab heading=\"Environment\" active=\"selectedTab.environment\" ng-if=\"deployment\">\n" +
     "<uib-tab-heading>Environment</uib-tab-heading>\n" +
-    "<ng-form name=\"forms.deploymentEnvVars\">\n" +
+    "<form name=\"forms.deploymentEnvVars\">\n" +
     "<confirm-on-exit ng-if=\"{ group: 'extensions', resource: 'deployments' } | canI : 'update'\" dirty=\"forms.deploymentEnvVars.$dirty\">\n" +
     "</confirm-on-exit>\n" +
     "<div ng-repeat=\"container in updatedDeployment.spec.template.spec.containers\">\n" +
@@ -2853,7 +2853,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<button class=\"btn btn-default\" ng-if=\"{ group: 'extensions', resource: 'deployments' } | canI : 'update'\" ng-click=\"saveEnvVars()\" ng-disabled=\"forms.deploymentEnvVars.$pristine || forms.deploymentEnvVars.$invalid\">Save</button>\n" +
     "<a ng-if=\"!forms.deploymentEnvVars.$pristine\" href=\"\" ng-click=\"clearEnvVarUpdates()\" class=\"mar-left-sm\" style=\"vertical-align: -2px\">Clear Changes</a>\n" +
-    "</ng-form>\n" +
+    "</form>\n" +
     "</uib-tab>\n" +
     "<uib-tab active=\"selectedTab.events\" ng-if=\"'events' | canI : 'watch'\">\n" +
     "<uib-tab-heading>Events</uib-tab-heading>\n" +
@@ -3294,7 +3294,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<em ng-if=\"!container.env.length\">The container specification has no environment variables set.</em>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<ng-form ng-if=\"!(replicaSet | hasDeployment) && !(replicaSet | hasDeploymentConfig)\" name=\"forms.envForm\">\n" +
+    "<form ng-if=\"!(replicaSet | hasDeployment) && !(replicaSet | hasDeploymentConfig)\" name=\"forms.envForm\">\n" +
     "<confirm-on-exit dirty=\"forms.envForm.$dirty\"></confirm-on-exit>\n" +
     "<div ng-repeat=\"container in updatedReplicaSet.spec.template.spec.containers\">\n" +
     "<div ng-if=\"resource | canI : 'update'\">\n" +
@@ -3307,7 +3307,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<em ng-if=\"!container.env.length\">The container specification has no environment variables set.</em>\n" +
     "</div>\n" +
     "</div>\n" +
-    "</ng-form>\n" +
+    "</form>\n" +
     "</uib-tab>\n" +
     "<uib-tab ng-if=\"metricsAvailable\" heading=\"Metrics\" active=\"selectedTab.metrics\">\n" +
     "\n" +


### PR DESCRIPTION
The enter key now submits the form for in-page env variable editors.
Previously we were using `ng-form` without a surrounding `form` element,
which prevented the enter key from working.

Fixes #1651