### PR TITLE
Mount path is not required for envFrom

### DIFF
--- a/app/views/directives/add-config-to-application.html
+++ b/app/views/directives/add-config-to-application.html
@@ -53,11 +53,11 @@
                        id="mountVolume"
                        placeholder="Enter a mount path"
                        type="text"
-                       required
                        ng-pattern="/^\/.*$/"
                        osc-unique="ctrl.existingMountPaths"
                        aria-describedby="mount-path-help"
                        ng-disabled="ctrl.addType !== 'volume' || ctrl.disableInputs || !ctrl.application"
+                       ng-required="ctrl.addType === 'volume'"
                        ng-model="ctrl.mountVolume"
                        autocorrect="off"
                        autocapitalize="off"

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5765,7 +5765,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"volume-options\">\n" +
     "<div ng-class=\"{'has-error': (addToApplicationForm.mountVolume.$error.oscUnique || (addToApplicationForm.mountVolume.$error.pattern && addToApplicationForm.mountVolume.$touched))}\">\n" +
-    "<input class=\"form-control\" name=\"mountVolume\" id=\"mountVolume\" placeholder=\"Enter a mount path\" type=\"text\" required ng-pattern=\"/^\\/.*$/\" osc-unique=\"ctrl.existingMountPaths\" aria-describedby=\"mount-path-help\" ng-disabled=\"ctrl.addType !== 'volume' || ctrl.disableInputs || !ctrl.application\" ng-model=\"ctrl.mountVolume\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\">\n" +
+    "<input class=\"form-control\" name=\"mountVolume\" id=\"mountVolume\" placeholder=\"Enter a mount path\" type=\"text\" ng-pattern=\"/^\\/.*$/\" osc-unique=\"ctrl.existingMountPaths\" aria-describedby=\"mount-path-help\" ng-disabled=\"ctrl.addType !== 'volume' || ctrl.disableInputs || !ctrl.application\" ng-required=\"ctrl.addType === 'volume'\" ng-model=\"ctrl.mountVolume\" autocorrect=\"off\" autocapitalize=\"off\" spellcheck=\"false\">\n" +
     "</div>\n" +
     "<div class=\"help-block bind-description\">\n" +
     "Mount Path for the volume. A file will be created in this directory for each key from the {{ctrl.apiObject.kind | humanizeKind}}. The file contents will be the value of the key.\n" +


### PR DESCRIPTION
In the add to application dialog, don't require a mount path when adding environment variables.

Fixes #2303 

cc @cfchase 