### PR TITLE
Bug 1476198 - Bump kubernetes-container-terminal to 2.0.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "selectize": "0.12.1",
     "c3": "0.4.11",
     "kubernetes-label-selector": "2.0.0",
-    "kubernetes-container-terminal": "2.0.1",
+    "kubernetes-container-terminal": "2.0.2",
     "registry-image-widgets": "0.0.11",
     "layout.attrs": "2.1.1",
     "kubernetes-object-describer": "1.0.4",

--- a/dist/scripts/vendor.js
+++ b/dist/scripts/vendor.js
@@ -57431,7 +57431,7 @@ g && 1 === g.readyState && g.send("0" + n(e));
 });
 var v = function() {
 var e = a.cols || 80;
-m.charMeasure.width && (document.getElementsByClassName("xterm-viewport")[0].style.width = m.charMeasure.width * e + 17 + "px");
+m.charMeasure.width && (s[0].getElementsByClassName("xterm-viewport")[0].style.width = m.charMeasure.width * e + 17 + "px");
 };
 m.charMeasure.on("charsizechanged", v);
 var b = function() {


### PR DESCRIPTION
Includes upstream PR https://github.com/kubernetes-ui/container-terminal/pull/28

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1476198