### PR TITLE
Don't include Failed pods in count beside mini donut

### DIFF
--- a/app/scripts/directives/podDonut.js
+++ b/app/scripts/directives/podDonut.js
@@ -28,14 +28,16 @@ angular.module('openshiftConsole')
 
         $scope.chartId = _.uniqueId('pods-donut-chart-');
 
-        function updateCenterText() {
-          if ($scope.mini) {
-            return;
-          }
-          var smallText;
+        function updatePodCount() {
           // Don't show failed pods like evicted pods in the donut.
           var pods = _.reject($scope.pods, { status: { phase: 'Failed' } });
           var total = _.size(pods);
+          if ($scope.mini) {
+            $scope.total = total;
+            return;
+          }
+
+          var smallText;
           if (!angular.isNumber($scope.desired) || $scope.desired === total) {
             smallText = (total === 1) ? "pod" : "pods";
           } else {
@@ -68,7 +70,7 @@ angular.module('openshiftConsole')
           legend: {
             show: false
           },
-          onrendered: updateCenterText,
+          onrendered: updatePodCount,
           tooltip: {
             format: {
               value: function(value, ratio, id) {
@@ -196,7 +198,7 @@ angular.module('openshiftConsole')
 
         var debounceUpdate = _.debounce(updateChart, 350, { maxWait: 500 });
         $scope.$watch(countPodPhases, debounceUpdate, true);
-        $scope.$watchGroup(['desired','idled'], updateCenterText);
+        $scope.$watchGroup(['desired','idled'], updatePodCount);
 
         $scope.$on('destroy', function() {
           if (chart) {

--- a/app/views/directives/pod-donut.html
+++ b/app/views/directives/pod-donut.html
@@ -2,9 +2,9 @@
 
 <div ng-if="mini" class="donut-mini-text">
   <span ng-if="!idled">
-    {{pods | hashSize}}
-    <span ng-if="(pods | hashSize) === 1">pod</span>
-    <span ng-if="(pods | hashSize) !== 1">pods</span>
+    {{total}}
+    <span ng-if="total === 1">pod</span>
+    <span ng-if="total !== 1">pods</span>
   </span>
   <span ng-if="idled">
     Idle

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -11463,14 +11463,14 @@ mini:"=?"
 templateUrl:"views/directives/pod-donut.html",
 link:function(a, f) {
 function h() {
-if (!a.mini) {
-var b, c = _.reject(a.pods, {
+var b = _.reject(a.pods, {
 status:{
 phase:"Failed"
 }
-}), d = _.size(c);
-b = angular.isNumber(a.desired) && a.desired !== d ? "scaling to " + a.desired + "..." :1 === d ? "pod" :"pods", a.idled ? g.updateDonutCenterText(f[0], "Idle") :g.updateDonutCenterText(f[0], d, b);
-}
+}), c = _.size(b);
+if (a.mini) return void (a.total = c);
+var d;
+d = angular.isNumber(a.desired) && a.desired !== c ? "scaling to " + a.desired + "..." :1 === c ? "pod" :"pods", a.idled ? g.updateDonutCenterText(f[0], "Idle") :g.updateDonutCenterText(f[0], c, d);
 }
 function i(b) {
 var c = {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8495,9 +8495,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-attr-id=\"{{chartId}}\" class=\"pod-donut\" ng-class=\"{ mini: mini }\"></div>\n" +
     "<div ng-if=\"mini\" class=\"donut-mini-text\">\n" +
     "<span ng-if=\"!idled\">\n" +
-    "{{pods | hashSize}}\n" +
-    "<span ng-if=\"(pods | hashSize) === 1\">pod</span>\n" +
-    "<span ng-if=\"(pods | hashSize) !== 1\">pods</span>\n" +
+    "{{total}}\n" +
+    "<span ng-if=\"total === 1\">pod</span>\n" +
+    "<span ng-if=\"total !== 1\">pods</span>\n" +
     "</span>\n" +
     "<span ng-if=\"idled\">\n" +
     "Idle\n" +


### PR DESCRIPTION
The mini donut in a collapsed overview row includes Failed pods, but the
center text when the row is expanded does not. Don't include Failed pods
in the collapsed state count so that the numbers match.

See #1689