### PR TITLE
Update addConfigVolume controller to use getPreferredVersion

### DIFF
--- a/app/scripts/controllers/addConfigVolume.js
+++ b/app/scripts/controllers/addConfigVolume.js
@@ -62,6 +62,9 @@ angular.module('openshiftConsole')
       subpage: 'Add Config Files'
     });
 
+    $scope.configMapVersion = APIService.getPreferredVersion('configmaps');
+    $scope.secretVersion = APIService.getPreferredVersion('secrets');
+
     var humanizeKind = $filter('humanizeKind');
     $scope.groupByKind = function(object) {
       return humanizeKind(object.kind);
@@ -137,7 +140,7 @@ angular.module('openshiftConsole')
           }
         );
 
-        DataService.list("configmaps", context, null, { errorNotification: false }).then(function(configMapData) {
+        DataService.list($scope.configMapVersion, context, null, { errorNotification: false }).then(function(configMapData) {
           $scope.configMaps = orderByDisplayName(configMapData.by("metadata.name"));
         }, function(e) {
           if (e.code === 403) {
@@ -148,7 +151,7 @@ angular.module('openshiftConsole')
           displayError('Could not load config maps', getErrorDetails(e));
         });
 
-        DataService.list("secrets", context, null, { errorNotification: false }).then(function(secretData) {
+        DataService.list($scope.secretVersion, context, null, { errorNotification: false }).then(function(secretData) {
           $scope.secrets = orderByDisplayName(secretData.by("metadata.name"));
         }, function(e) {
           if (e.code === 403) {

--- a/app/views/add-config-volume.html
+++ b/app/views/add-config-volume.html
@@ -11,7 +11,7 @@
         </div>
 
         <div ng-if="targetObject && configMaps && secrets">
-          <div ng-if="!configMaps.length && !secrets.length && !('configmaps' | canI : 'create') && !('secrets' | canI : 'create')" class="empty-state-message empty-state-full-page">
+          <div ng-if="!configMaps.length && !secrets.length && !(configMapVersion | canI : 'create') && !(secretVersion | canI : 'create')" class="empty-state-message empty-state-full-page">
             <h2 class="text-center">No config maps or secrets.</h2>
 
             <p class="gutter-top">
@@ -22,7 +22,7 @@
             <p ng-if="targetObject"><a ng-href="{{targetObject | navigateResourceURL}}">Back to {{kind | humanizeKind}} {{name}}</a></p>
           </div>
 
-          <div ng-if="configMaps.length || secrets.length || ('configmaps' | canI : 'create') || ('secrets' | canI : 'create')" class="mar-top-xl">
+          <div ng-if="configMaps.length || secrets.length || (configMapVersion | canI : 'create') || (secretVersion | canI : 'create')" class="mar-top-xl">
             <h1>Add Config Files to {{name}}</h1>
             <div class="help-block">
               Add values from a config map or secret as volume. This will make the data available as files for {{kind | humanizeKind}} {{name}}.
@@ -44,12 +44,12 @@
                       <span ng-bind-html="source.metadata.name | highlight : $select.search"></span>
                     </ui-select-choices>
                   </ui-select>
-                  <div ng-if="('configmaps' | canI : 'create') || ('secrets' | canI : 'create')" class="mar-top-md">
-                    <span ng-if="'configmaps' | canI : 'create'">
+                  <div ng-if="(configMapVersion | canI : 'create') || (secretVersion | canI : 'create')" class="mar-top-md">
+                    <span ng-if="configMapVersion | canI : 'create'">
                       <a ng-href="project/{{project.metadata.name}}/create-config-map">Create Config Map</a>
                     </span>
-                    <span ng-if="'secrets' | canI : 'create'">
-                      <span ng-if="'configmaps' | canI : 'create'" class="action-divider" aria-hidden="true">|</span>
+                    <span ng-if="secretVersion | canI : 'create'">
+                      <span ng-if="configMapVersion | canI : 'create'" class="action-divider" aria-hidden="true">|</span>
                       <a ng-href="project/{{project.metadata.name}}/create-secret">Create Secret</a>
                     </span>
                   </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8466,7 +8466,7 @@ name: n.name,
 kind: n.kind,
 namespace: n.project,
 subpage: "Add Config Files"
-});
+}), a.configMapVersion = o.getPreferredVersion("configmaps"), a.secretVersion = o.getPreferredVersion("secrets");
 var h = e("humanizeKind");
 a.groupByKind = function(e) {
 return h(e.kind);
@@ -8507,13 +8507,13 @@ subpage: "Add Config Files"
 });
 }, function(e) {
 a.error = e;
-}), c.list("configmaps", r, null, {
+}), c.list(a.configMapVersion, r, null, {
 errorNotification: !1
 }).then(function(e) {
 a.configMaps = o(e.by("metadata.name"));
 }, function(e) {
 403 !== e.code ? b("Could not load config maps", d(e)) : a.configMaps = [];
-}), c.list("secrets", r, null, {
+}), c.list(a.secretVersion, r, null, {
 errorNotification: !1
 }).then(function(e) {
 a.secrets = o(e.by("metadata.name"));

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -828,14 +828,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p>{{error | getErrorDetails}}</p>\n" +
     "</div>\n" +
     "<div ng-if=\"targetObject && configMaps && secrets\">\n" +
-    "<div ng-if=\"!configMaps.length && !secrets.length && !('configmaps' | canI : 'create') && !('secrets' | canI : 'create')\" class=\"empty-state-message empty-state-full-page\">\n" +
+    "<div ng-if=\"!configMaps.length && !secrets.length && !(configMapVersion | canI : 'create') && !(secretVersion | canI : 'create')\" class=\"empty-state-message empty-state-full-page\">\n" +
     "<h2 class=\"text-center\">No config maps or secrets.</h2>\n" +
     "<p class=\"gutter-top\">\n" +
     "There are no config maps or secrets in project {{project | displayName}} to use as a volume for this {{kind | humanizeKind}}.\n" +
     "</p>\n" +
     "<p ng-if=\"targetObject\"><a ng-href=\"{{targetObject | navigateResourceURL}}\">Back to {{kind | humanizeKind}} {{name}}</a></p>\n" +
     "</div>\n" +
-    "<div ng-if=\"configMaps.length || secrets.length || ('configmaps' | canI : 'create') || ('secrets' | canI : 'create')\" class=\"mar-top-xl\">\n" +
+    "<div ng-if=\"configMaps.length || secrets.length || (configMapVersion | canI : 'create') || (secretVersion | canI : 'create')\" class=\"mar-top-xl\">\n" +
     "<h1>Add Config Files to {{name}}</h1>\n" +
     "<div class=\"help-block\">\n" +
     "Add values from a config map or secret as volume. This will make the data available as files for {{kind | humanizeKind}} {{name}}.\n" +
@@ -855,12 +855,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-bind-html=\"source.metadata.name | highlight : $select.search\"></span>\n" +
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
-    "<div ng-if=\"('configmaps' | canI : 'create') || ('secrets' | canI : 'create')\" class=\"mar-top-md\">\n" +
-    "<span ng-if=\"'configmaps' | canI : 'create'\">\n" +
+    "<div ng-if=\"(configMapVersion | canI : 'create') || (secretVersion | canI : 'create')\" class=\"mar-top-md\">\n" +
+    "<span ng-if=\"configMapVersion | canI : 'create'\">\n" +
     "<a ng-href=\"project/{{project.metadata.name}}/create-config-map\">Create Config Map</a>\n" +
     "</span>\n" +
-    "<span ng-if=\"'secrets' | canI : 'create'\">\n" +
-    "<span ng-if=\"'configmaps' | canI : 'create'\" class=\"action-divider\" aria-hidden=\"true\">|</span>\n" +
+    "<span ng-if=\"secretVersion | canI : 'create'\">\n" +
+    "<span ng-if=\"configMapVersion | canI : 'create'\" class=\"action-divider\" aria-hidden=\"true\">|</span>\n" +
     "<a ng-href=\"project/{{project.metadata.name}}/create-secret\">Create Secret</a>\n" +
     "</span>\n" +
     "</div>\n" +


### PR DESCRIPTION
Moving these along.
Depends on web console [PR 161](https://github.com/openshift/origin-web-common/pull/161)

Question still lingers, is `getPreferredVersion` the best name? I pause probably because `version` becomes overloaded.  This just means "get what we are consistenly using", even though the method actually returns a `{resource, group}` w/o the version.

@spadgett 