### PR TITLE
Remove tasks.js reference from index.html

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -333,7 +333,6 @@
         <script src="scripts/directives/actionChip.js"></script>
         <script src="scripts/directives/addConfigToApplication.js"></script>
         <script src="scripts/directives/templateopt.js"></script>
-        <script src="scripts/directives/tasks.js"></script>
         <script src="scripts/directives/catalog.js"></script>
         <script src="scripts/directives/catalog/categoryContent.js"></script>
         <script src="scripts/directives/catalog/catalogImage.js"></script>


### PR DESCRIPTION
The file no longer exists. This only affects development environments, not the built binary since it only references the minified scripts.js.