### PR TITLE
Update storage filter empty state to new standard

### DIFF
--- a/app/scripts/controllers/storage.js
+++ b/app/scripts/controllers/storage.js
@@ -15,6 +15,9 @@ angular.module('openshiftConsole')
     $scope.labelSuggestions = {};
     $scope.alerts = $scope.alerts || {};
     $scope.outOfClaims = false;
+    $scope.clearFilter = function() {
+      LabelFilter.clear();
+    };
 
     var setOutOfClaimsWarning = function() {
       var isHidden = AlertMessageService.isAlertPermanentlyHidden("storage-quota-limit-reached", $scope.projectName);
@@ -64,22 +67,12 @@ angular.module('openshiftConsole')
         }));
 
         function updateFilterWarning() {
-          if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.pvcs)  && !$.isEmptyObject($scope.unfilteredPVCs)) {
-            $scope.alerts["storage"] = {
-              type: "warning",
-              details: "The active filters are hiding all persistent volume claims."
-            };
-            $scope.filterWithZeroResults = true;
-          }
-          else {
-            delete $scope.alerts["storage"];
-            $scope.filterWithZeroResults = false;
-          }
+          $scope.filterWithZeroResults = !LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.pvcs)  && !$.isEmptyObject($scope.unfilteredPVCs);
         }
 
         LabelFilter.onActiveFiltersChanged(function(labelSelector) {
           // trigger a digest loop
-          $scope.$apply(function() {
+          $scope.$evalAsync(function() {
             $scope.pvcs = labelSelector.select($scope.unfilteredPVCs);
             updateFilterWarning();
           });

--- a/app/views/storage.html
+++ b/app/views/storage.html
@@ -32,14 +32,19 @@
               Loading...
             </p>
             <div ng-if="pvcsLoaded" class="empty-state-message text-center">
-              <h2>No persistent volume claims.</h2>
-              <p ng-if="!filterWithZeroResults">
-                No persistent volume claims have been added to project {{projectName}}.
-              </p>
-              <p ng-if="project && ('persistentvolumeclaims' | canI : 'create') && !filterWithZeroResults">
-                <a ng-if="!outOfClaims" ng-href="project/{{project.metadata.name}}/create-pvc" class="btn btn-primary">Create Storage</a>
-                <a ng-if="outOfClaims" href="" class="btn btn-primary disabled" aria-disabled="true">Create Storage</a>
-              </p>
+              <div ng-if="!filterWithZeroResults">
+                <h2>No persistent volume claims.</h2>
+                <p>
+                  No persistent volume claims have been added to project {{projectName}}.
+                </p>
+                <p ng-if="project && ('persistentvolumeclaims' | canI : 'create') && !filterWithZeroResults">
+                  <a ng-if="!outOfClaims" ng-href="project/{{project.metadata.name}}/create-pvc" class="btn btn-primary">Create Storage</a>
+                  <a ng-if="outOfClaims" href="" class="btn btn-primary disabled" aria-disabled="true">Create Storage</a>
+                </p>
+              </div>
+              <div ng-if="filterWithZeroResults">
+                <h2>The filter is hiding all persistent volume claims. <a href="" ng-click="clearFilter()">Clear Filter</a></h2>
+              </div>
             </div>
           </div>
           <table ng-if="(pvcs | hashSize) > 0" class="table table-bordered table-mobile table-layout-fixed">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -6604,7 +6604,9 @@ r.unwatchAll(c);
 });
 }));
 } ]), angular.module("openshiftConsole").controller("StorageController", [ "$routeParams", "$scope", "AlertMessageService", "DataService", "ProjectsService", "QuotaService", "$filter", "LabelFilter", "Logger", function(e, t, n, a, r, o, i, s, c) {
-t.projectName = e.project, t.pvcs = {}, t.unfilteredPVCs = {}, t.labelSuggestions = {}, t.alerts = t.alerts || {}, t.outOfClaims = !1;
+t.projectName = e.project, t.pvcs = {}, t.unfilteredPVCs = {}, t.labelSuggestions = {}, t.alerts = t.alerts || {}, t.outOfClaims = !1, t.clearFilter = function() {
+s.clear();
+};
 var l = function() {
 var e = n.isAlertPermanentlyHidden("storage-quota-limit-reached", t.projectName);
 if (t.outOfClaims = o.isAnyStorageQuotaExceeded(t.quotas, t.clusterQuotas), !e && t.outOfClaims) {
@@ -6627,15 +6629,12 @@ return n.permanentlyHideAlert("storage-quota-limit-reached", t.projectName), !0;
 }, u = [];
 r.get(e.project).then(_.spread(function(e, n) {
 function r() {
-s.getLabelSelector().isEmpty() || !$.isEmptyObject(t.pvcs) || $.isEmptyObject(t.unfilteredPVCs) ? (delete t.alerts.storage, t.filterWithZeroResults = !1) : (t.alerts.storage = {
-type: "warning",
-details: "The active filters are hiding all persistent volume claims."
-}, t.filterWithZeroResults = !0);
+t.filterWithZeroResults = !s.getLabelSelector().isEmpty() && $.isEmptyObject(t.pvcs) && !$.isEmptyObject(t.unfilteredPVCs);
 }
 t.project = e, u.push(a.watch("persistentvolumeclaims", n, function(e) {
 t.pvcsLoaded = !0, t.unfilteredPVCs = e.by("metadata.name"), s.addLabelSuggestionsFromResources(t.unfilteredPVCs, t.labelSuggestions), s.setLabelSuggestions(t.labelSuggestions), t.pvcs = s.getLabelSelector().select(t.unfilteredPVCs), r(), c.log("pvcs (subscribe)", t.unfilteredPVCs);
 })), s.onActiveFiltersChanged(function(e) {
-t.$apply(function() {
+t.$evalAsync(function() {
 t.pvcs = e.select(t.unfilteredPVCs), r();
 });
 }), t.$on("$destroy", function() {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -13589,14 +13589,19 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Loading...\n" +
     "</p>\n" +
     "<div ng-if=\"pvcsLoaded\" class=\"empty-state-message text-center\">\n" +
+    "<div ng-if=\"!filterWithZeroResults\">\n" +
     "<h2>No persistent volume claims.</h2>\n" +
-    "<p ng-if=\"!filterWithZeroResults\">\n" +
+    "<p>\n" +
     "No persistent volume claims have been added to project {{projectName}}.\n" +
     "</p>\n" +
     "<p ng-if=\"project && ('persistentvolumeclaims' | canI : 'create') && !filterWithZeroResults\">\n" +
     "<a ng-if=\"!outOfClaims\" ng-href=\"project/{{project.metadata.name}}/create-pvc\" class=\"btn btn-primary\">Create Storage</a>\n" +
     "<a ng-if=\"outOfClaims\" href=\"\" class=\"btn btn-primary disabled\" aria-disabled=\"true\">Create Storage</a>\n" +
     "</p>\n" +
+    "</div>\n" +
+    "<div ng-if=\"filterWithZeroResults\">\n" +
+    "<h2>The filter is hiding all persistent volume claims. <a href=\"\" ng-click=\"clearFilter()\">Clear Filter</a></h2>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "<table ng-if=\"(pvcs | hashSize) > 0\" class=\"table table-bordered table-mobile table-layout-fixed\">\n" +


### PR DESCRIPTION
I overlooked the filtered empty state message for storage in https://github.com/openshift/origin-web-console/pull/2259.  This fixes that.

![screen shot 2017-10-23 at 11 05 38 am](https://user-images.githubusercontent.com/895728/31896715-765d8ffa-b7e2-11e7-9776-e9c5d36cc222.PNG)
