### PR TITLE
Align hover and expanded list-group-item bg colors with list-pf

### DIFF
--- a/app/styles/_list-view.less
+++ b/app/styles/_list-view.less
@@ -56,8 +56,13 @@
   h2 + & {
     margin-top: 20px;
   }
-  .list-group-item:first-child {
-    border-top-color: #eaeaea;
+  .list-group-item {
+    &:first-child {
+      border-top-color: #eaeaea;
+    }
+    &:hover {
+      background-color: @list-pf-hover-background-color;
+    }
   }
   .list-group-item-expandable {
     cursor: pointer;
@@ -67,7 +72,7 @@
     &.expanded {
       border-color: @table-border-color;
       &, &:hover {
-        background-color: @list-view-expanded-bg;
+        background-color: @list-pf-header-background-color;
       }
       .list-view-pf-checkbox {
         border-right-color: @table-border-color;

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3148,7 +3148,7 @@ a.disabled{color:#8b8d8f;cursor:not-allowed;text-decoration:none}
 .list-view-pf .list-group-item:after,.list-view-pf .list-group-item:before{content:" ";display:table}
 .list-view-pf .list-group-item.list-view-pf-expand-active{background-color:#fafafa;box-shadow:0 2px 6px rgba(3,3,3,.2);z-index:1}
 .list-view-pf .list-group-item.active{color:#555;background-color:#def3ff;background-clip:border-box;border-color:#bbb transparent transparent;z-index:auto}
-.list-view-pf .list-group-item:hover{background-color:#fafafa;border-left-color:transparent;border-right-color:transparent}
+.list-view-pf .list-group-item:hover{border-left-color:transparent;border-right-color:transparent}
 .list-view-pf .list-group-item.list-view-pf-expand-active{border:1px solid #bbb}
 .list-view-pf .list-group-item.list-view-pf-expand-active:first-child{border-top-color:#bbb}
 .list-view-pf .list-group-item:first-child{border-top:1px solid transparent}
@@ -4939,10 +4939,11 @@ pre.clipped.scroll{max-height:150px;overflow:auto;width:100%}
 .list-view-pf{margin-bottom:50px}
 h2+.list-view-pf{margin-top:20px}
 .list-view-pf .list-group-item:first-child{border-top-color:#eaeaea}
+.list-view-pf .list-group-item:hover{background-color:#edf8ff}
 .list-view-pf .list-group-item-expandable{cursor:pointer;border:1px solid #eaeaea;border-left-color:transparent;border-right-color:transparent}
 .build-count .icon-count,.build-count .icon-count [data-toggle=tooltip],.instance-status-notification [data-toggle=tooltip],.notification-icon-count [data-toggle=tooltip]{cursor:help}
 .list-view-pf .list-group-item-expandable.expanded{border-color:#d1d1d1}
-.list-view-pf .list-group-item-expandable.expanded,.list-view-pf .list-group-item-expandable.expanded:hover{background-color:#f5f5f5}
+.list-view-pf .list-group-item-expandable.expanded,.list-view-pf .list-group-item-expandable.expanded:hover{background-color:#ededed}
 .list-view-pf .list-group-item-expandable.expanded .list-view-pf-checkbox{border-right-color:#d1d1d1}
 .list-view-pf .list-group-item-heading{font-size:13px}
 .list-view-pf .list-group-item-heading small{overflow:hidden;text-overflow:ellipsis;color:#9c9c9c}


### PR DESCRIPTION
PatternFly deprecated list-view, so the hover and expanded bg colors
are still the old standard.  This fix remedies that until we can update
the monitoring page to use list-pf (I will open a separate tech debt
issue for that).
![screen shot 2017-10-23 at 9 40 09 am](https://user-images.githubusercontent.com/895728/31892522-3d90eefc-b7d7-11e7-8fe3-86594070dd6e.PNG)
![screen shot 2017-10-23 at 9 40 15 am](https://user-images.githubusercontent.com/895728/31892521-3d87e848-b7d7-11e7-92f5-44f45f8a83de.PNG)

