### PR TITLE
Prefill service labels when creating route

### DIFF
--- a/app/views/create-route.html
+++ b/app/views/create-route.html
@@ -32,7 +32,6 @@
                             can-toggle="false"
                             help-text="Labels for this route.">
                         </label-editor>
-                        <a href="" ng-click="copyServiceLabels()">Copy Service Labels</a>
                         <div class="button-group gutter-top gutter-bottom">
                           <button type="submit"
                               class="btn btn-primary btn-lg"

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8084,17 +8084,23 @@ n.routing.to = {
 kind: "Service",
 name: n.serviceName,
 weight: 1
-}, i.list("services", l).then(function(e) {
-p = e.by("metadata.name"), n.services = g(p);
-}), n.copyServiceLabels = function() {
-var e = _.get(n, "routing.to.name"), t = _.get(p, [ e, "metadata", "labels" ], {}), a = u.mapEntries(u.compactEntries(n.labels)), r = _.assign(a, t);
-n.labels = _.map(r, function(e, t) {
+};
+var f, h = function() {
+var e = f, t = _.get(n, "routing.to.name");
+f = _.get(p, [ t, "metadata", "labels" ], {});
+var a = u.mapEntries(u.compactEntries(n.labels)), r = _.assign(a, f);
+e && (r = _.omitBy(r, function(t, n) {
+return e[n] && !f[n];
+})), n.labels = _.map(r, function(e, t) {
 return {
 name: t,
 value: e
 };
 });
-}, n.createRoute = function() {
+};
+i.list("services", l).then(function(e) {
+p = e.by("metadata.name"), n.services = g(p), n.$watch("routing.to.name", h);
+}), n.createRoute = function() {
 if (n.createRouteForm.$valid) {
 d(), n.disableInputs = !0;
 var t = n.routing.to.name, a = u.mapEntries(u.compactEntries(n.labels)), o = r.createRoute(n.routing, t, a), s = _.get(n, "routing.alternateServices", []);

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4759,7 +4759,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</osc-routing>\n" +
     "<label-editor labels=\"labels\" expand=\"true\" can-toggle=\"false\" help-text=\"Labels for this route.\">\n" +
     "</label-editor>\n" +
-    "<a href=\"\" ng-click=\"copyServiceLabels()\">Copy Service Labels</a>\n" +
     "<div class=\"button-group gutter-top gutter-bottom\">\n" +
     "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-click=\"createRoute()\" ng-disabled=\"createRouteForm.$invalid || disableInputs || !createRoute\" value=\"\">Create</button>\n" +
     "<a class=\"btn btn-default btn-lg\" href=\"\" ng-click=\"cancel()\">Cancel</a>\n" +


### PR DESCRIPTION
Prefill the labels from the service by default when creating a route without making the user click "Copy Service Labels."

Fixes #1934