### PR TITLE
Bug 1476157 - Fix minification problems due to dependency injection

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -386,12 +386,13 @@
         <script src="scripts/directives/keyValueEditor.js"></script>
         <script src="scripts/directives/confirmOnExit.js"></script>
         <script src="scripts/directives/uiAceYaml.js"></script>
+        <script src="scripts/directives/affix.js"></script>
+        <script src="scripts/directives/editEnvironmentVariables.js"></script>
+        <script src="scripts/directives/initContainersSummary.js"></script>
         <script src="scripts/filters/date.js"></script>
         <script src="scripts/filters/resources.js"></script>
         <script src="scripts/filters/canI.js"></script>
         <script src="scripts/filters/util.js"></script>
-        <script src="scripts/directives/affix.js"></script>
-        <script src="scripts/directives/editEnvironmentVariables.js"></script>
         <script src="scripts/services/logLinks.js"></script>
 
         <!-- add bundled extensions here -->

--- a/app/scripts/directives/initContainersSummary.js
+++ b/app/scripts/directives/initContainersSummary.js
@@ -1,0 +1,33 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .component('initContainersSummary', {
+    bindings: {
+      apiObject: '<'
+    },
+    templateUrl: 'views/_init-containers-summary.html',
+    controller: [
+      '$filter',
+      function ($filter) {
+        var ctrl = this;
+
+        ctrl.$onChanges = function (changesObj) {
+          var apiObject = _.get(changesObj.apiObject, 'currentValue');
+
+          if (apiObject) {
+            ctrl.podTemplate = $filter('podTemplate')(apiObject);
+
+            switch (apiObject.kind) {
+              case 'DeploymentConfig':
+              case 'Deployment':
+                ctrl.tab = 'configuration';
+                break;
+              default:
+                ctrl.tab = 'details';
+                break;
+            }
+          }
+        };
+      }
+    ]
+  });

--- a/app/scripts/directives/resources.js
+++ b/app/scripts/directives/resources.js
@@ -1,33 +1,6 @@
 'use strict';
 
 angular.module('openshiftConsole')
-  .component('initContainersSummary', {
-    bindings: {
-      apiObject: '<'
-    },
-    templateUrl: 'views/_init-containers-summary.html',
-    controller: function ($filter) {
-      var ctrl = this;
-
-      ctrl.$onChanges = function (changesObj) {
-        var apiObject = _.get(changesObj.apiObject, 'currentValue');
-
-        if (apiObject) {
-          ctrl.podTemplate = $filter('podTemplate')(apiObject);
-
-          switch (apiObject.kind) {
-            case 'DeploymentConfig':
-            case 'Deployment':
-              ctrl.tab = 'configuration';
-              break;
-            default:
-              ctrl.tab = 'details';
-              break;
-          }
-        }
-      };
-    }
-  })
   .directive('containerStatuses', function($filter) {
     return {
       restrict: 'E',


### PR DESCRIPTION
Our version of ngAnnotate does not handle components, which causes
runtime errors in the built binary due to a recent component. Switch the
component to use the array notation for dependency injection and put it
in its own file.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1476157
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1476216

Opened tech debt issue #1889 for upgrading grunt-ng-annotate.