### PR TITLE
Incorporate badge-pf-bordered on notification drawer bell

### DIFF
--- a/app/styles/_navbar-vertical.less
+++ b/app/styles/_navbar-vertical.less
@@ -53,13 +53,14 @@
     @media(min-width: @screen-sm-min) {
       margin-right: @navbar-header-right-margin;
     }
+    // adjust positioning of notification drawer badge as our header
+    // heights are different, as is the bell icon size
     .badge {
-      margin: 0 !important;
-      position: absolute;
-      right: 13px;
-      top: 9px;
+      left: 14px !important;
+      top: 7px !important;
       @media(min-width: @screen-sm-min) {
-        top: 20px;
+        left: 21px !important;
+        top: 18px !important;
       }
     }
 

--- a/app/views/directives/notifications/notification-counter.html
+++ b/app/views/directives/notifications/notification-counter.html
@@ -1,4 +1,4 @@
 <li class="drawer-pf-trigger" ng-if="!$ctrl.hide">
   <!-- Cannot have whitespace inside the `a`, so keep everything on one line. -->
-  <a href="" class="nav-item-iconic" ng-click="$ctrl.onClick()"><span class="fa fa-bell" title="Notifications" aria-hidden="true"></span><span ng-if="$ctrl.showUnreadNotificationsIndicator" class="badge"> </span><span class="sr-only">Notifications</span></a>
+  <a href="" class="nav-item-iconic" ng-click="$ctrl.onClick()"><span class="fa fa-bell" title="Notifications" aria-hidden="true"></span><span ng-if="$ctrl.showUnreadNotificationsIndicator" class="badge badge-pf-bordered"> </span><span class="sr-only">Notifications</span></a>
 </li>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7921,7 +7921,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   $templateCache.put('views/directives/notifications/notification-counter.html',
     "<li class=\"drawer-pf-trigger\" ng-if=\"!$ctrl.hide\">\n" +
     "\n" +
-    "<a href=\"\" class=\"nav-item-iconic\" ng-click=\"$ctrl.onClick()\"><span class=\"fa fa-bell\" title=\"Notifications\" aria-hidden=\"true\"></span><span ng-if=\"$ctrl.showUnreadNotificationsIndicator\" class=\"badge\"> </span><span class=\"sr-only\">Notifications</span></a>\n" +
+    "<a href=\"\" class=\"nav-item-iconic\" ng-click=\"$ctrl.onClick()\"><span class=\"fa fa-bell\" title=\"Notifications\" aria-hidden=\"true\"></span><span ng-if=\"$ctrl.showUnreadNotificationsIndicator\" class=\"badge badge-pf-bordered\"> </span><span class=\"sr-only\">Notifications</span></a>\n" +
     "</li>"
   );
 

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4949,23 +4949,23 @@ h2+.list-view-pf{margin-top:20px}
 .navbar-pf-vertical .navbar-brand{padding:0}
 .navbar-pf-vertical .navbar-header{float:left}
 .navbar-pf-vertical .navbar-iconic{display:flex;float:right;margin:0}
-@media (min-width:768px){.navbar-pf-vertical .navbar-brand{padding-bottom:10px;padding-top:10px}
-.navbar-pf-vertical .navbar-iconic{margin-right:10px}
-}
-.navbar-pf-vertical .navbar-iconic .badge{margin:0!important;position:absolute;right:13px;top:9px}
+.navbar-pf-vertical .navbar-iconic .badge{left:14px!important;top:7px!important}
 .navbar-pf-vertical .navbar-iconic .drawer-pf-trigger{display:inline-block}
 .navbar-pf-vertical .navbar-iconic .drawer-pf-trigger a{display:block}
 .navbar-pf-vertical .navbar-iconic .dropdown .nav-item-iconic{padding-right:20px}
 .navbar-pf-vertical .navbar-iconic>li{display:none}
+@media (min-width:768px){.navbar-pf-vertical .navbar-brand{padding-bottom:10px;padding-top:10px}
+.navbar-pf-vertical .navbar-iconic{margin-right:10px}
+.navbar-pf-vertical .navbar-iconic .badge{left:21px!important;top:18px!important}
+.navbar-pf-vertical .navbar-iconic>li{display:inline-block}
+}
 .navbar-pf-vertical .navbar-iconic .nav-item-iconic{line-height:normal;padding-right:15px}
 @media (max-width:767px){.navbar-pf-vertical .navbar-iconic .nav-item-iconic{padding:10px 15px 10px 5px}
 }
 .navbar-pf-vertical .navbar-iconic .nav-item-iconic .username{display:inline-block;font-weight:300;max-width:170px;padding-right:2px;vertical-align:top}
 .navbar-pf-vertical .navbar-toggle{margin:4px 5px}
 .navbar-pf-vertical .navbar-toggle .icon-bar{width:20px}
-@media (min-width:768px){.navbar-pf-vertical .navbar-iconic .badge{top:20px}
-.navbar-pf-vertical .navbar-iconic>li{display:inline-block}
-.navbar-pf-vertical .navbar-toggle{margin:13px 15px}
+@media (min-width:768px){.navbar-pf-vertical .navbar-toggle{margin:13px 15px}
 .navbar-pf-vertical .navbar-toggle .icon-bar{width:22px}
 }
 .navbar-toggle:focus{color:#fff;outline:dotted thin!important;outline:-webkit-focus-ring-color auto 5px!important;outline-offset:-2px!important}


### PR DESCRIPTION
IMPORTANT:  #2324 must merge first as it bumps PatternFly to a version
including the upstream change that includes badge-pf-bordered

<img width="67" alt="screen shot 2017-10-20 at 10 11 14 am" src="https://user-images.githubusercontent.com/895728/31825374-1124ba1e-b580-11e7-9d09-f0b0392771a2.PNG">
<img width="253" alt="screen shot 2017-10-20 at 10 11 27 am" src="https://user-images.githubusercontent.com/895728/31825375-11354f00-b580-11e7-85ae-89f77a15c3f0.PNG">
