### PR TITLE
Update buildConfig controller to use getPreferredVersion

### DIFF
--- a/app/scripts/controllers/buildConfig.js
+++ b/app/scripts/controllers/buildConfig.js
@@ -44,6 +44,9 @@ angular.module('openshiftConsole')
       title: $routeParams.buildconfig
     });
 
+    $scope.buildConfigsVersion = APIService.getPreferredVersion('buildconfigs');
+    $scope.buildsVersion = APIService.getPreferredVersion('builds');
+
     $scope.emptyMessage = "Loading...";
 
     $scope.aceLoaded = function(editor) {
@@ -178,11 +181,11 @@ angular.module('openshiftConsole')
         $scope.project = project;
         requestContext = context;
         DataService
-          .get("buildconfigs", $routeParams.buildconfig, context, { errorNotification: false })
+          .get($scope.buildConfigsVersion, $routeParams.buildconfig, context, { errorNotification: false })
           .then(function(buildConfig) {
             buildConfigResolved(buildConfig);
             // If we found the item successfully, watch for changes on it
-            watches.push(DataService.watchObject("buildconfigs", $routeParams.buildconfig, context, buildConfigResolved));
+            watches.push(DataService.watchObject($scope.buildConfigsVersion, $routeParams.buildconfig, context, buildConfigResolved));
           },
           // failure
           function(e) {
@@ -195,7 +198,7 @@ angular.module('openshiftConsole')
           }
         );
 
-      watches.push(DataService.watch("builds", context, function(builds, action, build) {
+      watches.push(DataService.watch($scope.buildsVersion, context, function(builds, action, build) {
         $scope.emptyMessage = "No builds to show";
         if (!action) {
           $scope.unfilteredBuilds = BuildsService.validatedBuildsForBuildConfig($routeParams.buildconfig, builds.by('metadata.name'));

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -37,13 +37,13 @@
                 </span>
               </a>
             </li>
-            <li ng-if="'buildconfigs' | canI : 'update'">
+            <li ng-if="buildConfigsVersion | canI : 'update'">
               <a ng-href="{{buildConfig | editResourceURL}}" role="button">Edit</a>
             </li>
-            <li ng-if="'buildconfigs' | canI : 'update'">
+            <li ng-if="buildConfigsVersion | canI : 'update'">
               <a ng-href="{{buildConfig | editYamlURL}}" role="button">Edit YAML</a>
             </li>
-            <li ng-if="'buildconfigs' | canI : 'delete'">
+            <li ng-if="buildConfigsVersion | canI : 'delete'">
               <delete-link
                 kind="BuildConfig"
                 resource-name="{{buildConfig.metadata.name}}"
@@ -464,7 +464,7 @@
                 cannot-delete
                 show-header></key-value-editor>
               <ng-form name="forms.bcEnvVars" class="mar-bottom-xl block">
-                <div ng-if="'buildconfigs' | canI : 'update'">
+                <div ng-if="buildConfigsVersion | canI : 'update'">
                   <confirm-on-exit dirty="forms.bcEnvVars.$dirty"></confirm-on-exit>
                   <key-value-editor
                     entries="envVars"
@@ -487,7 +487,7 @@
                     style="vertical-align: -2px;">Clear Changes</a>
                 </div>
                 <key-value-editor
-                  ng-if="!('buildconfigs' | canI : 'update')"
+                  ng-if="!(buildConfigsVersion | canI : 'update')"
                   entries="envVars"
                   key-placeholder="Name"
                   value-placeholder="Value"

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5236,7 +5236,7 @@ title: "Builds",
 link: "project/" + n.project + "/browse/builds"
 }), e.breadcrumbs.push({
 title: n.buildconfig
-}), e.emptyMessage = "Loading...", e.aceLoaded = function(e) {
+}), e.buildConfigsVersion = a.getPreferredVersion("buildconfigs"), e.buildsVersion = a.getPreferredVersion("builds"), e.emptyMessage = "Loading...", e.aceLoaded = function(e) {
 var t = e.getSession();
 t.setOption("tabSize", 2), t.setOption("useSoftTabs", !0), e.$blockScrolling = 1 / 0;
 };
@@ -5296,17 +5296,17 @@ type: "warning",
 details: "The active filters are hiding all builds."
 };
 }
-e.project = a, p = o, i.get("buildconfigs", n.buildconfig, o, {
+e.project = a, p = o, i.get(e.buildConfigsVersion, n.buildconfig, o, {
 errorNotification: !1
-}).then(function(e) {
-y(e), g.push(i.watchObject("buildconfigs", n.buildconfig, o, y));
+}).then(function(t) {
+y(t), g.push(i.watchObject(e.buildConfigsVersion, n.buildconfig, o, y));
 }, function(n) {
 e.loaded = !0, e.alerts.load = {
 type: "error",
 message: 404 === n.status ? "This build configuration can not be found, it may have been deleted." : "The build configuration details could not be loaded.",
 details: 404 === n.status ? "Any remaining build history for this build will be shown." : t("getErrorDetails")(n)
 };
-}), g.push(i.watch("builds", o, function(t, a, o) {
+}), g.push(i.watch(e.buildsVersion, o, function(t, a, o) {
 if (e.emptyMessage = "No builds to show", a) {
 if (m(o) === n.buildconfig) {
 var i = o.metadata.name;

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1642,13 +1642,13 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</a>\n" +
     "</li>\n" +
-    "<li ng-if=\"'buildconfigs' | canI : 'update'\">\n" +
+    "<li ng-if=\"buildConfigsVersion | canI : 'update'\">\n" +
     "<a ng-href=\"{{buildConfig | editResourceURL}}\" role=\"button\">Edit</a>\n" +
     "</li>\n" +
-    "<li ng-if=\"'buildconfigs' | canI : 'update'\">\n" +
+    "<li ng-if=\"buildConfigsVersion | canI : 'update'\">\n" +
     "<a ng-href=\"{{buildConfig | editYamlURL}}\" role=\"button\">Edit YAML</a>\n" +
     "</li>\n" +
-    "<li ng-if=\"'buildconfigs' | canI : 'delete'\">\n" +
+    "<li ng-if=\"buildConfigsVersion | canI : 'delete'\">\n" +
     "<delete-link kind=\"BuildConfig\" resource-name=\"{{buildConfig.metadata.name}}\" project-name=\"{{buildConfig.metadata.namespace}}\" alerts=\"alerts\">\n" +
     "</delete-link>\n" +
     "</li>\n" +
@@ -2027,13 +2027,13 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "<key-value-editor ng-if=\"expand.imageEnv\" entries=\"BCEnvVarsFromImage\" key-placeholder=\"Name\" value-placeholder=\"Value\" is-readonly cannot-add cannot-sort cannot-delete show-header></key-value-editor>\n" +
     "<ng-form name=\"forms.bcEnvVars\" class=\"mar-bottom-xl block\">\n" +
-    "<div ng-if=\"'buildconfigs' | canI : 'update'\">\n" +
+    "<div ng-if=\"buildConfigsVersion | canI : 'update'\">\n" +
     "<confirm-on-exit dirty=\"forms.bcEnvVars.$dirty\"></confirm-on-exit>\n" +
     "<key-value-editor entries=\"envVars\" key-placeholder=\"Name\" value-placeholder=\"Value\" key-validator=\"[A-Za-z_][A-Za-z0-9_]*\" key-validator-error=\"Please enter a valid key\" key-validator-error-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" add-row-link=\"Add Environment Variable\" show-header></key-value-editor>\n" +
     "<button class=\"btn btn-default\" ng-click=\"saveEnvVars()\" ng-disabled=\"forms.bcEnvVars.$pristine || forms.bcEnvVars.$invalid\">Save</button>\n" +
     "<a ng-if=\"!forms.bcEnvVars.$pristine\" href=\"\" ng-click=\"clearEnvVarUpdates()\" class=\"mar-left-sm\" style=\"vertical-align: -2px\">Clear Changes</a>\n" +
     "</div>\n" +
-    "<key-value-editor ng-if=\"!('buildconfigs' | canI : 'update')\" entries=\"envVars\" key-placeholder=\"Name\" value-placeholder=\"Value\" is-readonly cannot-add cannot-sort cannot-delete show-header></key-value-editor>\n" +
+    "<key-value-editor ng-if=\"!(buildConfigsVersion | canI : 'update')\" entries=\"envVars\" key-placeholder=\"Name\" value-placeholder=\"Value\" is-readonly cannot-add cannot-sort cannot-delete show-header></key-value-editor>\n" +
     "</ng-form>\n" +
     "</uib-tab>\n" +
     "</uib-tabset>\n" +


### PR DESCRIPTION
After doing a few of these, trying to decide if I really like the pattern:

```JavaScript 
    $scope.buildConfigsVersion = APIService.getPreferredVersion('buildconfigs');
    $scope.buildsVersion = APIService.getPreferredVersion('builds');
```
or if it would be better to do something like:

```JavaScript 
$scope.versions = {
  buildConfig: APIService.getPreferredVersion('buildconfigs'),
  builds: APIService.getPreferredVersion('builds')
}
```
Not a huge difference, but 

```html 
<li ng-if="buildConfigsVersion | canI : 'update'">
<li ng-if="versions.buildConfig | canI : 'update'">
```
might be more readable?  

@spadgett 
