### PR TITLE
Make close notification link accessible

### DIFF
--- a/app/views/directives/notifications/notification-body.html
+++ b/app/views/directives/notifications/notification-body.html
@@ -4,7 +4,7 @@
   ng-click="$ctrl.customScope.markRead(notification)">
   <a
     class="pull-right"
-    tabindex="0"
+    href=""
     ng-click="$ctrl.customScope.clear(notification, $index, notificationGroup)">
     <span class="sr-only">Clear notification</span>
     <span

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7570,7 +7570,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/directives/notifications/notification-body.html',
     "<div class=\"drawer-pf-notification-inner\" tabindex=\"0\" ng-click=\"$ctrl.customScope.markRead(notification)\">\n" +
-    "<a class=\"pull-right\" tabindex=\"0\" ng-click=\"$ctrl.customScope.clear(notification, $index, notificationGroup)\">\n" +
+    "<a class=\"pull-right\" href=\"\" ng-click=\"$ctrl.customScope.clear(notification, $index, notificationGroup)\">\n" +
     "<span class=\"sr-only\">Clear notification</span>\n" +
     "<span ng-if=\"notification.event\" aria-hidden=\"true\" class=\"pull-left pficon pficon-close\"></span>\n" +
     "</a>\n" +


### PR DESCRIPTION
The link was missing an `href` and could not be triggered using the keyboard.