### PR TITLE
Changing gray background color to darker gray

### DIFF
--- a/app/styles/_variables.less
+++ b/app/styles/_variables.less
@@ -64,7 +64,7 @@
 @navbar-os-project-menu-color: @navbar-pf-vertical-color;
 @navbar-os-project-menu-hover-bg: lighten(@project-bar-bg, 8%);
 @panel-light: @body-bg;
-@panel-shaded: #f2f2f2;
+@panel-shaded: #ededed;
 @project-bar-bg: @color-pf-black-900; // #292e34 project bar
 @project-bar-border-color: #050505;
 @project-bar-border-inset-color: rgba(255,255,255,.04);

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4841,7 +4841,7 @@ pre.clipped.scroll{max-height:150px;overflow:auto;width:100%}
 .layout-pf.layout-pf-fixed .container-pf-nav-pf-vertical,.layout-pf.layout-pf-fixed .container-pf-nav-pf-vertical.collapsed-nav{margin-left:0}
 .layout-pf.layout-pf-fixed .container-pf-nav-pf-vertical .middle-header{margin-bottom:20px}
 .layout-pf.layout-pf-fixed .container-pf-nav-pf-vertical .view{height:100%}
-.surface-shaded{background-color:#f2f2f2;min-height:100%}
+.surface-shaded{background-color:#ededed;min-height:100%}
 .list-pf-actions .actions-dropdown-kebab{font-size:18px;margin-right:-5px}
 .list-pf-actions .dropdown .btn-link{color:#252525;font-size:17px;line-height:1;padding:4px 10px;margin-left:-10px;margin-right:-10px}
 .list-pf-actions .dropdown .btn-link:active,.list-pf-actions .dropdown .btn-link:focus,.list-pf-actions .dropdown .btn-link:hover{color:#0088ce}
@@ -5042,7 +5042,7 @@ h2+.list-view-pf{margin-top:20px}
 @media (min-width:992px){.overview .status-icons{margin-right:15px;width:40%}
 }
 .overview :not(.tab-pane)>overview-pipelines>.expanded-section{margin-bottom:30px}
-.overview .toolbar-container{padding-bottom:13px;padding-top:13px;background-color:#f2f2f2;min-height:100%}
+.overview .toolbar-container{padding-bottom:13px;padding-top:13px;background-color:#ededed;min-height:100%}
 .overview .triggers{margin-bottom:20px}
 .overview .usage-value{font-size:18px;font-weight:300;line-height:1}
 .overview .usage-label{font-size:84%;color:#9c9c9c}


### PR DESCRIPTION
per @jennyhaines, I've darkened the gray background color on pages that use it.  This completes the follow on in #1932 regarding use of .surface-shaded as @jennyhaines did not recommend any changes other than the color of gray being used.

![localhost-9000-dev-console- ipad](https://user-images.githubusercontent.com/895728/30482859-b36770e0-99f2-11e7-8002-0a4a8b8cbe9f.png)
![localhost-9000-dev-console- ipad 1](https://user-images.githubusercontent.com/895728/30482856-b361ecd8-99f2-11e7-9c7e-96975e56d4c5.png)
![localhost-9000-dev-console- ipad 2](https://user-images.githubusercontent.com/895728/30482858-b3651c46-99f2-11e7-8d04-fb7afed38c69.png)
![localhost-9000-dev-console- ipad 3](https://user-images.githubusercontent.com/895728/30482857-b363b716-99f2-11e7-881a-a5317df5d8c7.png)
![localhost-9000-dev-console- ipad 4](https://user-images.githubusercontent.com/895728/30482918-f015276c-99f2-11e7-98ba-ab6ff579d9e3.png)

