### PR TITLE
Bug 1496687: Consistent binding names

### DIFF
--- a/app/views/service-instances.html
+++ b/app/views/service-instances.html
@@ -63,7 +63,7 @@
                             {{application.metadata.name}}
                           </span>
                           <span ng-if="!application">
-                            {{firstBinding.spec.secretName}}
+                            {{firstBinding.metadata.name}}
                           </span>
                           <ng-pluralize count="bindingsByInstanceRef[serviceInstance.metadata.name].length"
                                         when="{'0':'', '1':'', '2':'and {} other', 'other':'and {} others'}"

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -13173,7 +13173,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "{{application.metadata.name}}\n" +
     "</span>\n" +
     "<span ng-if=\"!application\">\n" +
-    "{{firstBinding.spec.secretName}}\n" +
+    "{{firstBinding.metadata.name}}\n" +
     "</span>\n" +
     "<ng-pluralize count=\"bindingsByInstanceRef[serviceInstance.metadata.name].length\" when=\"{'0':'', '1':'', '2':'and {} other', 'other':'and {} others'}\" offset=\"1\">\n" +
     "</ng-pluralize>\n" +


### PR DESCRIPTION
Use the binding name instead of the secret name in the service instances
table to be consistent with the overview and service instance details page.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1496687