### PR TITLE
Adopt more service catalog API changes

### DIFF
--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -325,7 +325,7 @@ function OverviewController($scope,
   };
 
   // Updated on viewBy changes to include the app label when appropriate.
-  var filterFields = ['metadata.name', 'spec.externalServiceClassName'];
+  var filterFields = ['metadata.name', 'spec.externalClusterServiceClassName'];
   var filterByName = function(items) {
     return KeywordService.filterForKeywords(items, filterFields, state.filterKeywords);
   };

--- a/app/scripts/controllers/serviceInstance.js
+++ b/app/scripts/controllers/serviceInstance.js
@@ -29,7 +29,7 @@ angular.module('openshiftConsole')
     var serviceInstanceDisplayName = $filter('serviceInstanceDisplayName');
 
     // API Versions
-    var serviceInstancesVersion = APIService.getPreferredVersion('serviceinstances');
+    $scope.serviceInstancesVersion = APIService.getPreferredVersion('serviceinstances');
 
     var updateBreadcrumbs = function() {
       $scope.breadcrumbs.push({
@@ -81,10 +81,10 @@ angular.module('openshiftConsole')
         $scope.projectContext = context;
 
         DataService
-          .get(serviceInstancesVersion, $routeParams.instance, context, { errorNotification: false })
+          .get($scope.serviceInstancesVersion, $routeParams.instance, context, { errorNotification: false })
           .then(function(serviceInstance) {
             serviceResolved(serviceInstance);
-            watches.push(DataService.watchObject(serviceInstancesVersion, $routeParams.instance, context, serviceResolved));
+            watches.push(DataService.watchObject($scope.serviceInstancesVersion, $routeParams.instance, context, serviceResolved));
           }, function(error) {
             $scope.loaded = true;
             $scope.alerts["load"] = {

--- a/app/scripts/directives/overview/listRow.js
+++ b/app/scripts/directives/overview/listRow.js
@@ -44,6 +44,8 @@
     var isBinaryBuild = $filter('isBinaryBuild');
     var enableTechPreviewFeature = $filter('enableTechPreviewFeature');
 
+    row.serviceBindingsVersion = APIService.getPreferredVersion('servicebindings');
+
     var updateTriggers = function(apiObject) {
       var triggers = _.get(apiObject, 'spec.triggers');
       if (_.isEmpty(triggers)) {
@@ -174,13 +176,13 @@
         // Create Binding is displayed.
         if (enableTechPreviewFeature('pod_presets') &&
             !_.isEmpty(row.state.bindableServiceInstances) &&
-            canI({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'}, 'create')) {
+            canI(row.serviceBindingsVersion, 'create')) {
           return true;
         }
         // Delete Binding is displayed.
         if (enableTechPreviewFeature('pod_presets') &&
             !_.isEmpty(deleteableBindings) &&
-            canI({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'}, 'delete')) {
+            canI(row.serviceBindingsVersion, 'delete')) {
           return true;
         }
         // Check if one of the start build actions is displayed
@@ -210,13 +212,13 @@
         // Create Binding is displayed.
         if (enableTechPreviewFeature('pod_presets') &&
             !_.isEmpty(row.state.bindableServiceInstances) &&
-            canI({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'}, 'create')) {
+            canI(row.serviceBindingsVersion, 'create')) {
           return true;
         }
         // Delete Binding is displayed.
         if (enableTechPreviewFeature('pod_presets') &&
             !_.isEmpty(deleteableBindings) &&
-            canI({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'}, 'delete')) {
+            canI(row.serviceBindingsVersion, 'delete')) {
           return true;
         }
         return false;

--- a/app/scripts/directives/overview/serviceInstanceRow.js
+++ b/app/scripts/directives/overview/serviceInstanceRow.js
@@ -4,6 +4,7 @@
   angular.module('openshiftConsole').component('serviceInstanceRow', {
     controller: [
       '$filter',
+      'APIService',
       'AuthorizationService',
       'BindingService',
       'ListRowUtils',
@@ -20,6 +21,7 @@
   });
 
   function ServiceInstanceRow($filter,
+                              APIService,
                               AuthorizationService,
                               BindingService,
                               ListRowUtils,
@@ -31,6 +33,9 @@
     _.extend(row, ListRowUtils.ui);
 
     var serviceInstanceDisplayName = $filter('serviceInstanceDisplayName');
+
+    row.serviceBindingsVersion = APIService.getPreferredVersion('servicebindings');
+    row.serviceInstancesVersion = APIService.getPreferredVersion('serviceinstances');
 
     var getServiceClass = function() {
       var serviceClassName = ServiceInstancesService.getServiceClassNameForInstance(row.apiObject);
@@ -81,15 +86,15 @@
       }
 
       // We can create bindings
-      if (row.isBindable && AuthorizationService.canI({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'}, 'create')) {
+      if (row.isBindable && AuthorizationService.canI(row.serviceBindingsVersion, 'create')) {
         return true;
       }
       // We can delete bindings
-      if (!_.isEmpty(row.deleteableBindings) && AuthorizationService.canI({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'}, 'delete')) {
+      if (!_.isEmpty(row.deleteableBindings) && AuthorizationService.canI(row.serviceBindingsVersion, 'delete')) {
         return true;
       }
       // We can delete instances
-      if (AuthorizationService.canI({resource: 'serviceinstances', group: 'servicecatalog.k8s.io'}, 'delete')) {
+      if (AuthorizationService.canI(row.serviceInstancesVersion, 'delete')) {
         return true;
       }
 

--- a/app/scripts/directives/serviceBinding.js
+++ b/app/scripts/directives/serviceBinding.js
@@ -3,6 +3,8 @@
 (function() {
   angular.module('openshiftConsole').component('serviceBinding', {
     controller: [
+      "APIService",
+      "ServiceInstancesService",
       ServiceBinding
     ],
     controllerAs: '$ctrl',
@@ -17,14 +19,16 @@
     templateUrl: 'views/directives/_service-binding.html'
   });
 
-  function ServiceBinding() {
+  function ServiceBinding(APIService,
+                          ServiceInstancesService) {
     var ctrl = this;
+    ctrl.serviceBindingsVersion = APIService.getPreferredVersion('servicebindings');
 
     var updateServiceClass = function() {
       if (_.get(ctrl.refApiObject, 'kind') !== 'ServiceInstance') {
         var instanceName = _.get(ctrl.binding, 'spec.instanceRef.name');
         var instance = _.get(ctrl.serviceInstances, [instanceName]);
-        var serviceClassName = _.get(instance, 'spec.serviceClassRef.name');
+        var serviceClassName = ServiceInstancesService.getServiceClassNameForInstance(instance);
         ctrl.serviceClass = _.get(ctrl.serviceClasses, [serviceClassName]);
       }
     };

--- a/app/scripts/filters/canI.js
+++ b/app/scripts/filters/canI.js
@@ -34,7 +34,7 @@ angular
         _.assign({}, APIService.getPreferredVersion('imagestreams'), {verbs: ['update', 'delete']})
       ],
       'serviceInstances': [
-        {group: 'servicecatalog.k8s.io', resource: 'serviceinstances', verbs: ['update', 'delete']}
+        _.assign({}, APIService.getPreferredVersion('serviceinstances'), {verbs: ['update', 'delete']})
       ],
       'persistentVolumeClaims': [
         {group: '', resource: 'persistentvolumeclaims', verbs: ['update', 'delete']}

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -1316,45 +1316,6 @@ angular.module('openshiftConsole')
       return !_.isEmpty(alternateBackends);
     };
   })
-  .filter('serviceClassDisplayName', function() {
-    return function(serviceClass) {
-      var serviceClassDisplayName = _.get(serviceClass, 'spec.externalMetadata.displayName');
-      if (serviceClassDisplayName) {
-        return serviceClassDisplayName;
-      }
-
-      var serviceClassExternalName = _.get(serviceClass, 'spec.externalName');
-      if (serviceClassExternalName) {
-        return serviceClassExternalName;
-      }
-
-      return _.get(serviceClass, 'metadata.name');
-    };
-  })
-  .filter('serviceInstanceDisplayName', function(serviceClassDisplayNameFilter) {
-    return function(instance, serviceClass) {
-      if (serviceClass) {
-        return serviceClassDisplayNameFilter(serviceClass);
-      }
-
-      return _.get(instance, 'metadata.name');
-    };
-  })
-  .filter('serviceInstanceStatus', function(isServiceInstanceReadyFilter) {
-    return function(instance) {
-      var status = 'Pending';
-      var conditions = _.get(instance, 'status.conditions');
-      var instanceError = _.find(conditions, {type: 'Failed', status: 'True'});
-
-      if (instanceError) {
-        status = 'Failed';
-      } else if (isServiceInstanceReadyFilter(instance)) {
-        status = 'Ready';
-      }
-
-      return status;
-    };
-  })
   .filter('readyConditionMessage', function(statusConditionFilter) {
     return function(instance) {
       return _.get(statusConditionFilter(instance, 'Ready'), 'message');

--- a/app/scripts/services/serviceInstances.js
+++ b/app/scripts/services/serviceInstances.js
@@ -14,7 +14,7 @@ angular.module("openshiftConsole")
     var servicePlansVersion = APIService.getPreferredVersion('clusterserviceplans');
 
     var getServiceClassNameForInstance = function(serviceInstance) {
-      return _.get(serviceInstance, 'spec.serviceClassRef.name');
+      return _.get(serviceInstance, 'spec.clusterServiceClassRef.name');
     };
 
     var fetchServiceClassForInstance = function(serviceInstance) {
@@ -23,7 +23,7 @@ angular.module("openshiftConsole")
     };
 
     var getServicePlanNameForInstance = function(serviceInstance) {
-      return _.get(serviceInstance, 'spec.servicePlanRef.name');
+      return _.get(serviceInstance, 'spec.clusterServicePlanRef.name');
     };
 
     var fetchServicePlanForInstance = function(serviceInstance) {

--- a/app/views/browse/service-instance.html
+++ b/app/views/browse/service-instance.html
@@ -20,10 +20,10 @@
                    class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
                    data-toggle="dropdown"><i class="fa fa-ellipsis-v" aria-hidden="true"></i><span class="sr-only">Actions</span></a>
                 <ul class="dropdown-menu dropdown-menu-right actions action-button">
-                  <li ng-if="{resource: 'serviceinstances', group: 'servicecatalog.k8s.io'} | canI : 'update'">
+                  <li ng-if="serviceInstancesVersion | canI : 'update'">
                     <a ng-href="{{serviceInstance | editYamlURL}}" role="button">Edit YAML</a>
                   </li>
-                  <li ng-if="{resource: 'serviceinstances', group: 'servicecatalog.k8s.io'} | canI : 'delete'">
+                  <li ng-if="serviceInstancesVersion | canI : 'delete'">
                     <a href="" ng-click="deprovision()" role="button">Delete</a>
                   </li>
                 </ul>

--- a/app/views/directives/_service-binding.html
+++ b/app/views/directives/_service-binding.html
@@ -35,8 +35,8 @@
   </div>
   <div class="service-binding-actions" ng-if="!$ctrl.binding.metadata.deletionTimestamp">
     <delete-link
-      ng-if="({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'delete')"
-      kind="ServiceInstanceCredential"
+      ng-if="$ctrl.serviceBindingsVersion | canI : 'delete'"
+      kind="ServiceBinding"
       group="servicecatalog.k8s.io"
       type-display-name="binding"
       resource-name="{{$ctrl.binding.metadata.name}}"

--- a/app/views/overview/_list-row-actions.html
+++ b/app/views/overview/_list-row-actions.html
@@ -25,12 +25,12 @@
             </li>
             <li ng-if="('pod_presets' | enableTechPreviewFeature)
                       && row.state.bindableServiceInstances.length
-                      && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'create')" role="menuitem">
+                      && (row.serviceBindingsVersion | canI : 'create')" role="menuitem">
               <a href="" ng-click="row.showOverlayPanel('bindService', {target: row.apiObject})">Create Binding</a>
             </li>
             <li ng-if="('pod_presets' | enableTechPreviewFeature)
                       && row.state.deleteableBindingsByApplicationUID[row.apiObject.metadata.uid].length
-                      && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'delete')" role="menuitem">
+                      && (row.serviceBindingsVersion | canI : 'delete')" role="menuitem">
               <a href="" ng-click="row.showOverlayPanel('unbindService', {target: row.apiObject})">Delete Binding</a>
             </li>
             <li ng-if="row.current && ('deploymentconfigs/log' | canI : 'get')" role="menuitem">
@@ -65,12 +65,12 @@
             </li>
             <li ng-if="('pod_presets' | enableTechPreviewFeature)
                       && row.state.bindableServiceInstances.length
-                      && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'create')" role="menuitem">
+                      && (row.serviceBindingsVersion | canI : 'create')" role="menuitem">
               <a href="" ng-click="row.showOverlayPanel('bindService', {target: row.apiObject})">Create Binding</a>
             </li>
             <li ng-if="('pod_presets' | enableTechPreviewFeature)
                       && row.state.deleteableBindingsByApplicationUID[row.apiObject.metadata.uid].length
-                      && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'delete')" role="menuitem">
+                      && (row.serviceBindingsVersion | canI : 'delete')" role="menuitem">
               <a href="" ng-click="row.showOverlayPanel('unbindService', {target: row.apiObject})">Delete Binding</a>
             </li>
             <li ng-if="(pod = row.firstPod(row.current)) && ('pods/log' | canI : 'get')" role="menuitem">

--- a/app/views/overview/_service-bindings.html
+++ b/app/views/overview/_service-bindings.html
@@ -10,7 +10,7 @@
     service-instances="$ctrl.serviceInstances"
     secrets="$ctrl.secrets">
   </service-binding>
-  <div ng-if="!$ctrl.refApiObject.metadata.deletionTimestamp && (($ctrl.refApiObject.kind === 'ServiceInstance') || ($ctrl.bindableServiceInstances | size)) && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'create')">
+  <div ng-if="!$ctrl.refApiObject.metadata.deletionTimestamp && (($ctrl.refApiObject.kind === 'ServiceInstance') || ($ctrl.bindableServiceInstances | size)) && ({resource: 'servicebindings', group: 'servicecatalog.k8s.io'} | canI : 'create')">
     <a href="" ng-click="$ctrl.createBinding()" role="button">
       <span class="pficon pficon-add-circle-o" aria-hidden="true"></span>
       Create Binding

--- a/app/views/overview/_service-instance-row.html
+++ b/app/views/overview/_service-instance-row.html
@@ -34,7 +34,7 @@
       <div class="list-pf-details" ng-if="!row.expanded">
         <span ng-if="!row.bindings.length
                     && row.isBindable
-                    && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'create')"
+                    && (row.serviceBindingsVersion | canI : 'create')"
               class="hidden-xs hidden-sm">
           <a href="" ng-click="row.showOverlayPanel('bindService', {target: row.apiObject})">
             <span class="pficon pficon-add-circle-o" aria-hidden="true"></span>
@@ -74,16 +74,16 @@
         uib-dropdown-toggle
         class="actions-dropdown-kebab"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
         <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu role="menu">
-          <li role="menuitem" ng-if="row.isBindable && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'create')">
+          <li role="menuitem" ng-if="row.isBindable && (row.serviceBindingsVersion | canI : 'create')">
             <a href="" ng-click="row.showOverlayPanel('bindService', {target: row.apiObject})">
               Create Binding
             </a>
           </li>
-          <li role="menuitem" ng-if="row.deleteableBindings.length && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'delete')">
+          <li role="menuitem" ng-if="row.deleteableBindings.length && (row.serviceBindingsVersion | canI : 'delete')">
             <a href="" ng-click="row.showOverlayPanel('unbindService', {target: row.apiObject})">Delete Binding</a>
           </li>
           <li role="menuitem">
-            <a href="" ng-click="row.deprovision()" role="button" ng-if="{resource: 'serviceinstances', group: 'servicecatalog.k8s.io'} | canI : 'delete'">Delete</a>
+            <a href="" ng-click="row.deprovision()" role="button" ng-if="row.serviceInstancesVersion | canI : 'delete'">Delete</a>
           </li>
         </ul>
       </div>
@@ -116,7 +116,7 @@
                 <span class="mar-right-md">
                   <truncate-long-text content="row.apiObject | serviceInstanceFailedMessage" limit="265"></truncate-long-text>
                 </span>
-                <span ng-if="{resource: 'serviceinstances', group: 'servicecatalog.k8s.io'} | canI : 'delete'" class="nowrap">
+                <span ng-if="row.serviceInstancesVersion | canI : 'delete'" class="nowrap">
                   <a href="" ng-click="row.deprovision()">Delete This Service</a>
                 </span>
               </div>

--- a/bower.json
+++ b/bower.json
@@ -46,8 +46,8 @@
     "angular-moment": "1.0.0",
     "angular-utf8-base64": "0.0.5",
     "file-saver": "1.3.3",
-    "origin-web-common": "0.0.65",
-    "origin-web-catalog": "0.0.53"
+    "origin-web-common": "0.0.66",
+    "origin-web-catalog": "0.0.54"
   },
   "devDependencies": {
     "angular-mocks": "1.5.11",

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3,7 +3,7 @@
 function OverviewController(e, t, n, a, r, o, i, s, c, l, u, d, m, p, f, g, v, h, y, b, C, S, w, k, j, P) {
 var R = this, I = t("isIE")() || t("isEdge")();
 e.projectName = n.project, R.catalogLandingPageEnabled = !l.DISABLE_SERVICE_CATALOG_LANDING_PAGE;
-var E, T, N = t("annotation"), D = t("canI"), A = t("buildConfigForBuild"), B = t("deploymentIsInProgress"), L = t("imageObjectRef"), U = t("isJenkinsPipelineStrategy"), O = t("isNewerResource"), F = t("label"), x = t("podTemplate"), M = r.getPreferredVersion("servicebindings"), V = r.getPreferredVersion("clusterserviceclasses"), q = r.getPreferredVersion("serviceinstances"), z = r.getPreferredVersion("clusterserviceplans"), H = {}, G = {}, K = {}, W = R.state = {
+var E, T, N = t("annotation"), D = t("canI"), A = t("buildConfigForBuild"), B = t("deploymentIsInProgress"), L = t("imageObjectRef"), U = t("isJenkinsPipelineStrategy"), O = t("isNewerResource"), F = t("label"), x = t("podTemplate"), V = r.getPreferredVersion("servicebindings"), M = r.getPreferredVersion("clusterserviceclasses"), q = r.getPreferredVersion("serviceinstances"), z = r.getPreferredVersion("clusterserviceplans"), H = {}, G = {}, K = {}, W = R.state = {
 alerts: {},
 builds: {},
 clusterQuotas: {},
@@ -101,7 +101,7 @@ R.deploymentConfigsNoPipeline = _.sortBy(e, "metadata.name"), R.pipelineViewHasO
 R.disableFilter = "pipeline" === R.viewBy && _.isEmpty(R.pipelineBuildConfigs);
 }, se = function(e) {
 return v.getLabelSelector().select(e);
-}, ce = [ "metadata.name", "spec.externalServiceClassName" ], le = function(e) {
+}, ce = [ "metadata.name", "spec.externalClusterServiceClassName" ], le = function(e) {
 return g.filterForKeywords(e, ce, W.filterKeywords);
 }, ue = function(e) {
 switch (R.filterBy) {
@@ -261,10 +261,10 @@ return new LabelSelector(e.spec.selector);
 var e = [ R.deploymentConfigs, R.vanillaReplicationControllers, R.deployments, R.vanillaReplicaSets, R.statefulSets, R.monopods ];
 _.each(e, Fe), ae();
 }
-}, Me = function() {
+}, Ve = function() {
 var e = j.groupByService(R.routes, !0);
 W.routesByService = _.mapValues(e, j.sortRoutesByScore), ae();
-}, Ve = function() {
+}, Me = function() {
 W.hpaByResource = m.groupHPAs(R.horizontalPodAutoscalers);
 }, qe = function(e) {
 var t = A(e), n = R.buildConfigs[t];
@@ -412,7 +412,7 @@ W.allServices = e.by("metadata.name"), xe(), h.log("services (subscribe)", W.all
 poll: I,
 pollInterval: 6e4
 })), at.push(u.watch("routes", n, function(e) {
-R.routes = e.by("metadata.name"), Me(), h.log("routes (subscribe)", R.routes);
+R.routes = e.by("metadata.name"), Ve(), h.log("routes (subscribe)", R.routes);
 }, {
 poll: I,
 pollInterval: 6e4
@@ -426,7 +426,7 @@ group: "autoscaling",
 resource: "horizontalpodautoscalers",
 version: "v1"
 }, n, function(e) {
-R.horizontalPodAutoscalers = e.by("metadata.name"), Ve(), h.log("autoscalers (subscribe)", R.horizontalPodAutoscalers);
+R.horizontalPodAutoscalers = e.by("metadata.name"), Me(), h.log("autoscalers (subscribe)", R.horizontalPodAutoscalers);
 }, {
 poll: I,
 pollInterval: 6e4
@@ -449,7 +449,7 @@ pollInterval: 6e4
 var r, o, i = {}, s = {};
 c.SERVICE_CATALOG_ENABLED && D(q, "watch") && (r = function(e) {
 var t = P.getServiceClassNameForInstance(e);
-_.has(W, [ "serviceClasses", t ]) || i[t] || (i[t] = u.get(V, t, {}).then(function(e) {
+_.has(W, [ "serviceClasses", t ]) || i[t] || (i[t] = u.get(M, t, {}).then(function(e) {
 W.serviceClasses[t] = e;
 }).finally(function() {
 delete s[t];
@@ -469,7 +469,7 @@ ve(e, t), r(e), o(e);
 }, {
 poll: I,
 pollInterval: 6e4
-}))), c.SERVICE_CATALOG_ENABLED && D(M, "watch") && at.push(u.watch(M, n, function(e) {
+}))), c.SERVICE_CATALOG_ENABLED && D(V, "watch") && at.push(u.watch(V, n, function(e) {
 W.bindings = e.by("metadata.name"), R.bindingsByInstanceRef = _.groupBy(W.bindings, "spec.instanceRef.name"), tt();
 }, {
 poll: I,
@@ -4316,9 +4316,9 @@ controller: !0
 };
 }), angular.module("openshiftConsole").factory("ServiceInstancesService", [ "$filter", "$q", "$uibModal", "APIService", "BindingService", "CatalogService", "DataService", "Logger", "NotificationsService", function(e, t, n, a, r, o, i, s, c) {
 var l = a.getPreferredVersion("clusterserviceclasses"), u = a.getPreferredVersion("clusterserviceplans"), d = function(e) {
-return _.get(e, "spec.serviceClassRef.name");
+return _.get(e, "spec.clusterServiceClassRef.name");
 }, m = function(e) {
-return _.get(e, "spec.servicePlanRef.name");
+return _.get(e, "spec.clusterServicePlanRef.name");
 }, p = function(e, n) {
 if (angular.isDefined(n)) return t.when(n);
 var o = {
@@ -6313,29 +6313,31 @@ link: "project/" + n.project + "/browse/service-instances"
 } ], e.deprovision = function() {
 i.deprovision(e.serviceInstance);
 };
-var s = [], c = t("serviceInstanceDisplayName"), l = a.getPreferredVersion("serviceinstances"), u = function() {
+var s = [], c = t("serviceInstanceDisplayName");
+e.serviceInstancesVersion = a.getPreferredVersion("serviceinstances");
+var l = function() {
 e.breadcrumbs.push({
 title: e.displayName
 });
-}, d = function() {
+}, u = function() {
 e.serviceClass || i.fetchServiceClassForInstance(e.serviceInstance).then(function(t) {
-e.serviceClass = t, e.displayName = c(e.serviceInstance, t), u();
+e.serviceClass = t, e.displayName = c(e.serviceInstance, t), l();
 });
-}, m = function() {
+}, d = function() {
 i.isCurrentPlan(e.serviceInstance, e.plan) || i.fetchServicePlanForInstance(e.serviceInstance).then(function(t) {
 e.plan = t;
 });
-}, p = function(t, n) {
+}, m = function(t, n) {
 e.loaded = !0, e.serviceInstance = t, "DELETED" === n && (e.alerts.deleted = {
 type: "warning",
 message: "This provisioned service has been deleted."
-}), d(), m();
+}), u(), d();
 };
 o.get(n.project).then(_.spread(function(a, o) {
-e.project = a, e.projectContext = o, r.get(l, n.instance, o, {
+e.project = a, e.projectContext = o, r.get(e.serviceInstancesVersion, n.instance, o, {
 errorNotification: !1
-}).then(function(e) {
-p(e), s.push(r.watchObject(l, n.instance, o, p));
+}).then(function(t) {
+m(t), s.push(r.watchObject(e.serviceInstancesVersion, n.instance, o, m));
 }, function(n) {
 e.loaded = !0, e.alerts.load = {
 type: "error",
@@ -13327,15 +13329,17 @@ n.imageIDs = r ? [ r ] : t.getImageIDs(n.pods, e.name);
 };
 } ]), function() {
 angular.module("openshiftConsole").component("serviceBinding", {
-controller: [ function() {
-var e = this, t = function() {
-if ("ServiceInstance" !== _.get(e.refApiObject, "kind")) {
-var t = _.get(e.binding, "spec.instanceRef.name"), n = _.get(e.serviceInstances, [ t ]), a = _.get(n, "spec.serviceClassRef.name");
-e.serviceClass = _.get(e.serviceClasses, [ a ]);
+controller: [ "APIService", "ServiceInstancesService", function(e, t) {
+var n = this;
+n.serviceBindingsVersion = e.getPreferredVersion("servicebindings");
+var a = function() {
+if ("ServiceInstance" !== _.get(n.refApiObject, "kind")) {
+var e = _.get(n.binding, "spec.instanceRef.name"), a = _.get(n.serviceInstances, [ e ]), r = t.getServiceClassNameForInstance(a);
+n.serviceClass = _.get(n.serviceClasses, [ r ]);
 }
 };
 this.$onChanges = function(e) {
-(e.binding || e.serviceInstances || e.serviceClasses) && t();
+(e.binding || e.serviceInstances || e.serviceClasses) && a();
 };
 } ],
 controllerAs: "$ctrl",
@@ -13562,7 +13566,9 @@ angular.module("openshiftConsole").component("overviewListRow", {
 controller: [ "$filter", "$uibModal", "APIService", "BuildsService", "CatalogService", "DeploymentsService", "ListRowUtils", "Navigate", "NotificationsService", function(e, t, n, a, r, o, i, s, c) {
 var l = this;
 _.extend(l, i.ui);
-var u = e("canI"), d = e("deploymentIsInProgress"), m = e("isBinaryBuild"), p = e("enableTechPreviewFeature"), f = function(e) {
+var u = e("canI"), d = e("deploymentIsInProgress"), m = e("isBinaryBuild"), p = e("enableTechPreviewFeature");
+l.serviceBindingsVersion = n.getPreferredVersion("servicebindings");
+var f = function(e) {
 var t = _.get(e, "spec.triggers");
 _.isEmpty(t) || (l.imageChangeTriggers = _.filter(t, function(e) {
 return "ImageChange" === e.type && _.get(e, "imageChangeParams.automatic");
@@ -13600,25 +13606,13 @@ return !(!l.current || !l.previous) || d(l.current);
 var e = _.get(l, "apiObject.kind"), t = _.get(l, "apiObject.metadata.uid"), n = _.get(l.state.deleteableBindingsByApplicationUID, t);
 switch (e) {
 case "DeploymentConfig":
-return !!u("deploymentconfigs/instantiate", "create") || !!u("deploymentconfigs", "update") || !(!l.current || !u("deploymentconfigs/log", "get")) || !(!p("pod_presets") || _.isEmpty(l.state.bindableServiceInstances) || !u({
-resource: "serviceinstancecredentials",
-group: "servicecatalog.k8s.io"
-}, "create")) || !(!p("pod_presets") || _.isEmpty(n) || !u({
-resource: "serviceinstancecredentials",
-group: "servicecatalog.k8s.io"
-}, "delete")) || l.showStartPipelineAction() || l.showStartBuildAction();
+return !!u("deploymentconfigs/instantiate", "create") || !!u("deploymentconfigs", "update") || !(!l.current || !u("deploymentconfigs/log", "get")) || !(!p("pod_presets") || _.isEmpty(l.state.bindableServiceInstances) || !u(l.serviceBindingsVersion, "create")) || !(!p("pod_presets") || _.isEmpty(n) || !u(l.serviceBindingsVersion, "delete")) || l.showStartPipelineAction() || l.showStartBuildAction();
 
 case "Pod":
 return !!u("pods/log", "get") || !!u("pods", "update");
 
 default:
-return !((!l.firstPod(l.current) || !u("pods/log", "get")) && !u(l.rgv, "update") && (!p("pod_presets") || _.isEmpty(l.state.bindableServiceInstances) || !u({
-resource: "serviceinstancecredentials",
-group: "servicecatalog.k8s.io"
-}, "create")) && (!p("pod_presets") || _.isEmpty(n) || !u({
-resource: "serviceinstancecredentials",
-group: "servicecatalog.k8s.io"
-}, "delete")));
+return !((!l.firstPod(l.current) || !u("pods/log", "get")) && !u(l.rgv, "update") && (!p("pod_presets") || _.isEmpty(l.state.bindableServiceInstances) || !u(l.serviceBindingsVersion, "create")) && (!p("pod_presets") || _.isEmpty(n) || !u(l.serviceBindingsVersion, "delete")));
 }
 }, l.showStartBuildAction = function() {
 if (!_.isEmpty(l.pipelines)) return !1;
@@ -13691,41 +13685,34 @@ templateUrl: "views/overview/_list-row.html"
 });
 }(), function() {
 angular.module("openshiftConsole").component("serviceInstanceRow", {
-controller: [ "$filter", "AuthorizationService", "BindingService", "ListRowUtils", "ServiceInstancesService", function(e, t, n, a, r) {
-var o = this, i = e("isBindingFailed"), s = e("isBindingReady");
-_.extend(o, a.ui);
-var c = e("serviceInstanceDisplayName"), l = function() {
-var e = r.getServiceClassNameForInstance(o.apiObject);
-return _.get(o, [ "state", "serviceClasses", e ]);
-}, u = function() {
-var e = r.getServicePlanNameForInstance(o.apiObject);
-return _.get(o, [ "state", "servicePlans", e ]);
+controller: [ "$filter", "APIService", "AuthorizationService", "BindingService", "ListRowUtils", "ServiceInstancesService", function(e, t, n, a, r, o) {
+var i = this, s = e("isBindingFailed"), c = e("isBindingReady");
+_.extend(i, r.ui);
+var l = e("serviceInstanceDisplayName");
+i.serviceBindingsVersion = t.getPreferredVersion("servicebindings"), i.serviceInstancesVersion = t.getPreferredVersion("serviceinstances");
+var u = function() {
+var e = o.getServiceClassNameForInstance(i.apiObject);
+return _.get(i, [ "state", "serviceClasses", e ]);
 }, d = function() {
-_.get(o.apiObject, "metadata.deletionTimestamp") ? o.instanceStatus = "deleted" : i(o.apiObject) ? o.instanceStatus = "failed" : s(o.apiObject) ? o.instanceStatus = "ready" : o.instanceStatus = "pending";
+var e = o.getServicePlanNameForInstance(i.apiObject);
+return _.get(i, [ "state", "servicePlans", e ]);
+}, m = function() {
+_.get(i.apiObject, "metadata.deletionTimestamp") ? i.instanceStatus = "deleted" : s(i.apiObject) ? i.instanceStatus = "failed" : c(i.apiObject) ? i.instanceStatus = "ready" : i.instanceStatus = "pending";
 };
-o.$doCheck = function() {
-d(), o.notifications = a.getNotifications(o.apiObject, o.state), o.serviceClass = l(), o.servicePlan = u(), o.displayName = c(o.apiObject, o.serviceClass), o.isBindable = n.isServiceBindable(o.apiObject, o.serviceClass, o.servicePlan);
-}, o.$onChanges = function(e) {
-e.bindings && (o.deleteableBindings = _.reject(o.bindings, "metadata.deletionTimestamp"));
-}, o.getSecretForBinding = function(e) {
-return e && _.get(o, [ "state", "secrets", e.spec.secretName ]);
-}, o.actionsDropdownVisible = function() {
-return !(_.get(o.apiObject, "metadata.deletionTimestamp") || (!o.isBindable || !t.canI({
-resource: "serviceinstancecredentials",
-group: "servicecatalog.k8s.io"
-}, "create")) && (_.isEmpty(o.deleteableBindings) || !t.canI({
-resource: "serviceinstancecredentials",
-group: "servicecatalog.k8s.io"
-}, "delete")) && !t.canI({
-resource: "serviceinstances",
-group: "servicecatalog.k8s.io"
-}, "delete"));
-}, o.closeOverlayPanel = function() {
-_.set(o, "overlay.panelVisible", !1);
-}, o.showOverlayPanel = function(e, t) {
-_.set(o, "overlay.panelVisible", !0), _.set(o, "overlay.panelName", e), _.set(o, "overlay.state", t);
-}, o.deprovision = function() {
-r.deprovision(o.apiObject, o.deleteableBindings);
+i.$doCheck = function() {
+m(), i.notifications = r.getNotifications(i.apiObject, i.state), i.serviceClass = u(), i.servicePlan = d(), i.displayName = l(i.apiObject, i.serviceClass), i.isBindable = a.isServiceBindable(i.apiObject, i.serviceClass, i.servicePlan);
+}, i.$onChanges = function(e) {
+e.bindings && (i.deleteableBindings = _.reject(i.bindings, "metadata.deletionTimestamp"));
+}, i.getSecretForBinding = function(e) {
+return e && _.get(i, [ "state", "secrets", e.spec.secretName ]);
+}, i.actionsDropdownVisible = function() {
+return !(_.get(i.apiObject, "metadata.deletionTimestamp") || (!i.isBindable || !n.canI(i.serviceBindingsVersion, "create")) && (_.isEmpty(i.deleteableBindings) || !n.canI(i.serviceBindingsVersion, "delete")) && !n.canI(i.serviceInstancesVersion, "delete"));
+}, i.closeOverlayPanel = function() {
+_.set(i, "overlay.panelVisible", !1);
+}, i.showOverlayPanel = function(e, t) {
+_.set(i, "overlay.panelVisible", !0), _.set(i, "overlay.panelName", e), _.set(i, "overlay.state", t);
+}, i.deprovision = function() {
+o.deprovision(i.apiObject, i.deleteableBindings);
 };
 } ],
 controllerAs: "row",
@@ -15325,26 +15312,7 @@ return function(e) {
 var t = _.get(e, "spec.alternateBackends", []);
 return !_.isEmpty(t);
 };
-}).filter("serviceClassDisplayName", function() {
-return function(e) {
-var t = _.get(e, "spec.externalMetadata.displayName");
-if (t) return t;
-var n = _.get(e, "spec.externalName");
-return n || _.get(e, "metadata.name");
-};
-}).filter("serviceInstanceDisplayName", [ "serviceClassDisplayNameFilter", function(e) {
-return function(t, n) {
-return n ? e(n) : _.get(t, "metadata.name");
-};
-} ]).filter("serviceInstanceStatus", [ "isServiceInstanceReadyFilter", function(e) {
-return function(t) {
-var n = "Pending", a = _.get(t, "status.conditions");
-return _.find(a, {
-type: "Failed",
-status: "True"
-}) ? n = "Failed" : e(t) && (n = "Ready"), n;
-};
-} ]).filter("readyConditionMessage", [ "statusConditionFilter", function(e) {
+}).filter("readyConditionMessage", [ "statusConditionFilter", function(e) {
 return function(t) {
 return _.get(e(t, "Ready"), "message");
 };
@@ -15401,11 +15369,9 @@ verbs: [ "update", "delete" ]
 imageStreams: [ _.assign({}, e.getPreferredVersion("imagestreams"), {
 verbs: [ "update", "delete" ]
 }) ],
-serviceInstances: [ {
-group: "servicecatalog.k8s.io",
-resource: "serviceinstances",
+serviceInstances: [ _.assign({}, e.getPreferredVersion("serviceinstances"), {
 verbs: [ "update", "delete" ]
-} ],
+}) ],
 persistentVolumeClaims: [ {
 group: "",
 resource: "persistentvolumeclaims",

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3650,10 +3650,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</button>\n" +
     "<a href=\"\" class=\"dropdown-toggle actions-dropdown-kebab visible-xs-inline\" data-toggle=\"dropdown\"><i class=\"fa fa-ellipsis-v\" aria-hidden=\"true\"></i><span class=\"sr-only\">Actions</span></a>\n" +
     "<ul class=\"dropdown-menu dropdown-menu-right actions action-button\">\n" +
-    "<li ng-if=\"{resource: 'serviceinstances', group: 'servicecatalog.k8s.io'} | canI : 'update'\">\n" +
+    "<li ng-if=\"serviceInstancesVersion | canI : 'update'\">\n" +
     "<a ng-href=\"{{serviceInstance | editYamlURL}}\" role=\"button\">Edit YAML</a>\n" +
     "</li>\n" +
-    "<li ng-if=\"{resource: 'serviceinstances', group: 'servicecatalog.k8s.io'} | canI : 'delete'\">\n" +
+    "<li ng-if=\"serviceInstancesVersion | canI : 'delete'\">\n" +
     "<a href=\"\" ng-click=\"deprovision()\" role=\"button\">Delete</a>\n" +
     "</li>\n" +
     "</ul>\n" +
@@ -5590,7 +5590,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "<div class=\"service-binding-actions\" ng-if=\"!$ctrl.binding.metadata.deletionTimestamp\">\n" +
-    "<delete-link ng-if=\"({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'delete')\" kind=\"ServiceInstanceCredential\" group=\"servicecatalog.k8s.io\" type-display-name=\"binding\" resource-name=\"{{$ctrl.binding.metadata.name}}\" project-name=\"{{$ctrl.binding.metadata.namespace}}\" stay-on-current-page=\"true\">\n" +
+    "<delete-link ng-if=\"$ctrl.serviceBindingsVersion | canI : 'delete'\" kind=\"ServiceBinding\" group=\"servicecatalog.k8s.io\" type-display-name=\"binding\" resource-name=\"{{$ctrl.binding.metadata.name}}\" project-name=\"{{$ctrl.binding.metadata.namespace}}\" stay-on-current-page=\"true\">\n" +
     "</delete-link>\n" +
     "<a ng-if=\"('secrets' | canI : 'get') && ($ctrl.binding | isBindingReady)\" ng-href=\"{{$ctrl.binding.spec.secretName | navigateResourceURL : 'Secret' : $ctrl.namespace}}\">\n" +
     "View Secret\n" +
@@ -11762,12 +11762,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</li>\n" +
     "<li ng-if=\"('pod_presets' | enableTechPreviewFeature)\n" +
     "                      && row.state.bindableServiceInstances.length\n" +
-    "                      && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'create')\" role=\"menuitem\">\n" +
+    "                      && (row.serviceBindingsVersion | canI : 'create')\" role=\"menuitem\">\n" +
     "<a href=\"\" ng-click=\"row.showOverlayPanel('bindService', {target: row.apiObject})\">Create Binding</a>\n" +
     "</li>\n" +
     "<li ng-if=\"('pod_presets' | enableTechPreviewFeature)\n" +
     "                      && row.state.deleteableBindingsByApplicationUID[row.apiObject.metadata.uid].length\n" +
-    "                      && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'delete')\" role=\"menuitem\">\n" +
+    "                      && (row.serviceBindingsVersion | canI : 'delete')\" role=\"menuitem\">\n" +
     "<a href=\"\" ng-click=\"row.showOverlayPanel('unbindService', {target: row.apiObject})\">Delete Binding</a>\n" +
     "</li>\n" +
     "<li ng-if=\"row.current && ('deploymentconfigs/log' | canI : 'get')\" role=\"menuitem\">\n" +
@@ -11798,12 +11798,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</li>\n" +
     "<li ng-if=\"('pod_presets' | enableTechPreviewFeature)\n" +
     "                      && row.state.bindableServiceInstances.length\n" +
-    "                      && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'create')\" role=\"menuitem\">\n" +
+    "                      && (row.serviceBindingsVersion | canI : 'create')\" role=\"menuitem\">\n" +
     "<a href=\"\" ng-click=\"row.showOverlayPanel('bindService', {target: row.apiObject})\">Create Binding</a>\n" +
     "</li>\n" +
     "<li ng-if=\"('pod_presets' | enableTechPreviewFeature)\n" +
     "                      && row.state.deleteableBindingsByApplicationUID[row.apiObject.metadata.uid].length\n" +
-    "                      && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'delete')\" role=\"menuitem\">\n" +
+    "                      && (row.serviceBindingsVersion | canI : 'delete')\" role=\"menuitem\">\n" +
     "<a href=\"\" ng-click=\"row.showOverlayPanel('unbindService', {target: row.apiObject})\">Delete Binding</a>\n" +
     "</li>\n" +
     "<li ng-if=\"(pod = row.firstPod(row.current)) && ('pods/log' | canI : 'get')\" role=\"menuitem\">\n" +
@@ -12277,7 +12277,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"section-title hidden-xs\">{{$ctrl.sectionTitle}}</div>\n" +
     "<service-binding ng-repeat=\"binding in $ctrl.bindings track by (binding | uid)\" is-overview=\"true\" namespace=\"$ctrl.namespace\" ref-api-object=\"$ctrl.refApiObject\" binding=\"binding\" service-classes=\"$ctrl.serviceClasses\" service-instances=\"$ctrl.serviceInstances\" secrets=\"$ctrl.secrets\">\n" +
     "</service-binding>\n" +
-    "<div ng-if=\"!$ctrl.refApiObject.metadata.deletionTimestamp && (($ctrl.refApiObject.kind === 'ServiceInstance') || ($ctrl.bindableServiceInstances | size)) && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'create')\">\n" +
+    "<div ng-if=\"!$ctrl.refApiObject.metadata.deletionTimestamp && (($ctrl.refApiObject.kind === 'ServiceInstance') || ($ctrl.bindableServiceInstances | size)) && ({resource: 'servicebindings', group: 'servicecatalog.k8s.io'} | canI : 'create')\">\n" +
     "<a href=\"\" ng-click=\"$ctrl.createBinding()\" role=\"button\">\n" +
     "<span class=\"pficon pficon-add-circle-o\" aria-hidden=\"true\"></span>\n" +
     "Create Binding\n" +
@@ -12348,7 +12348,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"list-pf-details\" ng-if=\"!row.expanded\">\n" +
     "<span ng-if=\"!row.bindings.length\n" +
     "                    && row.isBindable\n" +
-    "                    && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'create')\" class=\"hidden-xs hidden-sm\">\n" +
+    "                    && (row.serviceBindingsVersion | canI : 'create')\" class=\"hidden-xs hidden-sm\">\n" +
     "<a href=\"\" ng-click=\"row.showOverlayPanel('bindService', {target: row.apiObject})\">\n" +
     "<span class=\"pficon pficon-add-circle-o\" aria-hidden=\"true\"></span>\n" +
     "Create Binding\n" +
@@ -12381,16 +12381,16 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div uib-dropdown ng-if=\"row.actionsDropdownVisible()\">\n" +
     "<a href=\"\" uib-dropdown-toggle class=\"actions-dropdown-kebab\"><i class=\"fa fa-ellipsis-v\"></i><span class=\"sr-only\">Actions</span></a>\n" +
     "<ul class=\"dropdown-menu dropdown-menu-right\" uib-dropdown-menu role=\"menu\">\n" +
-    "<li role=\"menuitem\" ng-if=\"row.isBindable && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'create')\">\n" +
+    "<li role=\"menuitem\" ng-if=\"row.isBindable && (row.serviceBindingsVersion | canI : 'create')\">\n" +
     "<a href=\"\" ng-click=\"row.showOverlayPanel('bindService', {target: row.apiObject})\">\n" +
     "Create Binding\n" +
     "</a>\n" +
     "</li>\n" +
-    "<li role=\"menuitem\" ng-if=\"row.deleteableBindings.length && ({resource: 'serviceinstancecredentials', group: 'servicecatalog.k8s.io'} | canI : 'delete')\">\n" +
+    "<li role=\"menuitem\" ng-if=\"row.deleteableBindings.length && (row.serviceBindingsVersion | canI : 'delete')\">\n" +
     "<a href=\"\" ng-click=\"row.showOverlayPanel('unbindService', {target: row.apiObject})\">Delete Binding</a>\n" +
     "</li>\n" +
     "<li role=\"menuitem\">\n" +
-    "<a href=\"\" ng-click=\"row.deprovision()\" role=\"button\" ng-if=\"{resource: 'serviceinstances', group: 'servicecatalog.k8s.io'} | canI : 'delete'\">Delete</a>\n" +
+    "<a href=\"\" ng-click=\"row.deprovision()\" role=\"button\" ng-if=\"row.serviceInstancesVersion | canI : 'delete'\">Delete</a>\n" +
     "</li>\n" +
     "</ul>\n" +
     "</div>\n" +
@@ -12420,7 +12420,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"mar-right-md\">\n" +
     "<truncate-long-text content=\"row.apiObject | serviceInstanceFailedMessage\" limit=\"265\"></truncate-long-text>\n" +
     "</span>\n" +
-    "<span ng-if=\"{resource: 'serviceinstances', group: 'servicecatalog.k8s.io'} | canI : 'delete'\" class=\"nowrap\">\n" +
+    "<span ng-if=\"row.serviceInstancesVersion | canI : 'delete'\" class=\"nowrap\">\n" +
     "<a href=\"\" ng-click=\"row.deprovision()\">Delete This Service</a>\n" +
     "</span>\n" +
     "</div>\n" +

--- a/dist/scripts/vendor.js
+++ b/dist/scripts/vendor.js
@@ -72763,7 +72763,7 @@ maxlength: 253,
 description: "Name must consist of lower-case letters, numbers, periods, and hyphens. It must start and end with a letter or a number."
 }).constant("IS_IOS", /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream), hawtioPluginLoader.addModule("openshiftCommonUI"), angular.module("openshiftCommonUI").run([ "$templateCache", function(e) {
 "use strict";
-e.put("src/components/binding/bindApplicationForm.html", '<div class="bind-form">\n  <form>\n    <div class="form-group">\n      <label>\n        <h3>Create a binding for application <strong>{{ctrl.applicationName}}</strong></h3>\n      </label>\n      <span class="help-block">\n        Bindings create a secret containing the necessary information for an application to use a service.\n      </span>\n    </div>\n  </form>\n\n  <label ng-if="!ctrl.allowNoBinding">\n    Select a service:\n  </label>\n  <form name="ctrl.formName">\n    <fieldset>\n      <div class="radio">\n        <div ng-if="ctrl.allowNoBinding" class="bind-service-selection">\n          <label>\n            <input type="radio" ng-model="ctrl.serviceToBind" ng-value="null">\n            Do not bind at this time.\n          </label>\n          <div class="bind-description">\n          <span class="help-block service-instance-name">\n            Bindings can be created later from within a project.\n          </span>\n          </div>\n        </div>\n        <div ng-repeat="serviceInstance in ctrl.bindableServiceInstances" class="bind-service-selection">\n          <label>\n            <input type="radio" ng-model="ctrl.serviceToBind" ng-value="serviceInstance">\n            {{ctrl.serviceClasses[serviceInstance.spec.serviceClassRef.name].spec.externalMetadata.displayName || serviceInstance.spec.serviceClassRef.name}}\n          </label>\n          <div class="bind-description">\n            <span class="pficon pficon-info"\n                  ng-if="!(serviceInstance | isServiceInstanceReady)"\n                  data-content="This service is not yet ready. If you bind to it, then the binding will be pending until the service is ready."\n                  data-toggle="popover"\n                  data-trigger="hover">\n            </span>\n            <span class="help-block service-instance-name">\n              {{serviceInstance.metadata.name}}\n            </span>\n          </div>\n        </div>\n        <h4 ng-if="!ctrl.bindableServiceInstances.length">\n          <span class="pficon pficon-info" aria-hidden="true"></span>\n          <span class="help-block service-instance-name">\n            There are no bindable services in this project\n          </span>\n        </h4>\n      </div>\n    </fieldset>\n  </form>\n</div>\n'), 
+e.put("src/components/binding/bindApplicationForm.html", '<div class="bind-form">\n  <form>\n    <div class="form-group">\n      <label>\n        <h3>Create a binding for application <strong>{{ctrl.applicationName}}</strong></h3>\n      </label>\n      <span class="help-block">\n        Bindings create a secret containing the necessary information for an application to use a service.\n      </span>\n    </div>\n  </form>\n\n  <label ng-if="!ctrl.allowNoBinding">\n    Select a service:\n  </label>\n  <form name="ctrl.formName">\n    <fieldset>\n      <div class="radio">\n        <div ng-if="ctrl.allowNoBinding" class="bind-service-selection">\n          <label>\n            <input type="radio" ng-model="ctrl.serviceToBind" ng-value="null">\n            Do not bind at this time.\n          </label>\n          <div class="bind-description">\n          <span class="help-block service-instance-name">\n            Bindings can be created later from within a project.\n          </span>\n          </div>\n        </div>\n        <div ng-repeat="serviceInstance in ctrl.bindableServiceInstances" class="bind-service-selection">\n          <label>\n            <input type="radio" ng-model="ctrl.serviceToBind" ng-value="serviceInstance">\n            {{ctrl.serviceClasses[serviceInstance.spec.clusterServiceClassRef.name].spec.externalMetadata.displayName || serviceInstance.spec.clusterServiceClassRef.name}}\n          </label>\n          <div class="bind-description">\n            <span class="pficon pficon-info"\n                  ng-if="!(serviceInstance | isServiceInstanceReady)"\n                  data-content="This service is not yet ready. If you bind to it, then the binding will be pending until the service is ready."\n                  data-toggle="popover"\n                  data-trigger="hover">\n            </span>\n            <span class="help-block service-instance-name">\n              {{serviceInstance.metadata.name}}\n            </span>\n          </div>\n        </div>\n        <h4 ng-if="!ctrl.bindableServiceInstances.length">\n          <span class="pficon pficon-info" aria-hidden="true"></span>\n          <span class="help-block service-instance-name">\n            There are no bindable services in this project\n          </span>\n        </h4>\n      </div>\n    </fieldset>\n  </form>\n</div>\n'), 
 e.put("src/components/binding/bindResults.html", '<div ng-if="!ctrl.error && !(ctrl.binding | isBindingFailed)">\n  <div ng-if="ctrl.binding && !(ctrl.binding | isBindingReady)" class="results-status">\n    <span class="fa fa-clock-o text-muted" aria-hidden="true"></span>\n    <span class="sr-only">Pending</span>\n    <div class="results-message">\n      <h3>\n        The binding is being created.\n      </h3>\n      <p class="results-message-details">This may take several minutes.</p>\n    </div>\n  </div>\n  <div ng-if="(ctrl.binding | isBindingReady)">\n    <div class="results-status">\n      <span class="pficon pficon-ok" aria-hidden="true"></span>\n      <span class="sr-only">Success</span>\n      <div class="results-message">\n        <h3>\n          <span ng-if="ctrl.bindType === \'application\'">\n            <strong>{{ctrl.serviceToBind}}</strong> has been bound to\n            <strong>{{ctrl.applicationToBind}}</strong> successfully.\n          </span>\n          <span ng-if="ctrl.bindType !== \'application\'">\n            The binding <strong>{{ctrl.serviceToBind}}</strong> has been created successfully.\n          </span>\n        </h3>\n        <p class="results-message-details">\n          The binding operation created the secret\n          <a ng-if="ctrl.secretHref" ng-href="{{ctrl.secretHref}}">{{ctrl.binding.spec.secretName}}</a>\n          <span ng-if="!ctrl.secretHref">{{ctrl.binding.spec.secretName}}</span>\n          that you may need to reference in your application.\n          <span ng-if="ctrl.showPodPresets">Its data will be available to your application as environment variables.</span>\n        </p>\n      </div>\n    </div>\n    <div class="alert alert-info results-info" ng-if="ctrl.bindType === \'application\'">\n      <span class="pficon pficon-info" aria-hidden="true"></span>\n      <span class="sr-only">Info</span>\n      The binding secret will only be available to new pods. You will need to redeploy your application.\n    </div>\n  </div>\n</div>\n<div ng-if="ctrl.error || (ctrl.binding | isBindingFailed)">\n  <div class="results-status">\n    <span class="pficon pficon-error-circle-o text-danger" aria-hidden="true"></span>\n    <span class="sr-only">Error</span>\n    <div class="results-message">\n      <h3>\n        The binding could not be created.\n      </h3>\n    </div>\n  </div>\n  <div ng-if="ctrl.error" class="sub-title">\n    <span ng-if="ctrl.error.data.message">\n      {{ctrl.error.data.message | upperFirst}}\n    </span>\n    <span ng-if="!ctrl.error.data.message">\n      An error occurred creating the binding.\n    </span>\n  </div>\n  <div ng-if="!ctrl.error" class="sub-title">\n    {{ctrl.binding | bindingFailedMessage}}\n  </div>\n</div>\n'), 
 e.put("src/components/binding/bindServiceForm.html", '<div class="bind-form">\n  <form>\n    <div class="form-group">\n      <label>\n        <h3>Create a binding for <strong>{{ctrl.serviceClass.spec.externalMetadata.displayName || ctrl.serviceClass.spec.externalName}}</strong></h3>\n      </label>\n      <span class="help-block">Bindings create a secret containing the necessary information for an application to use this service.</span>\n    </div>\n  </form>\n\n  <form ng-if="ctrl.allowNoBinding || ctrl.showPodPresets" name="ctrl.formName" class="mar-bottom-lg">\n    <fieldset>\n      <div class="radio">\n        <label ng-if="ctrl.showPodPresets" class="bind-choice" ng-disabled="!ctrl.applications.length">\n          <input type="radio" ng-model="ctrl.bindType" value="application" ng-disabled="!ctrl.applications.length">\n          Create a secret and inject it into an application\n        </label>\n        <div ng-if="ctrl.showPodPresets" class="application-select">\n          <ui-select ng-model="ctrl.appToBind"\n                     ng-disabled="ctrl.bindType !== \'application\'"\n                     ng-required="ctrl.bindType === \'application\'">\n            <ui-select-match placeholder="{{ctrl.applications.length ? \'Select an application\' : \'There are no applications in this project\'}}">\n              <span>\n                {{$select.selected.metadata.name}}\n                <small class="text-muted">&ndash; {{$select.selected.kind | humanizeKind : true}}</small>\n              </span>\n            </ui-select-match>\n            <ui-select-choices\n              repeat="application in (ctrl.applications) | filter : { metadata: { name: $select.search } } track by (application | uid)"\n              group-by="ctrl.groupByKind">\n              <span ng-bind-html="application.metadata.name | highlight : $select.search"></span>\n            </ui-select-choices>\n          </ui-select>\n        </div>\n        <label class="bind-choice">\n          <input type="radio" ng-model="ctrl.bindType" value="secret-only">\n          Create a secret in <strong>{{ctrl.projectName}}</strong> to be used later\n        </label>\n        <div class="help-block bind-description">\n          Secrets can be referenced later from an application.\n        </div>\n        <label ng-if="ctrl.allowNoBinding" class="bind-choice">\n          <input type="radio" ng-model="ctrl.bindType" value="none">\n          Do not bind at this time\n        </label>\n        <div ng-if="ctrl.allowNoBinding" class="help-block bind-description">\n          Bindings can be created later from within a project.\n        </div>\n      </div>\n    </fieldset>\n  </form>\n</div>\n'), 
 e.put("src/components/create-project/createProject.html", '<form name="createProjectForm" novalidate>\n  <fieldset ng-disabled="disableInputs">\n    <div class="form-group">\n      <label for="name" class="required">Name</label>\n      <span ng-class="{\'has-error\': (createProjectForm.name.$error.pattern && createProjectForm.name.$touched) || nameTaken}">\n        <input class="form-control"\n            name="name"\n            id="name"\n            placeholder="my-project"\n            type="text"\n            required\n            take-focus\n            minlength="2"\n            maxlength="63"\n            pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?"\n            aria-describedby="nameHelp"\n            ng-model="name"\n            ng-model-options="{ updateOn: \'default blur\' }"\n            ng-change="nameTaken = false"\n            autocorrect="off"\n            autocapitalize="off"\n            spellcheck="false">\n      </span>\n      <div>\n        <span class="help-block">A unique name for the project.</span>\n      </div>\n      <div class="has-error">\n        <span id="nameHelp" class="help-block" ng-if="createProjectForm.name.$error.required && createProjectForm.name.$dirty">\n          Name is required.\n        </span>\n      </div>\n      <div class="has-error">\n        <span id="nameHelp" class="help-block" ng-if="createProjectForm.name.$error.minlength && createProjectForm.name.$touched">\n          Name must have at least two characters.\n        </span>\n      </div>\n      <div class="has-error">\n        <span id="nameHelp" class="help-block" ng-if="createProjectForm.name.$error.pattern && createProjectForm.name.$touched">\n          Project names may only contain lower-case letters, numbers, and dashes.\n          They may not start or end with a dash.\n        </span>\n      </div>\n      <div class="has-error">\n        <span class="help-block" ng-if="nameTaken">\n          This name is already in use. Please choose a different name.\n        </span>\n      </div>\n    </div>\n\n    <div class="form-group">\n      <label for="displayName">Display Name</label>\n      <input class="form-control"\n          name="displayName"\n          id="displayName"\n          placeholder="My Project"\n          type="text"\n          ng-model="displayName">\n    </div>\n\n    <div class="form-group">\n      <label for="description">Description</label>\n      <textarea class="form-control"\n          name="description"\n          id="description"\n          placeholder="A short description."\n          ng-model="description"></textarea>\n    </div>\n\n    <div class="button-group">\n      <button type="submit"\n          class="btn btn-primary"\n          ng-class="{\'dialog-btn\': isDialog}"\n          ng-click="createProject()"\n          ng-disabled="createProjectForm.$invalid || nameTaken || disableInputs"\n          value="">\n        Create\n      </button>\n      <button\n          class="btn btn-default"\n          ng-class="{\'dialog-btn\': isDialog}"\n          ng-click="cancelCreateProject()">\n        Cancel\n      </button>\n    </div>\n  </fieldset>\n</form>\n'), 
@@ -73181,11 +73181,13 @@ resource: "configmaps"
 },
 clusterserviceclasses: {
 group: "servicecatalog.k8s.io",
-resource: "serviceclasses"
+version: "v1beta1",
+resource: "clusterserviceclasses"
 },
 clusterserviceplans: {
 group: "servicecatalog.k8s.io",
-resource: "serviceplans"
+version: "v1beta1",
+resource: "clusterserviceplans"
 },
 deployments: {
 group: "apps",
@@ -73289,10 +73291,12 @@ resource: "serviceaccounts"
 },
 servicebindings: {
 group: "servicecatalog.k8s.io",
-resource: "serviceinstancecredentials"
+version: "v1beta1",
+resource: "servicebindings"
 },
 serviceinstances: {
 group: "servicecatalog.k8s.io",
+version: "v1beta1",
 resource: "serviceinstances"
 },
 statefulsets: {
@@ -73577,6 +73581,25 @@ return !!e(t, "deployment.kubernetes.io/revision");
 } ]).filter("hasDeploymentConfig", [ "annotationFilter", function(e) {
 return function(t) {
 return !!e(t, "deploymentConfig");
+};
+} ]).filter("serviceClassDisplayName", function() {
+return function(e) {
+var t = _.get(e, "spec.externalMetadata.displayName");
+if (t) return t;
+var n = _.get(e, "spec.externalName");
+return n || _.get(e, "metadata.name");
+};
+}).filter("serviceInstanceDisplayName", [ "serviceClassDisplayNameFilter", function(e) {
+return function(t, n) {
+return n ? e(n) : _.get(t, "metadata.name");
+};
+} ]).filter("serviceInstanceStatus", [ "isServiceInstanceReadyFilter", function(e) {
+return function(t) {
+var n = "Pending", i = _.get(t, "status.conditions");
+return _.find(i, {
+type: "Failed",
+status: "True"
+}) ? n = "Failed" : e(t) && (n = "Ready"), n;
 };
 } ]), angular.module("openshiftCommonUI").filter("camelToLower", function() {
 return function(e) {
@@ -74073,8 +74096,8 @@ stringData: {}
 return i.stringData.parameters = JSON.stringify(t), i;
 }, u = function(e, t, n) {
 var i = e.metadata.name, r = l(e.metadata.name + "-credentials-"), o = {
-kind: "ServiceInstanceCredential",
-apiVersion: "servicecatalog.k8s.io/v1alpha1",
+kind: "ServiceBinding",
+apiVersion: "servicecatalog.k8s.io/v1beta1",
 metadata: {
 generateName: i + "-"
 },
@@ -74115,9 +74138,11 @@ return {
 bindingResource: a,
 getServiceClassForInstance: function(e, t) {
 if (!t) return null;
-var n = _.get(e, "spec.serviceClassRef.name");
+var n = _.get(e, "spec.clusterServiceClassRef.name");
 return n ? t[n] : null;
 },
+makeParametersSecret: c,
+generateSecretName: l,
 bindService: function(e, t, n, i) {
 var o;
 _.isEmpty(i) || (o = l(e.metadata.name + "-bind-parameters-"));
@@ -74142,14 +74167,14 @@ t.covers(i) && r.push(e[n]);
 },
 filterBindableServiceInstances: function(e, t, n) {
 return e && t && n ? _.filter(e, function(e) {
-var i = _.get(e, "spec.serviceClassRef.name"), r = _.get(e, "spec.servicePlanRef.name");
+var i = _.get(e, "spec.clusterServiceClassRef.name"), r = _.get(e, "spec.clusterServicePlanRef.name");
 return d(e, t[i], n[r]);
 }) : null;
 },
 sortServiceInstances: function(e, t) {
 return e || t ? _.sortBy(e, function(e) {
-var n = _.get(e, "spec.serviceClassRef.name");
-return _.get(t, [ n, "spec", "externalMetadata", "displayName" ]) || e.spec.externalServiceClassName;
+var n = _.get(e, "spec.clusterServiceClassRef.name");
+return _.get(t, [ n, "spec", "externalMetadata", "displayName" ]) || e.spec.externalClusterServiceClassName;
 }, function(e) {
 return _.get(e, "metadata.name", "");
 }) : null;
@@ -75280,7 +75305,7 @@ return !0;
 }
 },
 linkify: function(e, t, n) {
-return e ? (n || (e = _.escape(e)), e.replace(/https?:\/\/[A-Za-z0-9._%+-]+\S*[^\s.;,(){}<>"\u201d\u2019]/gm, function(e) {
+return e ? (n || (e = _.escape(e)), e.replace(/https?:\/\/[A-Za-z0-9._%+-]+[^\s<]*[^\s.,()\[\]{}<>"\u201d\u2019]/gm, function(e) {
 return t ? '<a href="' + e + '" target="' + t + '">' + e + ' <i class="fa fa-external-link" aria-hidden="true"></i></a>' : '<a href="' + e + '">' + e + "</a>";
 })) : e;
 }
@@ -77278,7 +77303,7 @@ e.exports = '<div class="order-service-config">\n  <bind-application-form applic
 }, function(e, t) {
 e.exports = '<div class="order-service-config">\n  <div class="config-top">\n    <form name="$ctrl.builderForm" class="config-form">\n      <div class="form-group">\n        <label class="control-label" for="version">Version</label>\n        <ui-select ng-model="$ctrl.istag" required search-enabled="false">\n          <ui-select-match>\n            {{$select.selected.name}}\n          </ui-select-match>\n          <ui-select-choices repeat="tag in $ctrl.versions track by tag.name">\n            {{tag.name}}\n            <small ng-repeat="otherTag in $ctrl.referencedBy[tag.name]">\n              <span ng-if="$first"> &mdash; </span>{{otherTag}}<span ng-if="!$last">,</span>\n            </small>\n          </ui-select-choices>\n        </ui-select>\n      </div>\n      <select-project selected-project="$ctrl.selectedProject" name-taken="$ctrl.projectNameTaken"></select-project>\n      <div class="form-group">\n        <label class="control-label required" for="app-name">Application Name</label>\n        <div ng-class="{ \'has-error\': $ctrl.builderForm.name.$touched && $ctrl.builderForm.name.$invalid }">\n          <input\n            class="form-control"\n            type="text"\n            id="app-name"\n            required\n            minlength="2"\n            ng-maxlength="$ctrl.nameMaxLength"\n            ng-pattern="$ctrl.namePattern"\n            ng-model="$ctrl.name"\n            name="name"\n            autocorrect="off"\n            autocapitalize="none"\n            spellcheck="false">\n          \x3c!-- Wait until users leave the field to avoid flashing errors as they type. --\x3e\n          <div ng-if="$ctrl.builderForm.name.$touched">\n            <div class="has-error" ng-show="$ctrl.builderForm.name.$error.required">\n              <span class="help-block">\n                Application name is required.\n              </span>\n            </div>\n            <div class="has-error" ng-show="$ctrl.builderForm.name.$error.pattern">\n              <span class="help-block">\n                Application name consists of lower-case letters, numbers, and dashes. It must start with a letter and can\'t end with a <code>-</code>.\n              </span>\n            </div>\n            <div class="has-error" ng-show="$ctrl.builderForm.name.$error.minlength">\n              <span class="help-block">\n                Application name must be at least 2 characters.\n              </span>\n            </div>\n            <div class="has-error" ng-show="$ctrl.builderForm.name.$error.maxlength">\n              <span class="help-block">\n                Application name can\'t be more than 24 characters.\n              </span>\n            </div>\n          </div>\n        </div>\n      </div>\n\n      <div class="form-group">\n        <label class="control-label required" for="repository">Git Repository</label>\n        <div ng-class="{ \'has-error\': $ctrl.builderForm.repository.$touched && $ctrl.builderForm.repository.$error.$required }">\n          <input class="form-control"\n            type="text"\n            id="repository"\n            name="repository"\n            required\n            ng-model="$ctrl.repository"\n            autocorrect="off"\n            autocapitalize="off"\n            spellcheck="false">\n          <div ng-if="$ctrl.istag.annotations.sampleRepo" class="help-block">\n            <a href="" ng-click="$ctrl.fillSampleRepo()">Try Sample Repository\n              <i class="fa fa-level-up" aria-hidden="true"></i></a>\n          </div>\n          <div class="has-error" ng-if="$ctrl.builderForm.repository.$touched && $ctrl.builderForm.repository.$error.$required">\n            <span class="help-block">\n              Git repository is required.\n            </span>\n          </div>\n          <div class="has-warning" ng-if="$ctrl.builderForm.repository.$touched && $ctrl.repository && !$ctrl.repositoryPattern.test($ctrl.repository)">\n            <span class="help-block">\n              This might not be a valid Git URL. Check that it is the correct URL to a remote Git repository.\n            </span>\n          </div>\n        </div>\n      </div>\n\n      \x3c!--\n        Only show the link for existing projects. It will be broken for new\n        projects.  Use class `invisible` when the project list is still loading\n        so the dialog doesn\'t resize.\n      --\x3e\n      <div ng-hide="$ctrl.selectedProject && !$ctrl.selectedProject.metadata.uid"\n           ng-class="{ invisible: !$ctrl.selectedProject || !$ctrl.istag }"\n           class="form-group">\n        If you have a private Git repository or need to change application defaults, view\n        <a href="" ng-click="$ctrl.navigateToAdvancedForm()">advanced options</a>.\n      </div>\n    </form>\n  </div>\n</div>\n';
 }, function(e, t) {
-e.exports = '<div class="order-service-details">\n  <div class="order-service-details-top">\n    <div class="service-icon">\n      <span ng-if="!$ctrl.imageStream.imageUrl" class="icon {{$ctrl.imageStreamiconClass}}" aria-hidden="true"></span>\n      <span ng-if="$ctrl.imageStream.imageUrl" class="image"><img ng-src="{{$ctrl.imageStream.imageUrl}}" alt=""></span>\n    </div>\n    <div class="service-title-area">\n      <div class="service-title">\n        {{$ctrl.imageStream.name}}\n        {{$ctrl.istag.name}}\n      </div>\n      <div class="order-service-tags">\n        <span ng-repeat="tag in $ctrl.istag.annotations.tags.split(\',\')" class="tag">\n          {{tag}}\n        </span>\n      </div>\n    </div>\n  </div>\n  <div class="order-service-description-block">\n    <p ng-bind-html="$ctrl.istag.annotations.description | linky : \'_blank\'" class="description"></p>\n    <p ng-if="$ctrl.istag.annotations.sampleRepo">\n      Sample Repository:\n      \x3c!-- TODO: Use Git link filter, needs to be added to origin-web-common --\x3e\n      <span ng-bind-html="$ctrl.istag.annotations.sampleRepo | linky : \'_blank\'">\n    </p>\n  </div>\n</div>\n';
+e.exports = '<div class="order-service-details">\n  <div class="order-service-details-top">\n    <div class="service-icon">\n      <span ng-if="!$ctrl.imageStream.imageUrl" class="icon {{$ctrl.imageStream.iconClass}}" aria-hidden="true"></span>\n      <span ng-if="$ctrl.imageStream.imageUrl" class="image"><img ng-src="{{$ctrl.imageStream.imageUrl}}" alt=""></span>\n    </div>\n    <div class="service-title-area">\n      <div class="service-title">\n        {{$ctrl.imageStream.name}}\n        {{$ctrl.istag.name}}\n      </div>\n      <div class="order-service-tags">\n        <span ng-repeat="tag in $ctrl.istag.annotations.tags.split(\',\')" class="tag">\n          {{tag}}\n        </span>\n      </div>\n    </div>\n  </div>\n  <div class="order-service-description-block">\n    <p ng-bind-html="$ctrl.istag.annotations.description | linky : \'_blank\'" class="description"></p>\n    <p ng-if="$ctrl.istag.annotations.sampleRepo">\n      Sample Repository:\n      \x3c!-- TODO: Use Git link filter, needs to be added to origin-web-common --\x3e\n      <span ng-bind-html="$ctrl.istag.annotations.sampleRepo | linky : \'_blank\'">\n    </p>\n  </div>\n</div>\n';
 }, function(e, t) {
 e.exports = '<div class="order-service-config">\n  <div ng-if="!$ctrl.success && !$ctrl.error">\n    <div class="results-status">\n      <span class="fa fa-clock-o text-muted" aria-hidden="true"></span>\n      <span class="sr-only">Pending</span>\n      <div class="results-message">\n        <h3>\n          <strong>{{$ctrl.name}}</strong> is being created in <strong>{{$ctrl.selectedProject | displayName}}</strong>.\n        </h3>\n      </div>\n    </div>\n  </div>\n  <div ng-if="$ctrl.success">\n    <div class="results-status">\n      <span class="pficon pficon-ok" aria-hidden="true"></span>\n      <span class="sr-only">Success</span>\n      <div class="results-message">\n        <h3>\n          <strong>{{$ctrl.name}}</strong> has been created in <strong>{{$ctrl.selectedProject | displayName}}</strong> successfully.\n        </h3>\n      </div>\n    </div>\n  </div>\n  <div ng-if="$ctrl.success && $ctrl.binding">\n    <bind-results error="$ctrl.bindError"\n                  binding="$ctrl.binding"\n                  service-to-bind="$ctrl.serviceToBind.metadata.name"\n                  bind-type="application"\n                  application-to-bind="$ctrl.name"\n                  show-pod-presets="$ctrl.showPodPresets">\n    </bind-results>\n  </div>\n  <div ng-if="$ctrl.success">\n    <p ng-if="!$ctrl.serviceToBind || $ctrl.bindComplete">\n      <a ng-href="{{$ctrl.selectedProject | projectUrl : $ctrl.baseProjectUrl}}">Continue to the project overview</a> to check the status of your application as it builds and deploys.\n    </p>\n  </div>\n  <div class="results-failure" ng-if="$ctrl.error">\n    <div class="results-status">\n      <span class="pficon pficon-error-circle-o text-danger" aria-hidden="true"></span>\n      <div class="results-message">\n        <h3>\n          <strong>{{$ctrl.name}}</strong> failed to create in <strong>{{$ctrl.selectedProject | displayName}}</strong>.\n        </h3>\n      </div>\n    </div>\n    <div class="sub-title">\n      <span ng-if="$ctrl.error.data.message">\n        {{$ctrl.error.data.message | upperFirst}}\n      </span>\n      <span ng-if="!$ctrl.error.data.message">\n        An error occurred creating the application.\n      </span>\n    </div>\n    \x3c!-- TODO: Improve error message presentation --\x3e\n    <ul ng-if="$ctrl.error.failure.length" class="failure-messages">\n      <li ng-repeat="failure in $ctrl.error.failure">\n        {{failure.data.message}}\n      </li>\n    </ul>\n  </div>\n</div>\n';
 }, function(e, t) {
@@ -77893,36 +77918,40 @@ function e(e, t, n, i, r, o) {
 this.vendors = [], this.$filter = e, this.$q = t, this.constants = n, this.apiService = i, this.dataService = r, this.logger = o;
 }
 return e.prototype.getCatalogItems = function(e) {
-var t = this, n = this.$q.defer(), i = {}, r = 0, o = 0, a = [], s = this.apiService.getPreferredVersion("clusterserviceclasses");
-this.apiService.apiInfo(s) && (++r, this.dataService.list(s, {}).then(function(e) {
-i.serviceClasses = e.by("metadata.name");
+var t = this, n = this.$q.defer(), i = {}, o = 0, a = 0, s = [], l = this.apiService.getPreferredVersion("clusterserviceclasses");
+this.apiService.apiInfo(l) && (++o, this.dataService.list(l, {}).then(function(e) {
+i.serviceClasses = r.reject(e.by("metadata.name"), {
+status: {
+removedFromBrokerCatalog: !0
+}
+});
 }, function() {
-a.push("service classes");
+s.push("service classes");
 }).finally(function() {
-t.returnCatalogItems(n, i, ++o, r, a);
-})), ++r;
-var l = this.apiService.getPreferredVersion("imagestreams");
-if (this.dataService.list(l, {
+t.returnCatalogItems(n, i, ++a, o, s);
+})), ++o;
+var c = this.apiService.getPreferredVersion("imagestreams");
+if (this.dataService.list(c, {
 namespace: "openshift"
 }).then(function(e) {
 i.imageStreams = e.by("metadata.name");
 }, function() {
-a.push("builder images");
+s.push("builder images");
 }).finally(function() {
-t.returnCatalogItems(n, i, ++o, r, a);
+t.returnCatalogItems(n, i, ++a, o, s);
 }), e) {
-++r;
-var c = this.apiService.getPreferredVersion("templates");
-this.dataService.list(c, {
+++o;
+var u = this.apiService.getPreferredVersion("templates");
+this.dataService.list(u, {
 namespace: "openshift"
 }, null, {
 partialObjectMetadataList: !0
 }).then(function(e) {
 i.templates = e.by("metadata.name");
 }, function() {
-a.push("templates");
+s.push("templates");
 }).finally(function() {
-t.returnCatalogItems(n, i, ++o, r, a);
+t.returnCatalogItems(n, i, ++a, o, s);
 });
 }
 return n.promise;
@@ -77930,7 +77959,7 @@ return n.promise;
 var e = this.apiService.getPreferredVersion("clusterserviceplans");
 return this.apiService.apiInfo(e) ? this.dataService.list(e, {}) : this.$q.when(null);
 }, e.prototype.groupPlansByServiceClassName = function(e) {
-return r.groupBy(e, "spec.serviceClassRef.name");
+return r.groupBy(e, "spec.clusterServiceClassRef.name");
 }, e.prototype.getProjectCatalogItems = function(e, t, n, i) {
 var r = this;
 void 0 === t && (t = !0), void 0 === n && (n = !0), void 0 === i && (i = !1);
@@ -77965,9 +77994,7 @@ return o = o.concat(r.map(t, function(e) {
 return i.getImageItem(e);
 })), o = o.concat(r.map(n, function(e) {
 return i.getTemplateItem(e);
-})), o = r.reject(o, function(e) {
-return !e;
-}), o = o.sort(function(e, t) {
+})), o = r.reject(o, "hidden"), o = o.sort(function(e, t) {
 var n = r.get(e, "name", "").localeCompare(r.get(t, "name", ""), void 0, {
 sensitivity: "base"
 });
@@ -77980,8 +78007,7 @@ sensitivity: "base"
 }, e.prototype.getServiceItem = function(e) {
 return new a(e, this);
 }, e.prototype.getImageItem = function(e) {
-var t = new s(e, this);
-return t.builderSpecTagName ? t : null;
+return new s(e, this);
 }, e.prototype.getTemplateItem = function(e) {
 return new l(e, this);
 }, e.prototype.getPublisherSynonym = function(e) {
@@ -78056,7 +78082,7 @@ return 1 === e.length ? t = e[0] : 2 === e.length ? t = e.join(" and ") : e.leng
 o.$inject = [ "$filter", "$q", "Constants", "APIService", "DataService", "Logger" ], t.CatalogService = o;
 var a = function() {
 function e(e, t) {
-this.resource = e, this.catalogSrv = t, this.imageUrl = this.getImage(), this.iconClass = this.getIcon(), this.name = this.getName(), this.description = this.getDescription(), this.longDescription = this.getLongDescription(), this.tags = this.getTags(), this.kind = "ServiceClass", this.vendor = this.getVendor();
+this.resource = e, this.catalogSrv = t, this.imageUrl = this.getImage(), this.iconClass = this.getIcon(), this.name = this.getName(), this.description = this.getDescription(), this.longDescription = this.getLongDescription(), this.tags = this.getTags(), this.kind = "ClusterServiceClass", this.vendor = this.getVendor(), this.hidden = r.includes(this.tags, "hidden");
 }
 return e.prototype.getImage = function() {
 var e = r.get(this.resource, "spec.externalMetadata.imageUrl");
@@ -78069,7 +78095,7 @@ return e = -1 !== e.indexOf("icon-") ? "font-icon " + e : e;
 }, e.prototype.getName = function() {
 return r.get(this.resource, "spec.externalMetadata.displayName") || this.resource.metadata.name;
 }, e.prototype.getDescription = function() {
-return r.get(this.resource, "description") || "";
+return r.get(this.resource, "spec.description") || "";
 }, e.prototype.getLongDescription = function() {
 return r.get(this.resource, "spec.externalMetadata.longDescription") || "";
 }, e.prototype.getTags = function() {
@@ -78082,7 +78108,7 @@ return this.catalogSrv.getPublisherSynonym(e);
 t.ServiceItem = a;
 var s = function() {
 function e(e, t) {
-this.resource = e, this.catalogSrv = t, this.builderSpecTagName = this.getBuilderSpecTagName(), this.builderSpecTagName && (this.tags = this.getTags(), this.imageUrl = this.getImage(), this.iconClass = this.getIcon(), this.name = this.getName(), this.description = this.getDescription(), this.longDescription = this.getLongDescription(), this.kind = "ImageStream", this.vendor = this.getVendor());
+this.resource = e, this.catalogSrv = t, this.builderSpecTagName = this.getBuilderSpecTagName(), this.builderSpecTagName ? (this.tags = this.getTags(), this.imageUrl = this.getImage(), this.iconClass = this.getIcon(), this.name = this.getName(), this.description = this.getDescription(), this.longDescription = this.getLongDescription(), this.kind = "ImageStream", this.vendor = this.getVendor(), this.hidden = !1) : this.hidden = !0;
 }
 return e.prototype.getBuilderSpecTagName = function() {
 var e, t = this;
@@ -78114,7 +78140,7 @@ return null;
 t.ImageItem = s;
 var l = function() {
 function e(e, t) {
-this.resource = e, this.catalogSrv = t, this.imageUrl = this.getImage(), this.iconClass = this.getIcon(), this.name = this.getName(), this.description = this.getDescription(), this.longDescription = this.getLongDescription(), this.tags = this.getTags(), this.kind = "Template", this.vendor = this.getVendor();
+this.resource = e, this.catalogSrv = t, this.imageUrl = this.getImage(), this.iconClass = this.getIcon(), this.name = this.getName(), this.description = this.getDescription(), this.longDescription = this.getLongDescription(), this.tags = this.getTags(), this.kind = "Template", this.vendor = this.getVendor(), this.hidden = r.includes(this.tags, "hidden");
 }
 return e.prototype.getImage = function() {
 var e = r.get(this.resource, "metadata.annotations.iconClass");
@@ -78165,7 +78191,7 @@ e.exports = '<div class="catalog-search">\n  <form role="form" class="landing-se
 }, function(e, t) {
 e.exports = '<div class="order-service">\n  <pf-wizard\n       title="{{$ctrl.imageStream.name}} {{$ctrl.istag.name}}"\n       hide-sidebar="true"\n       step-class="order-service-wizard-step"\n       wizard-ready="$ctrl.wizardReady"\n       next-title="$ctrl.nextTitle"\n       on-finish="$ctrl.closePanel()"\n       on-cancel="$ctrl.closePanel()"\n       wizard-done="$ctrl.wizardDone">\n    <pf-wizard-step ng-repeat="step in $ctrl.steps track by $index"\n         step-title="{{step.label}}"\n         wz-disabled="{{step.hidden}}"\n         allow-click-nav="step.allowClickNav"\n         next-enabled="step.valid && !$ctrl.updating"\n         prev-enabled="step.prevEnabled"\n         on-show="step.onShow"\n         step-id="{{step.id}}"\n         step-priority="{{$index}}">\n      <div class="wizard-pf-main-inner-shadow-covers">\n        <div class="order-service-config">\n          <div ng-include="step.view" class="wizard-pf-main-form-contents"></div>\n        </div>\n      </div>\n    </>\n  </>\n</div>\n';
 }, function(e, t) {
-e.exports = '<div class="landing-search-area" ng-transclude="landingsearch"></div>\n<div class="landing">\n  <overlay-panel show-panel="$ctrl.orderingPanelVisible" handle-close="$ctrl.closeOrderingPanel">\n    <order-service\n        ng-if="$ctrl.selectedItem.resource.kind === \'ServiceClass\'"\n        base-project-url="{{$ctrl.baseProjectUrl}}"\n        service-class="$ctrl.selectedItem"\n        service-plans="$ctrl.servicePlansForItem"\n        handle-close="$ctrl.closeOrderingPanel">\n    </order-service>\n    <create-from-builder\n        ng-if="$ctrl.selectedItem.resource.kind === \'ImageStream\'"\n        base-project-url="{{$ctrl.baseProjectUrl}}"\n        image-stream="$ctrl.selectedItem"\n        handle-close="$ctrl.closeOrderingPanel">\n    </create-from-builder>\n  </overlay-panel>\n  <div class="landing-main-area">\n    <div class="landing-header-area" ng-transclude="landingheader"></div>\n    <div class="landing-body-area">\n      <div class="landing-body" ng-transclude="landingbody"></div>\n    </div>\n  </div>\n  <div class="landing-side-bar" ng-transclude="landingside"></div>\n</div>\n';
+e.exports = '<div class="landing-search-area" ng-transclude="landingsearch"></div>\n<div class="landing">\n  <overlay-panel show-panel="$ctrl.orderingPanelVisible" handle-close="$ctrl.closeOrderingPanel">\n    <order-service\n        ng-if="$ctrl.selectedItem.resource.kind === \'ClusterServiceClass\'"\n        base-project-url="{{$ctrl.baseProjectUrl}}"\n        service-class="$ctrl.selectedItem"\n        service-plans="$ctrl.servicePlansForItem"\n        handle-close="$ctrl.closeOrderingPanel">\n    </order-service>\n    <create-from-builder\n        ng-if="$ctrl.selectedItem.resource.kind === \'ImageStream\'"\n        base-project-url="{{$ctrl.baseProjectUrl}}"\n        image-stream="$ctrl.selectedItem"\n        handle-close="$ctrl.closeOrderingPanel">\n    </create-from-builder>\n  </overlay-panel>\n  <div class="landing-main-area">\n    <div class="landing-header-area" ng-transclude="landingheader"></div>\n    <div class="landing-body-area">\n      <div class="landing-body" ng-transclude="landingbody"></div>\n    </div>\n  </div>\n  <div class="landing-side-bar" ng-transclude="landingside"></div>\n</div>\n';
 }, function(e, t) {
 e.exports = '<div class="order-service">\n  <pf-wizard\n       title="{{$ctrl.serviceName}}"\n       hide-sidebar="true"\n       step-class="order-service-wizard-step"\n       wizard-ready="$ctrl.wizardReady"\n       next-title="$ctrl.nextTitle"\n       on-finish="$ctrl.closePanel()"\n       on-cancel="$ctrl.closePanel()"\n       wizard-done="$ctrl.wizardDone">\n    <pf-wizard-step ng-repeat="step in $ctrl.steps track by step.id"\n         step-title="{{step.label}}"\n         wz-disabled="{{step.hidden}}"\n         allow-click-nav="step.allowClickNav"\n         next-enabled="step.valid && !$ctrl.updating"\n         prev-enabled="step.prevEnabled"\n         on-show="step.onShow"\n         step-id="{{step.id}}"\n         step-priority="{{$index}}">\n      <div class="wizard-pf-main-inner-shadow-covers">\n        <div ng-include="step.view" class="wizard-pf-main-form-contents"></div>\n      </div>\n    </pf-wizard-step>\n  </pf-wizard>\n</div>\n';
 }, function(e, t) {
@@ -78554,7 +78580,7 @@ a.$inject = [ "$scope", "$filter", "$location", "$q", "BuilderAppService", "Proj
 }, function(e, t, n) {
 "use strict";
 t.__esModule = !0;
-var i = function() {
+var i = n(0), r = function() {
 function e(e, t, n) {
 var i = this;
 this.ctrl = this, this.closeOrderingPanel = function() {
@@ -78564,9 +78590,13 @@ i.RecentlyViewed.addItem(i.ctrl.selectedItem.resource.metadata.uid), i.ctrl.orde
 return e.prototype.$onInit = function() {
 var e = this;
 this.ctrl.searchText = "", this.ctrl.orderingPanelVisible = !1, this.Catalog.getServicePlans().then(function(t) {
-t && (t = t.by("metadata.name"), e.plansByServiceClassName = e.Catalog.groupPlansByServiceClassName(t));
+t && (t = i.reject(t.by("metadata.name"), {
+status: {
+removedFromBrokerCatalog: !0
+}
+}), e.plansByServiceClassName = e.Catalog.groupPlansByServiceClassName(t));
 }), this.$scope.$on("open-overlay-panel", function(t, n) {
-if (e.ctrl.servicePlansForItem = null, "Template" !== n.kind) "ServiceClass" === n.kind && (e.ctrl.servicePlansForItem = e.plansByServiceClassName[n.resource.metadata.name]), e.ctrl.selectedItem = n, e.ctrl.orderingPanelVisible = !0; else {
+if (e.ctrl.servicePlansForItem = null, "Template" !== n.kind) "ClusterServiceClass" === n.kind && (e.ctrl.servicePlansForItem = e.plansByServiceClassName[n.resource.metadata.name]), e.ctrl.selectedItem = n, e.ctrl.orderingPanelVisible = !0; else {
 var i = e.ctrl.onTemplateSelected();
 i && i(n.resource);
 }
@@ -78575,7 +78605,7 @@ i && i(n.resource);
 this.ctrl.orderingPanelVisible && this.closeOrderingPanel();
 }, e;
 }();
-i.$inject = [ "$scope", "Catalog", "RecentlyViewedServiceItems" ], t.LandingPageController = i;
+r.$inject = [ "$scope", "Catalog", "RecentlyViewedServiceItems" ], t.LandingPageController = r;
 }, function(e, t, n) {
 "use strict";
 t.__esModule = !0;
@@ -78745,10 +78775,10 @@ this.ctrl.parameterSchema = r.get(e, "spec.instanceCreateParameterSchema"), this
 return r.omitBy(this.ctrl.parameterData, function(e) {
 return "" === e;
 });
-}, e.prototype.getExternalServiceClassName = function() {
+}, e.prototype.getExternalClusterServiceClassName = function() {
 return r.get(this, "ctrl.serviceClass.resource.spec.externalName");
 }, e.prototype.generateSecretName = function() {
-var e = r.truncate(this.getExternalServiceClassName() + "-parameters", {
+var e = r.truncate(this.getExternalClusterServiceClassName() + "-parameters", {
 length: this.DNS1123_SUBDOMAIN_VALIDATION.maxlength - 5 - 1,
 omission: ""
 });
@@ -78774,16 +78804,16 @@ parameters: JSON.stringify(t)
 }
 };
 }, e.prototype.makeServiceInstance = function(e) {
-var t = this.getExternalServiceClassName(), n = {
+var t = this.getExternalClusterServiceClassName(), n = {
 kind: "ServiceInstance",
-apiVersion: "servicecatalog.k8s.io/v1alpha1",
+apiVersion: "servicecatalog.k8s.io/v1beta1",
 metadata: {
 namespace: this.ctrl.selectedProject.metadata.name,
 generateName: t + "-"
 },
 spec: {
-externalServiceClassName: t,
-externalServicePlanName: this.ctrl.selectedPlan.spec.externalName
+externalClusterServiceClassName: t,
+externalClusterServicePlanName: this.ctrl.selectedPlan.spec.externalName
 }
 };
 return e && (n.spec.parametersFrom = [ {
@@ -78837,7 +78867,7 @@ i.isDefined(e.help) && (e.href = p.Constants.HELP_BASE_URL + (e.help ? p.Constan
 p.ctrl.recentlyViewedItems = p.getRecentlyViewedItems();
 });
 }, this.onProjectsUpdate = function(e) {
-var t = r.toArray(e.by("metadata.creationTimestamp"));
+var t = r.toArray(e.by("metadata.name"));
 p.ctrl.projects = p.RecentlyViewedProjectsService.orderByMostRecentlyViewed(t), p.ctrl.totalProjects = p.ctrl.projects.length, p.ctrl.projects = r.take(p.ctrl.projects, p.maxDisplayProjects), p.ctrl.loading = !1, p.ctrl.showGetStarted = !p.ctrl.projects || p.ctrl.projects.length < 2;
 }, this.goToProject = function(e) {
 var t = p.$filter("projectUrl")(e, p.ctrl.baseProjectUrl);

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4299,6 +4299,7 @@ body.overlay-open,body.overlay-open .landing,body.overlay-open .landing-side-bar
 .services-view .services-item.ng-leave.ng-leave-active{opacity:0}
 .services-view .services-item .services-item-icon:after{border:2px solid transparent;border-radius:84px;content:"";height:84px;left:50%;margin:-42px 0 0 -42px;position:absolute;top:50%;transition:border 125ms linear;width:84px;will-change:border}
 .services-view .services-item .services-item-icon .fa,.services-view .services-item .services-item-icon .font-icon,.services-view .services-item .services-item-icon img{position:relative;z-index:1}
+.services-view .services-item .services-item-icon img[src$=".svg"]{height:50px}
 .services-view .services-item .fa-question,.services-view .services-item .icon-ruby{right:2px}
 .services-view .services-item .icon-wildfly{right:-1px}
 .services-view .services-item-icon{align-items:center;display:flex;font-size:48px;height:92px;justify-content:center;position:relative}


### PR DESCRIPTION
Bumps origin-web-common to 0.0.66 and origin-web-catalog to 0.0.54

Requires https://github.com/openshift/origin-web-common/pull/223
Requires https://github.com/openshift/origin-web-catalog/pull/475

* Update to v1beta1 instead of v1alpha1
* Cluster prefix for service classes and plans
* ServiceInstanceCredential -> ServiceBinding
* Check removedFromBrokerCatalog

cc @jeff-phillips-18 @pmorie 