### PR TITLE
Don't let users accidentally and permanently dismiss router hostname message

### DIFF
--- a/app/scripts/controllers/route.js
+++ b/app/scripts/controllers/route.js
@@ -72,11 +72,6 @@ angular.module('openshiftConsole')
       return !AlertMessageService.isAlertPermanentlyHidden(alertKey, $scope.projectName);
     };
 
-    $scope.hideRouterHostnameAlert = function(ingress) {
-      var alertKey = routerHostnameAlertKey(ingress);
-      AlertMessageService.permanentlyHideAlert(alertKey, $scope.projectName);
-    };
-
     ProjectsService
       .get($routeParams.project)
       .then(_.spread(function(project, context) {

--- a/app/views/browse/route.html
+++ b/app/views/browse/route.html
@@ -82,11 +82,8 @@
               <div ng-if="showRouterHostnameAlert(ingress, admittedCondition)" class="mar-top-lg">
                 <div class="alert alert-info">
                   <span class="pficon pficon-info" aria-hidden="true"></span>
-                  <span class="mar-right-sm">
-                    The DNS admin should set up a CNAME from the route's hostname, {{ingress.host}},
-                    to the router's canonical hostname, {{ingress.routerCanonicalHostname}}.
-                  </span>
-                  <a href="" ng-click="hideRouterHostnameAlert(ingress)" role="button" class="nowrap">Don't Show Me Again</a>
+                  The DNS admin should set up a CNAME from the route's hostname, {{ingress.host}},
+                  to the router's canonical hostname, {{ingress.routerCanonicalHostname}}.
                 </div>
               </div>
             </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -6475,9 +6475,6 @@ if (!t || !t.host || !t.routerCanonicalHostname) return !1;
 if (!n || "True" !== n.status) return !1;
 var r = u(t);
 return !a.isAlertPermanentlyHidden(r, e.projectName);
-}, e.hideRouterHostnameAlert = function(t) {
-var n = u(t);
-a.permanentlyHideAlert(n, e.projectName);
 }, o.get(n.project).then(_.spread(function(a, o) {
 e.project = a, r.get("routes", n.route, o, {
 errorNotification: !1

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3350,10 +3350,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"showRouterHostnameAlert(ingress, admittedCondition)\" class=\"mar-top-lg\">\n" +
     "<div class=\"alert alert-info\">\n" +
     "<span class=\"pficon pficon-info\" aria-hidden=\"true\"></span>\n" +
-    "<span class=\"mar-right-sm\">\n" +
     "The DNS admin should set up a CNAME from the route's hostname, {{ingress.host}}, to the router's canonical hostname, {{ingress.routerCanonicalHostname}}.\n" +
-    "</span>\n" +
-    "<a href=\"\" ng-click=\"hideRouterHostnameAlert(ingress)\" role=\"button\" class=\"nowrap\">Don't Show Me Again</a>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
Knowing the router hostname is vital for setting up a CNAME for routes
with custom hosts. Remove the "Don't Show Me Again" link to prevent
users from accidentally dismissing the message without being able to get
it back.

See https://github.com/openshift/origin-web-console/pull/1194#issuecomment-333160295

@Download FYI, we're also looking at the other feedback you've given.