### PR TITLE
Improve monitoring page collapsed rows

### DIFF
--- a/app/scripts/controllers/monitoring.js
+++ b/app/scripts/controllers/monitoring.js
@@ -266,12 +266,13 @@ angular.module('openshiftConsole')
       }
     };
 
-    $scope.viewPodsForReplicaSet = function(replicaSet) {
-      if (_.isEmpty($scope.podsByOwnerUID[replicaSet.metadata.uid])) {
+    $scope.viewPodsForSet = function(set) {
+      var pods = _.get($scope, ['podsByOwnerUID', set.metadata.uid], []);
+      if (_.isEmpty(pods)) {
         return;
       }
 
-      Navigate.toPodsForDeployment(replicaSet);
+      Navigate.toPodsForDeployment(set, pods);
     };
 
     ProjectsService

--- a/app/views/directives/build-status.html
+++ b/app/views/directives/build-status.html
@@ -1,12 +1,12 @@
 <status-icon status="build.status.phase" disable-animation></status-icon>
-<span ng-if="!build.status.reason || build.status.phase === 'Cancelled'">{{build.status.phase}}</span><span
-  ng-if="build.status.reason && build.status.phase !== 'Cancelled'">{{build.status.reason | sentenceCase}}</span><span
-  ng-switch="build.status.phase" class="hide-ng-leave" ng-if="build.status.startTimestamp"><span
-    ng-switch-when="Complete">, ran for {{build.status.startTimestamp | timeOnlyDurationFromTimestamps : build.status.completionTimestamp}}</span><span
-    ng-switch-when="Failed">, ran for {{build.status.startTimestamp | timeOnlyDurationFromTimestamps : build.status.completionTimestamp}}</span><span
-    ng-switch-when="Cancelled"> after {{build.status.startTimestamp | timeOnlyDurationFromTimestamps : build.status.completionTimestamp}}</span><span
-    ng-switch-when="Running"> for <time-only-duration-until-now timestamp="build.status.startTimestamp" time-only></time-only-duration-until-now></span><span
-    ng-switch-when="New"></span><span
-    ng-switch-when="Pending"></span><span
-    ng-switch-default>, ran for {{build.status.startTimestamp | duration : build.status.completionTimestamp}}</span>
+<span ng-if="!build.status.reason || build.status.phase === 'Cancelled'">{{build.status.phase}}</span>
+<span ng-if="build.status.reason && build.status.phase !== 'Cancelled'">{{build.status.reason | sentenceCase}}</span>
+<span ng-if="build.status.startTimestamp" class="small text-muted">
+  &ndash;
+  <span ng-if="build.status.completionTimestamp">
+    {{build.status.startTimestamp | timeOnlyDurationFromTimestamps : build.status.completionTimestamp}}
+  </span>
+  <span ng-if="!build.status.completionTimestamp">
+    <time-only-duration-until-now timestamp="build.status.startTimestamp" time-only></time-only-duration-until-now>
+  </span>
 </span>

--- a/app/views/monitoring.html
+++ b/app/views/monitoring.html
@@ -96,6 +96,10 @@
                             <div class="list-group-item-text">
                               <status-icon status="pod | podStatus" disable-animation></status-icon>
                               {{pod | podStatus | sentenceCase}}
+                              <small ng-if="(pod | podStatus) === 'Running'" class="text-muted">
+                                &ndash;
+                                {{pod | numContainersReady}}/{{pod.spec.containers.length}} ready
+                              </small>
                             </div>
                           </div>
                           <div class="list-view-pf-additional-info">
@@ -177,8 +181,12 @@
                               <small>created <span am-time-ago="replicationController.metadata.creationTimestamp"></span></small>
                             </div>
                             <div class="list-group-item-text">
-                              <status-icon status="replicationController | deploymentStatus" disable-animation></status-icon>
-                              {{replicationController | deploymentStatus | sentenceCase}}<span ng-if="(replicationController | deploymentStatus) === 'Active'">, {{replicationController.status.replicas}} replica<span ng-if="replicationController.status.replicas !== 1">s</span></span>
+                              <a href=""
+                                 ng-click="viewPodsForSet(replicationController)"
+                                 class="mini-donut-link"
+                                 ng-class="{ 'disabled-link': !(podsByOwnerUID[replicationController.metadata.uid] | size) }">
+                                <pod-donut pods="podsByOwnerUID[replicationController.metadata.uid]" mini="true"></pod-donut>
+                              </a>
                             </div>
                           </div>
                           <div class="list-view-pf-additional-info">
@@ -235,7 +243,12 @@
                               <small>created <span am-time-ago="replicaSet.metadata.creationTimestamp"></span></small>
                             </div>
                             <div class="list-group-item-text">
-                              {{replicaSet.status.replicas}} replica<span ng-if="replicaSet.status.replicas !== 1">s</span>
+                              <a href=""
+                                 ng-click="viewPodsForSet(replicaSet)"
+                                 class="mini-donut-link"
+                                 ng-class="{ 'disabled-link': !(podsByOwnerUID[replicaSet.metadata.uid] | size) }">
+                                <pod-donut pods="podsByOwnerUID[replicaSet.metadata.uid]" mini="true"></pod-donut>
+                              </a>
                             </div>
                           </div>
                           <div class="list-view-pf-additional-info">
@@ -301,9 +314,12 @@
                               <small>created <span am-time-ago="set.metadata.creationTimestamp"></span></small>
                             </div>
                             <div class="list-group-item-text">
-                              <status-icon status="set | deploymentStatus" disable-animation></status-icon>
-                              {{set | deploymentStatus | sentenceCase}},
-                              <span ng-if="(podsByOwnerUID[set.metadata.uid] | hashSize) !== set.spec.replicas">{{podsByOwnerUID[set.metadata.uid] | hashSize}}/</span>{{set.spec.replicas}} replica<span ng-if="set.spec.replicas != 1">s</span>
+                              <a href=""
+                                 ng-click="viewPodsForSet(set)"
+                                 class="mini-donut-link"
+                                 ng-class="{ 'disabled-link': !(podsByOwnerUID[set.metadata.uid] | size) }">
+                                <pod-donut pods="podsByOwnerUID[set.metadata.uid]" mini="true"></pod-donut>
+                              </a>
                             </div>
                           </div>
                           <div class="list-view-pf-additional-info">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4612,8 +4612,9 @@ case "StatefulSet":
 g = !c.expanded.statefulSets[e.metadata.name], c.expanded.statefulSets[e.metadata.name] = g, h = g ? "event.resource.highlight" :"event.resource.clear-highlight", n.$emit(h, e);
 }
 }
-}, c.viewPodsForReplicaSet = function(a) {
-_.isEmpty(c.podsByOwnerUID[a.metadata.uid]) || k.toPodsForDeployment(a);
+}, c.viewPodsForSet = function(a) {
+var b = _.get(c, [ "podsByOwnerUID", a.metadata.uid ], []);
+_.isEmpty(b) || k.toPodsForDeployment(a, b);
 }, m.get(a.project).then(_.spread(function(a, d) {
 c.project = a, c.projectContext = d, f.watch("pods", d, function(a) {
 c.podsByName = a.by("metadata.name"), c.pods = u(c.podsByName, !0), c.podsByOwnerUID = l.groupByOwnerUID(c.pods), c.podsLoaded = !0, _.each(c.pods, y), C(), i.log("pods", c.pods);

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5942,7 +5942,16 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/directives/build-status.html',
     "<status-icon status=\"build.status.phase\" disable-animation></status-icon>\n" +
-    "<span ng-if=\"!build.status.reason || build.status.phase === 'Cancelled'\">{{build.status.phase}}</span><span ng-if=\"build.status.reason && build.status.phase !== 'Cancelled'\">{{build.status.reason | sentenceCase}}</span><span ng-switch=\"build.status.phase\" class=\"hide-ng-leave\" ng-if=\"build.status.startTimestamp\"><span ng-switch-when=\"Complete\">, ran for {{build.status.startTimestamp | timeOnlyDurationFromTimestamps : build.status.completionTimestamp}}</span><span ng-switch-when=\"Failed\">, ran for {{build.status.startTimestamp | timeOnlyDurationFromTimestamps : build.status.completionTimestamp}}</span><span ng-switch-when=\"Cancelled\"> after {{build.status.startTimestamp | timeOnlyDurationFromTimestamps : build.status.completionTimestamp}}</span><span ng-switch-when=\"Running\"> for <time-only-duration-until-now timestamp=\"build.status.startTimestamp\" time-only></time-only-duration-until-now></span><span ng-switch-when=\"New\"></span><span ng-switch-when=\"Pending\"></span><span ng-switch-default>, ran for {{build.status.startTimestamp | duration : build.status.completionTimestamp}}</span>\n" +
+    "<span ng-if=\"!build.status.reason || build.status.phase === 'Cancelled'\">{{build.status.phase}}</span>\n" +
+    "<span ng-if=\"build.status.reason && build.status.phase !== 'Cancelled'\">{{build.status.reason | sentenceCase}}</span>\n" +
+    "<span ng-if=\"build.status.startTimestamp\" class=\"small text-muted\">\n" +
+    "&ndash;\n" +
+    "<span ng-if=\"build.status.completionTimestamp\">\n" +
+    "{{build.status.startTimestamp | timeOnlyDurationFromTimestamps : build.status.completionTimestamp}}\n" +
+    "</span>\n" +
+    "<span ng-if=\"!build.status.completionTimestamp\">\n" +
+    "<time-only-duration-until-now timestamp=\"build.status.startTimestamp\" time-only></time-only-duration-until-now>\n" +
+    "</span>\n" +
     "</span>"
   );
 
@@ -10877,6 +10886,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"list-group-item-text\">\n" +
     "<status-icon status=\"pod | podStatus\" disable-animation></status-icon>\n" +
     "{{pod | podStatus | sentenceCase}}\n" +
+    "<small ng-if=\"(pod | podStatus) === 'Running'\" class=\"text-muted\">\n" +
+    "&ndash; {{pod | numContainersReady}}/{{pod.spec.containers.length}} ready\n" +
+    "</small>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"list-view-pf-additional-info\">\n" +
@@ -10940,8 +10952,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<small>created <span am-time-ago=\"replicationController.metadata.creationTimestamp\"></span></small>\n" +
     "</div>\n" +
     "<div class=\"list-group-item-text\">\n" +
-    "<status-icon status=\"replicationController | deploymentStatus\" disable-animation></status-icon>\n" +
-    "{{replicationController | deploymentStatus | sentenceCase}}<span ng-if=\"(replicationController | deploymentStatus) === 'Active'\">, {{replicationController.status.replicas}} replica<span ng-if=\"replicationController.status.replicas !== 1\">s</span></span>\n" +
+    "<a href=\"\" ng-click=\"viewPodsForSet(replicationController)\" class=\"mini-donut-link\" ng-class=\"{ 'disabled-link': !(podsByOwnerUID[replicationController.metadata.uid] | size) }\">\n" +
+    "<pod-donut pods=\"podsByOwnerUID[replicationController.metadata.uid]\" mini=\"true\"></pod-donut>\n" +
+    "</a>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"list-view-pf-additional-info\">\n" +
@@ -10981,7 +10994,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<small>created <span am-time-ago=\"replicaSet.metadata.creationTimestamp\"></span></small>\n" +
     "</div>\n" +
     "<div class=\"list-group-item-text\">\n" +
-    "{{replicaSet.status.replicas}} replica<span ng-if=\"replicaSet.status.replicas !== 1\">s</span>\n" +
+    "<a href=\"\" ng-click=\"viewPodsForSet(replicaSet)\" class=\"mini-donut-link\" ng-class=\"{ 'disabled-link': !(podsByOwnerUID[replicaSet.metadata.uid] | size) }\">\n" +
+    "<pod-donut pods=\"podsByOwnerUID[replicaSet.metadata.uid]\" mini=\"true\"></pod-donut>\n" +
+    "</a>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"list-view-pf-additional-info\">\n" +
@@ -11037,9 +11052,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<small>created <span am-time-ago=\"set.metadata.creationTimestamp\"></span></small>\n" +
     "</div>\n" +
     "<div class=\"list-group-item-text\">\n" +
-    "<status-icon status=\"set | deploymentStatus\" disable-animation></status-icon>\n" +
-    "{{set | deploymentStatus | sentenceCase}},\n" +
-    "<span ng-if=\"(podsByOwnerUID[set.metadata.uid] | hashSize) !== set.spec.replicas\">{{podsByOwnerUID[set.metadata.uid] | hashSize}}/</span>{{set.spec.replicas}} replica<span ng-if=\"set.spec.replicas != 1\">s</span>\n" +
+    "<a href=\"\" ng-click=\"viewPodsForSet(set)\" class=\"mini-donut-link\" ng-class=\"{ 'disabled-link': !(podsByOwnerUID[set.metadata.uid] | size) }\">\n" +
+    "<pod-donut pods=\"podsByOwnerUID[set.metadata.uid]\" mini=\"true\"></pod-donut>\n" +
+    "</a>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"list-view-pf-additional-info\">\n" +


### PR DESCRIPTION
- Show how many containers are ready for individual pods
- Use the mini pod donut for deployments and stateful sets

The mini donut lets you click through to get to the pods and shows when
pods are crashing and not ready.

![screen shot 2017-07-10 at 9 41 57 am](https://user-images.githubusercontent.com/1167259/28021141-d6afde52-6554-11e7-8cec-42f2e67749d2.png)

Fixes #1489