### PR TITLE
bug 1480988. Use project annotation to determine kibana url for ops namespaces

### DIFF
--- a/app/scripts/directives/logViewer.js
+++ b/app/scripts/directives/logViewer.js
@@ -431,7 +431,7 @@ angular.module('openshiftConsole')
             // Kibana archives -------------------------------------------------
 
             APIDiscovery
-              .getLoggingURL()
+              .getLoggingURL($scope.context.project)
               .then(function(url) {
                 var projectName = _.get($scope.context, 'project.metadata.name');
                 var containerName = _.get($scope.options, 'container');

--- a/app/scripts/services/discovery.js
+++ b/app/scripts/services/discovery.js
@@ -1,12 +1,18 @@
 'use strict';
 
 angular.module('openshiftConsole')
-  .factory('APIDiscovery', ['LOGGING_URL', 'METRICS_URL', '$q', function(LOGGING_URL, METRICS_URL, $q) {
+  .factory('APIDiscovery', ['LOGGING_URL', 'METRICS_URL', '$q', '$filter', function(LOGGING_URL, METRICS_URL, $q, $filter) {
     return {
       // Simulate asynchronous requests for now. If these are ever updated to call to a discovery
       // endpoint, we need to make sure to trigger a digest loop using (or update all callers).
-      getLoggingURL: function() {
-        return $q.when(LOGGING_URL);
+      getLoggingURL: function(project) {
+        var loggingURL = LOGGING_URL;
+        var loggingUIHostname = $filter('annotation')(project, 'loggingUIHostname');
+        if(loggingUIHostname) {
+           loggingURL = 'https://' + loggingUIHostname;
+        }
+
+        return $q.when(loggingURL);
       },
       getMetricsURL: function() {
         return $q.when(METRICS_URL);

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3,7 +3,7 @@
 function OverviewController(e, t, n, a, r, o, i, s, c, l, u, d, m, p, g, f, h, v, y, b, C, S, w, k, j) {
 var P = this, R = t("isIE")() || t("isEdge")();
 e.projectName = n.project;
-var E, T, N = t("annotation"), I = t("buildConfigForBuild"), D = t("deploymentIsInProgress"), A = t("imageObjectRef"), B = t("isJenkinsPipelineStrategy"), L = t("isNewerResource"), U = t("label"), O = t("podTemplate"), x = {}, F = {}, M = {}, V = P.state = {
+var E, T, I = t("annotation"), N = t("buildConfigForBuild"), D = t("deploymentIsInProgress"), A = t("imageObjectRef"), B = t("isJenkinsPipelineStrategy"), L = t("isNewerResource"), U = t("label"), O = t("podTemplate"), x = {}, F = {}, M = {}, V = P.state = {
 alerts: {},
 builds: {},
 clusterQuotas: {},
@@ -205,13 +205,13 @@ _.isEmpty(e) || (f.addLabelSuggestionsFromResources(e, x), "pipeline" !== P.view
 }, ke = function(e) {
 _.isEmpty(e) || (f.addLabelSuggestionsFromResources(e, F), "pipeline" === P.viewBy && f.setLabelSuggestions(F));
 }, je = function(e) {
-return "Succeeded" !== e.status.phase && "Failed" !== e.status.phase && (!U(e, "openshift.io/deployer-pod-for.name") && (!N(e, "openshift.io/build.name") && "slave" !== U(e, "jenkins")));
+return "Succeeded" !== e.status.phase && "Failed" !== e.status.phase && (!U(e, "openshift.io/deployer-pod-for.name") && (!I(e, "openshift.io/build.name") && "slave" !== U(e, "jenkins")));
 }, Pe = function() {
 V.podsByOwnerUID = C.groupByOwnerUID(P.pods), P.monopods = _.filter(V.podsByOwnerUID[""], je);
 }, Re = function(e) {
-return !!_.get(e, "status.replicas") || (!N(e, "deploymentConfig") || D(e));
+return !!_.get(e, "status.replicas") || (!I(e, "deploymentConfig") || D(e));
 }, Ee = function(e) {
-return N(e, "deploymentConfig");
+return I(e, "deploymentConfig");
 }, Te = function() {
 if (P.deploymentConfigs && P.replicationControllers) {
 var e = [];
@@ -223,7 +223,7 @@ var r = Ee(a) || "";
 var o = M[r];
 o && !L(a, o) || (M[r] = a);
 var i;
-"Complete" === N(a, "deploymentStatus") && ((i = t[r]) && !L(a, i) || (t[r] = a)), Re(a) && _.set(n, [ r, a.metadata.name ], a);
+"Complete" === I(a, "deploymentStatus") && ((i = t[r]) && !L(a, i) || (t[r] = a)), Re(a) && _.set(n, [ r, a.metadata.name ], a);
 }), _.each(t, function(e, t) {
 _.set(n, [ t, e.metadata.name ], e);
 }), _.each(n, function(e, t) {
@@ -231,15 +231,15 @@ var n = u.sortByDeploymentVersion(e, !0);
 P.replicationControllersByDeploymentConfig[t] = n, P.currentByDeploymentConfig[t] = _.head(n);
 }), P.vanillaReplicationControllers = _.sortBy(e, "metadata.name"), ve();
 }
-}, Ne = function(e, t) {
+}, Ie = function(e, t) {
 if (_.get(e, "status.replicas")) return !0;
 var n = u.getRevision(e);
 return !n || !!t && u.getRevision(t) === n;
-}, Ie = function() {
+}, Ne = function() {
 P.replicaSets && E && (P.replicaSetsByDeploymentUID = b.groupByControllerUID(P.replicaSets), P.currentByDeploymentUID = {}, _.each(P.replicaSetsByDeploymentUID, function(e, t) {
 if (t) {
 var n = E[t], a = _.filter(e, function(e) {
-return Ne(e, n);
+return Ie(e, n);
 }), r = u.sortByRevision(a);
 P.replicaSetsByDeploymentUID[t] = r, P.currentByDeploymentUID[t] = _.head(r);
 }
@@ -265,7 +265,7 @@ V.routesByService = _.mapValues(e, j.sortRoutesByScore), Y();
 }, Le = function() {
 V.hpaByResource = d.groupHPAs(P.horizontalPodAutoscalers);
 }, Ue = function(e) {
-var t = I(e), n = P.buildConfigs[t];
+var t = N(e), n = P.buildConfigs[t];
 if (n) {
 P.recentPipelinesByBuildConfig[t] = P.recentPipelinesByBuildConfig[t] || [], P.recentPipelinesByBuildConfig[t].push(e);
 var a = i.usesDeploymentConfigs(n);
@@ -320,7 +320,7 @@ if (V.builds && P.buildConfigs) {
 P.recentPipelinesByBuildConfig = {}, V.recentBuildsByBuildConfig = {}, V.recentPipelinesByDeploymentConfig = {};
 var e = {};
 _.each(i.interestingBuilds(V.builds), function(t) {
-var n = I(t);
+var n = N(t);
 B(t) ? Ue(t) : (e[n] = e[n] || [], e[n].push(t));
 }), P.recentPipelinesByBuildConfig = _.mapValues(P.recentPipelinesByBuildConfig, function(e) {
 return i.sortBuilds(e, !0);
@@ -388,12 +388,12 @@ P.deploymentConfigs = e.by("metadata.name"), Te(), $e(P.deploymentConfigs), $e(P
 group: "extensions",
 resource: "replicasets"
 }, a, function(e) {
-P.replicaSets = e.by("metadata.name"), Ie(), $e(P.vanillaReplicaSets), $e(P.monopods), pe(P.vanillaReplicaSets), we(P.vanillaReplicaSets), Qe(), ie(), h.log("replicasets (subscribe)", P.replicaSets);
+P.replicaSets = e.by("metadata.name"), Ne(), $e(P.vanillaReplicaSets), $e(P.monopods), pe(P.vanillaReplicaSets), we(P.vanillaReplicaSets), Qe(), ie(), h.log("replicasets (subscribe)", P.replicaSets);
 })), Ye.push(l.watch({
 group: "apps",
 resource: "deployments"
 }, a, function(e) {
-E = e.by("metadata.uid"), P.deployments = _.sortBy(E, "metadata.name"), Ie(), $e(P.deployments), $e(P.vanillaReplicaSets), we(P.deployments), Qe(), ie(), h.log("deployments (subscribe)", P.deploymentsByUID);
+E = e.by("metadata.uid"), P.deployments = _.sortBy(E, "metadata.name"), Ne(), $e(P.deployments), $e(P.vanillaReplicaSets), we(P.deployments), Qe(), ie(), h.log("deployments (subscribe)", P.deploymentsByUID);
 })), Ye.push(l.watch("builds", a, function(e) {
 V.builds = e.by("metadata.name"), Ge(), h.log("builds (subscribe)", V.builds);
 })), Ye.push(l.watch({
@@ -1265,10 +1265,11 @@ loadJSON: function(t, n) {
 return JSON.parse(e[t].getItem("openshift/" + n) || "{}");
 }
 };
-} ]), angular.module("openshiftConsole").factory("APIDiscovery", [ "LOGGING_URL", "METRICS_URL", "$q", function(e, t, n) {
+} ]), angular.module("openshiftConsole").factory("APIDiscovery", [ "LOGGING_URL", "METRICS_URL", "$q", "$filter", function(e, t, n, a) {
 return {
-getLoggingURL: function() {
-return n.when(e);
+getLoggingURL: function(t) {
+var r = e, o = a("annotation")(t, "loggingUIHostname");
+return o && (r = "https://" + o), n.when(r);
 },
 getMetricsURL: function() {
 return n.when(t);
@@ -4708,12 +4709,12 @@ n.filteredStatefulSets = s.filterForKeywords(_.values(n.statefulSets), S, w);
 b = _.filter(n.pods, function(e) {
 return !n.filters.hideOlderResources || "Succeeded" !== e.status.phase && "Failed" !== e.status.phase;
 }), n.filteredPods = s.filterForKeywords(b, S, w);
-}, N = a("isIncompleteBuild"), I = a("buildConfigForBuild"), D = a("isRecentBuild"), A = function() {
+}, I = a("isIncompleteBuild"), N = a("buildConfigForBuild"), D = a("isRecentBuild"), A = function() {
 moment().subtract(5, "m");
 h = _.filter(n.builds, function(e) {
 if (!n.filters.hideOlderResources) return !0;
-if (N(e)) return !0;
-var t = I(e);
+if (I(e)) return !0;
+var t = N(e);
 return t ? n.latestBuildByConfig[t].metadata.name === e.metadata.name : D(e);
 }), n.filteredBuilds = s.filterForKeywords(h, S, w);
 }, B = a("deploymentStatus"), L = a("deploymentIsInProgress"), U = function() {
@@ -4925,7 +4926,7 @@ return e ? a + (v(e, "description") || "") : "";
 }
 }
 });
-var N = function(e, t, n, r) {
+var I = function(e, t, n, r) {
 var o = {
 alerts: {},
 detailsMarkup: C.remove.areYouSure.html.subject({
@@ -4971,7 +4972,7 @@ project: n,
 subjectKinds: T,
 canUpdateRolebindings: y("rolebindings", "update", f),
 confirmRemove: function(n, r, i) {
-var c = null, l = N(n, r, i, a.user.metadata.name);
+var c = null, l = I(n, r, i, a.user.metadata.name);
 _.isEqual(n, a.user.metadata.name) && u.isLastRole(a.user.metadata.name, a.roleBindings) && (c = !0), o.open({
 animation: !0,
 templateUrl: "views/modals/confirm.html",
@@ -5738,14 +5739,14 @@ e.autoscalers = e.hpaForRS.concat(t);
 var a = s.filterHPA(v, "Deployment", e.deployment.metadata.name);
 e.autoscalers = e.hpaForRS.concat(a);
 } else e.autoscalers = e.hpaForRS;
-}, N = function() {
+}, I = function() {
 j.push(o.watch(e.resource, f, function(t) {
 var n, a = [];
 angular.forEach(t.by("metadata.name"), function(t) {
 (C(t, "deploymentConfig") || "") === e.deploymentConfigName && a.push(t);
 }), n = i.getActiveDeployment(a), e.isActive = n && n.metadata.uid === e.replicaSet.metadata.uid, T();
 }));
-}, I = function() {
+}, N = function() {
 s.getHPAWarnings(e.replicaSet, e.autoscalers, e.limitRanges, u).then(function(t) {
 e.hpaWarnings = t;
 });
@@ -5827,14 +5828,14 @@ break;
 case "ReplicaSet":
 L();
 }
-I(), e.breadcrumbs = r.getBreadcrumbs({
+N(), e.breadcrumbs = r.getBreadcrumbs({
 object: t
 }), j.push(o.watchObject(e.resource, n.replicaSet, f, function(t, n) {
 "DELETED" === n && (e.alerts.deleted = {
 type: "warning",
 message: "This " + S + " has been deleted."
-}), e.replicaSet = t, R(t), I(), U(), e.deployment && $();
-})), e.deploymentConfigName && N(), j.push(o.watch("pods", f, function(t) {
+}), e.replicaSet = t, R(t), N(), U(), e.deployment && $();
+})), e.deploymentConfigName && I(), j.push(o.watch("pods", f, function(t) {
 var n = t.by("metadata.name");
 e.podsForDeployment = g.filterForOwner(n, e.replicaSet);
 }));
@@ -5864,12 +5865,12 @@ group: "autoscaling",
 resource: "horizontalpodautoscalers",
 version: "v1"
 }, f, function(e) {
-v = e.by("metadata.name"), T(), I();
+v = e.by("metadata.name"), T(), N();
 }, {
 poll: E,
 pollInterval: 6e4
 })), o.list("limitranges", f).then(function(t) {
-e.limitRanges = t.by("metadata.name"), I();
+e.limitRanges = t.by("metadata.name"), N();
 });
 j.push(o.watch("resourcequotas", f, function(t) {
 e.quotas = t.by("metadata.name");
@@ -7566,8 +7567,8 @@ title: R
 var E = {
 name: "app",
 value: ""
-}, T = t("orderByDisplayName"), N = t("getErrorDetails"), I = {}, D = function() {
-f.hideNotification("create-builder-list-config-maps-error"), f.hideNotification("create-builder-list-secrets-error"), _.each(I, function(e) {
+}, T = t("orderByDisplayName"), I = t("getErrorDetails"), N = {}, D = function() {
+f.hideNotification("create-builder-list-config-maps-error"), f.hideNotification("create-builder-list-secrets-error"), _.each(N, function(e) {
 !e.id || "error" !== e.type && "warning" !== e.type || f.hideNotification(e.id);
 });
 };
@@ -7637,7 +7638,7 @@ a = T(t.by("metadata.name")), e.valueFromObjects = a.concat(o);
 id: "create-builder-list-config-maps-error",
 type: "error",
 message: "Could not load config maps.",
-details: N(e)
+details: I(e)
 });
 }), c.list("secrets", i, null, {
 errorNotification: !1
@@ -7654,7 +7655,7 @@ e.unshift("");
 id: "create-builder-list-secrets-error",
 type: "error",
 message: "Could not load secrets.",
-details: N(e)
+details: I(e)
 });
 }), c.get("imagestreams", t.imageName, {
 namespace: t.namespace || r.project
@@ -7731,11 +7732,11 @@ cancelButtonText: "Cancel"
 }
 }).result.then(B);
 }, U = function(t) {
-D(), I = t.quotaAlerts || [], e.nameTaken || _.some(I, {
+D(), N = t.quotaAlerts || [], e.nameTaken || _.some(N, {
 type: "error"
-}) ? (e.disableInputs = !1, _.each(I, function(e) {
+}) ? (e.disableInputs = !1, _.each(N, function(e) {
 e.id = _.uniqueId("create-builder-alert-"), f.addNotification(e);
-})) : _.isEmpty(I) ? B() : (L(I), e.disableInputs = !1);
+})) : _.isEmpty(N) ? B() : (L(N), e.disableInputs = !1);
 };
 e.projectDisplayName = function() {
 return k(this.project) || this.projectName;
@@ -9107,7 +9108,7 @@ scope: p
 }).result.then(function() {
 l.getLatestQuotaAlerts(p.createResources, {
 namespace: p.input.selectedProject.metadata.name
-}).then(I);
+}).then(N);
 });
 }
 function y() {
@@ -9119,7 +9120,7 @@ t > 0 && a.push(k()), e > 0 && a.push(w()), n.all(a).then(b);
 }
 function b() {
 var e, n;
-N(), "Template" === p.resourceKind && p.templateOptions.process && !p.errorOccurred ? p.isDialog ? p.$emit("fileImportedFromYAMLOrJSON", {
+I(), "Template" === p.resourceKind && p.templateOptions.process && !p.errorOccurred ? p.isDialog ? p.$emit("fileImportedFromYAMLOrJSON", {
 project: p.input.selectedProject,
 template: p.resource
 }) : (n = p.templateOptions.add || p.updateResources.length > 0 ? p.input.selectedProject.metadata.name : "", e = s.createFromTemplateURL(p.resource, p.input.selectedProject.metadata.name, {
@@ -9285,12 +9286,12 @@ cancelButtonText: "Cancel"
 }
 }
 }).result.then(y);
-}, T = {}, N = function() {
+}, T = {}, I = function() {
 c.hideNotification("from-file-error"), _.each(T, function(e) {
 !e.id || "error" !== e.type && "warning" !== e.type || c.hideNotification(e.id);
 });
-}, I = function(e) {
-N(), T = u.getSecurityAlerts(p.createResources, p.input.selectedProject.metadata.name);
+}, N = function(e) {
+I(), T = u.getSecurityAlerts(p.createResources, p.input.selectedProject.metadata.name);
 var t = e.quotaAlerts || [];
 T = T.concat(t), _.filter(T, {
 type: "error"
@@ -9316,7 +9317,7 @@ e.push(C(t));
 p.input.selectedProject = t, n.all(e).then(function() {
 p.errorOccurred || (1 === p.createResources.length && "Template" === p.resourceList[0].kind ? h() : _.isEmpty(p.updateResources) ? l.getLatestQuotaAlerts(p.createResources, {
 namespace: p.input.selectedProject.metadata.name
-}).then(I) : (p.updateTemplate = 1 === p.updateResources.length && "Template" === p.updateResources[0].kind, p.updateTemplate ? h() : v()));
+}).then(N) : (p.updateTemplate = 1 === p.updateResources.length && "Template" === p.updateResources[0].kind, p.updateTemplate ? h() : v()));
 });
 }, function(e) {
 c.addNotification({
@@ -9328,10 +9329,10 @@ details: R(e)
 });
 }
 }, p.cancel = function() {
-N(), s.toProjectOverview(p.input.selectedProject.metadata.name);
+I(), s.toProjectOverview(p.input.selectedProject.metadata.name);
 };
 var $ = e("displayName");
-p.$on("importFileFromYAMLOrJSON", p.create), p.$on("$destroy", N);
+p.$on("importFileFromYAMLOrJSON", p.create), p.$on("$destroy", I);
 } ]
 };
 } ]), angular.module("openshiftConsole").directive("oscFileInput", [ "Logger", function(e) {
@@ -10756,12 +10757,12 @@ if (!m.pod) return null;
 var t = m.options.selectedContainer;
 switch (e) {
 case "memory/usage":
-var n = N(t);
+var n = I(t);
 if (n) return s.bytesToMiB(d(n));
 break;
 
 case "cpu/usage_rate":
-var a = I(t);
+var a = N(t);
 if (a) return d(a);
 }
 return null;
@@ -10882,7 +10883,7 @@ m.loaded = !0;
 }
 }
 m.includedMetrics = m.includedMetrics || [ "cpu", "memory", "network" ];
-var R, E = {}, T = {}, N = n("resources.limits.memory"), I = n("resources.limits.cpu"), D = 30, $ = !1;
+var R, E = {}, T = {}, I = n("resources.limits.memory"), N = n("resources.limits.cpu"), D = 30, $ = !1;
 m.uniqueID = c.uniqueID(), m.metrics = [], _.includes(m.includedMetrics, "memory") && m.metrics.push({
 label: "Memory",
 units: "MiB",
@@ -11046,9 +11047,9 @@ return e[0];
 }), i);
 }
 function u(e) {
-k || (I = 0, t.showAverage = _.size(t.pods) > 5 || w, _.each(t.metrics, function(n) {
+k || (N = 0, t.showAverage = _.size(t.pods) > 5 || w, _.each(t.metrics, function(n) {
 var a, r = o(e, n), i = n.descriptor;
-w && n.compactCombineWith && (i = n.compactCombineWith, n.lastValue && (N[i].lastValue = (N[i].lastValue || 0) + n.lastValue)), C[i] ? (C[i].load(r), t.showAverage ? C[i].legend.hide() : C[i].legend.show()) : ((a = D(n)).data = r, C[i] = c3.generate(a));
+w && n.compactCombineWith && (i = n.compactCombineWith, n.lastValue && (I[i].lastValue = (I[i].lastValue || 0) + n.lastValue)), C[i] ? (C[i].load(r), t.showAverage ? C[i].legend.hide() : C[i].legend.show()) : ((a = D(n)).data = r, C[i] = c3.generate(a));
 }));
 }
 function d() {
@@ -11072,10 +11073,10 @@ return w || (n.containerName = t.options.selectedContainer.name), n.start = j ||
 }
 }
 function f(e) {
-if (!k) if (I++, t.noData) t.metricsError = {
+if (!k) if (N++, t.noData) t.metricsError = {
 status: _.get(e, "status", 0),
 details: _.get(e, "data.errorMsg") || _.get(e, "statusText") || "Status code " + _.get(e, "status", 0)
-}; else if (!(I < 2) && t.alerts) {
+}; else if (!(N < 2) && t.alerts) {
 var n = "metrics-failed-" + t.uniqueID;
 t.alerts[n] = {
 type: "error",
@@ -11084,14 +11085,14 @@ links: [ {
 href: "",
 label: "Retry",
 onClick: function() {
-delete t.alerts[n], I = 1, y();
+delete t.alerts[n], N = 1, y();
 }
 } ]
 };
 }
 }
 function h() {
-return _.isEmpty(t.pods) ? (t.loaded = !0, !1) : !t.metricsError && I < 2;
+return _.isEmpty(t.pods) ? (t.loaded = !0, !1) : !t.metricsError && N < 2;
 }
 function v(e, n, a) {
 t.noData = !1;
@@ -11168,11 +11169,11 @@ compactDatasetLabel: "Received",
 compactType: "spline",
 chartID: "network-rx-" + t.uniqueID
 } ];
-var N = _.keyBy(t.metrics, "descriptor");
+var I = _.keyBy(t.metrics, "descriptor");
 t.loaded = !1, t.noData = !0, t.showComputeUnitsHelp = function() {
 l.showComputeUnitsHelp();
 };
-var I = 0;
+var N = 0;
 c.getMetricsURL().then(function(e) {
 t.metricsURL = e;
 }), t.options = {
@@ -11252,7 +11253,7 @@ top: t.followAffixTop || 0
 }));
 }, T = function() {
 return $("#" + t.logViewerID + " .log-view-output");
-}, N = function(e) {
+}, I = function(e) {
 var n = T(), a = n.offset().top;
 if (!(a < 0)) {
 var r = $(".ellipsis-pulser").outerHeight(!0), o = t.fixedHeight ? t.fixedHeight : Math.floor($(window).height() - a - r);
@@ -11260,7 +11261,7 @@ t.chromeless || t.fixedHeight || (o -= 40), e ? n.animate({
 "min-height": o + "px"
 }, "fast") : n.css("min-height", o + "px"), t.fixedHeight && n.css("max-height", o);
 }
-}, I = function() {
+}, N = function() {
 if (!S) {
 var e = function() {
 clearInterval(S), S = null, t.$evalAsync(function() {
@@ -11268,11 +11269,11 @@ t.sized = !0;
 });
 }, n = 0;
 S = setInterval(function() {
-n > 10 ? e() : (n++, T().is(":visible") && (N(), e()));
+n > 10 ? e() : (n++, T().is(":visible") && (I(), e()));
 }, 100);
 }
 }, D = _.debounce(function() {
-N(!0), w(), R(), k(), E(), P();
+I(!0), w(), R(), k(), E(), P();
 }, 100);
 p.on("resize", D);
 var A, B = function() {
@@ -11307,7 +11308,7 @@ n++, L.appendChild(f(n, e)), U();
 };
 (A = c.createStream(b, C, t.context, e)).onMessage(function(r, o, i) {
 t.$evalAsync(function() {
-t.empty = !1, "logs" !== t.state && (t.state = "logs", I());
+t.empty = !1, "logs" !== t.state && (t.state = "logs", N());
 }), r && (e.limitBytes && i >= e.limitBytes && (t.$evalAsync(function() {
 t.limitReached = !0, t.loading = !1;
 }), O(!0)), a(r), !t.largeLog && n >= e.tailLines && t.$evalAsync(function() {
@@ -11329,7 +11330,7 @@ autoScrollActive: !1
 });
 });
 };
-if (s.getLoggingURL().then(function(a) {
+if (s.getLoggingURL(t.context.project).then(function(a) {
 var r = _.get(t.context, "project.metadata.name"), i = _.get(t.options, "container");
 r && i && C && a && (angular.extend(t, {
 kibanaAuthUrl: e.trustAsResourceUrl(URI(a).segment("auth").segment("token").normalizePathname().toString()),
@@ -13875,14 +13876,14 @@ e.totalUnread = P(e.notifications).length, e.hasUnread = !!e.totalUnread, o.$emi
 _.each(y, R);
 }, T = function(e) {
 return _.orderBy(e, [ "event.lastTimestamp", "event.firstTimestamp" ], [ "desc", "desc" ]);
-}, N = function(e) {
+}, I = function(e) {
 var t = _.sortBy(e, function(e) {
 return e.heading;
 });
 return _.each(t, function(e) {
 e.notifications = T(e.notifications), e.counts = R(e);
 }), t;
-}, I = function(e) {
+}, N = function(e) {
 var t = {};
 return S(t, r.project), _.each(e, function(e) {
 l.isImportantEvent(e) && !l.isCleared(e) && (S(t, e.metadata.namespace), t[e.metadata.namespace].notifications.push({
@@ -13904,7 +13905,7 @@ return e.project.metadata.name === r.project;
 });
 });
 }, B = function(e) {
-h = e.by("metadata.name"), v = I(h), y = N(v), A();
+h = e.by("metadata.name"), v = N(h), y = I(v), A();
 }, L = {
 Normal: "pficon pficon-info",
 Warning: "pficon pficon-warning-triangle-o"


### PR DESCRIPTION
This PR provides a fix to BZ1480988 to direct users to an operations instance of Kibana when the logging stack is deployed to have the ops logging cluster.  This PR depends on openshift/openshift-ansible#5219