### PR TITLE
Bug 1496687 - Consistent binding names

### DIFF
--- a/app/views/directives/_service-binding.html
+++ b/app/views/directives/_service-binding.html
@@ -3,9 +3,6 @@
     <div ng-class="{'col-sm-5 col-md-6': $ctrl.isOverview,
                     'col-sm-8 col-md-6 col-lg-8': !$ctrl.isOverview}">
       <h3>
-        <div class="component-label">
-          Secret
-        </div>
         {{$ctrl.binding.metadata.name}}
         <span ng-if="$ctrl.refApiObject.kind !== 'ServiceInstance'">
           <small ng-if="$ctrl.serviceClass">

--- a/app/views/overview/_service-instance-row.html
+++ b/app/views/overview/_service-instance-row.html
@@ -48,7 +48,7 @@
               {{application.metadata.name}}
             </span>
             <span ng-if="!application">
-              {{firstBinding.spec.secretName}}
+              {{firstBinding.metadata.name}}
             </span>
             <span ng-if="row.bindings.length > 1">
               and

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5607,9 +5607,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-class=\"{'col-sm-5 col-md-6': $ctrl.isOverview,\n" +
     "                    'col-sm-8 col-md-6 col-lg-8': !$ctrl.isOverview}\">\n" +
     "<h3>\n" +
-    "<div class=\"component-label\">\n" +
-    "Secret\n" +
-    "</div>\n" +
     "{{$ctrl.binding.metadata.name}}\n" +
     "<span ng-if=\"$ctrl.refApiObject.kind !== 'ServiceInstance'\">\n" +
     "<small ng-if=\"$ctrl.serviceClass\">\n" +
@@ -12408,7 +12405,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "{{application.metadata.name}}\n" +
     "</span>\n" +
     "<span ng-if=\"!application\">\n" +
-    "{{firstBinding.spec.secretName}}\n" +
+    "{{firstBinding.metadata.name}}\n" +
     "</span>\n" +
     "<span ng-if=\"row.bindings.length > 1\">\n" +
     "and\n" +


### PR DESCRIPTION
* Show binding name rather than secret name in collapsed overview row to be consistent with what we show when expanded.
* Remove "Secret" heading above binding name to avoid confusion. We shouldn't label a ServiceBinding as a Secret since they're different resources.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1496687

![openshift web console 2017-09-29 07-54-40](https://user-images.githubusercontent.com/1167259/31014945-7d42f7a6-a4eb-11e7-8a01-134bf9040557.png)

![openshift web console 2017-09-29 07-55-31](https://user-images.githubusercontent.com/1167259/31014964-94b4ed22-a4eb-11e7-9283-ef1f71d586e3.png)

cc @ncameronbritt 