### PR TITLE
Fix excessively large notification blank state message

### DIFF
--- a/app/styles/_notifications.less
+++ b/app/styles/_notifications.less
@@ -3,6 +3,9 @@
 // -----------------------------------------------
 
 notification-drawer-wrapper {
+  .blank-state-pf-title {
+    font-size: @font-size-h4;
+  }
   .drawer-pf {
     height: calc(100vh ~"-" (@navbar-os-header-height-mobile + @project-bar-height-mobile));
     opacity: 1;

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5848,6 +5848,7 @@ kubernetes-container-terminal .terminal-actions .spinner{top:5px}
 .membership .content-pane .col-name input{max-width:175px}
 .membership .content-pane .select-role{width:150px}
 }
+notification-drawer-wrapper .blank-state-pf-title{font-size:14px}
 notification-drawer-wrapper .drawer-pf{height:calc(100vh - 69px);opacity:1;position:fixed;right:0;top:69px;transition:top 150ms ease-in-out,opacity 150ms;z-index:1028}
 @media (max-width:350px){notification-drawer-wrapper .drawer-pf{left:0;width:100%}
 }


### PR DESCRIPTION
Following @sg00dwin's update, we prob need to patch the blank state as well to reduce the crazy font size: 

fix #2022 

![screen shot 2017-09-06 at 3 50 31 pm](https://user-images.githubusercontent.com/280512/30131610-65a212f8-931b-11e7-8e8b-727b13e8c03a.png)

A corrective fix will come upstream in angular-patternfly [angular-patternfly](https://github.com/patternfly/angular-patternfly/issues/604) in the future.  

@spadgett @jeff-phillips-18 @sg00dwin 