### PR TITLE
File path input should always be readonly

### DIFF
--- a/app/views/directives/osc-file-input.html
+++ b/app/views/directives/osc-file-input.html
@@ -10,7 +10,6 @@
         readonly
         ng-show="supportsFileUpload"
         ng-disabled="disabled"
-        ng-readonly="readonly"
         ng-attr-aria-describedby="{{helpText ? helpID : undefined}}">
     <span class="input-group-btn">
       <span class="btn btn-default btn-file" ng-show="supportsFileUpload" ng-attr-disabled="{{ (disabled || readonly) || undefined }}">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7734,7 +7734,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p>Drop file here</p>\n" +
     "</div>\n" +
     "<div class=\"input-group\">\n" +
-    "<input type=\"text\" class=\"form-control\" ng-model=\"fileName\" readonly=\"readonly\" ng-show=\"supportsFileUpload\" ng-disabled=\"disabled\" ng-readonly=\"readonly\" ng-attr-aria-describedby=\"{{helpText ? helpID : undefined}}\">\n" +
+    "<input type=\"text\" class=\"form-control\" ng-model=\"fileName\" readonly=\"readonly\" ng-show=\"supportsFileUpload\" ng-disabled=\"disabled\" ng-attr-aria-describedby=\"{{helpText ? helpID : undefined}}\">\n" +
     "<span class=\"input-group-btn\">\n" +
     "<span class=\"btn btn-default btn-file\" ng-show=\"supportsFileUpload\" ng-attr-disabled=\"{{ (disabled || readonly) || undefined }}\">\n" +
     "Browse&hellip;\n" +


### PR DESCRIPTION
The text input for uploading files should always be readonly since you can't type a file name. You have to use the browse button or drag and drop.

Regression introduced in #1935