### PR TITLE
Fix binding ready logic

### DIFF
--- a/app/views/directives/_service-binding.html
+++ b/app/views/directives/_service-binding.html
@@ -46,7 +46,7 @@
       project-name="{{$ctrl.binding.metadata.namespace}}"
       stay-on-current-page="true">
     </delete-link>
-    <a ng-if="('secrets' | canI : 'get') && !($ctrl.binding | isBindingFailed) && !(binding | isBindingReady)"
+    <a ng-if="('secrets' | canI : 'get') && ($ctrl.binding | isBindingReady)"
        ng-href="{{$ctrl.binding.spec.secretName | navigateResourceURL : 'Secret' : $ctrl.namespace}}">
       View Secret
     </a>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5636,7 +5636,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"service-binding-actions\" ng-if=\"!ctrl.binding.metadata.deletionTimestamp\">\n" +
     "<delete-link ng-if=\"({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'delete')\" kind=\"ServiceInstanceCredential\" group=\"servicecatalog.k8s.io\" type-display-name=\"binding\" resource-name=\"{{$ctrl.binding.metadata.name}}\" project-name=\"{{$ctrl.binding.metadata.namespace}}\" stay-on-current-page=\"true\">\n" +
     "</delete-link>\n" +
-    "<a ng-if=\"('secrets' | canI : 'get') && !($ctrl.binding | isBindingFailed) && !(binding | isBindingReady)\" ng-href=\"{{$ctrl.binding.spec.secretName | navigateResourceURL : 'Secret' : $ctrl.namespace}}\">\n" +
+    "<a ng-if=\"('secrets' | canI : 'get') && ($ctrl.binding | isBindingReady)\" ng-href=\"{{$ctrl.binding.spec.secretName | navigateResourceURL : 'Secret' : $ctrl.namespace}}\">\n" +
     "View Secret\n" +
     "</a>\n" +
     "</div>\n" +


### PR DESCRIPTION
The binding ready logic was flipped in the service-binding component, so the View Secret link was showing up at the wrong time.

![openshift web console 2017-09-25 07-51-38](https://user-images.githubusercontent.com/1167259/30807244-04ece3ec-a1c7-11e7-8914-fa7b272a56b7.png)
