### PR TITLE
Fix bug where secondary nav items truncate in IE11

### DIFF
--- a/app/styles/_vertical-nav.less
+++ b/app/styles/_vertical-nav.less
@@ -68,6 +68,7 @@
       }
       .list-group-item-value {
         line-height: inherit;
+        max-width: none; // IE11, fixes https://github.com/patternfly/patternfly/issues/807
         text-decoration: none !important;
       }
     }

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5778,7 +5778,7 @@ alerts+.chromeless .log-loading-msg{margin-top:130px}
 .nav-pf-vertical .list-group-item>a .fa,.nav-pf-vertical .list-group-item>a .pficon{color:#72767b;font-size:15px}
 @media (min-width:768px){.nav-pf-vertical .list-group-item>a .fa,.nav-pf-vertical .list-group-item>a .pficon{font-size:18px}
 }
-.nav-pf-vertical .list-group-item>a .list-group-item-value{line-height:inherit;text-decoration:none!important}
+.nav-pf-vertical .list-group-item>a .list-group-item-value{line-height:inherit;max-width:none;text-decoration:none!important}
 .nav-pf-vertical .list-group-item.secondary-nav-item-pf>a:after{font-size:14px;padding:16px 0}
 @media (max-width:767px){.nav-pf-vertical .list-group-item.secondary-nav-item-pf>a:after{padding:8px 0}
 }


### PR DESCRIPTION
Addresses https://github.com/patternfly/patternfly/issues/807 until it can be resolved upstream

Before:
![screen shot 2017-10-27 at 9 29 33 am](https://user-images.githubusercontent.com/895728/32108442-b6cd53d4-baff-11e7-9f0f-78b3635c9786.PNG)

After:
![screen shot 2017-10-27 at 10 02 54 am](https://user-images.githubusercontent.com/895728/32108443-b6dd3b00-baff-11e7-9591-0f5333500dfd.PNG)
