### PR TITLE
Check 'auth' field when displaying .dockercfg config

### DIFF
--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3168,32 +3168,37 @@ message: null
 };
 }
 };
-}), angular.module("openshiftConsole").factory("SecretsService", function() {
-var e = function(e) {
-var t = {
+}), angular.module("openshiftConsole").factory("SecretsService", [ "$filter", "Logger", "NotificationsService", function(e, t, n) {
+var a = function(a, r) {
+n.addNotification({
+type: "error",
+message: "Base64-encoded " + r + " string could not be decoded.",
+details: e("getErrorDetails")(a)
+}), t.error("Base64-encoded " + r + " string could not be decoded.", a);
+}, r = function(e) {
+var t = _.pick(e, [ "email", "username", "password" ]);
+if (e.auth) try {
+_.spread(function(e, n) {
+t.username = e, t.password = n;
+})(_.split(window.atob(e.auth), ":", 2));
+} catch (e) {
+return void a(e, "username:password");
+}
+return t;
+}, o = function(e, t) {
+var n, o = {
 auths: {}
-}, n = JSON.parse(window.atob(e));
-return _.each(n, function(e, n) {
-t.auths[n] = {
-username: e.username,
-password: e.password,
-email: e.email
 };
-}), t;
-}, t = function(e) {
-var t = {
-auths: {}
-}, n = JSON.parse(window.atob(e));
-return _.each(n.auths, function(e, n) {
-if (e.auth) {
-var a = window.atob(e.auth).split(":");
-t.auths[n] = {
-username: a[0],
-password: a[1],
-email: e.email
-};
-} else t.auths[n] = e;
-}), n.credsStore && (t.credsStore = n.credsStore), t;
+try {
+n = JSON.parse(window.atob(e));
+} catch (e) {
+a(e, t);
+}
+return ".dockercfg" === t ? _.each(n, function(e, t) {
+o.auths[t] = r(e);
+}) : (_.each(n.auths, function(e, t) {
+e.auth ? o.auths[t] = r(e) : o.auths[t] = e;
+}), n.credsStore && (o.credsStore = n.credsStore)), o;
 };
 return {
 groupSecretsByType: function(e) {
@@ -3220,24 +3225,15 @@ t.other.push(e);
 }
 }), t;
 },
-decodeSecretData: function(n) {
-var a = {}, r = _.mapValues(n, function(n, r) {
-var o;
-switch (r) {
-case ".dockercfg":
-return e(n);
-
-case ".dockerconfigjson":
-return t(n);
-
-default:
-return o = window.atob(n), /[\x00-\x09\x0E-\x1F]/.test(o) ? (a[r] = !0, n) : o;
-}
+decodeSecretData: function(e) {
+var t = {}, n = _.mapValues(e, function(e, n) {
+var a;
+return ".dockercfg" === n || ".dockerconfigjson" === n ? o(e, n) : (a = window.atob(e), /[\x00-\x09\x0E-\x1F]/.test(a) ? (t[n] = !0, e) : a);
 });
-return r.$$nonprintable = a, r;
+return n.$$nonprintable = t, n;
 }
 };
-}), angular.module("openshiftConsole").factory("ServicesService", [ "$filter", "$q", "DataService", function(e, t, n) {
+} ]), angular.module("openshiftConsole").factory("ServicesService", [ "$filter", "$q", "DataService", function(e, t, n) {
 var a = "service.alpha.openshift.io/dependencies", r = e("annotation"), o = function(e) {
 var t = r(e, a);
 if (!t) return null;


### PR DESCRIPTION
While working on https://bugzilla.redhat.com/show_bug.cgi?id=1506998 I've noticed that we are not checking for `auth` field in the old **.dockercfg** format, which looks like:
```
{
        "registryaddress": {
                "auth": "auth string",
                "email": "email@domain.com"
        }
}
```

The `registryaddress` could also contain `username` and `password` fields.

@spadgett PTAL

Will add the dist after review
