### PR TITLE
Fixes title attribute on the "delete role" action on the membership page

### DIFF
--- a/app/scripts/directives/actionChip.js
+++ b/app/scripts/directives/actionChip.js
@@ -28,7 +28,8 @@ angular
         keyHelp: '=?',    // optional, or empty string for false
         valueHelp: '=',   // optional, or empty string for false
         action: '&?',     // callback fn,
-        actionIcon: '=?', // default is pficon pficon-close
+        actionIcon: '=?', // default is pficon pficon-close,
+        actionTitle: '@',
         showAction: '=?'  // bool to show-hide the action button
       },
       templateUrl: 'views/directives/action-chip.html'

--- a/app/views/directives/action-chip.html
+++ b/app/views/directives/action-chip.html
@@ -37,7 +37,7 @@
     class="item action"
     ng-if="showAction"
     ng-click="action()"
-    ng-attr-title="actionTitle">
+    ng-attr-title="{{actionTitle}}">
     <i ng-class="icon || 'pficon pficon-close'"></i>
   </a>
 

--- a/app/views/membership.html
+++ b/app/views/membership.html
@@ -122,7 +122,7 @@
                         key-help="roleHelp(role)"
                         show-action="mode.edit"
                         action="confirmRemove(subject.name, subjectKind.name, role.metadata.name)"
-                        action-title="remove role {{role}} from {{subject.name}}"></action-chip>
+                        action-title="Remove role {{role.metadata.name}} from {{subject.name}}"></action-chip>
                     </div>
                     <div
                       ng-if="mode.edit"

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10464,6 +10464,7 @@ keyHelp: "=?",
 valueHelp: "=",
 action: "&?",
 actionIcon: "=?",
+actionTitle: "@",
 showAction: "=?"
 },
 templateUrl: "views/directives/action-chip.html"

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5804,7 +5804,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a ng-if=\"value && valueHelp\" href=\"\" class=\"item value truncate\" data-toggle=\"popover\" data-trigger=\"focus\" data-content=\"{{valueHelp}}\">\n" +
     "{{value}}\n" +
     "</a>\n" +
-    "<a href=\"\" class=\"item action\" ng-if=\"showAction\" ng-click=\"action()\" ng-attr-title=\"actionTitle\">\n" +
+    "<a href=\"\" class=\"item action\" ng-if=\"showAction\" ng-click=\"action()\" ng-attr-title=\"{{actionTitle}}\">\n" +
     "<i ng-class=\"icon || 'pficon pficon-close'\"></i>\n" +
     "</a>\n" +
     "</span>"
@@ -10499,7 +10499,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"action-set\" flex row tablet=\"column\" mobile=\"column\">\n" +
     "<div class=\"col-roles\" row tablet=\"column\" flex wrap axis=\"start\">\n" +
-    "<action-chip ng-repeat=\"role in subject.roles\" key=\"role.metadata.name\" key-help=\"roleHelp(role)\" show-action=\"mode.edit\" action=\"confirmRemove(subject.name, subjectKind.name, role.metadata.name)\" action-title=\"remove role {{role}} from {{subject.name}}\"></action-chip>\n" +
+    "<action-chip ng-repeat=\"role in subject.roles\" key=\"role.metadata.name\" key-help=\"roleHelp(role)\" show-action=\"mode.edit\" action=\"confirmRemove(subject.name, subjectKind.name, role.metadata.name)\" action-title=\"Remove role {{role.metadata.name}} from {{subject.name}}\"></action-chip>\n" +
     "</div>\n" +
     "<div ng-if=\"mode.edit\" class=\"col-add-role\">\n" +
     "<div row>\n" +


### PR DESCRIPTION
Currently the title doesn't display, it actually shows the binding name instead:
<img width="195" alt="action-chip-incorrect-title" src="https://user-images.githubusercontent.com/280512/28333396-cab57c5c-6bc5-11e7-819e-19bb963d1991.png">
Corrected:
<img width="233" alt="action-chip-correct-title" src="https://user-images.githubusercontent.com/280512/28333403-d01dac14-6bc5-11e7-9807-ae68c25cf518.png">

@jwforres @spadgett 
