### PR TITLE
Change margin to padding for loading message, so it doesn't cause scrollbar during loading state.

### DIFF
--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -359,7 +359,7 @@
     width: 100%;
   }
   .loading-message {
-    margin-top: 20px;
+    padding-top: 20px;
   }
   .metrics-collapsed {
     flex-grow: 1;

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5008,7 +5008,7 @@ h2+.list-view-pf{margin-top:20px}
 }
 .overview .list-row-tabset .nav-tabs>li.active>a .build-count{color:#4d5258}
 .overview .list-view-pf-actions .actions-dropdown-kebab{font-size:18px;width:100%}
-.overview .loading-message{margin-top:20px}
+.overview .loading-message{padding-top:20px}
 .overview .metrics-collapsed{flex-grow:1;text-align:center}
 .overview .metrics-summary{display:inline-block;text-align:center}
 .overview .metrics-summary+.metrics-summary{margin-left:20px}


### PR DESCRIPTION

Fixes https://github.com/openshift/origin-web-console/issues/2049
after:
<img width="814" alt="screen shot 2017-09-12 at 9 45 43 am" src="https://user-images.githubusercontent.com/1874151/30330859-3087a8ca-97a4-11e7-98dc-b880b0b88420.png">

before:
<img width="770" alt="screen shot 2017-09-12 at 10 25 38 am" src="https://user-images.githubusercontent.com/1874151/30331059-c6edac60-97a4-11e7-8248-f4a9ffd155b7.png">
