### PR TITLE
Bug 1496396 - Don't warn on navigate when YAML isn't changed

### DIFF
--- a/app/scripts/controllers/edit/yaml.js
+++ b/app/scripts/controllers/edit/yaml.js
@@ -48,12 +48,6 @@ angular.module('openshiftConsole')
       $window.history.back();
     };
 
-    $scope.$watch('updated.resource', function(current, previous) {
-      if (current !== previous) {
-        $scope.modified = true;
-      }
-    });
-
     var watches = [];
     ProjectsService
       .get($routeParams.project)
@@ -75,6 +69,14 @@ angular.module('openshiftConsole')
 
             // Modify a copy of the resource.
             _.set($scope, 'updated.resource', angular.copy(result));
+            $scope.$watch('updated.resource', function(updated, previous) {
+              // Skip the initial $watch callback when we first add the listener.
+              if (updated === previous) {
+                return;
+              }
+
+              $scope.modified = true;
+            });
 
             // TODO: Update the BreadcrumbsService to handle types without browse pages.
             // $scope.breadcrumbs = BreadcrumbsService.getBreadcrumbs({

--- a/app/scripts/directives/uiAceYaml.js
+++ b/app/scripts/directives/uiAceYaml.js
@@ -70,11 +70,18 @@
       });
     };
 
-    var updated = function() {
+    var updated = function(current, previous) {
+      var resource;
       // Check for errors, then check for warnings.
       try {
-        ctrl.resource = parseYAML(false);
+        resource = parseYAML(false);
         setValid(true);
+
+        // Only update `ctrl.resource` if the value has changed.
+        if (current !== previous) {
+          ctrl.resource = resource;
+        }
+
         // Check for warnings.
         try {
           parseYAML(true);
@@ -86,6 +93,7 @@
         setAnnotation(e, 'error');
         setValid(false);
       }
+
     };
 
     $scope.$watch(function() {
@@ -106,7 +114,6 @@
       }
     };
 
-    ctrl.aceChanged = updated;
     ctrl.aceLoaded = function(editor) {
       // Keep a reference to use later in event callbacks.
       aceEditor = editor;
@@ -116,6 +123,10 @@
       session.setOption('useSoftTabs', true);
       editor.setDragDelay = 0;
     };
+
+    $scope.$watch(function() {
+      return ctrl.model;
+    }, updated);
 
     ctrl.gotoLine = function(line) {
       aceEditor.gotoLine(line);

--- a/app/views/directives/ui-ace-yaml.html
+++ b/app/views/directives/ui-ace-yaml.html
@@ -31,7 +31,6 @@
       mode: 'yaml',
       theme: 'eclipse',
       onLoad: $ctrl.aceLoaded,
-      onChange: $ctrl.aceChanged,
       rendererOptions: {
         showPrintMargin: false
       }

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7650,11 +7650,7 @@ title: "Edit YAML"
 } ];
 var m = function() {
 e.modified = !1, a.returnURL ? n.url(a.returnURL) : r.history.back();
-};
-e.$watch("updated.resource", function(t, n) {
-t !== n && (e.modified = !0);
-});
-var f = [];
+}, f = [];
 d.get(a.project).then(_.spread(function(n, r) {
 var s = {
 resource: o.kindToResource(a.kind),
@@ -7664,7 +7660,9 @@ i.canI(s, "update", a.project) ? (c.get(s, e.name, r, {
 errorNotification: !1
 }).then(function(n) {
 var i = n;
-_.set(e, "updated.resource", angular.copy(n));
+_.set(e, "updated.resource", angular.copy(n)), e.$watch("updated.resource", function(t, n) {
+t !== n && (e.modified = !0);
+});
 var l = function(e) {
 return _.get(e, "metadata.resourceVersion");
 };
@@ -14140,9 +14138,16 @@ e !== t && (n.model = e);
 n.resource && (n.model = jsyaml.safeDump(n.resource, {
 sortKeys: !0
 }));
-}, n.aceChanged = function() {
+}, n.aceLoaded = function(e) {
+t = e;
+var n = e.getSession();
+n.setOption("tabSize", 2), n.setOption("useSoftTabs", !0), e.setDragDelay = 0;
+}, e.$watch(function() {
+return n.model;
+}, function(e, t) {
+var s;
 try {
-n.resource = a(!1), i(!0);
+s = a(!1), i(!0), e !== t && (n.resource = s);
 try {
 a(!0), r();
 } catch (e) {
@@ -14151,11 +14156,7 @@ o(e, "warning");
 } catch (e) {
 o(e, "error"), i(!1);
 }
-}, n.aceLoaded = function(e) {
-t = e;
-var n = e.getSession();
-n.setOption("tabSize", 2), n.setOption("useSoftTabs", !0), e.setDragDelay = 0;
-}, n.gotoLine = function(e) {
+}), n.gotoLine = function(e) {
 t.gotoLine(e);
 };
 } ],

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -9167,7 +9167,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "      mode: 'yaml',\n" +
     "      theme: 'eclipse',\n" +
     "      onLoad: $ctrl.aceLoaded,\n" +
-    "      onChange: $ctrl.aceChanged,\n" +
     "      rendererOptions: {\n" +
     "        showPrintMargin: false\n" +
     "      }\n" +


### PR DESCRIPTION
Don't prompt the user about unsaved changes on the edit YAML page if the user hasn't made any edits.

Fixes #2144
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1496396