### PR TITLE
Use PhantomJS for Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: node_js
 node_js:
   - "4"
-cache:
-  directories:
-  - node_modules
-  - bower_components
 before_script:
   - make build
 script:
-  - hack/test-headless.sh test
+  - grunt test --browsers=PhantomJS
   - hack/verify-dist.sh

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "karma-firefox-launcher": "^1.0.0",
     "karma-jasmine": "0.1.5",
     "karma-ng-html2js-preprocessor": "1.0.0",
+    "karma-phantomjs-launcher": "^1.0.4",
     "less": "2.6.1",
     "load-grunt-tasks": "0.4.0",
     "lodash": "3.10.1",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -120,6 +120,7 @@ module.exports = function(config) {
     plugins: [
       'karma-firefox-launcher',
       'karma-chrome-launcher',
+      'karma-phantomjs-launcher',
       'karma-ng-html2js-preprocessor',
       'karma-jasmine',
       'karma-coverage'


### PR DESCRIPTION
Fixes a problem where our tests fail in Firefox after Travis switched to Ubuntu Trusty. Also removes the node_modules and bower_components cache since that has caused problems in the past.

See also #1864