### PR TITLE
Bug 1495460 - Fix build config source namespace

### DIFF
--- a/app/scripts/services/applicationGenerator.js
+++ b/app/scripts/services/applicationGenerator.js
@@ -351,7 +351,8 @@ angular.module("openshiftConsole")
             sourceStrategy: {
               from: {
                 kind: "ImageStreamTag",
-                name: input.imageName + ":" + input.imageTag
+                name: input.imageName + ":" + input.imageTag,
+                namespace: input.namespace
               },
               env: env
             }
@@ -359,9 +360,7 @@ angular.module("openshiftConsole")
           triggers: triggers
         }
       };
-      if(input.namespace) {
-        bc.spec.strategy.namespace = input.namespace;
-      }
+
       if (_.get(input, 'buildConfig.secrets.gitSecret[0].name')) {
         bc.spec.source.sourceSecret = _.head(input.buildConfig.secrets.gitSecret);
       }

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1496,7 +1496,8 @@ type: "Source",
 sourceStrategy: {
 from: {
 kind: "ImageStreamTag",
-name: e.imageName + ":" + e.imageTag
+name: e.imageName + ":" + e.imageTag,
+namespace: e.namespace
 },
 env: n
 }
@@ -1504,7 +1505,7 @@ env: n
 triggers: a
 }
 };
-return e.namespace && (l.spec.strategy.namespace = e.namespace), _.get(e, "buildConfig.secrets.gitSecret[0].name") && (l.spec.source.sourceSecret = _.head(e.buildConfig.secrets.gitSecret)), e.buildConfig.contextDir && (l.spec.source.contextDir = e.buildConfig.contextDir), l;
+return _.get(e, "buildConfig.secrets.gitSecret[0].name") && (l.spec.source.sourceSecret = _.head(e.buildConfig.secrets.gitSecret)), e.buildConfig.contextDir && (l.spec.source.contextDir = e.buildConfig.contextDir), l;
 }, o._generateImageStream = function(e) {
 return {
 apiVersion: "v1",

--- a/test/spec/services/applicationGeneratorSpec.js
+++ b/test/spec/services/applicationGeneratorSpec.js
@@ -15,6 +15,7 @@ describe("ApplicationGenerator", function(){
 
     inputTemplate = {
       name: "ruby-hello-world",
+      namespace: "openshift",
       routing: {
         include: true,
         targetPort: {
@@ -288,7 +289,8 @@ describe("ApplicationGenerator", function(){
             "sourceStrategy" : {
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "origin-ruby-sample:latest"
+                "name": "origin-ruby-sample:latest",
+                "namespace": "openshift"
               },
               "env": [{
                 "name": "BUILD_ENV_1",


### PR DESCRIPTION
Correctly set the build config source image namespace when adding a builder using advanced options.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1495460