### PR TITLE
Disable clicking number to go to results step

### DIFF
--- a/app/scripts/directives/bindService.js
+++ b/app/scripts/directives/bindService.js
@@ -123,6 +123,7 @@
       label: 'Binding',
       view: 'views/directives/bind-service/bind-service-form.html',
       valid: true,
+      allowClickNav: true,
       onShow: showBind
     };
 
@@ -131,6 +132,7 @@
       label: 'Parameters',
       view: 'views/directives/bind-service/bind-parameters.html',
       hidden: true,
+      allowClickNav: true,
       onShow: showParameters
     };
 
@@ -139,6 +141,7 @@
       label: 'Results',
       view: 'views/directives/bind-service/results.html',
       valid: true,
+      allowClickNav: false,
       onShow: showResults
     };
 

--- a/app/scripts/directives/processTemplateDialog.js
+++ b/app/scripts/directives/processTemplateDialog.js
@@ -41,6 +41,7 @@
       hidden: ctrl.useProjectTemplate !== true,
       allowed: true,
       valid: false,
+      allowClickNav: true,
       onShow: showSelect
     };
 
@@ -52,6 +53,7 @@
       // is displayed and the template has required fields.
       valid: false,
       allowed: true,
+      allowClickNav: true,
       onShow: showConfig
     };
 
@@ -62,6 +64,7 @@
       valid: true,
       allowed: false,
       prevEnabled: false,
+      allowClickNav: false,
       onShow: showResults
     };
 

--- a/app/views/directives/bind-service.html
+++ b/app/views/directives/bind-service.html
@@ -8,12 +8,13 @@
        on-finish="ctrl.closeWizard()"
        on-cancel="ctrl.closeWizard()"
        wizard-done="ctrl.wizardComplete">
-    <pf-wizard-step ng-repeat="step in ctrl.steps track by $index"
+    <pf-wizard-step ng-repeat="step in ctrl.steps track by step.id"
        step-title="{{step.label}}"
        next-enabled="step.valid"
        on-show="step.onShow"
        step-id="{{step.id}}"
-       step-priority="{{$index}}">
+       step-priority="{{$index}}"
+       allow-click-nav="step.allowClickNav">
       <div class="wizard-pf-main-inner-shadow-covers">
         <div class="bind-service-config">
           <div ng-include="step.view" class="wizard-pf-main-form-contents"></div>

--- a/app/views/directives/process-template-dialog.html
+++ b/app/views/directives/process-template-dialog.html
@@ -15,7 +15,7 @@
     <pf-wizard-step ng-repeat="step in $ctrl.steps track by step.id"
          step-title="{{step.label}}"
          wz-disabled="{{step.hidden}}"
-         allow-click-nav="step.allowed"
+         allow-click-nav="step.allowClickNav"
          next-enabled="step.valid"
          prev-enabled="step.prevEnabled"
          on-show="step.onShow"

--- a/app/views/directives/unbind-service.html
+++ b/app/views/directives/unbind-service.html
@@ -11,9 +11,10 @@
     wizard-done="ctrl.wizardComplete"
     class="pf-wizard-no-back">
     <pf-wizard-step
-      ng-repeat="step in ctrl.steps track by $index"
+      ng-repeat="step in ctrl.steps track by step.id"
       step-title="{{step.label}}"
       next-enabled="step.valid"
+      allow-click-nav="false"
       on-show="step.onShow"
       step-id="{{step.id}}"
       step-priority="{{$index}}">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12590,6 +12590,7 @@ id: "bindForm",
 label: "Binding",
 view: "views/directives/bind-service/bind-service-form.html",
 valid: !0,
+allowClickNav: !0,
 onShow: function() {
 d.nextTitle = i.hidden ? "Bind" : "Next >", d.podPresets && !c && (c = e.$watch("ctrl.selectionForm.$valid", function(e) {
 o.valid = e;
@@ -12600,6 +12601,7 @@ id: "bindParameters",
 label: "Parameters",
 view: "views/directives/bind-service/bind-parameters.html",
 hidden: !0,
+allowClickNav: !0,
 onShow: function() {
 d.nextTitle = "Bind", l || (l = e.$watch("ctrl.parametersForm.$valid", function(e) {
 i.valid = e;
@@ -12610,6 +12612,7 @@ id: "results",
 label: "Results",
 view: "views/directives/bind-service/results.html",
 valid: !0,
+allowClickNav: !1,
 onShow: function() {
 c && (c(), c = void 0), l && (l(), l = void 0), d.nextTitle = "Close", d.wizardComplete = !0, d.bindService();
 }
@@ -12894,6 +12897,7 @@ view: "views/directives/process-template-dialog/process-template-select.html",
 hidden: !0 !== v.useProjectTemplate,
 allowed: !0,
 valid: !1,
+allowClickNav: !0,
 onShow: function() {
 v.selectStep.selected = !0, v.configStep.selected = !1, v.resultsStep.selected = !1, v.nextTitle = "Next >", u(), g();
 }
@@ -12903,6 +12907,7 @@ label: "Configuration",
 view: "views/directives/process-template-dialog/process-template-config.html",
 valid: !1,
 allowed: !0,
+allowClickNav: !0,
 onShow: function() {
 v.selectStep.selected = !1, v.configStep.selected = !0, v.resultsStep.selected = !1, v.nextTitle = "Create", v.resultsStep.allowed = v.configStep.valid, h = e.$watch("$ctrl.form.$valid", function(e) {
 v.configStep.valid = e && v.selectedProject, v.resultsStep.allowed = e;
@@ -12915,6 +12920,7 @@ view: "views/directives/process-template-dialog/process-template-results.html",
 valid: !0,
 allowed: !1,
 prevEnabled: !1,
+allowClickNav: !1,
 onShow: function() {
 v.selectStep.selected = !1, v.configStep.selected = !1, v.resultsStep.selected = !0, v.nextTitle = "Close", u(), v.wizardDone = !0;
 }

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5818,7 +5818,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   $templateCache.put('views/directives/bind-service.html',
     "<div class=\"bind-service-wizard\">\n" +
     "<pf-wizard hide-header=\"true\" hide-sidebar=\"true\" step-class=\"bind-service-wizard-step\" wizard-ready=\"ctrl.wizardReady\" next-title=\"ctrl.nextTitle\" on-finish=\"ctrl.closeWizard()\" on-cancel=\"ctrl.closeWizard()\" wizard-done=\"ctrl.wizardComplete\">\n" +
-    "<pf-wizard-step ng-repeat=\"step in ctrl.steps track by $index\" step-title=\"{{step.label}}\" next-enabled=\"step.valid\" on-show=\"step.onShow\" step-id=\"{{step.id}}\" step-priority=\"{{$index}}\">\n" +
+    "<pf-wizard-step ng-repeat=\"step in ctrl.steps track by step.id\" step-title=\"{{step.label}}\" next-enabled=\"step.valid\" on-show=\"step.onShow\" step-id=\"{{step.id}}\" step-priority=\"{{$index}}\" allow-click-nav=\"step.allowClickNav\">\n" +
     "<div class=\"wizard-pf-main-inner-shadow-covers\">\n" +
     "<div class=\"bind-service-config\">\n" +
     "<div ng-include=\"step.view\" class=\"wizard-pf-main-form-contents\"></div>\n" +
@@ -8785,7 +8785,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   $templateCache.put('views/directives/process-template-dialog.html',
     "<div class=\"order-service\">\n" +
     "<pf-wizard hide-header=\"true\" hide-sidebar=\"true\" hide-back-button=\"!$ctrl.useProjectTemplate\" step-class=\"order-service-wizard-step\" wizard-ready=\"$ctrl.wizardReady\" next-title=\"$ctrl.nextTitle\" next-callback=\"$ctrl.next\" on-finish=\"$ctrl.close()\" on-cancel=\"$ctrl.close()\" wizard-done=\"$ctrl.wizardDone\" current-step=\"$ctrl.currentStep\" ng-class=\"{'pf-wizard-no-back': !$ctrl.useProjectTemplate}\">\n" +
-    "<pf-wizard-step ng-repeat=\"step in $ctrl.steps track by step.id\" step-title=\"{{step.label}}\" wz-disabled=\"{{step.hidden}}\" allow-click-nav=\"step.allowed\" next-enabled=\"step.valid\" prev-enabled=\"step.prevEnabled\" on-show=\"step.onShow\" step-id=\"{{step.id}}\" step-priority=\"{{$index}}\">\n" +
+    "<pf-wizard-step ng-repeat=\"step in $ctrl.steps track by step.id\" step-title=\"{{step.label}}\" wz-disabled=\"{{step.hidden}}\" allow-click-nav=\"step.allowClickNav\" next-enabled=\"step.valid\" prev-enabled=\"step.prevEnabled\" on-show=\"step.onShow\" step-id=\"{{step.id}}\" step-priority=\"{{$index}}\">\n" +
     "<div class=\"wizard-pf-main-inner-shadow-covers\">\n" +
     "<div class=\"order-service-details\" ng-if=\"!$ctrl.selectStep.selected\">\n" +
     "<div class=\"order-service-details-top\">\n" +
@@ -9138,7 +9138,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   $templateCache.put('views/directives/unbind-service.html',
     "<div class=\"bind-service-wizard unbind-service\">\n" +
     "<pf-wizard hide-header=\"true\" hide-sidebar=\"true\" hide-back-button=\"true\" step-class=\"bind-service-wizard-step\" wizard-ready=\"ctrl.wizardReady\" next-title=\"ctrl.nextTitle\" on-finish=\"ctrl.closeWizard()\" on-cancel=\"ctrl.closeWizard()\" wizard-done=\"ctrl.wizardComplete\" class=\"pf-wizard-no-back\">\n" +
-    "<pf-wizard-step ng-repeat=\"step in ctrl.steps track by $index\" step-title=\"{{step.label}}\" next-enabled=\"step.valid\" on-show=\"step.onShow\" step-id=\"{{step.id}}\" step-priority=\"{{$index}}\">\n" +
+    "<pf-wizard-step ng-repeat=\"step in ctrl.steps track by step.id\" step-title=\"{{step.label}}\" next-enabled=\"step.valid\" allow-click-nav=\"false\" on-show=\"step.onShow\" step-id=\"{{step.id}}\" step-priority=\"{{$index}}\">\n" +
     "<div class=\"wizard-pf-main-inner-shadow-covers\">\n" +
     "<div class=\"bind-service-config\">\n" +
     "<div ng-include=\"step.view\" class=\"wizard-pf-main-form-contents\"></div>\n" +


### PR DESCRIPTION
Prevent accidentally creating and deleting things in the wizard dialogs by clicking the last step indicator.

Fixes #1829 (with https://github.com/openshift/origin-web-catalog/pull/441)

cc @ncameronbritt 