### PR TITLE
Bug 1502914 - Compact empty envFrom entries

### DIFF
--- a/app/scripts/services/environment.js
+++ b/app/scripts/services/environment.js
@@ -31,6 +31,9 @@ angular.module("openshiftConsole")
         var containers = getContainers(object);
         _.each(containers, function(container) {
           container.env = keyValueEditorUtils.compactEntries(container.env);
+          container.envFrom = _.reject(container.envFrom, function(envFromEntry) {
+            return !_.get(envFromEntry, 'configMapRef.name') && !_.get(envFromEntry, 'secretRef.name');
+          });
         });
       },
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3953,7 +3953,9 @@ e.env = e.env || [], e.envFrom = e.envFrom || [];
 compact: function(e) {
 var a = n(e);
 _.each(a, function(e) {
-e.env = t.compactEntries(e.env);
+e.env = t.compactEntries(e.env), e.envFrom = _.reject(e.envFrom, function(e) {
+return !_.get(e, "configMapRef.name") && !_.get(e, "secretRef.name");
+});
 });
 },
 copyAndNormalize: function(e) {


### PR DESCRIPTION
Don't include empty `envFrom` entries when updating environment variables. This causes a validation failure.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1502914

@jwforres PTAL