### PR TITLE
Making add config files empty state formatting consistent with add volume

### DIFF
--- a/app/views/add-config-volume.html
+++ b/app/views/add-config-volume.html
@@ -11,10 +11,10 @@
         </div>
 
         <div ng-if="targetObject && configMaps && secrets">
-          <div ng-if="!configMaps.length && !secrets.length && !(configMapVersion | canI : 'create') && !(secretVersion | canI : 'create')" class="empty-state-message empty-state-full-page">
-            <h2 class="text-center">No config maps or secrets.</h2>
+          <div ng-if="!configMaps.length && !secrets.length && !(configMapVersion | canI : 'create') && !(secretVersion | canI : 'create')" class="empty-state-message empty-state-full-page text-center">
+            <h2>No config maps or secrets.</h2>
 
-            <p class="gutter-top">
+            <p>
               There are no config maps or secrets in project {{project | displayName}} to use
               as a volume for this {{kind | humanizeKind}}.
             </p>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -784,9 +784,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p>{{error | getErrorDetails}}</p>\n" +
     "</div>\n" +
     "<div ng-if=\"targetObject && configMaps && secrets\">\n" +
-    "<div ng-if=\"!configMaps.length && !secrets.length && !(configMapVersion | canI : 'create') && !(secretVersion | canI : 'create')\" class=\"empty-state-message empty-state-full-page\">\n" +
-    "<h2 class=\"text-center\">No config maps or secrets.</h2>\n" +
-    "<p class=\"gutter-top\">\n" +
+    "<div ng-if=\"!configMaps.length && !secrets.length && !(configMapVersion | canI : 'create') && !(secretVersion | canI : 'create')\" class=\"empty-state-message empty-state-full-page text-center\">\n" +
+    "<h2>No config maps or secrets.</h2>\n" +
+    "<p>\n" +
     "There are no config maps or secrets in project {{project | displayName}} to use as a volume for this {{kind | humanizeKind}}.\n" +
     "</p>\n" +
     "<p ng-if=\"targetObject\"><a ng-href=\"{{targetObject | navigateResourceURL}}\">Back to {{kind | humanizeKind}} {{name}}</a></p>\n" +


### PR DESCRIPTION
Companion to https://github.com/openshift/origin-web-console/pull/2353

This one is unlikely to ever be seen given there are always secrets, but I figured I'd make it consistent anyhow...

<img width="1116" alt="screen shot 2017-10-23 at 4 41 27 pm" src="https://user-images.githubusercontent.com/895728/31912405-c33a2a8e-b811-11e7-8ec8-05e1790cb4d3.PNG">

