### PR TITLE
Show "binding" as type in delete dialog

### DIFF
--- a/app/views/directives/_service-binding.html
+++ b/app/views/directives/_service-binding.html
@@ -44,8 +44,9 @@
   <div class="service-binding-actions" ng-if="!ctrl.binding.metadata.deletionTimestamp">
     <delete-link
       ng-if="({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'delete')"
-      kind="serviceinstancecredential"
+      kind="ServiceInstanceCredential"
       group="servicecatalog.k8s.io"
+      type-display-name="binding"
       resource-name="{{$ctrl.binding.metadata.name}}"
       project-name="{{$ctrl.binding.metadata.namespace}}"
       stay-on-current-page="true">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5639,7 +5639,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "<div class=\"service-binding-actions\" ng-if=\"!ctrl.binding.metadata.deletionTimestamp\">\n" +
-    "<delete-link ng-if=\"({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'delete')\" kind=\"serviceinstancecredential\" group=\"servicecatalog.k8s.io\" resource-name=\"{{$ctrl.binding.metadata.name}}\" project-name=\"{{$ctrl.binding.metadata.namespace}}\" stay-on-current-page=\"true\">\n" +
+    "<delete-link ng-if=\"({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'delete')\" kind=\"ServiceInstanceCredential\" group=\"servicecatalog.k8s.io\" type-display-name=\"binding\" resource-name=\"{{$ctrl.binding.metadata.name}}\" project-name=\"{{$ctrl.binding.metadata.namespace}}\" stay-on-current-page=\"true\">\n" +
     "</delete-link>\n" +
     "<a ng-if=\"('secrets' | canI : 'get') && !($ctrl.binding | isBindingFailed) && !(binding | isBindingReady)\" ng-href=\"{{$ctrl.binding.spec.secretName | navigateResourceURL : 'Secret' : $ctrl.namespace}}\">\n" +
     "View Secret\n" +


### PR DESCRIPTION
`serviceinstancecredentials` was previously displayed as the type. Also the kind passed to `delete-link` should be `ServiceInstanceCredential`.

Fixes #2142