### PR TITLE
Remove "tasks" message from overview

### DIFF
--- a/app/views/overview.html
+++ b/app/views/overview.html
@@ -101,7 +101,6 @@
       </div>
       <div class="middle-content">
         <div class="container-fluid">
-          <tasks></tasks>
           <alerts alerts="overview.state.alerts"></alerts>
           <div ng-if="overview.everythingFiltered && overview.viewBy !== 'pipeline'">
             <div class="empty-state-message text-center h2">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -11537,7 +11537,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
-    "<tasks></tasks>\n" +
     "<alerts alerts=\"overview.state.alerts\"></alerts>\n" +
     "<div ng-if=\"overview.everythingFiltered && overview.viewBy !== 'pipeline'\">\n" +
     "<div class=\"empty-state-message text-center h2\">\n" +


### PR DESCRIPTION
The wizard results step and next step pages show the tasks result. It's not needed on the overview and results in multiple different alert styles.

I removed one of these in #2184, but I missed the other:

https://github.com/openshift/origin-web-console/pull/2184/files#diff-361579fdd045e14f6dc3e106d5feb425L5