### PR TITLE
Improving display of tech-preview label

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -1267,8 +1267,21 @@ pre.clipped {
   }
 }
 
-.tech-preview-header {
-  justify-content: space-between;
+.label-tech-preview {
+  display: inline-block;
+  margin-top: 7px;
+  @media(min-width: @screen-xs-min) {
+    float: right;
+    margin-left: 10px;
+  }
+  + h1 {
+    @media(max-width: @screen-xxs-max) {
+      margin-top: 11px;
+    }
+  }
+  .page-header & {
+    margin-top: 3px;
+  }
 }
 
 // add an option for a single-column display at screen resolutions 0-479px

--- a/app/views/browse/stateful-set.html
+++ b/app/views/browse/stateful-set.html
@@ -5,12 +5,8 @@
 
       <div class="middle-header">
         <div class="container-fluid">
-          <div row mobile="column" class="tech-preview-header">
-            <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
-            <span class="pad-top-md">
-              <span class="label label-warning">Technology Preview</span>
-            </span>
-          </div>
+          <span class="label label-warning label-tech-preview">Technology Preview</span>
+          <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
           <alerts alerts="alerts"></alerts>
           <div>
             <h1>

--- a/app/views/browse/stateful-sets.html
+++ b/app/views/browse/stateful-sets.html
@@ -7,9 +7,7 @@
         <div class="container-fluid">
           <div
             class="page-header page-header-bleed-right page-header-bleed-left">
-            <span class="pad-top-xs pull-right">
-              <span class="label label-warning">Technology Preview</span>
-            </span>
+            <span class="label label-warning label-tech-preview">Technology Preview</span>
             <h1>
               Stateful Sets
               <!-- TODO: docs are in progress

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3862,12 +3862,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-container\">\n" +
     "<div class=\"middle-header\">\n" +
     "<div class=\"container-fluid\">\n" +
-    "<div row mobile=\"column\" class=\"tech-preview-header\">\n" +
+    "<span class=\"label label-warning label-tech-preview\">Technology Preview</span>\n" +
     "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
-    "<span class=\"pad-top-md\">\n" +
-    "<span class=\"label label-warning\">Technology Preview</span>\n" +
-    "</span>\n" +
-    "</div>\n" +
     "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div>\n" +
     "<h1>\n" +
@@ -3993,9 +3989,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-header header-toolbar\">\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
-    "<span class=\"pad-top-xs pull-right\">\n" +
-    "<span class=\"label label-warning\">Technology Preview</span>\n" +
-    "</span>\n" +
+    "<span class=\"label label-warning label-tech-preview\">Technology Preview</span>\n" +
     "<h1>\n" +
     "Stateful Sets\n" +
     "\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4698,9 +4698,13 @@ pre.clipped.scroll{max-height:150px;overflow:auto;width:100%}
 .environment-variables.table.table-bordered>tbody>tr>td:last-child .env-var-value a{font-family:"Open Sans",Helvetica,Arial,sans-serif}
 .info-popover,.warnings-popover{cursor:help;vertical-align:middle;margin-left:2px}
 .info-popover.pficon-info,.warnings-popover.pficon-info{color:#4d5258}
-.tech-preview-header{justify-content:space-between}
-@media (max-width:479px){.col-xxs-12{width:100%}
+.label-tech-preview{display:inline-block;margin-top:7px}
+@media (min-width:480px){.label-tech-preview{float:right;margin-left:10px}
 }
+@media (max-width:479px){.label-tech-preview+h1{margin-top:11px}
+.col-xxs-12{width:100%}
+}
+.page-header .label-tech-preview{margin-top:3px}
 .icon-row .icon-wrap{text-align:center;width:30px}
 .data-toolbar{padding:5px 0}
 .data-toolbar.other-resources-toolbar .data-toolbar-dropdown{min-width:210px}


### PR DESCRIPTION
Fixes #1802 

This refactors the markup and CSS so the application of tech preview label is consistent across pages.  In doing so, it reduces the height of the label so that it's not so large when in the context of the breadcrumb.

![screen shot 2017-07-07 at 4 10 46 pm](https://user-images.githubusercontent.com/895728/27975258-69c3494a-632f-11e7-89e8-5e00de2fce91.PNG)
![screen shot 2017-07-07 at 4 10 54 pm](https://user-images.githubusercontent.com/895728/27975259-69c6ad74-632f-11e7-83b0-733ac62c38e9.PNG)
![localhost-9000-dev-console-project-myproject-browse-stateful-sets- iphone 6](https://user-images.githubusercontent.com/895728/27975267-6fda116a-632f-11e7-8375-f3cb81020865.png)
![localhost-9000-dev-console-project-myproject-browse-stateful-sets-helloisthegreatestnameofall-ok-maybe-just-ok-tab details iphone 6](https://user-images.githubusercontent.com/895728/27975268-6fe02bcc-632f-11e7-8cce-495b745ca0bb.png)

