### PR TITLE
Bug 1492949 - Don't prompt for project processing template from YAML

### DIFF
--- a/app/views/directives/from-file-dialog.html
+++ b/app/views/directives/from-file-dialog.html
@@ -62,7 +62,7 @@
           <div class="osc-form">
             <alerts alerts="$ctrl.alerts"></alerts>
             <form name="$ctrl.templateForm">
-              <process-template project="$ctrl.project" template="$ctrl.template" alerts="$ctrl.alerts" is-dialog="true"></process-template>
+              <process-template project="$ctrl.selectedProject" template="$ctrl.template" alerts="$ctrl.alerts" is-dialog="true"></process-template>
             </form>
           </div>
         </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7022,7 +7022,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"osc-form\">\n" +
     "<alerts alerts=\"$ctrl.alerts\"></alerts>\n" +
     "<form name=\"$ctrl.templateForm\">\n" +
-    "<process-template project=\"$ctrl.project\" template=\"$ctrl.template\" alerts=\"$ctrl.alerts\" is-dialog=\"true\"></process-template>\n" +
+    "<process-template project=\"$ctrl.selectedProject\" template=\"$ctrl.template\" alerts=\"$ctrl.alerts\" is-dialog=\"true\"></process-template>\n" +
     "</form>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
Don't prompt for project a second time when processing a template from the "Import YAML" action. The user already selected a project on the first step.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1492949