### PR TITLE
Bug 1504511 - Remember template values when clicking back

### DIFF
--- a/app/views/directives/process-template-dialog.html
+++ b/app/views/directives/process-template-dialog.html
@@ -20,7 +20,7 @@
          step-id="{{step.id}}"
          step-priority="{{$index}}">
       <div class="wizard-pf-main-inner-shadow-covers">
-        <div ng-if="step.selected" ng-include="step.view" class="wizard-pf-main-form-contents"></div>
+        <div ng-show="step.selected" ng-include="step.view" class="wizard-pf-main-form-contents"></div>
       </div>
     </pf-wizard-step>
   </pf-wizard>

--- a/app/views/directives/process-template.html
+++ b/app/views/directives/process-template.html
@@ -1,4 +1,4 @@
-<fieldset ng-disabled="disableInputs">
+<fieldset ng-if="$ctrl.template" ng-disabled="disableInputs">
   <ng-form name="$ctrl.templateForm">
     <template-options is-dialog="$ctrl.isDialog" parameters="$ctrl.template.parameters" expand="true" can-toggle="false">
       <select-project ng-if="!$ctrl.project" on-project-selected="$ctrl.onProjectSelected" available-projects="$ctrl.availableProjects" selected-project="$ctrl.selectedProject" name-taken="$ctrl.projectNameTaken"></select-project>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8965,7 +8965,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<pf-wizard wizard-title=\"{{!$ctrl.useProjectTemplate && ($ctrl.template | displayName) || 'Select from Project'}}\" hide-sidebar=\"true\" step-class=\"order-service-wizard-step\" wizard-ready=\"$ctrl.wizardReady\" next-title=\"$ctrl.nextTitle\" next-callback=\"$ctrl.next\" on-finish=\"$ctrl.close()\" on-cancel=\"$ctrl.close()\" wizard-done=\"$ctrl.wizardDone\" current-step=\"$ctrl.currentStep\">\n" +
     "<pf-wizard-step ng-repeat=\"step in $ctrl.steps track by step.id\" step-title=\"{{step.label}}\" wz-disabled=\"{{step.hidden}}\" allow-click-nav=\"step.allowClickNav\" next-enabled=\"step.valid\" prev-enabled=\"step.prevEnabled\" on-show=\"step.onShow\" step-id=\"{{step.id}}\" step-priority=\"{{$index}}\">\n" +
     "<div class=\"wizard-pf-main-inner-shadow-covers\">\n" +
-    "<div ng-if=\"step.selected\" ng-include=\"step.view\" class=\"wizard-pf-main-form-contents\"></div>\n" +
+    "<div ng-show=\"step.selected\" ng-include=\"step.view\" class=\"wizard-pf-main-form-contents\"></div>\n" +
     "</div>\n" +
     "</pf-wizard-step>\n" +
     "</pf-wizard>\n" +
@@ -9070,7 +9070,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
 
   $templateCache.put('views/directives/process-template.html',
-    "<fieldset ng-disabled=\"disableInputs\">\n" +
+    "<fieldset ng-if=\"$ctrl.template\" ng-disabled=\"disableInputs\">\n" +
     "<ng-form name=\"$ctrl.templateForm\">\n" +
     "<template-options is-dialog=\"$ctrl.isDialog\" parameters=\"$ctrl.template.parameters\" expand=\"true\" can-toggle=\"false\">\n" +
     "<select-project ng-if=\"!$ctrl.project\" on-project-selected=\"$ctrl.onProjectSelected\" available-projects=\"$ctrl.availableProjects\" selected-project=\"$ctrl.selectedProject\" name-taken=\"$ctrl.projectNameTaken\"></select-project>\n" +


### PR DESCRIPTION
When editing template parameter values, remember the values when the
user clicks back and then forward again. This will still correctly clear
the values if the user switches templates in the "Select from Project"
dialog.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1504511

@jeff-phillips-18 @jwforres 