### PR TITLE
Update stepChanged listener for angular-patternfly 4.2.0

### DIFF
--- a/app/scripts/directives/deployImageDialog.js
+++ b/app/scripts/directives/deployImageDialog.js
@@ -43,14 +43,14 @@
       return true;
     };
 
-    $scope.$on("wizard:stepChanged", function (e, parameters) {
-      if (parameters.step.stepId === 'results') {
+    ctrl.stepChanged = function(step) {
+      if (step.stepId === 'results') {
         ctrl.nextButtonTitle = "Close";
         ctrl.wizardDone = true;
       } else {
         ctrl.nextButtonTitle = "Deploy";
       }
-    });
+    };
 
     ctrl.nextCallback = function (step) {
       if (step.stepId === 'image') {

--- a/app/scripts/directives/fromFileDialog.js
+++ b/app/scripts/directives/fromFileDialog.js
@@ -65,14 +65,14 @@
       return true;
     };
 
-    $scope.$on("wizard:stepChanged", function (e, parameters) {
-      if (parameters.step.stepId === 'results') {
+    ctrl.stepChanged = function(step) {
+      if (step.stepId === 'results') {
         ctrl.nextButtonTitle = "Close";
         ctrl.wizardDone = true;
       } else {
         ctrl.nextButtonTitle = "Create";
       }
-    });
+    };
 
     ctrl.currentStep = "JSON / YAML";
 

--- a/app/views/directives/deploy-image-dialog.html
+++ b/app/views/directives/deploy-image-dialog.html
@@ -8,6 +8,7 @@
        next-title="$ctrl.nextButtonTitle"
        next-callback="$ctrl.nextCallback"
        current-step="$ctrl.currentStep"
+       on-step-changed="$ctrl.stepChanged(step)"
        step-class="order-service-wizard-step"
        wizard-done="$ctrl.wizardDone"
        class="pf-wizard-no-back">

--- a/app/views/directives/from-file-dialog.html
+++ b/app/views/directives/from-file-dialog.html
@@ -8,6 +8,7 @@
        next-callback="$ctrl.nextCallback"
        current-step="$ctrl.currentStep"
        wizard-done="$ctrl.wizardDone"
+       on-step-changed="$ctrl.stepChanged(step)"
        step-class="order-service-wizard-step">
     <pf-wizard-step
          step-title="JSON / YAML"

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12387,9 +12387,9 @@ n.selectedProject = t.project, n.currentStep = "Results";
 }), n.close = function() {
 var e = n.onDialogClosed();
 return _.isFunction(e) && e(), n.wizardDone = !1, !0;
-}, e.$on("wizard:stepChanged", function(e, t) {
-"results" === t.step.stepId ? (n.nextButtonTitle = "Close", n.wizardDone = !0) : n.nextButtonTitle = "Deploy";
-}), n.nextCallback = function(e) {
+}, n.stepChanged = function(e) {
+"results" === e.stepId ? (n.nextButtonTitle = "Close", n.wizardDone = !0) : n.nextButtonTitle = "Deploy";
+}, n.nextCallback = function(e) {
 return "image" === e.stepId ? (n.deployImage(), !1) : ("results" === e.stepId && n.close(), !0);
 };
 } ],
@@ -12426,9 +12426,9 @@ r.selectedProject = t.project, r.currentStep = "Results";
 r.template = null;
 var e = r.onDialogClosed();
 return _.isFunction(e) && e(), r.wizardDone = !1, !0;
-}, e.$on("wizard:stepChanged", function(e, t) {
-"results" === t.step.stepId ? (r.nextButtonTitle = "Close", r.wizardDone = !0) : r.nextButtonTitle = "Create";
-}), r.currentStep = "JSON / YAML", r.nextCallback = function(e) {
+}, r.stepChanged = function(e) {
+"results" === e.stepId ? (r.nextButtonTitle = "Close", r.wizardDone = !0) : r.nextButtonTitle = "Create";
+}, r.currentStep = "JSON / YAML", r.nextCallback = function(e) {
 return "file" === e.stepId ? (r.importFile(), !1) : "template" === e.stepId ? (r.instantiateTemplate(), !1) : "results" !== e.stepId || (r.close(), !1);
 };
 } ],

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6234,7 +6234,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/directives/deploy-image-dialog.html',
     "<overlay-panel show-panel=\"$ctrl.visible\" show-close=\"true\" handle-close=\"$ctrl.close\">\n" +
-    "<pf-wizard on-cancel=\"$ctrl.close()\" on-finish=\"$ctrl.close()\" hide-header=\"true\" hide-back-button=\"true\" hide-sidebar=\"true\" next-title=\"$ctrl.nextButtonTitle\" next-callback=\"$ctrl.nextCallback\" current-step=\"$ctrl.currentStep\" step-class=\"order-service-wizard-step\" wizard-done=\"$ctrl.wizardDone\" class=\"pf-wizard-no-back\">\n" +
+    "<pf-wizard on-cancel=\"$ctrl.close()\" on-finish=\"$ctrl.close()\" hide-header=\"true\" hide-back-button=\"true\" hide-sidebar=\"true\" next-title=\"$ctrl.nextButtonTitle\" next-callback=\"$ctrl.nextCallback\" current-step=\"$ctrl.currentStep\" on-step-changed=\"$ctrl.stepChanged(step)\" step-class=\"order-service-wizard-step\" wizard-done=\"$ctrl.wizardDone\" class=\"pf-wizard-no-back\">\n" +
     "<pf-wizard-step step-title=\"Image\" step-id=\"image\" step-priority=\"1\" substeps=\"false\" ok-to-nav-away=\"true\" allow-click-nav=\"false\" next-enabled=\"!$ctrl.deployForm.$invalid\">\n" +
     "<div class=\"wizard-pf-main-inner-shadow-covers\">\n" +
     "<div class=\"order-service-config order-service-config-single-column\">\n" +
@@ -6965,7 +6965,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/directives/from-file-dialog.html',
     "<overlay-panel show-panel=\"$ctrl.visible\" show-close=\"true\" handle-close=\"$ctrl.close\" ng-if=\"$ctrl.project\">\n" +
-    "<pf-wizard on-cancel=\"$ctrl.close()\" on-finish=\"$ctrl.close()\" hide-header=\"true\" hide-sidebar=\"true\" next-title=\"$ctrl.nextButtonTitle\" next-callback=\"$ctrl.nextCallback\" current-step=\"$ctrl.currentStep\" wizard-done=\"$ctrl.wizardDone\" step-class=\"order-service-wizard-step\">\n" +
+    "<pf-wizard on-cancel=\"$ctrl.close()\" on-finish=\"$ctrl.close()\" hide-header=\"true\" hide-sidebar=\"true\" next-title=\"$ctrl.nextButtonTitle\" next-callback=\"$ctrl.nextCallback\" current-step=\"$ctrl.currentStep\" wizard-done=\"$ctrl.wizardDone\" on-step-changed=\"$ctrl.stepChanged(step)\" step-class=\"order-service-wizard-step\">\n" +
     "<pf-wizard-step step-title=\"JSON / YAML\" step-id=\"file\" step-priority=\"1\" substeps=\"false\" ok-to-nav-away=\"true\" allow-click-nav=\"false\" next-enabled=\"!$ctrl.importForm.$invalid\">\n" +
     "<div class=\"wizard-pf-main-inner-shadow-covers\">\n" +
     "<div class=\"order-service-config order-service-config-single-column\">\n" +


### PR DESCRIPTION
Pass `on-step-changed` to the `pf-wizard` component rather than using `$scope.$on('wizard:stepChanged')`, which no longer works. Fixes the button label on the last page of the deploy image and import YAML dialogs.

cc @rhamilto 