### PR TITLE
Let users edit app label directly for "add to project"

### DIFF
--- a/app/scripts/controllers/create/createFromImage.js
+++ b/app/scripts/controllers/create/createFromImage.js
@@ -116,8 +116,7 @@ angular.module("openshiftConsole")
             include: true,
             portOptions: []
           };
-          scope.userDefinedLabels = [];
-          scope.systemLabels = [appLabel];
+          scope.labelArray = [appLabel];
           scope.annotations = {};
           scope.scaling = {
             replicas: 1,
@@ -276,8 +275,11 @@ angular.module("openshiftConsole")
 
         $scope.$watch('scaling.autoscale', checkCPURequest);
         $scope.$watch('container', checkCPURequest, true);
-        $scope.$watch('name', function(newValue) {
-          appLabel.value = newValue;
+        $scope.$watch('name', function(newValue, oldValue) {
+          // Only change the app label if the user hasn't modified it themselves.
+          if (!appLabel.value || appLabel.value === oldValue) {
+            appLabel.value = newValue;
+          }
         });
 
         initAndValidate($scope);
@@ -384,9 +386,9 @@ angular.module("openshiftConsole")
           hideErrorNotifications();
           $scope.buildConfig.envVars = keyValueEditorUtils.compactEntries($scope.buildConfigEnvVars);
           $scope.deploymentConfig.envVars = keyValueEditorUtils.compactEntries($scope.DCEnvVarsFromUser);
-          var userLabels = keyValueEditorUtils.mapEntries(keyValueEditorUtils.compactEntries($scope.userDefinedLabels));
-          var systemLabels = keyValueEditorUtils.mapEntries(keyValueEditorUtils.compactEntries($scope.systemLabels));
-          $scope.labels = _.extend(systemLabels, userLabels);
+
+          // Remove empty values and convert the label array to a map.
+          $scope.labels = keyValueEditorUtils.mapEntries(keyValueEditorUtils.compactEntries($scope.labelArray));
 
           var resourceMap = ApplicationGenerator.generate($scope);
           //init tasks

--- a/app/scripts/directives/deployImage.js
+++ b/app/scripts/directives/deployImage.js
@@ -32,8 +32,7 @@ angular.module("openshiftConsole")
 
         $scope.app = {};
         $scope.env = [];
-        $scope.labels = [];
-        $scope.systemLabels = [{
+        $scope.labels = [{
           name: 'app',
           value: ''
         }];
@@ -122,8 +121,7 @@ angular.module("openshiftConsole")
         };
 
         function getResources() {
-          var userLabels = keyValueEditorUtils.mapEntries(keyValueEditorUtils.compactEntries($scope.labels));
-          var systemLabels = keyValueEditorUtils.mapEntries(keyValueEditorUtils.compactEntries($scope.systemLabels));
+          var labels = keyValueEditorUtils.mapEntries(keyValueEditorUtils.compactEntries($scope.labels));
 
           return ImagesService.getResources({
             name: $scope.app.name,
@@ -133,7 +131,7 @@ angular.module("openshiftConsole")
             ports: $scope.ports,
             volumes: $scope.volumes,
             env: keyValueEditorUtils.compactEntries($scope.env),
-            labels: _.extend(systemLabels, userLabels),
+            labels: labels,
             pullSecrets: $scope.pullSecrets
           });
         }
@@ -170,12 +168,13 @@ angular.module("openshiftConsole")
               });
           };
 
-          $scope.$watch('app.name', function() {
+          $scope.$watch('app.name', function(name, previous) {
             $scope.nameTaken = false;
-            _.set(
-              _.find($scope.systemLabels, { name: 'app' }),
-              'value',
-              $scope.app.name);
+
+            var appLabel = _.find($scope.labels, { name: 'app' });
+            if (appLabel && (!appLabel.value || appLabel.value === previous)) {
+              appLabel.value = name;
+            }
           });
 
           $scope.$watch('mode', function(newMode, oldMode) {

--- a/app/scripts/directives/labels.js
+++ b/app/scripts/directives/labels.js
@@ -54,7 +54,6 @@ angular.module('openshiftConsole')
       restrict: 'E',
       scope: {
         labels: "=",
-        systemLabels: "=",
         expand: "=?",
         canToggle: "=?",
         // Optional help text to show with the label controls

--- a/app/scripts/directives/processTemplate.js
+++ b/app/scripts/directives/processTemplate.js
@@ -217,9 +217,7 @@
         context = {
           namespace: ctrl.selectedProject.metadata.name
         };
-        var userLabels = keyValueEditorUtils.mapEntries(keyValueEditorUtils.compactEntries(ctrl.labels));
-        var systemLabels = keyValueEditorUtils.mapEntries(keyValueEditorUtils.compactEntries(ctrl.systemLabels));
-        ctrl.template.labels = _.extend(systemLabels, userLabels);
+        ctrl.template.labels = keyValueEditorUtils.mapEntries(keyValueEditorUtils.compactEntries(ctrl.labels));
 
         DataService.create("processedtemplates", null, ctrl.template, context).then(
           function(config) { // success
@@ -289,7 +287,7 @@
         });
       }
 
-      ctrl.systemLabels = _.map(ctrl.template.labels, function(value, key) {
+      ctrl.labels = _.map(ctrl.template.labels, function(value, key) {
         return {
           name: key,
           value: value
@@ -297,7 +295,7 @@
       });
 
       if (shouldAddAppLabel()) {
-        ctrl.systemLabels.push({
+        ctrl.labels.push({
           name: 'app',
           value: ctrl.template.metadata.name
         });

--- a/app/scripts/services/images.js
+++ b/app/scripts/services/images.js
@@ -131,6 +131,10 @@ angular.module("openshiftConsole")
         resources.push(imageStream);
       }
 
+      var dcLabels = _.assign({
+        deploymentconfig: config.name
+      }, config.labels);
+
       var deploymentConfig = {
         kind: "DeploymentConfig",
         apiVersion: "v1",
@@ -164,15 +168,10 @@ angular.module("openshiftConsole")
           }],
           replicas: 1,
           test: false,
-          selector: {
-            app: config.name,
-            deploymentconfig: config.name
-          },
+          selector: dcLabels,
           template: {
             metadata: {
-              labels: _.assign({
-                deploymentconfig: config.name
-              }, config.labels),
+              labels: dcLabels,
               annotations: annotations
             },
             spec: {

--- a/app/views/create/fromimage.html
+++ b/app/views/create/fromimage.html
@@ -401,8 +401,7 @@
                             <!-- /limits -->
 
                             <label-editor
-                                labels="userDefinedLabels"
-                                system-labels="systemLabels"
+                                labels="labelArray"
                                 expand="true"
                                 can-toggle="false"
                                 help-text="Each label is applied to each created resource.">
@@ -415,7 +414,6 @@
                             for source, routes, builds, and deployments.
                           </div>
                           <div class="buttons gutter-bottom" ng-class="{'gutter-top': !alerts.length}">
-                            <!-- unable to use form.valid.  need to fix validators in labels and key values directive -->
                             <button type="submit"
                                 class="btn btn-primary btn-lg"
                                 ng-disabled="form.$invalid || nameTaken || cpuProblems.length || memoryProblems.length || disableInputs"

--- a/app/views/directives/deploy-image.html
+++ b/app/views/directives/deploy-image.html
@@ -177,7 +177,6 @@
 
         <label-editor
             labels="labels"
-            system-labels="systemLabels"
             expand="true"
             can-toggle="false"
             help-text="Each label is applied to each created resource.">

--- a/app/views/directives/label-editor.html
+++ b/app/views/directives/label-editor.html
@@ -5,19 +5,6 @@
   expand="expand"
   can-toggle="canToggle">
 
-  <div ng-if="systemLabels.length">
-    <div class="help-block">
-      The following labels are being added automatically. If you want to override them, you can do so below.
-    </div>
-    <key-value-editor
-      entries="systemLabels"
-      is-readonly
-      cannot-sort
-      cannot-delete
-      cannot-add
-      key-placeholder="Name"></key-value-editor>
-  </div>
-
   <div ng-if="helpText && ((labels | hashSize) !== 0 || $parent.expand)" class="help-block">
     {{helpText}}
   </div>

--- a/app/views/directives/process-template.html
+++ b/app/views/directives/process-template.html
@@ -5,7 +5,6 @@
     </template-options>
     <label-editor
         labels="$ctrl.labels"
-        system-labels="$ctrl.systemLabels"
         expand="true"
         can-toggle="false"
         help-text="Each label is applied to each created resource.">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3189,7 +3189,9 @@ importPolicy: {}
 };
 n.push(l);
 }
-var u = {
+var u = _.assign({
+deploymentconfig: e.name
+}, e.labels), d = {
 kind: "DeploymentConfig",
 apiVersion: "v1",
 metadata: {
@@ -3217,15 +3219,10 @@ namespace: e.namespace
 } ],
 replicas: 1,
 test: !1,
-selector: {
-app: e.name,
-deploymentconfig: e.name
-},
+selector: u,
 template: {
 metadata: {
-labels: _.assign({
-deploymentconfig: e.name
-}, e.labels),
+labels: u,
 annotations: r
 },
 spec: {
@@ -3243,9 +3240,9 @@ resources: {}
 },
 status: {}
 };
-_.first(e.pullSecrets).name && (u.spec.template.spec.imagePullSecrets = e.pullSecrets), n.push(u);
-var d;
-return _.isEmpty(e.ports) || (d = {
+_.first(e.pullSecrets).name && (d.spec.template.spec.imagePullSecrets = e.pullSecrets), n.push(d);
+var m;
+return _.isEmpty(e.ports) || (m = {
 kind: "Service",
 apiVersion: "v1",
 metadata: {
@@ -3261,7 +3258,7 @@ ports: _.map(e.ports, function(e) {
 return t.getServicePort(e);
 })
 }
-}, n.push(d)), n;
+}, n.push(m)), n;
 },
 getEnvironment: function(e) {
 return _.map(_.get(e, "image.dockerImageMetadata.Config.Env"), function(e) {
@@ -7446,8 +7443,8 @@ c.list("resourcequotas", i).then(function(e) {
 y = e.by("metadata.name"), m.log("quotas", y);
 }), c.list("appliedclusterresourcequotas", i).then(function(e) {
 S = e.by("metadata.name"), m.log("cluster quotas", S);
-}), e.$watch("scaling.autoscale", $), e.$watch("container", $, !0), e.$watch("name", function(e) {
-T.value = e;
+}), e.$watch("scaling.autoscale", $), e.$watch("container", $, !0), e.$watch("name", function(e, t) {
+T.value && T.value !== t || (T.value = e);
 }), function(t) {
 t.name = r.name, t.imageName = R, t.imageTag = r.imageTag, t.namespace = r.namespace, t.buildConfig = {
 buildOnSourceChange: !0,
@@ -7467,7 +7464,7 @@ deployOnConfigChange: !0
 }, t.DCEnvVarsFromImage, t.DCEnvVarsFromUser = [], t.routing = {
 include: !0,
 portOptions: []
-}, t.userDefinedLabels = [], t.systemLabels = [ T ], t.annotations = {}, t.scaling = {
+}, t.labelArray = [ T ], t.annotations = {}, t.scaling = {
 replicas: 1,
 autoscale: !1,
 autoscaleOptions: [ {
@@ -7600,17 +7597,15 @@ e.id = _.uniqueId("create-builder-alert-"), f.addNotification(e);
 e.projectDisplayName = function() {
 return k(this.project) || this.projectName;
 }, e.createApp = function() {
-e.disableInputs = !0, I(), e.buildConfig.envVars = w.compactEntries(e.buildConfigEnvVars), e.deploymentConfig.envVars = w.compactEntries(e.DCEnvVarsFromUser);
-var t = w.mapEntries(w.compactEntries(e.userDefinedLabels)), n = w.mapEntries(w.compactEntries(e.systemLabels));
-e.labels = _.extend(n, t);
-var a = s.generate(e);
-A = [], angular.forEach(a, function(e) {
+e.disableInputs = !0, I(), e.buildConfig.envVars = w.compactEntries(e.buildConfigEnvVars), e.deploymentConfig.envVars = w.compactEntries(e.DCEnvVarsFromUser), e.labels = w.mapEntries(w.compactEntries(e.labelArray));
+var t = s.generate(e);
+A = [], angular.forEach(t, function(e) {
 null !== e && (m.debug("Generated resource definition:", e), A.push(e));
 });
-var r = s.ifResourcesDontExist(A, e.projectName), o = v.getLatestQuotaAlerts(A, i), c = function(t) {
-return e.nameTaken = t.nameTaken, o;
+var n = s.ifResourcesDontExist(A, e.projectName), a = v.getLatestQuotaAlerts(A, i), r = function(t) {
+return e.nameTaken = t.nameTaken, a;
 };
-r.then(c, c).then(U, U);
+n.then(r, r).then(U, U);
 };
 })), e.cancel = function() {
 g.toProjectOverview(e.projectName);
@@ -10213,7 +10208,6 @@ return {
 restrict: "E",
 scope: {
 labels: "=",
-systemLabels: "=",
 expand: "=?",
 canToggle: "=?",
 helpText: "@?"
@@ -12175,12 +12169,12 @@ return a;
 function p() {
 f.prefillParameters && _.each(f.template.parameters, function(e) {
 f.prefillParameters[e.name] && (e.value = f.prefillParameters[e.name]);
-}), f.systemLabels = _.map(f.template.labels, function(e, t) {
+}), f.labels = _.map(f.template.labels, function(e, t) {
 return {
 name: t,
 value: e
 };
-}), R() && f.systemLabels.push({
+}), R() && f.labels.push({
 name: "app",
 value: f.template.metadata.name
 });
@@ -12268,9 +12262,7 @@ f.createFromTemplate = function() {
 f.disableInputs = !0, j().then(function(e) {
 f.selectedProject = e, g = {
 namespace: f.selectedProject.metadata.name
-};
-var t = d.mapEntries(d.compactEntries(f.labels)), n = d.mapEntries(d.compactEntries(f.systemLabels));
-f.template.labels = _.extend(n, t), r.create("processedtemplates", null, f.template, g).then(function(e) {
+}, f.template.labels = d.mapEntries(d.compactEntries(f.labels)), r.create("processedtemplates", null, f.template, g).then(function(e) {
 s.setTemplateData(e.parameters, f.template.parameters, e.message), y = e.objects, c.getLatestQuotaAlerts(y, g).then(k);
 }, function(e) {
 f.disableInputs = !1;
@@ -13044,7 +13036,7 @@ isDialog: "="
 templateUrl: "views/directives/deploy-image.html",
 link: function(n) {
 function l() {
-var e = p.mapEntries(p.compactEntries(n.labels)), t = p.mapEntries(p.compactEntries(n.systemLabels));
+var e = p.mapEntries(p.compactEntries(n.labels));
 return i.getResources({
 name: n.app.name,
 image: n.import.name,
@@ -13053,11 +13045,11 @@ tag: n.import.tag || "latest",
 ports: n.ports,
 volumes: n.volumes,
 env: p.compactEntries(n.env),
-labels: _.extend(t, e),
+labels: e,
 pullSecrets: n.pullSecrets
 });
 }
-n.mode = "istag", n.istag = {}, n.app = {}, n.env = [], n.labels = [], n.systemLabels = [ {
+n.mode = "istag", n.istag = {}, n.app = {}, n.env = [], n.labels = [ {
 name: "app",
 value: ""
 } ], n.pullSecrets = [ {
@@ -13115,10 +13107,12 @@ t && (n.app.name = R(), n.runsAsRoot = i.runsAsRoot(t), n.ports = r.parsePorts(t
 }, function(t) {
 n.import.error = e("getErrorDetails")(t) || "An error occurred finding the image.", n.loading = !1;
 });
-}, n.$watch("app.name", function() {
-n.nameTaken = !1, _.set(_.find(n.systemLabels, {
+}, n.$watch("app.name", function(e, t) {
+n.nameTaken = !1;
+var a = _.find(n.labels, {
 name: "app"
-}), "value", n.app.name);
+});
+!a || a.value && a.value !== t || (a.value = e);
 }), n.$watch("mode", function(e, t) {
 e !== t && (delete n.import, n.istag = {}, "dockerImage" === e ? n.forms.imageSelection.imageName.$setValidity("imageLoaded", !1) : n.forms.imageSelection.imageName.$setValidity("imageLoaded", !0));
 }), n.$watch("istag", function(t, a) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5119,7 +5119,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</osc-form-section>\n" +
     "\n" +
-    "<label-editor labels=\"userDefinedLabels\" system-labels=\"systemLabels\" expand=\"true\" can-toggle=\"false\" help-text=\"Each label is applied to each created resource.\">\n" +
+    "<label-editor labels=\"labelArray\" expand=\"true\" can-toggle=\"false\" help-text=\"Each label is applied to each created resource.\">\n" +
     "</label-editor>\n" +
     "</div>\n" +
     "<div class=\"mar-top-md\">\n" +
@@ -5129,7 +5129,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "for source, routes, builds, and deployments.\n" +
     "</div>\n" +
     "<div class=\"buttons gutter-bottom\" ng-class=\"{'gutter-top': !alerts.length}\">\n" +
-    "\n" +
     "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-disabled=\"form.$invalid || nameTaken || cpuProblems.length || memoryProblems.length || disableInputs\">Create</button>\n" +
     "<a class=\"btn btn-default btn-lg\" href=\"\" ng-click=\"cancel()\" role=\"button\">Cancel</a>\n" +
     "</div>\n" +
@@ -6367,7 +6366,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<osc-form-section header=\"Environment Variables\" about-title=\"Environment Variables\" about=\"Environment variables are used to configure and pass information to running containers.\" expand=\"true\" can-toggle=\"false\" class=\"first-section\">\n" +
     "<key-value-editor entries=\"env\" key-placeholder=\"Name\" key-validator=\"[A-Za-z_][A-Za-z0-9_]*\" key-validator-error=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" value-placeholder=\"Value\" value-from-selector-options=\"valueFromObjects\" add-row-link=\"Add Environment Variable\" add-row-with-selectors-link=\"Add Environment Variable Using a Config Map or Secret\"></key-value-editor>\n" +
     "</osc-form-section>\n" +
-    "<label-editor labels=\"labels\" system-labels=\"systemLabels\" expand=\"true\" can-toggle=\"false\" help-text=\"Each label is applied to each created resource.\">\n" +
+    "<label-editor labels=\"labels\" expand=\"true\" can-toggle=\"false\" help-text=\"Each label is applied to each created resource.\">\n" +
     "</label-editor>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div ng-if=\"!isDialog\" class=\"button-group gutter-bottom\" ng-class=\"{'gutter-top': !alerts.length}\">\n" +
@@ -7358,12 +7357,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/directives/label-editor.html',
     "<osc-form-section header=\"Labels\" about-title=\"Labels\" about=\"Labels are used to organize, group, or select objects and resources, such as pods.\" expand=\"expand\" can-toggle=\"canToggle\">\n" +
-    "<div ng-if=\"systemLabels.length\">\n" +
-    "<div class=\"help-block\">\n" +
-    "The following labels are being added automatically. If you want to override them, you can do so below.\n" +
-    "</div>\n" +
-    "<key-value-editor entries=\"systemLabels\" is-readonly cannot-sort cannot-delete cannot-add key-placeholder=\"Name\"></key-value-editor>\n" +
-    "</div>\n" +
     "<div ng-if=\"helpText && ((labels | hashSize) !== 0 || $parent.expand)\" class=\"help-block\">\n" +
     "{{helpText}}\n" +
     "</div>\n" +
@@ -8758,7 +8751,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<template-options is-dialog=\"$ctrl.isDialog\" parameters=\"$ctrl.template.parameters\" expand=\"true\" can-toggle=\"false\">\n" +
     "<select-project ng-if=\"!$ctrl.project\" selected-project=\"$ctrl.selectedProject\" name-taken=\"$ctrl.projectNameTaken\"></select-project>\n" +
     "</template-options>\n" +
-    "<label-editor labels=\"$ctrl.labels\" system-labels=\"$ctrl.systemLabels\" expand=\"true\" can-toggle=\"false\" help-text=\"Each label is applied to each created resource.\">\n" +
+    "<label-editor labels=\"$ctrl.labels\" expand=\"true\" can-toggle=\"false\" help-text=\"Each label is applied to each created resource.\">\n" +
     "</label-editor>\n" +
     "<div ng-if=\"!$ctrl.isDialog\" class=\"buttons gutter-top-bottom\">\n" +
     "<button class=\"btn btn-primary btn-lg\" ng-click=\"$ctrl.createFromTemplate()\" ng-disabled=\"$ctrl.templateForm.$invalid || $ctrl.disableInputs\">Create</button>\n" +


### PR DESCRIPTION
Prefill the label values instead of having a separate "system labels"
section that is read-only. Fixes a usability bug where it wasn't obvious
the app label could be overridden.

Fixes #1422 