### PR TITLE
Add track by to overview service instance row

### DIFF
--- a/app/views/overview.html
+++ b/app/views/overview.html
@@ -362,7 +362,7 @@
               </h2>
               <div class="list-pf">
                 <service-instance-row
-                  ng-repeat="serviceInstance in overview.filteredServiceInstances"
+                  ng-repeat="serviceInstance in overview.filteredServiceInstances track by (serviceInstance | uid)"
                   api-object="serviceInstance"
                   bindings="overview.bindingsByInstanceRef[serviceInstance.metadata.name]"
                   state="overview.state"></service-instance-row>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -11457,7 +11457,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Provisioned Services\n" +
     "</h2>\n" +
     "<div class=\"list-pf\">\n" +
-    "<service-instance-row ng-repeat=\"serviceInstance in overview.filteredServiceInstances\" api-object=\"serviceInstance\" bindings=\"overview.bindingsByInstanceRef[serviceInstance.metadata.name]\" state=\"overview.state\"></service-instance-row>\n" +
+    "<service-instance-row ng-repeat=\"serviceInstance in overview.filteredServiceInstances track by (serviceInstance | uid)\" api-object=\"serviceInstance\" bindings=\"overview.bindingsByInstanceRef[serviceInstance.metadata.name]\" state=\"overview.state\"></service-instance-row>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
This fixes a bug where the binding dialog can disappear when the provisioned service status changes.