### PR TITLE
Add vertical-scrollbar width spacingfor when log-view-output has vertical scroll. This…

### DIFF
--- a/app/styles/_log.less
+++ b/app/styles/_log.less
@@ -143,6 +143,7 @@
       font-size: 12px;
     }
     padding: 40px 0;
+    padding-right: @scrollbar-width; // allot space for vertical scrollbar to prevent horizontal scrollbar
     @media only screen and (max-device-width: 736px) and (-webkit-min-device-pixel-ratio: 0) {
       // On an iPhone, add additional margin so that following logs is never obscured
       // by the bottom buttons that are displayed and hidden.

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5671,7 +5671,7 @@ alerts+.chromeless .log-loading-msg{margin-top:130px}
 @media (min-width:768px){.log-view .log-scroll-top.affix{top:111px}
 }
 .chromeless .log-view .log-scroll-top.affix{right:25px;top:51px}
-.log-view .log-view-output{font-size:11px;padding:40px 0}
+.log-view .log-view-output{font-size:11px;padding:40px 15px 40px 0}
 @media (min-width:768px){.chromeless .log-view .log-scroll-top.affix{top:71px}
 .log-view .log-view-output{font-size:12px}
 }


### PR DESCRIPTION
… prevents a horizontal scrollbar. This issue also effected the chromeless `log-view-output`

Fixes https://github.com/openshift/origin-web-console/issues/2189

<img width="353" alt="screen shot 2017-09-29 at 12 16 13 pm" src="https://user-images.githubusercontent.com/1874151/31025934-7eeb6f08-a512-11e7-9b5c-02fa0b6b1a48.png">

<img width="343" alt="screen shot 2017-09-29 at 12 18 36 pm" src="https://user-images.githubusercontent.com/1874151/31025941-83c94d1a-a512-11e7-868b-56144f2398ab.png">
