### PR TITLE
Special case some humanized reasons codes

### DIFF
--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -1340,4 +1340,14 @@ angular.module('openshiftConsole')
 
       return serviceInstanceMessage;
     };
+  })
+  .filter('humanizeReason', function() {
+    return function(reason) {
+      var humanizedReason = _.startCase(reason);
+      // Special case some values like "BackOff" -> "Back-off"
+      return humanizedReason.replace("Back Off", "Back-off").replace("O Auth", "OAuth");
+    };
+  })
+  .filter('humanizePodStatus', function(humanizeReasonFilter) {
+    return humanizeReasonFilter;
   });

--- a/app/views/browse/_pod-details.html
+++ b/app/views/browse/_pod-details.html
@@ -12,7 +12,7 @@
         <dt>Status:</dt>
         <dd>
           <status-icon status="pod | podStatus"></status-icon>
-          {{pod | podStatus | sentenceCase}}<span ng-if="pod | podCompletionTime">, ran for {{(pod | podStartTime) | duration : (pod | podCompletionTime)}}</span>
+          {{pod | podStatus | humanizePodStatus}}<span ng-if="pod | podCompletionTime">, ran for {{(pod | podStartTime) | duration : (pod | podCompletionTime)}}</span>
           <span ng-if="pod.metadata.deletionTimestamp">(expires {{pod.metadata.deletionTimestamp | date : 'medium'}})</span>
         </dd>
         <dt ng-if-start="pod.status.message">Message:</dt>

--- a/app/views/directives/events-sidebar.html
+++ b/app/views/directives/events-sidebar.html
@@ -35,7 +35,7 @@
         <div class="event-details">
           <div class="detail-group">
             <div class="event-reason">
-              {{event.reason | sentenceCase}}
+              {{event.reason | humanizeReason}}
             </div>
             <div
               class="event-object"

--- a/app/views/directives/events.html
+++ b/app/views/directives/events.html
@@ -90,11 +90,11 @@
           <span class="sr-only">{{event.type}}</span>
           <span class="pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-original-title="Warning"></span></td>
         <td class="hidden-sm hidden-md" data-title="Reason">
-          <span ng-bind-html="event.reason | sentenceCase | highlightKeywords : filterExpressions"></span>&nbsp;<span class="visible-xs-inline pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-original-title="Warning"></span>
+          <span ng-bind-html="event.reason | humanizeReason | highlightKeywords : filterExpressions"></span>&nbsp;<span class="visible-xs-inline pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-original-title="Warning"></span>
         </td>
         <td data-title="Message">
           <div class="hidden-xs-block visible-sm-block visible-md-block hidden-lg-block">
-            <span ng-bind-html="event.reason | sentenceCase | highlightKeywords : filterExpressions"></span>&nbsp;
+            <span ng-bind-html="event.reason | humanizeReason | highlightKeywords : filterExpressions"></span>&nbsp;
             <span class="pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-original-title="Warning"></span>
           </div>
           <!-- Truncate long messages to 1000 chars or 4 lines. -->

--- a/app/views/directives/pods-table.html
+++ b/app/views/directives/pods-table.html
@@ -32,7 +32,7 @@
       <td data-title="Status">
         <div row class="status">
           <status-icon status="pod | podStatus" disable-animation></status-icon>
-          <span flex>{{pod | podStatus | sentenceCase}}</span>
+          <span flex>{{pod | podStatus | humanizePodStatus}}</span>
         </div>
       </td>
       <td data-title="Ready">{{pod | numContainersReady}}/{{pod.spec.containers.length}}</td>

--- a/app/views/modals/debug-terminal.html
+++ b/app/views/modals/debug-terminal.html
@@ -4,7 +4,7 @@
     <small class="text-muted">
       {{debugPod.metadata.name}} &mdash;
       <status-icon status="debugPod | podStatus"></status-icon>
-      {{debugPod | podStatus | sentenceCase}}
+      {{debugPod | podStatus | humanizePodStatus}}
     </small>
   </div>
   <div class="modal-body">

--- a/app/views/monitoring.html
+++ b/app/views/monitoring.html
@@ -90,7 +90,7 @@
                         </div>
                         <div class="list-group-item-text">
                           <status-icon status="pod | podStatus" disable-animation></status-icon>
-                          {{pod | podStatus | sentenceCase}}
+                          {{pod | podStatus | humanizeReason}}
                           <small ng-if="(pod | podStatus) === 'Running'" class="text-muted">
                             &ndash;
                             {{pod | numContainersReady}}/{{pod.spec.containers.length}} ready

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -15350,6 +15350,12 @@ r = _.get(t(n, a), "message");
 }
 return r;
 };
+} ]).filter("humanizeReason", function() {
+return function(e) {
+return _.startCase(e).replace("Back Off", "Back-off").replace("O Auth", "OAuth");
+};
+}).filter("humanizePodStatus", [ "humanizeReasonFilter", function(e) {
+return e;
 } ]), angular.module("openshiftConsole").filter("canIDoAny", [ "APIService", "canIFilter", function(e, t) {
 var n = {
 buildConfigs: [ {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1247,7 +1247,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt>Status:</dt>\n" +
     "<dd>\n" +
     "<status-icon status=\"pod | podStatus\"></status-icon>\n" +
-    "{{pod | podStatus | sentenceCase}}<span ng-if=\"pod | podCompletionTime\">, ran for {{(pod | podStartTime) | duration : (pod | podCompletionTime)}}</span>\n" +
+    "{{pod | podStatus | humanizePodStatus}}<span ng-if=\"pod | podCompletionTime\">, ran for {{(pod | podStartTime) | duration : (pod | podCompletionTime)}}</span>\n" +
     "<span ng-if=\"pod.metadata.deletionTimestamp\">(expires {{pod.metadata.deletionTimestamp | date : 'medium'}})</span>\n" +
     "</dd>\n" +
     "<dt ng-if-start=\"pod.status.message\">Message:</dt>\n" +
@@ -6881,7 +6881,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"event-details\">\n" +
     "<div class=\"detail-group\">\n" +
     "<div class=\"event-reason\">\n" +
-    "{{event.reason | sentenceCase}}\n" +
+    "{{event.reason | humanizeReason}}\n" +
     "</div>\n" +
     "<div class=\"event-object\" ng-init=\"resourceURL = (event | navigateEventInvolvedObjectURL)\">\n" +
     "<a ng-if=\"resourceURL\" ng-attr-title=\"Navigate to {{event.involvedObject.name}}\" href=\"{{resourceURL}}\">\n" +
@@ -6991,11 +6991,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"sr-only\">{{event.type}}</span>\n" +
     "<span class=\"pficon pficon-warning-triangle-o\" ng-show=\"event.type === 'Warning'\" aria-hidden=\"true\" data-toggle=\"tooltip\" data-original-title=\"Warning\"></span></td>\n" +
     "<td class=\"hidden-sm hidden-md\" data-title=\"Reason\">\n" +
-    "<span ng-bind-html=\"event.reason | sentenceCase | highlightKeywords : filterExpressions\"></span>&nbsp;<span class=\"visible-xs-inline pficon pficon-warning-triangle-o\" ng-show=\"event.type === 'Warning'\" aria-hidden=\"true\" data-toggle=\"tooltip\" data-original-title=\"Warning\"></span>\n" +
+    "<span ng-bind-html=\"event.reason | humanizeReason | highlightKeywords : filterExpressions\"></span>&nbsp;<span class=\"visible-xs-inline pficon pficon-warning-triangle-o\" ng-show=\"event.type === 'Warning'\" aria-hidden=\"true\" data-toggle=\"tooltip\" data-original-title=\"Warning\"></span>\n" +
     "</td>\n" +
     "<td data-title=\"Message\">\n" +
     "<div class=\"hidden-xs-block visible-sm-block visible-md-block hidden-lg-block\">\n" +
-    "<span ng-bind-html=\"event.reason | sentenceCase | highlightKeywords : filterExpressions\"></span>&nbsp;\n" +
+    "<span ng-bind-html=\"event.reason | humanizeReason | highlightKeywords : filterExpressions\"></span>&nbsp;\n" +
     "<span class=\"pficon pficon-warning-triangle-o\" ng-show=\"event.type === 'Warning'\" aria-hidden=\"true\" data-toggle=\"tooltip\" data-original-title=\"Warning\"></span>\n" +
     "</div>\n" +
     "\n" +
@@ -8819,7 +8819,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<td data-title=\"Status\">\n" +
     "<div row class=\"status\">\n" +
     "<status-icon status=\"pod | podStatus\" disable-animation></status-icon>\n" +
-    "<span flex>{{pod | podStatus | sentenceCase}}</span>\n" +
+    "<span flex>{{pod | podStatus | humanizePodStatus}}</span>\n" +
     "</div>\n" +
     "</td>\n" +
     "<td data-title=\"Ready\">{{pod | numContainersReady}}/{{pod.spec.containers.length}}</td>\n" +
@@ -10770,7 +10770,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<small class=\"text-muted\">\n" +
     "{{debugPod.metadata.name}} &mdash;\n" +
     "<status-icon status=\"debugPod | podStatus\"></status-icon>\n" +
-    "{{debugPod | podStatus | sentenceCase}}\n" +
+    "{{debugPod | podStatus | humanizePodStatus}}\n" +
     "</small>\n" +
     "</div>\n" +
     "<div class=\"modal-body\">\n" +
@@ -11019,7 +11019,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"list-group-item-text\">\n" +
     "<status-icon status=\"pod | podStatus\" disable-animation></status-icon>\n" +
-    "{{pod | podStatus | sentenceCase}}\n" +
+    "{{pod | podStatus | humanizeReason}}\n" +
     "<small ng-if=\"(pod | podStatus) === 'Running'\" class=\"text-muted\">\n" +
     "&ndash; {{pod | numContainersReady}}/{{pod.spec.containers.length}} ready\n" +
     "</small>\n" +


### PR DESCRIPTION
* BackOff -> Back-off (instead of "Back off")
* OAuth -> OAuth (instead of "O auth")

Used in the events page, notification drawer, and for pod status, which
shows failed container reason codes.

@ncameronbritt Fixing your "back off" bug