### PR TITLE
Update bower to 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^7.0.1",
-    "bower": "1.8.0",
+    "bower": "1.8.2",
     "clean-css": "3.4.12",
     "connect-modrewrite": "0.7.9",
     "geckodriver": "1.3.0",


### PR DESCRIPTION
The https://bower.herokuapp.com registry is deprecated. We need to update Bower to switch to the new https://registry.bower.io URL.