### PR TITLE
Wrap notification message with word-break to enable wrapping

### DIFF
--- a/app/views/directives/notifications/notification-body.html
+++ b/app/views/directives/notifications/notification-body.html
@@ -50,7 +50,7 @@
   <div class="drawer-pf-notification-content">
 
     <div
-      class="drawer-pf-notification-message"
+      class="drawer-pf-notification-message word-break"
       ng-attr-title="{{notification.event.message}}">
       <div>
 

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7880,7 +7880,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"pull-left {{notification.type | alertIcon}}\" aria-hidden=\"true\"></span>\n" +
     "<span class=\"sr-only\">{{notification.event.type}}</span>\n" +
     "<div class=\"drawer-pf-notification-content\">\n" +
-    "<div class=\"drawer-pf-notification-message\" ng-attr-title=\"{{notification.event.message}}\">\n" +
+    "<div class=\"drawer-pf-notification-message word-break\" ng-attr-title=\"{{notification.event.message}}\">\n" +
     "<div>\n" +
     "<span ng-if=\"notification.event.reason\">\n" +
     "{{notification.event.reason | humanize}} &mdash; <span ng-if=\"notification.event.involvedObject\">{{notification.event.involvedObject.kind | humanize}}</span>\n" +


### PR DESCRIPTION
fixes https://github.com/openshift/origin-web-console/issues/2254

tested in Chrome, FF, Edge, Safari