### PR TITLE
Separate Makefile flags for e2e & unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,9 @@ build: install
 # Examples:
 #   make test
 #   make test GRUNT_FLAGS='--gruntfile=~/special/Gruntfile.js'
+#   make test GRUNT_UNIT_TEST_FLAGS='--browser=chrome' GRUNT_INTEGRATION_TEST_FLAG='--foo'
 test: build
 	hack/verify-dist.sh
-	hack/test-headless.sh test $(GRUNT_FLAGS)
-	hack/test-headless.sh test-integration $(GRUNT_FLAGS)
+	hack/test-headless.sh test-unit $(GRUNT_UNIT_TEST_FLAGS)
+	hack/test-headless.sh test-integration $(GRUNT_INTEGRATION_TEST_FLAGS)
 .PHONY: test


### PR DESCRIPTION
I think we should separate out the var for unit & e2e test flags in our Makefile.  Currently we are not using any flags, but we could (and the flags would be different):

https://github.com/openshift/aos-cd-jobs/blob/master/sjb/config/test_cases/test_branch_origin_web_console.yml#L21

