### PR TITLE
[stage] Bug 1502914 - Compact empty envFrom entries

### DIFF
--- a/app/scripts/services/environment.js
+++ b/app/scripts/services/environment.js
@@ -31,6 +31,9 @@ angular.module("openshiftConsole")
         var containers = getContainers(object);
         _.each(containers, function(container) {
           container.env = keyValueEditorUtils.compactEntries(container.env);
+          container.envFrom = _.reject(container.envFrom, function(envFromEntry) {
+            return !envFromEntry.configMapRef && !envFromEntry.secretRef;
+          });
         });
       },
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3917,7 +3917,9 @@ e.env = e.env || [], e.envFrom = e.envFrom || [];
 compact: function(e) {
 var a = n(e);
 _.each(a, function(e) {
-e.env = t.compactEntries(e.env);
+e.env = t.compactEntries(e.env), e.envFrom = _.reject(e.envFrom, function(e) {
+return !e.configMapRef && !e.secretRef;
+});
 });
 },
 copyAndNormalize: function(e) {


### PR DESCRIPTION
Don't include empty `envFrom` entries when updating environment variables. This causes a validation failure.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1502914

Backport of #2275 to stage branch.