### PR TITLE
Fix the hack/verify-dist.sh message

### DIFF
--- a/hack/verify-dist.sh
+++ b/hack/verify-dist.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+RED='\033[0;31m'
+NOCOLOR='\033[0m'
+GREEN='\033[0;32m'
+
 # We don't need grunt to be installed globally for the system,  so
 # we can amend our path to look into the local node_modules for the
 # correct binaries.
@@ -12,9 +16,9 @@ grunt build
 
 echo "Verifying that checked in built files under dist match the source..."
 if [[ $(git status -s -u dist*) ]]; then
+    echo -e "${RED}Built /dist does not match what is committed, run 'grunt build' and include the results in your commit.${NOCOLOR}"
     git diff --exit-code dist*
-    echo "Built dist does not match what is committed, run 'grunt build' and include the results in your commit."
     exit 1
 else
-    echo "Verified."
+    echo -e "${GREEN}Verified. Rebuilt /dist matches what has been committed.${NOCOLOR}"
 fi


### PR DESCRIPTION
- currently the verify-dist.sh error message is not printing
- alternates the order of fail output to ensure message prints
- adds some color codes to make it easier to find messages when scanning lengthy logs
	- the desire is for this to work in travis

Deliberately breaking the dist to ensure it works in travis.

@spadgett 