### PR TITLE
[WIP] Change styling of <registry-imagestream-listing> for consistency

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -225,8 +225,14 @@ registry-imagestream-listing {
   .registry-image-tag {
     max-width: 115px;
   }
-  table {
-    width: 100%;
+  table td.image-identifier div.col {
+    max-width: none;
+    @media(max-width: @screen-xxs-max) {
+      .word-break();
+    }
+  }
+  tr.listing-ct-item td:last-child {
+    text-align: left;
   }
 }
 

--- a/app/views/browse/imagestream.html
+++ b/app/views/browse/imagestream.html
@@ -48,7 +48,7 @@
               </registry-imagestream-body>
               <registry-imagestream-meta imagestream="imageStream">
               </registry-imagestream-meta>
-              <registry-imagestream-listing imagestream="imageStream" imagestream-path="imagestreamPath">
+              <registry-imagestream-listing imagestream="imageStream" imagestream-path="imagestreamPath" class-names="table table-bordered table-hover">
               </registry-imagestream-listing>
               <registry-imagestream-push settings="settings" imagestream="imageStream">
               </registry-imagestream-push>


### PR DESCRIPTION
Fixes #1849 

Dependency: https://github.com/openshift/registry-image-widgets/pull/18 and subsequent release of registry-image-widgets

![screen shot 2017-08-03 at 9 13 44 am](https://user-images.githubusercontent.com/895728/28923520-5cdfa96e-782c-11e7-9ec0-2b4daa438869.PNG)

![screen shot 2017-08-03 at 9 14 03 am](https://user-images.githubusercontent.com/895728/28923522-5ce112b8-782c-11e7-80ad-9d0a4fea451d.PNG)

If the viewport is < 480px, the SHA is allowed to wrap.  Normally we'd use .table-mobile to flip the orientation of the table, but given [the complexity of the identifier cell layout](https://github.com/openshift/registry-image-widgets/blob/master/views/imagestream-listing.html#L45-L64) in &lt;registry-imagestream-listing&gt;, I figured it was safer to do this.
![screen shot 2017-08-03 at 9 14 27 am](https://user-images.githubusercontent.com/895728/28923521-5ce0680e-782c-11e7-831b-6470ade4a75e.PNG)
