### PR TITLE
Fix deployment empty state message when multiple ICT

### DIFF
--- a/app/views/overview/_list-row-empty-state.html
+++ b/app/views/overview/_list-row-empty-state.html
@@ -6,7 +6,7 @@
     <a ng-href="{{row.urlForImageChangeTrigger(row.imageChangeTriggers[0])}}">
       {{row.imageChangeTriggers[0].imageChangeParams.from | imageObjectRef : row.apiObject.metadata.namespace}}</a>.
   </span>
-  <span ng-if="row.imageChangeParams.length > 1">
+  <span ng-if="row.imageChangeTriggers.length > 1">
     one of the images referenced by this deployment config changes.
   </span>
 </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -11915,7 +11915,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a ng-href=\"{{row.urlForImageChangeTrigger(row.imageChangeTriggers[0])}}\">\n" +
     "{{row.imageChangeTriggers[0].imageChangeParams.from | imageObjectRef : row.apiObject.metadata.namespace}}</a>.\n" +
     "</span>\n" +
-    "<span ng-if=\"row.imageChangeParams.length > 1\">\n" +
+    "<span ng-if=\"row.imageChangeTriggers.length > 1\">\n" +
     "one of the images referenced by this deployment config changes.\n" +
     "</span>\n" +
     "</div>\n" +


### PR DESCRIPTION
Show the correct empty state message on the overview when a deployment config has multiple image change triggers.

![openshift web console 2017-09-22 15-04-36](https://user-images.githubusercontent.com/1167259/30760250-6832e0ae-9fa7-11e7-8255-cb972b358d57.png)
