### PR TITLE
Update mini donut total in `$evalAsync` block

### DIFF
--- a/app/scripts/directives/podDonut.js
+++ b/app/scripts/directives/podDonut.js
@@ -33,7 +33,9 @@ angular.module('openshiftConsole')
           var pods = _.reject($scope.pods, { status: { phase: 'Failed' } });
           var total = _.size(pods);
           if ($scope.mini) {
-            $scope.total = total;
+            $scope.$evalAsync(function() {
+              $scope.total = total;
+            });
             return;
           }
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -11468,7 +11468,9 @@ status:{
 phase:"Failed"
 }
 }), c = _.size(b);
-if (a.mini) return void (a.total = c);
+if (a.mini) return void a.$evalAsync(function() {
+a.total = c;
+});
 var d;
 d = angular.isNumber(a.desired) && a.desired !== c ? "scaling to " + a.desired + "..." :1 === c ? "pod" :"pods", a.idled ? g.updateDonutCenterText(f[0], "Idle") :g.updateDonutCenterText(f[0], c, d);
 }


### PR DESCRIPTION
Since the function is called in response to chart `onrendered`, it's
possible for it to execute outside of a digest loop. This causes the UI
to display the wrong number of pods beside the mini donut until the next
digest loop.