### PR TITLE
Add `serviceClass` url param to jump into service-catalog flow

### DIFF
--- a/app/scripts/controllers/landingPage.js
+++ b/app/scripts/controllers/landingPage.js
@@ -111,6 +111,24 @@ angular.module('openshiftConsole')
     });
 
     function dataLoaded() {
+      // Check for a service class param to launch the catalog flow for
+      var paramClass = $location.search()['serviceClass'];
+      if (paramClass) {
+        // Search by class name e.g. cakephp-mysql-persistent
+        var paramItem = _.find($scope.catalogItems, {
+          resource: {
+            metadata: {
+              name: paramClass
+            }
+          }
+        });
+        // If a catalog item matches, lauch the catalog flow
+        if (paramItem) {
+          $scope.$broadcast('open-overlay-panel', paramItem);
+          return;
+        }
+      }
+
       if (!tourEnabled) {
         return;
       }

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4228,12 +4228,23 @@ controller: !0
 };
 }), angular.module("openshiftConsole").controller("LandingPageController", [ "$scope", "$rootScope", "AuthService", "Catalog", "Constants", "DataService", "Navigate", "NotificationsService", "RecentlyViewedServiceItems", "GuidedTourService", "HTMLService", "$timeout", "$q", "$routeParams", "$location", function(e, t, n, a, r, o, i, s, c, l, u, d, m, p, f) {
 function g() {
+var n = f.search().serviceClass;
+if (n) {
+var a = _.find(e.catalogItems, {
+resource: {
+metadata: {
+name: n
+}
+}
+});
+if (a) return void e.$broadcast("open-overlay-panel", a);
+}
 if (v) if (p.startTour) d(function() {
 f.replace(), f.search("startTour", null), e.startGuidedTour();
 }, 500); else if (_.get(h, "auto_launch")) {
-var n = "openshift/viewedHomePage/" + t.user.metadata.name;
-"true" !== localStorage.getItem(n) && d(function() {
-e.startGuidedTour() && localStorage.setItem(n, "true");
+var r = "openshift/viewedHomePage/" + t.user.metadata.name;
+"true" !== localStorage.getItem(r) && d(function() {
+e.startGuidedTour() && localStorage.setItem(r, "true");
 }, 500);
 }
 }

--- a/dist/styles/vendor.css
+++ b/dist/styles/vendor.css
@@ -1,5 +1,5 @@
 /*!
- * angularjs-datatables - v0.5.7
+ * angularjs-datatables - v0.5.9
  * https://github.com/dtaylor113/angularjs-datatables
  * License: MIT
  */
@@ -19,7 +19,7 @@ div.DTTT .btn,ul.DTTT_dropdown.dropdown-menu a{color:#333!important}
 .dataTables_wrapper .dataTables_paginate .paginate_button{padding:.3em .8em}
 .dataTables_wrapper .dataTables_paginate .paginate_button:hover{padding:.3em .8em;background:#D6D6D6;border:1px solid transparent}
 /*!
- * angularjs-datatables - v0.5.7
+ * angularjs-datatables - v0.5.9
  * https://github.com/dtaylor113/angularjs-datatables
  * License: MIT
  */


### PR DESCRIPTION
https://trello.com/c/w8LiRRSg

If a `serviceClass` param is present, look up the serviceClass and
launch the service-catalog modal for that class.
The param can be the service id e.g. 'cakephp-mysql-persistent'
or the service display name e.g. CakePHP + MySQL (Persistent)

Fixes https://github.com/openshift/origin-web-catalog/issues/423

The reason for allowing the service id or the service display is to allow for 'not very deterministic' id's.
This is somewhat the case for service classes returned by the ansible-service-broker.
For example, an apb for keycloak would have an generated serviceclass name of `dh-myorg-keycloak-latest`,
where `dh` is the image stream, `myorg` is the org, `keycloak` is the apb name and `latest` is the apb image tag. Having to know all 4 of these details seems a little contrived, rather than having a simple id.