### PR TITLE
Fix bug deleting bindings for service instance

### DIFF
--- a/app/scripts/services/serviceInstances.js
+++ b/app/scripts/services/serviceInstances.js
@@ -60,7 +60,7 @@ angular.module("openshiftConsole")
       var resource = APIService.getPreferredVersion('serviceinstancecredentials');
       getBindingsIfNecessary(apiObject, bindings).then(function(serviceBindings) {
         _.each(serviceBindings, function (binding) {
-          if (!binding.metadata.deletionTimestamp) {
+          if (binding.metadata.deletionTimestamp) {
             return;
           }
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4315,7 +4315,7 @@ namespace: t.metadata.namespace
 }, u = a.getPreferredVersion("serviceinstancecredentials");
 l(t, n).then(function(t) {
 _.each(t, function(t) {
-t.metadata.deletionTimestamp && i.delete(u, t.metadata.name, r).then(function() {
+t.metadata.deletionTimestamp || i.delete(u, t.metadata.name, r).then(function() {
 c.addNotification({
 type: "success",
 message: "Binding " + t.metadata.name + "' was marked for deletion."


### PR DESCRIPTION
The logic checking if the binding was already deleted was flipped.