### PR TITLE
Skip digest when watching events

### DIFF
--- a/app/scripts/directives/events.js
+++ b/app/scripts/directives/events.js
@@ -157,7 +157,7 @@ angular.module('openshiftConsole')
           allEvents = events.by("metadata.name");
           debounceUpdate();
           Logger.log("events (subscribe)", $scope.filteredEvents);
-        }));
+        }, { skipDigest: true }));
 
         $scope.$on('$destroy', function(){
           DataService.unwatchAll(watches);

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8853,6 +8853,8 @@ sortType: "alpha"
 });
 }), i.push(n.watch("events", e.projectContext, function(n) {
 t = n.by("metadata.name"), v(), o.log("events (subscribe)", e.filteredEvents);
+}, {
+skipDigest: !0
 })), e.$on("$destroy", function() {
 n.unwatchAll(i);
 });


### PR DESCRIPTION
The events directive already debounces updates because it filters and
sorts. Pass the `skipDigest` flag to `DataService` to avoid unnecessary
Angular digest loops.