### PR TITLE
Don't show parameters step when bind has no parameters

### DIFF
--- a/app/scripts/directives/bindService.js
+++ b/app/scripts/directives/bindService.js
@@ -161,6 +161,7 @@
       ctrl.parameterSchema = _.get(ctrl.plan, 'serviceInstanceCredentialCreateParameterSchema');
       bindParametersStep.hidden = !_.has(ctrl.parameterSchema, 'properties');
       ctrl.nextTitle = bindParametersStep.hidden ? 'Bind' : 'Next >';
+      ctrl.hideBack = bindParametersStep.hidden;
     };
 
     $scope.$watch("ctrl.serviceToBind", updateInstance);
@@ -172,6 +173,7 @@
       ctrl.parameterData = {};
 
       ctrl.steps = [ bindFormStep, bindParametersStep, resultsStep ];
+      ctrl.hideBack = bindParametersStep.hidden;
 
       // We will want ServiceClasses either way for display purposes
       DataService.list({

--- a/app/styles/_wizard.less
+++ b/app/styles/_wizard.less
@@ -1,7 +1,3 @@
-.pf-wizard-no-back .wizard-pf-footer .btn-cancel {
-  margin-right: 0;
-}
-
 .wizard-pf-steps-indicator .wizard-pf-step-number {
   // The numbers do not center inside the step indicator bubble otherwise since
   // the console changes the base font size.

--- a/app/views/directives/bind-service.html
+++ b/app/views/directives/bind-service.html
@@ -5,19 +5,21 @@
        step-class="bind-service-wizard-step"
        wizard-ready="ctrl.wizardReady"
        next-title="ctrl.nextTitle"
+       hide-back-button="{{ctrl.hideBack}}"
        on-finish="ctrl.closeWizard()"
        on-cancel="ctrl.closeWizard()"
        wizard-done="ctrl.wizardComplete">
     <pf-wizard-step ng-repeat="step in ctrl.steps track by step.id"
        step-title="{{step.label}}"
        next-enabled="step.valid"
+       wz-disabled="{{step.hidden}}"
        on-show="step.onShow"
        step-id="{{step.id}}"
        step-priority="{{$index}}"
        allow-click-nav="step.allowClickNav">
       <div class="wizard-pf-main-inner-shadow-covers">
         <div class="bind-service-config">
-          <div ng-include="step.view" class="wizard-pf-main-form-contents"></div>
+          <div ng-if="!step.hidden" ng-include="step.view" class="wizard-pf-main-form-contents"></div>
         </div>
       </div>
     </pf-wizard-step>

--- a/app/views/directives/deploy-image-dialog.html
+++ b/app/views/directives/deploy-image-dialog.html
@@ -9,8 +9,7 @@
      current-step="$ctrl.currentStep"
      on-step-changed="$ctrl.stepChanged(step)"
      step-class="order-service-wizard-step"
-     wizard-done="$ctrl.wizardDone"
-     class="pf-wizard-no-back">
+     wizard-done="$ctrl.wizardDone">
   <pf-wizard-step
        step-title="Image"
        step-id="image"

--- a/app/views/directives/process-template-dialog.html
+++ b/app/views/directives/process-template-dialog.html
@@ -2,7 +2,6 @@
   <pf-wizard
        title="{{!$ctrl.useProjectTemplate && ($ctrl.template | displayName) || 'Select from Project'}}"
        hide-sidebar="true"
-       hide-back-button="!$ctrl.useProjectTemplate"
        step-class="order-service-wizard-step"
        wizard-ready="$ctrl.wizardReady"
        next-title="$ctrl.nextTitle"
@@ -10,8 +9,7 @@
        on-finish="$ctrl.close()"
        on-cancel="$ctrl.close()"
        wizard-done="$ctrl.wizardDone"
-       current-step="$ctrl.currentStep"
-       ng-class="{'pf-wizard-no-back': !$ctrl.useProjectTemplate}">
+       current-step="$ctrl.currentStep">
     <pf-wizard-step ng-repeat="step in $ctrl.steps track by step.id"
          step-title="{{step.label}}"
          wz-disabled="{{step.hidden}}"

--- a/app/views/directives/unbind-service.html
+++ b/app/views/directives/unbind-service.html
@@ -8,8 +8,7 @@
     next-title="ctrl.nextTitle"
     on-finish="ctrl.closeWizard()"
     on-cancel="ctrl.closeWizard()"
-    wizard-done="ctrl.wizardComplete"
-    class="pf-wizard-no-back">
+    wizard-done="ctrl.wizardComplete">
     <pf-wizard-step
       ng-repeat="step in ctrl.steps track by step.id"
       step-title="{{step.label}}"

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12660,11 +12660,11 @@ c && (c(), c = void 0), l && (l(), l = void 0), d.nextTitle = "Close", d.wizardC
 var y = function() {
 if (d.serviceClasses) {
 var e = "ServiceInstance" === d.target.kind ? d.target : d.serviceToBind;
-e && (d.serviceClass = d.serviceClasses[e.spec.serviceClassName], d.serviceClassName = e.spec.serviceClassName, d.plan = r.getPlanForInstance(e, d.serviceClass), d.parameterSchema = _.get(d.plan, "serviceInstanceCredentialCreateParameterSchema"), i.hidden = !_.has(d.parameterSchema, "properties"), d.nextTitle = i.hidden ? "Bind" : "Next >");
+e && (d.serviceClass = d.serviceClasses[e.spec.serviceClassName], d.serviceClassName = e.spec.serviceClassName, d.plan = r.getPlanForInstance(e, d.serviceClass), d.parameterSchema = _.get(d.plan, "serviceInstanceCredentialCreateParameterSchema"), i.hidden = !_.has(d.parameterSchema, "properties"), d.nextTitle = i.hidden ? "Bind" : "Next >", d.hideBack = i.hidden);
 }
 };
 e.$watch("ctrl.serviceToBind", y), d.$onInit = function() {
-d.serviceSelection = {}, d.projectDisplayName = t("displayName")(d.project), d.podPresets = m("pod_presets"), d.parameterData = {}, d.steps = [ o, i, s ], a.list({
+d.serviceSelection = {}, d.projectDisplayName = t("displayName")(d.project), d.podPresets = m("pod_presets"), d.parameterData = {}, d.steps = [ o, i, s ], d.hideBack = i.hidden, a.list({
 group: "servicecatalog.k8s.io",
 resource: "serviceclasses"
 }, {}).then(function(e) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5836,11 +5836,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/directives/bind-service.html',
     "<div class=\"bind-service-wizard\">\n" +
-    "<pf-wizard title=\"Create Binding\" hide-sidebar=\"true\" step-class=\"bind-service-wizard-step\" wizard-ready=\"ctrl.wizardReady\" next-title=\"ctrl.nextTitle\" on-finish=\"ctrl.closeWizard()\" on-cancel=\"ctrl.closeWizard()\" wizard-done=\"ctrl.wizardComplete\">\n" +
-    "<pf-wizard-step ng-repeat=\"step in ctrl.steps track by step.id\" step-title=\"{{step.label}}\" next-enabled=\"step.valid\" on-show=\"step.onShow\" step-id=\"{{step.id}}\" step-priority=\"{{$index}}\" allow-click-nav=\"step.allowClickNav\">\n" +
+    "<pf-wizard title=\"Create Binding\" hide-sidebar=\"true\" step-class=\"bind-service-wizard-step\" wizard-ready=\"ctrl.wizardReady\" next-title=\"ctrl.nextTitle\" hide-back-button=\"{{ctrl.hideBack}}\" on-finish=\"ctrl.closeWizard()\" on-cancel=\"ctrl.closeWizard()\" wizard-done=\"ctrl.wizardComplete\">\n" +
+    "<pf-wizard-step ng-repeat=\"step in ctrl.steps track by step.id\" step-title=\"{{step.label}}\" next-enabled=\"step.valid\" wz-disabled=\"{{step.hidden}}\" on-show=\"step.onShow\" step-id=\"{{step.id}}\" step-priority=\"{{$index}}\" allow-click-nav=\"step.allowClickNav\">\n" +
     "<div class=\"wizard-pf-main-inner-shadow-covers\">\n" +
     "<div class=\"bind-service-config\">\n" +
-    "<div ng-include=\"step.view\" class=\"wizard-pf-main-form-contents\"></div>\n" +
+    "<div ng-if=\"!step.hidden\" ng-include=\"step.view\" class=\"wizard-pf-main-form-contents\"></div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</pf-wizard-step>\n" +
@@ -6255,7 +6255,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/directives/deploy-image-dialog.html',
-    "<pf-wizard title=\"Deploy Image\" on-cancel=\"$ctrl.close()\" on-finish=\"$ctrl.close()\" hide-back-button=\"true\" hide-sidebar=\"true\" next-title=\"$ctrl.nextButtonTitle\" next-callback=\"$ctrl.nextCallback\" current-step=\"$ctrl.currentStep\" on-step-changed=\"$ctrl.stepChanged(step)\" step-class=\"order-service-wizard-step\" wizard-done=\"$ctrl.wizardDone\" class=\"pf-wizard-no-back\">\n" +
+    "<pf-wizard title=\"Deploy Image\" on-cancel=\"$ctrl.close()\" on-finish=\"$ctrl.close()\" hide-back-button=\"true\" hide-sidebar=\"true\" next-title=\"$ctrl.nextButtonTitle\" next-callback=\"$ctrl.nextCallback\" current-step=\"$ctrl.currentStep\" on-step-changed=\"$ctrl.stepChanged(step)\" step-class=\"order-service-wizard-step\" wizard-done=\"$ctrl.wizardDone\">\n" +
     "<pf-wizard-step step-title=\"Image\" step-id=\"image\" step-priority=\"1\" substeps=\"false\" ok-to-nav-away=\"true\" allow-click-nav=\"false\" next-enabled=\"$ctrl.deployForm.$valid || $ctrl.deployImageNewAppCreated\">\n" +
     "<div class=\"wizard-pf-main-inner-shadow-covers\">\n" +
     "<div class=\"order-service-config\">\n" +
@@ -8812,7 +8812,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/directives/process-template-dialog.html',
     "<div class=\"order-service\">\n" +
-    "<pf-wizard title=\"{{!$ctrl.useProjectTemplate && ($ctrl.template | displayName) || 'Select from Project'}}\" hide-sidebar=\"true\" hide-back-button=\"!$ctrl.useProjectTemplate\" step-class=\"order-service-wizard-step\" wizard-ready=\"$ctrl.wizardReady\" next-title=\"$ctrl.nextTitle\" next-callback=\"$ctrl.next\" on-finish=\"$ctrl.close()\" on-cancel=\"$ctrl.close()\" wizard-done=\"$ctrl.wizardDone\" current-step=\"$ctrl.currentStep\" ng-class=\"{'pf-wizard-no-back': !$ctrl.useProjectTemplate}\">\n" +
+    "<pf-wizard title=\"{{!$ctrl.useProjectTemplate && ($ctrl.template | displayName) || 'Select from Project'}}\" hide-sidebar=\"true\" step-class=\"order-service-wizard-step\" wizard-ready=\"$ctrl.wizardReady\" next-title=\"$ctrl.nextTitle\" next-callback=\"$ctrl.next\" on-finish=\"$ctrl.close()\" on-cancel=\"$ctrl.close()\" wizard-done=\"$ctrl.wizardDone\" current-step=\"$ctrl.currentStep\">\n" +
     "<pf-wizard-step ng-repeat=\"step in $ctrl.steps track by step.id\" step-title=\"{{step.label}}\" wz-disabled=\"{{step.hidden}}\" allow-click-nav=\"step.allowClickNav\" next-enabled=\"step.valid\" prev-enabled=\"step.prevEnabled\" on-show=\"step.onShow\" step-id=\"{{step.id}}\" step-priority=\"{{$index}}\">\n" +
     "<div class=\"wizard-pf-main-inner-shadow-covers\">\n" +
     "<div ng-if=\"step.selected\" ng-include=\"step.view\" class=\"wizard-pf-main-form-contents\"></div>\n" +
@@ -9173,7 +9173,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/directives/unbind-service.html',
     "<div class=\"bind-service-wizard unbind-service\">\n" +
-    "<pf-wizard title=\"Delete Binding\" hide-sidebar=\"true\" hide-back-button=\"true\" step-class=\"bind-service-wizard-step\" wizard-ready=\"ctrl.wizardReady\" next-title=\"ctrl.nextTitle\" on-finish=\"ctrl.closeWizard()\" on-cancel=\"ctrl.closeWizard()\" wizard-done=\"ctrl.wizardComplete\" class=\"pf-wizard-no-back\">\n" +
+    "<pf-wizard title=\"Delete Binding\" hide-sidebar=\"true\" hide-back-button=\"true\" step-class=\"bind-service-wizard-step\" wizard-ready=\"ctrl.wizardReady\" next-title=\"ctrl.nextTitle\" on-finish=\"ctrl.closeWizard()\" on-cancel=\"ctrl.closeWizard()\" wizard-done=\"ctrl.wizardComplete\">\n" +
     "<pf-wizard-step ng-repeat=\"step in ctrl.steps track by step.id\" step-title=\"{{step.label}}\" next-enabled=\"step.valid\" allow-click-nav=\"false\" on-show=\"step.onShow\" step-id=\"{{step.id}}\" step-priority=\"{{$index}}\">\n" +
     "<div class=\"wizard-pf-main-inner-shadow-covers\">\n" +
     "<div class=\"bind-service-config\">\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5946,7 +5946,6 @@ notification-drawer-wrapper .expanded-notification.unread .drawer-pf-notificatio
 .applauncher-pf.open>a,.applauncher-pf.open>a:focus,.applauncher-pf.open>a:hover{background:0 0}
 .applauncher-pf .dropdown-toggle{color:#d1d1d1;display:block;font-size:16px;padding:17px 15px 15px 12px!important}
 .applauncher-pf .dropdown-toggle:focus,.applauncher-pf .dropdown-toggle:hover{color:#fff}
-.pf-wizard-no-back .wizard-pf-footer .btn-cancel{margin-right:0}
 .wizard-pf-steps-indicator .wizard-pf-step-number{font-size:12px}
 .build-triggers .copy-to-clipboard{margin-bottom:10px}
 .ace-bordered{border:1px solid #8b8d8f}


### PR DESCRIPTION
* Remove unnecessary `pf-wizard-no-back` class since it's handled by the wizard component itself now
* Don't hide button in `process-template-dialog` since there's now an extra info step

Fixes #2151