### PR TITLE
Update unit test dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: node_js
 node_js:
-  - "4"
+  - "6"
 before_script:
-  - make build
+  - make build 
+  # FIXME:
+  # This needs to be enabled again when we eliminate PhantomJS for Firefox
+  # Even the unit tests require a browser
+  # - export DISPLAY=:99.0
+  # - sh -e /etc/init.d/xvfb start
+  # - sleep 3 # give xvfb some time to start
 script:
-  - grunt test --browsers=PhantomJS
+  - grunt test
   - hack/verify-dist.sh

--- a/app/scripts/services/applicationGenerator.js
+++ b/app/scripts/services/applicationGenerator.js
@@ -351,8 +351,7 @@ angular.module("openshiftConsole")
             sourceStrategy: {
               from: {
                 kind: "ImageStreamTag",
-                name: input.imageName + ":" + input.imageTag,
-                namespace: input.namespace
+                name: input.imageName + ":" + input.imageTag
               },
               env: env
             }
@@ -360,6 +359,9 @@ angular.module("openshiftConsole")
           triggers: triggers
         }
       };
+      if(input.namespace) {
+        bc.spec.strategy.namespace = input.namespace;
+      }
       if (_.get(input, 'buildConfig.secrets.gitSecret[0].name')) {
         bc.spec.source.sourceSecret = _.head(input.buildConfig.secrets.gitSecret);
       }

--- a/app/scripts/services/membership/membership.js
+++ b/app/scripts/services/membership/membership.js
@@ -96,12 +96,16 @@ angular
                           if(!result[subject.kind].subjects[subjectKey]) {
                             result[subject.kind].subjects[subjectKey]  = {
                               name: subject.name,
-                              namespace: subject.namespace,
                               roles: {}
                             };
+                            if(subject.namespace) {
+                              result[subject.kind].subjects[subjectKey].namespace = subject.namespace;
+                            }
                           }
                           if(!_.includes(result[subject.kind].subjects[subjectKey].roles, roleKey)) {
-                            result[subject.kind].subjects[subjectKey].roles[roleKey] = roles[roleKey];
+                            if(roles[roleKey]) {
+                              result[subject.kind].subjects[subjectKey].roles[roleKey] = roles[roleKey];
+                            }
                           }
                         });
                         return result;

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1479,8 +1479,7 @@ type: "Source",
 sourceStrategy: {
 from: {
 kind: "ImageStreamTag",
-name: e.imageName + ":" + e.imageTag,
-namespace: e.namespace
+name: e.imageName + ":" + e.imageTag
 },
 env: n
 }
@@ -1488,7 +1487,7 @@ env: n
 triggers: a
 }
 };
-return _.get(e, "buildConfig.secrets.gitSecret[0].name") && (l.spec.source.sourceSecret = _.head(e.buildConfig.secrets.gitSecret)), e.buildConfig.contextDir && (l.spec.source.contextDir = e.buildConfig.contextDir), l;
+return e.namespace && (l.spec.strategy.namespace = e.namespace), _.get(e, "buildConfig.secrets.gitSecret[0].name") && (l.spec.source.sourceSecret = _.head(e.buildConfig.secrets.gitSecret)), e.buildConfig.contextDir && (l.spec.source.contextDir = e.buildConfig.contextDir), l;
 }, o._generateImageStream = function(e) {
 return {
 apiVersion: "v1",
@@ -2324,9 +2323,8 @@ return _.each(a.subjects, function(a) {
 var o = n(a.namespace, a.name);
 e[a.kind].subjects[o] || (e[a.kind].subjects[o] = {
 name: a.name,
-namespace: a.namespace,
 roles: {}
-}), _.includes(e[a.kind].subjects[o].roles, r) || (e[a.kind].subjects[o].roles[r] = t[r]);
+}, a.namespace && (e[a.kind].subjects[o].namespace = a.namespace)), _.includes(e[a.kind].subjects[o].roles, r) || t[r] && (e[a.kind].subjects[o].roles[r] = t[r]);
 }), e;
 }, {
 User: {

--- a/package.json
+++ b/package.json
@@ -12,13 +12,17 @@
     "clean-css": "3.4.12",
     "connect-modrewrite": "0.7.9",
     "geckodriver": "1.3.0",
+
     "grunt": "0.4.5",
+
     "grunt-angular-templates": "1.0.3",
     "grunt-cli": "1.1.0",
     "grunt-concurrent": "2.3.1",
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-concat": "1.0.0",
+
     "grunt-contrib-connect": "1.0.2",
+
     "grunt-contrib-copy": "1.0.0",
     "grunt-contrib-cssmin": "1.0.1",
     "grunt-contrib-htmlmin": "1.3.0",
@@ -29,7 +33,9 @@
     "grunt-contrib-watch": "1.0.0",
     "grunt-htmlhint": "0.4.1",
     "grunt-istanbul-coverage": "0.0.5",
-    "grunt-karma": "0.9.0",
+
+    "grunt-karma": "^2.0.0",
+
     "grunt-newer": "0.7.0",
     "grunt-ng-annotate": "0.3.2",
     "grunt-postcss": "^0.8.0",
@@ -40,21 +46,30 @@
     "grunt-wiredep": "3.0.0",
     "html-minifier": "1.1.1",
     "imagemin": "1.0.5",
+
+    "jasmine-core": "^2.8.0",
     "jasmine-beforeall": "0.1.1",
     "jasmine-spec-reporter": "1.1.2",
+
     "jshint-stylish": "0.2.0",
-    "karma": "0.12.23",
-    "karma-chrome-launcher": "^2.0.0",
-    "karma-coverage": "0.2.6",
-    "karma-firefox-launcher": "^1.0.0",
-    "karma-jasmine": "0.1.5",
-    "karma-ng-html2js-preprocessor": "1.0.0",
+
+    "karma": "^1.7.1",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-coverage": "^1.1.1",
+    "karma-firefox-launcher": "^1.0.1",
+    "karma-jasmine": "^1.1.0",
+    "karma-ng-html2js-preprocessor": "^1.0.0",
+    "karma-jasmine-diff-reporter": "^1.1.0",
     "karma-phantomjs-launcher": "^1.0.4",
+    "karma-nightmare": "^0.4.10",
+
     "less": "2.6.1",
     "load-grunt-tasks": "0.4.0",
     "lodash": "3.10.1",
+
     "protractor": "1.7.0",
-    "protractor-screenshot-reporter": "0.0.5",
+    "protractor-screenshot-reporter": "^0.0.5",
+
     "serve-static": "1.10.2",
     "time-grunt": "0.3.2"
   },

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -7,8 +7,14 @@ module.exports = function(config) {
   'use strict';
 
   config.set({
+    // maximum boot-up time allowed for a browser to start and connect to Karma
+    // a browser gets 3x changes within this timeout range to connect to Karma
+    // there are other timeouts as well, consult the config file
+    // docs: https://karma-runner.github.io/1.0/config/configuration-file.html
+    captureTimeout: 3000,
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
+    // why set to true when we have grunt watch?
+    autoWatch: false,
 
     // base path, that will be used to resolve files and exclude
     basePath: '../',
@@ -107,7 +113,7 @@ module.exports = function(config) {
     exclude: [],
 
     // web server port
-    port: 8443,
+    // port: 8443,
 
     // Start these browsers, currently available:
     // - Chrome
@@ -121,25 +127,23 @@ module.exports = function(config) {
       'karma-firefox-launcher',
       'karma-chrome-launcher',
       'karma-phantomjs-launcher',
+      'karma-nightmare',
       'karma-ng-html2js-preprocessor',
       'karma-jasmine',
-      'karma-coverage'
+      'karma-coverage',
+      'karma-jasmine-diff-reporter'
     ],
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit
-    singleRun: false,
+     singleRun: false,
 
-    colors: true,
+     colors: true,
 
     // level of logging
     // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
-    logLevel: config.LOG_DEBUG,
+    logLevel: config.LOG_ERROR,
 
-    // Help karma find the views on disk in the app subdirectory
-    proxies: {
-      '/views/': '/app/views/'
-    },
     // URL root prevent conflicts with the site root
     // urlRoot: '_karma_'
 
@@ -153,18 +157,28 @@ module.exports = function(config) {
 
     ngHtml2JsPreprocessor: {
       moduleName: 'openshiftConsoleTemplates',
-      cacheIdFromPath: function(filepath) {
-        return filepath.replace('app/', '');
-      },
+      stripPrefix: '/app',
     },
 
-    reporters: ['progress', 'coverage'],
+    // order of reporters matters, input/output may break
+    reporters: ['jasmine-diff', 'progress', 'coverage'],
 
     coverageReporter: {
-      reporters:[
-        {type: 'json', dir:'test/coverage/'},
-        {type: 'text-summary', dir:'test/coverage/'}
-      ]
+      type: 'text',
+      // outputs the results of coverage reporter to this dir
+      dir: 'test-results/coverage/'
+    },
+
+    jasmineDiffReporter: {
+      // jasmine kinda has its own diff now, but its sub-par.
+      legacy: true
+    },
+
+    nightmareOptions: {
+      width: 1048,
+      height: 600,
+      show: false,
     }
+
   });
 };

--- a/test/spec/services/applicationGeneratorSpec.js
+++ b/test/spec/services/applicationGeneratorSpec.js
@@ -255,77 +255,69 @@ describe("ApplicationGenerator", function(){
     });
 
     it("should generate a BuildConfig for the source", function(){
-      expect(resources.buildConfig).toEqual(
-        {
-            "apiVersion": "v1",
-            "kind": "BuildConfig",
-            "metadata": {
-                "name": "ruby-hello-world",
-                "labels": {
-                  "foo" : "bar",
-                  "abc" : "xyz"
-                },
-                "annotations": {
-                  "openshift.io/generated-by": "OpenShiftWebConsole"
-                }
-            },
-            "spec": {
-                "output": {
-                    "to": {
-                        "name": "ruby-hello-world:latest",
-                        "kind": "ImageStreamTag"
-                    }
-                },
-                "source": {
-                    "git": {
-                        "ref": "master",
-                        "uri": "https://github.com/openshift/ruby-hello-world.git"
-                    },
-                    "type": "Git"
-                },
-                "strategy": {
-                    "type": "Source",
-                    "sourceStrategy" : {
-                      "from": {
-                        "kind": "ImageStreamTag",
-                        "name": "origin-ruby-sample:latest"
-                      },
-                      "env": [
-                        {
-                          "name": "BUILD_ENV_1",
-                          "value": "someValue"
-                        },
-                        {
-                          "name": "BUILD_ENV_2",
-                          "value": "anotherValue"
-                        }
-                      ]
-                    }
-                },
-                "triggers": [
-                    {
-                        "generic": {
-                            "secret": "secret101"
-                        },
-                        "type": "Generic"
-                    },
-                    {
-                        "github": {
-                            "secret": "secret101"
-                        },
-                        "type": "GitHub"
-                    },
-                    {
-                      "imageChange" : {},
-                      "type" : "ImageChange"
-                    },
-                    {
-                        "type": "ConfigChange"
-                    }
-                ]
-            }
+      // the full output tree should match
+      expect(resources.buildConfig).toEqual({
+        "apiVersion": "v1",
+        "kind": "BuildConfig",
+        "metadata": {
+          "name": "ruby-hello-world",
+          "labels": {
+            "foo" : "bar",
+            "abc" : "xyz"
+          },
+          "annotations": {
+            "openshift.io/generated-by": "OpenShiftWebConsole"
           }
-      );
+        },
+        "spec": {
+          "output": {
+            "to": {
+              "name": "ruby-hello-world:latest",
+              "kind": "ImageStreamTag"
+            }
+          },
+          "source": {
+            "git": {
+              "ref": "master",
+              "uri": "https://github.com/openshift/ruby-hello-world.git"
+            },
+            "type": "Git"
+          },
+          "strategy": {
+            "type": "Source",
+            "sourceStrategy" : {
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "origin-ruby-sample:latest"
+              },
+              "env": [{
+                "name": "BUILD_ENV_1",
+                "value": "someValue"
+              },{
+                "name": "BUILD_ENV_2",
+                "value": "anotherValue"
+              }]
+            }
+          },
+          "triggers": [{
+              "generic": {
+                "secret": "secret101"
+              },
+              "type": "Generic"
+            },{
+              "github": {
+                "secret": "secret101"
+              },
+              "type": "GitHub"
+            },{
+              "imageChange" : {},
+              "type" : "ImageChange"
+            },{
+              "type": "ConfigChange"
+            }
+           ]
+         }
+       });
     });
 
     it("should generate an ImageStream for the build output", function(){

--- a/test/spec/services/membership/membershipSpec.js
+++ b/test/spec/services/membership/membershipSpec.js
@@ -236,6 +236,8 @@ describe('MembershipService', function() {
     // NOTE: ideally the above tests catch any issues as they do a better job of
     // declaring intent, if not, this test will compare raw output.
     it('should build a map for the tabbed role list interface', function() {
+
+      // the full output tree should match
       expect(MembershipService.mapRolebindingsForUI(roleBindings, keyedRoles))
         .toEqual([{
             "kind": "User",
@@ -304,6 +306,7 @@ describe('MembershipService', function() {
             "name": "SystemGroup",
             "subjects": {}
         }]);
+
     });
   });
 


### PR DESCRIPTION
https://trello.com/c/w3vdwj85

Updates `karma` related dependencies for unit testing.

![screen shot 2017-09-13 at 3 12 37 pm](https://user-images.githubusercontent.com/280512/30396372-697d163a-9897-11e7-9420-1f72e1b0786d.png)

Looking into why a few tests now fail, will update again shortly (did we always have this pretty coverage tool?)(is a lot of red reported by that pretty coverage tool 😄 ). 

to fix:
- [x] one of the updates, probably jasmine, is more strictly comparing objects than previously, resulting in some tests failing.
- [x] the coverage table is being output twice since I'm running the tests in Firefox & Chrome concurrently by default.  This is a little annoying.
  
@spadgett 