### PR TITLE
Don't show "Applications" as step label when pod presets are disabled

### DIFF
--- a/app/scripts/directives/unbindService.js
+++ b/app/scripts/directives/unbindService.js
@@ -23,6 +23,7 @@
     var ctrl = this;
     var validityWatcher;
     var context;
+    var enableTechPreviewFeature = $filter('enableTechPreviewFeature');
     var serviceInstanceDisplayName = $filter('serviceInstanceDisplayName');
 
     var unbindService = function() {
@@ -77,7 +78,12 @@
     };
 
     ctrl.$onInit = function() {
-      var formStepLabel = (ctrl.target.kind === 'ServiceInstance') ? 'Applications' : 'Services';
+      var formStepLabel;
+      if (ctrl.target.kind === 'ServiceInstance') {
+        formStepLabel = enableTechPreviewFeature('pod_presets') ? 'Applications' : 'Bindings';
+      } else {
+        formStepLabel = 'Services';
+      }
       ctrl.displayName = serviceInstanceDisplayName(ctrl.target);
       ctrl.steps = [{
         id: 'deleteForm',

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12490,7 +12490,7 @@ templateUrl: "views/directives/bind-service.html"
 }(), function() {
 angular.module("openshiftConsole").component("unbindService", {
 controller: [ "$scope", "$filter", "DataService", function(e, t, n) {
-var a, r, o = this, i = t("serviceInstanceDisplayName"), s = function() {
+var a, r, o = this, i = t("enableTechPreviewFeature"), s = t("serviceInstanceDisplayName"), c = function() {
 var e = o.selectedBinding.metadata.name;
 o.unboundApps = o.appsForBinding(e), n.delete({
 group: "servicecatalog.k8s.io",
@@ -12500,30 +12500,30 @@ propagationPolicy: null
 }).then(_.noop, function(e) {
 o.error = e;
 });
-}, c = function() {
+}, l = function() {
 var t = _.head(o.steps);
 t.valid = !1, a = e.$watch("ctrl.selectedBinding", function(e) {
 t.valid = !!e;
 });
-}, l = function() {
-a && (a(), a = void 0);
 }, u = function() {
-o.nextTitle = "Delete", c();
+a && (a(), a = void 0);
 }, d = function() {
-o.nextTitle = "Close", o.wizardComplete = !0, s(), l();
+o.nextTitle = "Delete", l();
+}, m = function() {
+o.nextTitle = "Close", o.wizardComplete = !0, c(), u();
 };
 o.$onInit = function() {
-var e = "ServiceInstance" === o.target.kind ? "Applications" : "Services";
-o.displayName = i(o.target), o.steps = [ {
+var e;
+e = "ServiceInstance" === o.target.kind ? i("pod_presets") ? "Applications" : "Bindings" : "Services", o.displayName = s(o.target), o.steps = [ {
 id: "deleteForm",
 label: e,
 view: "views/directives/bind-service/delete-binding-select-form.html",
-onShow: u
+onShow: d
 }, {
 id: "results",
 label: "Results",
 view: "views/directives/bind-service/delete-binding-result.html",
-onShow: d
+onShow: m
 } ], r = {
 namespace: _.get(o.target, "metadata.namespace")
 };
@@ -12532,7 +12532,7 @@ return _.get(o.applicationsByBinding, e);
 }, o.closeWizard = function() {
 _.isFunction(o.onClose) && o.onClose();
 }, o.$onDestroy = function() {
-l();
+u();
 };
 } ],
 controllerAs: "ctrl",


### PR DESCRIPTION
@ncameronbritt Opinion on this change? The step title used to be "Applications". Noticed this after working on #2092

![openshift web console 2017-09-15 17-46-48](https://user-images.githubusercontent.com/1167259/30504655-0d31d426-9a3e-11e7-835a-daf7aef9d19d.png)
