### PR TITLE
List serviceclasses as a cluster-scoped resource

### DIFF
--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -1354,7 +1354,7 @@ function OverviewController($scope,
       DataService.list({
         group: 'servicecatalog.k8s.io',
         resource: 'serviceclasses'
-      }, context, function(serviceClasses) {
+      }, {}, function(serviceClasses) {
         state.serviceClasses = serviceClasses.by('metadata.name');
         sortServiceInstances();
         updateFilter();

--- a/app/scripts/controllers/serviceInstance.js
+++ b/app/scripts/controllers/serviceInstance.js
@@ -93,7 +93,7 @@ angular.module('openshiftConsole')
         DataService.list({
           group: 'servicecatalog.k8s.io',
           resource: 'serviceclasses'
-        }, context, function(serviceClasses) {
+        }, {}, function(serviceClasses) {
           $scope.serviceClasses = serviceClasses.by('metadata.name');
           updateServiceClassMetadata();
           updateBreadcrumbs();

--- a/app/scripts/controllers/serviceInstances.js
+++ b/app/scripts/controllers/serviceInstances.js
@@ -64,7 +64,7 @@ angular.module('openshiftConsole')
         DataService.list({
           group: 'servicecatalog.k8s.io',
           resource: 'serviceclasses'
-        }, context, function(serviceClasses) {
+        }, {}, function(serviceClasses) {
           $scope.serviceClasses = serviceClasses.by('metadata.name');
           sortServiceInstances();
           updateFilter();

--- a/app/scripts/directives/resourceServiceBindings.js
+++ b/app/scripts/directives/resourceServiceBindings.js
@@ -85,7 +85,7 @@ function ResourceServiceBindings($filter, DataService, BindingService, CatalogSe
       DataService.list({
         group: 'servicecatalog.k8s.io',
         resource: 'serviceclasses'
-      }, ctrl.projectContext, function(serviceClasses) {
+      }, {}, function(serviceClasses) {
         ctrl.serviceClasses = serviceClasses.by('metadata.name');
         sortServiceInstances();
       });

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -478,7 +478,7 @@ group: "servicecatalog.k8s.io"
 }, "watch") && l.list({
 group: "servicecatalog.k8s.io",
 resource: "serviceclasses"
-}, a, function(e) {
+}, {}, function(e) {
 V.serviceClasses = e.by("metadata.name"), Je(), ie();
 });
 var i = c.SAMPLE_PIPELINE_TEMPLATE;
@@ -533,7 +533,7 @@ pollInterval: 6e4
 })), t.list({
 group: "servicecatalog.k8s.io",
 resource: "serviceclasses"
-}, r.projectContext, function(e) {
+}, {}, function(e) {
 r.serviceClasses = e.by("metadata.name"), u();
 }));
 };
@@ -6230,7 +6230,7 @@ e.emptyMessage = "No provisioned services to show", e.unfilteredServiceInstances
 })), i.list({
 group: "servicecatalog.k8s.io",
 resource: "serviceclasses"
-}, n, function(t) {
+}, {}, function(t) {
 e.serviceClasses = t.by("metadata.name"), p(), d();
 }), s.onActiveFiltersChanged(function(t) {
 e.$evalAsync(function() {
@@ -6284,7 +6284,7 @@ details: t("getErrorDetails")(n)
 }), a.list({
 group: "servicecatalog.k8s.io",
 resource: "serviceclasses"
-}, o, function(t) {
+}, {}, function(t) {
 e.serviceClasses = t.by("metadata.name"), c(), s();
 }), e.$on("$destroy", function() {
 a.unwatchAll(i);


### PR DESCRIPTION
Do not pass a project context when listing serviceclasses since they are not scoped to a namespace.