### PR TITLE
Make tags wider in image stream listing table

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -217,14 +217,20 @@ registry-imagestream-push {
   margin-top: @grid-gutter-width;
 }
 
-/* No expandable listing when shown in the Openshift Web Console */
-registry-imagestream-listing .listing-ct-toggle {
-  display: none;
+registry-imagestream-listing {
+  /* No expandable listing when shown in the Openshift Web Console */
+  .listing-ct-toggle {
+    display: none;
+  }
+  .registry-image-tag {
+    max-width: 115px;
+  }
+  table {
+    width: 100%;
+  }
 }
 
-registry-imagestream-listing table {
-  width: 100%;
-}
+
 
 registry-image-body dt:after,
 registry-image-config dt:after,

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4458,6 +4458,7 @@ mark{padding:0;background-color:rgba(252,248,160,.5)}
 registry-image-pull{margin-bottom:20px}
 registry-imagestream-push{margin-top:40px}
 registry-imagestream-listing .listing-ct-toggle{display:none}
+registry-imagestream-listing .registry-image-tag{max-width:115px}
 registry-imagestream-listing table{width:100%}
 registry-image-body dt:after,registry-image-config dt:after,registry-image-meta dt:after,registry-imagestream-body dt:after,registry-imagestream-meta dt:after{content:':'}
 .image-sources .destination-dir:before,.image-sources .source-path:after{content:"\00a0 "}


### PR DESCRIPTION
Doubles the width of the tags in the table. There is a `title` attribute if it still gets clipped.

Fixes #1848