### PR TITLE
Update table label filter to reuse .data-toolbar, .data-toolbar-filter and extend on top of tables

### DIFF
--- a/app/styles/_tables.less
+++ b/app/styles/_tables.less
@@ -147,16 +147,12 @@
   border-top: none;
 }
 
-.table-filter-wrapper {
+.table-filter-extention {
   background-color: #f9f9f9;
   border-left: 1px solid @table-border-color;
   border-right: 1px solid @table-border-color;
   border-top: 1px solid @table-border-color;
-  display: flex;
-  padding: 10px 10px 5px 10px;
-  .form-group {
-    margin-bottom: 5px;
-  }
+  padding: 5px 10px;
 }
 
 @media (max-width: @screen-xs-max) {

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -175,8 +175,12 @@
                       <build-trends-chart builds="builds"></build-trends-chart>
                     </div>
                     <div ng-if="loaded && (unfilteredBuilds | hashSize) > 0" class="mar-bottom-xl">
-                      <div class="table-filter-wrapper">
-                        <project-filter></project-filter>
+                      <div class="table-filter-extention">
+                        <div class="data-toolbar">
+                          <div class="data-toolbar-filter">
+                            <project-filter></project-filter>
+                          </div>
+                        </div>
                       </div>
                       <table ng-if="!(buildConfig | isJenkinsPipelineStrategy)" class="table table-bordered table-hover table-mobile">
                         <thead>

--- a/app/views/browse/deployment-config.html
+++ b/app/views/browse/deployment-config.html
@@ -127,8 +127,12 @@
                         created <span am-time-ago="mostRecent.metadata.creationTimestamp"></span>
                       </div>
                     </div>
-                    <div class="table-filter-wrapper">
-                      <project-filter></project-filter>
+                    <div class="table-filter-extention">
+                      <div class="data-toolbar">
+                        <div class="data-toolbar-filter">
+                          <project-filter></project-filter>
+                        </div>
+                      </div>
                     </div>
                     <table class="table table-bordered table-hover table-mobile">
                       <thead>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1770,8 +1770,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<build-trends-chart builds=\"builds\"></build-trends-chart>\n" +
     "</div>\n" +
     "<div ng-if=\"loaded && (unfilteredBuilds | hashSize) > 0\" class=\"mar-bottom-xl\">\n" +
-    "<div class=\"table-filter-wrapper\">\n" +
+    "<div class=\"table-filter-extention\">\n" +
+    "<div class=\"data-toolbar\">\n" +
+    "<div class=\"data-toolbar-filter\">\n" +
     "<project-filter></project-filter>\n" +
+    "</div>\n" +
+    "</div>\n" +
     "</div>\n" +
     "<table ng-if=\"!(buildConfig | isJenkinsPipelineStrategy)\" class=\"table table-bordered table-hover table-mobile\">\n" +
     "<thead>\n" +
@@ -2425,8 +2429,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "created <span am-time-ago=\"mostRecent.metadata.creationTimestamp\"></span>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"table-filter-wrapper\">\n" +
+    "<div class=\"table-filter-extention\">\n" +
+    "<div class=\"data-toolbar\">\n" +
+    "<div class=\"data-toolbar-filter\">\n" +
     "<project-filter></project-filter>\n" +
+    "</div>\n" +
+    "</div>\n" +
     "</div>\n" +
     "<table class=\"table table-bordered table-hover table-mobile\">\n" +
     "<thead>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5433,15 +5433,14 @@ body,html{margin:0;padding:0}
 .key-value-table>tbody>tr>td.value .truncated-content{white-space:pre}
 .table{background-color:#fff}
 .table.table-bordered>tbody>tr td,.table.table-bordered>tbody>tr th,.table.table-bordered>thead>tr td,.table.table-bordered>thead>tr th{border-left:0;border-right:0;padding-bottom:8px;padding-top:8px;vertical-align:middle}
-.table-filter-wrapper,.table.table-bordered-columns tbody>tr td,.table.table-bordered-columns tbody>tr th,.table.table-bordered-columns thead>tr td,.table.table-bordered-columns thead>tr th{border-left:1px solid #d1d1d1;border-right:1px solid #d1d1d1}
+.table-filter-extention,.table.table-bordered-columns tbody>tr td,.table.table-bordered-columns tbody>tr th,.table.table-bordered-columns thead>tr td,.table.table-bordered-columns thead>tr th{border-left:1px solid #d1d1d1;border-right:1px solid #d1d1d1}
 .table.table-layout-fixed{table-layout:fixed}
 .table.table-layout-fixed td{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .table>tbody+tbody{border-top-width:1px}
 .table th .pficon-help{color:#999;cursor:help}
 .table th .pficon-help:not(:first-child){margin-left:5px}
 .table-borderless>tbody>tr>td,.table-borderless>tbody>tr>th,.table-borderless>tfoot>tr>td,.table-borderless>tfoot>tr>th,.table-borderless>thead>tr>td{border-top:none}
-.table-filter-wrapper{background-color:#f9f9f9;border-top:1px solid #d1d1d1;display:flex;padding:10px 10px 5px}
-.table-filter-wrapper .form-group{margin-bottom:5px}
+.table-filter-extention{background-color:#f9f9f9;border-top:1px solid #d1d1d1;padding:5px 10px}
 @media (max-width:767px){.table-mobile{border-top-width:0;table-layout:fixed}
 .table-mobile col,.table-mobile colgroup{display:none}
 .table-mobile tbody,.table-mobile td,.table-mobile th,.table-mobile thead,.table-mobile tr{display:block}

--- a/dist/styles/vendor.css
+++ b/dist/styles/vendor.css
@@ -178,7 +178,7 @@ kubernetes-container-terminal{position:relative;display:block}
 kubernetes-container-terminal .terminal{font-family:"Monospace Regular","DejaVu Sans Mono",Menlo,Monaco,Consolas,monospace;font-size:10px;color:#F0F0F0;text-align:left;outline:0;background-color:#000;border:1px solid #000;padding:10px;display:inline-block;line-height:1em}
 @media (min-width:568px){kubernetes-container-terminal .terminal{font-size:12px}
 }
-kubernetes-container-terminal .terminal-cursor{color:#000;background:#f0f0f0}
+kubernetes-container-terminal .terminal-cursor{background:#f0f0f0;color:#000;position:absolute}
 kubernetes-container-terminal .terminal-wrapper{display:inline-block;vertical-align:top}
 kubernetes-container-terminal .terminal-actions{display:inline-block;vertical-align:top;position:absolute;top:10px;right:34px;z-index:1}
 .spinner-white{border-bottom:4px solid rgba(255,255,255,.25)!important;border-left:4px solid rgba(255,255,255,.25)!important;border-right:4px solid rgba(255,255,255,.25)!important;border-top:4px solid rgba(255,255,255,.75)!important}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin-web-console/issues/1824

tested on Chrome, Safari, Firefox, IE

<img width="811" alt="screen shot 2017-07-12 at 11 06 59 am" src="https://user-images.githubusercontent.com/1874151/28127141-95173318-66f9-11e7-9e4b-99ef30c5c06f.png">
<img width="545" alt="screen shot 2017-07-12 at 11 07 26 am" src="https://user-images.githubusercontent.com/1874151/28127144-96c75710-66f9-11e7-9ebd-8b4e380c34ca.png">

<img width="750" alt="screen shot 2017-07-12 at 11 24 56 am" src="https://user-images.githubusercontent.com/1874151/28127130-8fc4e4c8-66f9-11e7-98ac-f226bc7b40f8.png">

![28127725-85c9aed4-66fb-11e7-85de-b07a004252bc](https://user-images.githubusercontent.com/1874151/28127755-a60c0c82-66fb-11e7-835e-cdcc43ab1626.png)



