### PR TITLE
Copy login command shouldn't be wrapped in quotes

### DIFF
--- a/app/scripts/directives/util.js
+++ b/app/scripts/directives/util.js
@@ -103,12 +103,12 @@ angular.module('openshiftConsole')
       }
     };
   })
-  .directive('copyLoginToClipboard', function(AlertMessageService, NotificationsService) {
+  .directive('copyLoginToClipboard', function(NotificationsService) {
     return {
       restrict: 'E',
       replace: true,
       scope: {
-        clipboardText: "="
+        clipboardText: "@"
       },
       template: '<a href="" data-clipboard-text="">Copy Login Command</a>',
       link: function($scope, element) {
@@ -121,22 +121,20 @@ angular.module('openshiftConsole')
           });
 
           var tokenWarningAlertID = 'openshift/token-warning';
-          if (!AlertMessageService.isAlertPermanentlyHidden(tokenWarningAlertID)) {
-            NotificationsService.addNotification({
-              id: tokenWarningAlertID,
-              type: 'warning',
-              message: 'A token is a form of a password. Do not share your API token.',
-              links: [{
-                href: "",
-                label: "Don't Show Me Again",
-                onClick: function() {
-                  AlertMessageService.permanentlyHideAlert(tokenWarningAlertID);
-                  // Return true close the existing alert.
-                  return true;
-                }
-              }]
-            });
-          }
+          NotificationsService.addNotification({
+            id: tokenWarningAlertID,
+            type: 'warning',
+            message: 'A token is a form of a password. Do not share your API token.',
+            links: [{
+              href: "",
+              label: "Don't Show Me Again",
+              onClick: function() {
+                NotificationsService.permanentlyHideNotification(tokenWarningAlertID);
+                // Return true close the existing notification.
+                return true;
+              }
+            }]
+          });
         });
         clipboard.on('error', function () {
           NotificationsService.addNotification({

--- a/app/scripts/extensions/nav/userDropdown.js
+++ b/app/scripts/extensions/nav/userDropdown.js
@@ -8,7 +8,10 @@ angular.module('openshiftConsole')
         if (!_.get(window, 'OPENSHIFT_CONSTANTS.DISABLE_COPY_LOGIN_COMMAND')) {
           items.push({
             type: 'dom',
-            node: '<li><copy-login-to-clipboard clipboard-text="\'oc login ' + DataService.openshiftAPIBaseUrl() + ' --token=' + AuthService.UserStore().getToken() + '\'"></copy-login-to-clipboard></li>'
+            node: '<li><copy-login-to-clipboard clipboard-text="oc login ' +
+                  _.escape(DataService.openshiftAPIBaseUrl()) +
+                  ' --token=' +
+                  _.escape(AuthService.UserStore().getToken()) + '"></copy-login-to-clipboard></li>'
           });
         }
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10566,23 +10566,23 @@ r.destroy();
 });
 }
 };
-}).directive("copyLoginToClipboard", [ "AlertMessageService", "NotificationsService", function(e, t) {
+}).directive("copyLoginToClipboard", [ "NotificationsService", function(e) {
 return {
 restrict: "E",
 replace: !0,
 scope: {
-clipboardText: "="
+clipboardText: "@"
 },
 template: '<a href="" data-clipboard-text="">Copy Login Command</a>',
-link: function(n, a) {
-var r = new Clipboard(a.get(0));
-r.on("success", function() {
-t.addNotification({
+link: function(t, n) {
+var a = new Clipboard(n.get(0));
+a.on("success", function() {
+e.addNotification({
 id: "copy-login-command-success",
 type: "success",
 message: "Login command copied."
 });
-e.isAlertPermanentlyHidden("openshift/token-warning") || t.addNotification({
+e.addNotification({
 id: "openshift/token-warning",
 type: "warning",
 message: "A token is a form of a password. Do not share your API token.",
@@ -10590,18 +10590,18 @@ links: [ {
 href: "",
 label: "Don't Show Me Again",
 onClick: function() {
-return e.permanentlyHideAlert("openshift/token-warning"), !0;
+return e.permanentlyHideNotification("openshift/token-warning"), !0;
 }
 } ]
 });
-}), r.on("error", function() {
-t.addNotification({
+}), a.on("error", function() {
+e.addNotification({
 id: "copy-login-command-error",
 type: "error",
 message: "Unable to copy the login command."
 });
-}), a.on("$destroy", function() {
-r.destroy();
+}), n.on("$destroy", function() {
+a.destroy();
 });
 }
 };
@@ -15693,7 +15693,7 @@ e.add("nav-user-dropdown", function() {
 var e = [];
 _.get(window, "OPENSHIFT_CONSTANTS.DISABLE_COPY_LOGIN_COMMAND") || e.push({
 type: "dom",
-node: "<li><copy-login-to-clipboard clipboard-text=\"'oc login " + n.openshiftAPIBaseUrl() + " --token=" + a.UserStore().getToken() + "'\"></copy-login-to-clipboard></li>"
+node: '<li><copy-login-to-clipboard clipboard-text="oc login ' + _.escape(n.openshiftAPIBaseUrl()) + " --token=" + _.escape(a.UserStore().getToken()) + '"></copy-login-to-clipboard></li>'
 });
 var r = "Log Out";
 return t.user.fullName && t.user.fullName !== t.user.metadata.name && (r += " (" + t.user.metadata.name + ")"), e.push({


### PR DESCRIPTION
* Fix the copy login command menu item so that it doesn't include single quotes around the copied command
* HTML-escape special characters in login command
* Use NotificationsService.permanentlyHideNotification to simply copyLoginToClipboard directive

Fixes #2131