### PR TITLE
Set form definition for bind parameters when creating a binding.

### DIFF
--- a/app/scripts/directives/bindService.js
+++ b/app/scripts/directives/bindService.js
@@ -159,6 +159,7 @@
       ctrl.serviceClassName = instance.spec.serviceClassName;
       ctrl.plan = BindingService.getPlanForInstance(instance, ctrl.serviceClass);
       ctrl.parameterSchema = _.get(ctrl.plan, 'serviceInstanceCredentialCreateParameterSchema');
+      ctrl.parameterFormDefinition = _.get(ctrl.plan, 'externalMetadata.schemas.service_binding.create.openshift_form_definition');
       bindParametersStep.hidden = !_.has(ctrl.parameterSchema, 'properties');
       ctrl.nextTitle = bindParametersStep.hidden ? 'Bind' : 'Next >';
       ctrl.hideBack = bindParametersStep.hidden;

--- a/app/views/directives/bind-service/bind-parameters.html
+++ b/app/views/directives/bind-service/bind-parameters.html
@@ -1,3 +1,7 @@
 <form name="ctrl.parametersForm">
-  <catalog-parameters model="ctrl.parameterData" parameter-schema="ctrl.parameterSchema"></catalog-parameters>
+  <catalog-parameters
+    model="ctrl.parameterData"
+    parameter-schema="ctrl.parameterSchema"
+    parameter-form-definition="ctrl.parameterFormDefinition">
+  </catalog-parameters>
 </form>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12768,7 +12768,7 @@ c && (c(), c = void 0), l && (l(), l = void 0), d.nextTitle = "Close", d.wizardC
 var y = function() {
 if (d.serviceClasses) {
 var e = "ServiceInstance" === d.target.kind ? d.target : d.serviceToBind;
-e && (d.serviceClass = d.serviceClasses[e.spec.serviceClassName], d.serviceClassName = e.spec.serviceClassName, d.plan = r.getPlanForInstance(e, d.serviceClass), d.parameterSchema = _.get(d.plan, "serviceInstanceCredentialCreateParameterSchema"), i.hidden = !_.has(d.parameterSchema, "properties"), d.nextTitle = i.hidden ? "Bind" : "Next >", d.hideBack = i.hidden);
+e && (d.serviceClass = d.serviceClasses[e.spec.serviceClassName], d.serviceClassName = e.spec.serviceClassName, d.plan = r.getPlanForInstance(e, d.serviceClass), d.parameterSchema = _.get(d.plan, "serviceInstanceCredentialCreateParameterSchema"), d.parameterFormDefinition = _.get(d.plan, "externalMetadata.schemas.service_binding.create.openshift_form_definition"), i.hidden = !_.has(d.parameterSchema, "properties"), d.nextTitle = i.hidden ? "Bind" : "Next >", d.hideBack = i.hidden);
 }
 };
 e.$watch("ctrl.serviceToBind", y), d.$onInit = function() {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5805,7 +5805,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/directives/bind-service/bind-parameters.html',
     "<form name=\"ctrl.parametersForm\">\n" +
-    "<catalog-parameters model=\"ctrl.parameterData\" parameter-schema=\"ctrl.parameterSchema\"></catalog-parameters>\n" +
+    "<catalog-parameters model=\"ctrl.parameterData\" parameter-schema=\"ctrl.parameterSchema\" parameter-form-definition=\"ctrl.parameterFormDefinition\">\n" +
+    "</catalog-parameters>\n" +
     "</form>"
   );
 


### PR DESCRIPTION
Form definition for bind parameters were not being set, rendering input fields out of order.