### PR TITLE
Don't show "Service Instance" in Other Resources list

### DIFF
--- a/app/scripts/controllers/otherResources.js
+++ b/app/scripts/controllers/otherResources.js
@@ -19,27 +19,28 @@ angular.module('openshiftConsole')
     $scope.kindSelector = {disabled: true};
     $scope.kinds = _.filter(APIService.availableKinds(), function(kind) {
       switch (kind.kind) {
-        case "ReplicationController":
+        case "AppliedClusterResourceQuota":
+        case "Build":
+        case "BuildConfig":
+        case "ConfigMap":
         case "Deployment":
         case "DeploymentConfig":
-        case "BuildConfig":
-        case "Build":
-        case "ConfigMap":
-        case "Pod":
-        case "PersistentVolumeClaim":
         case "Event":
-        case "Secret":
-        case "Service":
-        case "Route":
         case "ImageStream":
-        case "ImageStreamTag":
         case "ImageStreamImage":
         case "ImageStreamImport":
         case "ImageStreamMapping":
+        case "ImageStreamTag":
         case "LimitRange":
+        case "PersistentVolumeClaim":
+        case "Pod":
         case "ReplicaSet":
+        case "ReplicationController":
         case "ResourceQuota":
-        case "AppliedClusterResourceQuota":
+        case "Route":
+        case "Secret":
+        case "Service":
+        case "ServiceInstance":
         case "StatefulSet":
           return false;
         default:

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -6565,27 +6565,28 @@ n.projectName = e.project, n.labelSuggestions = {}, n.alerts = n.alerts || {}, n
 disabled: !0
 }, n.kinds = _.filter(l.availableKinds(), function(e) {
 switch (e.kind) {
-case "ReplicationController":
+case "AppliedClusterResourceQuota":
+case "Build":
+case "BuildConfig":
+case "ConfigMap":
 case "Deployment":
 case "DeploymentConfig":
-case "BuildConfig":
-case "Build":
-case "ConfigMap":
-case "Pod":
-case "PersistentVolumeClaim":
 case "Event":
-case "Secret":
-case "Service":
-case "Route":
 case "ImageStream":
-case "ImageStreamTag":
 case "ImageStreamImage":
 case "ImageStreamImport":
 case "ImageStreamMapping":
+case "ImageStreamTag":
 case "LimitRange":
+case "PersistentVolumeClaim":
+case "Pod":
 case "ReplicaSet":
+case "ReplicationController":
 case "ResourceQuota":
-case "AppliedClusterResourceQuota":
+case "Route":
+case "Secret":
+case "Service":
+case "ServiceInstance":
 case "StatefulSet":
 return !1;
 


### PR DESCRIPTION
Since we have a dedicated page for service instances now, don't show it in the other resources list.