### PR TITLE
Bug 1505289 - Fix visible expression in HPA error message

### DIFF
--- a/app/views/directives/osc-autoscaling.html
+++ b/app/views/directives/osc-autoscaling.html
@@ -92,7 +92,7 @@
       <span class="help-block" ng-if="form.maxReplicas.$error.min">
         Max pods must be greater than or equal to
         <span ng-if="autoscaling.minReplicas">min pods, which is</span>
-        {{autoscaling.minReplicas || 1}.
+        {{autoscaling.minReplicas || 1}}.
       </span>
       <span class="help-block" ng-if="form.maxReplicas.$error.required">
         Max pods is a required field.

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8000,7 +8000,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"help-block\" ng-if=\"form.maxReplicas.$error.min\">\n" +
     "Max pods must be greater than or equal to\n" +
     "<span ng-if=\"autoscaling.minReplicas\">min pods, which is</span>\n" +
-    "{{autoscaling.minReplicas || 1}.\n" +
+    "{{autoscaling.minReplicas || 1}}.\n" +
     "</span>\n" +
     "<span class=\"help-block\" ng-if=\"form.maxReplicas.$error.required\">\n" +
     "Max pods is a required field.\n" +


### PR DESCRIPTION
Fix a visible AngularJS expression when max pods is smaller than min pods in the edit autoscaler form.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1505289