### PR TITLE
Remove incorrect warning when deleting build config

### DIFF
--- a/app/views/modals/delete-resource.html
+++ b/app/views/modals/delete-resource.html
@@ -14,10 +14,6 @@
           This will delete the deployment, all rollout history, and any running pods.
         </span>
 
-        <span ng-if="kind === 'BuildConfig'">
-          This will delete the build config and all build history.
-        </span>
-
         <span ng-if="kind === 'ReplicationController' || kind === 'ReplicaSet' || kind === 'StatefulSet'">
           This will delete the {{typeDisplayName || (kind | humanizeKind)}} and any running pods.
         </span>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -10586,9 +10586,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"kind === 'Deployment'\">\n" +
     "This will delete the deployment, all rollout history, and any running pods.\n" +
     "</span>\n" +
-    "<span ng-if=\"kind === 'BuildConfig'\">\n" +
-    "This will delete the build config and all build history.\n" +
-    "</span>\n" +
     "<span ng-if=\"kind === 'ReplicationController' || kind === 'ReplicaSet' || kind === 'StatefulSet'\">\n" +
     "This will delete the {{typeDisplayName || (kind | humanizeKind)}} and any running pods.\n" +
     "</span>\n" +


### PR DESCRIPTION
Not all build history is necessarily deleted, so remove that message.
Builds without owner references will no be garbage collected.

Closes https://github.com/openshift/origin/issues/16177