### PR TITLE
Ensure kve does not render on browser builds if no envs to show

### DIFF
--- a/app/views/browse/build.html
+++ b/app/views/browse/build.html
@@ -99,6 +99,7 @@
                   Environment variables can be edited on the <a ng-href="{{build | configURLForResource}}?tab=environment">build configuration</a>.
                 </p>
                 <key-value-editor
+                  ng-if="(build | buildStrategy).env | size"
                   entries="(build | buildStrategy).env"
                   key-placeholder="Name"
                   value-placeholder="Value"

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2114,7 +2114,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"pficon pficon-info\" aria-hidden=\"true\"></span>\n" +
     "Environment variables can be edited on the <a ng-href=\"{{build | configURLForResource}}?tab=environment\">build configuration</a>.\n" +
     "</p>\n" +
-    "<key-value-editor entries=\"(build | buildStrategy).env\" key-placeholder=\"Name\" value-placeholder=\"Value\" cannot-add cannot-delete cannot-sort is-readonly show-header class=\"mar-bottom-xl block\"></key-value-editor>\n" +
+    "<key-value-editor ng-if=\"(build | buildStrategy).env | size\" entries=\"(build | buildStrategy).env\" key-placeholder=\"Name\" value-placeholder=\"Value\" cannot-add cannot-delete cannot-sort is-readonly show-header class=\"mar-bottom-xl block\"></key-value-editor>\n" +
     "<p ng-if=\"!(build | buildStrategy).env\"><em>The build strategy had no environment variables defined.</em></p>\n" +
     "</uib-tab>\n" +
     "<uib-tab active=\"selectedTab.logs\" ng-if=\"!(build | isJenkinsPipelineStrategy) && ('builds/log' | canI : 'get')\">\n" +


### PR DESCRIPTION
related to #1438 

There is already a good message `The build strategy had no environment variables defined.`, this just ensures the `kve` doesn't render at all (rather than renders but is empty).

@spadgett 