### PR TITLE
Preserve newlines in broker status messages

### DIFF
--- a/app/scripts/directives/overview/serviceInstanceRow.js
+++ b/app/scripts/directives/overview/serviceInstanceRow.js
@@ -29,6 +29,8 @@
     var row = this;
     var isBindingFailed = $filter('isBindingFailed');
     var isBindingReady = $filter('isBindingReady');
+    var serviceInstanceFailedMessage = $filter('serviceInstanceFailedMessage');
+    var truncate = $filter('truncate');
 
     _.extend(row, ListRowUtils.ui);
 
@@ -109,6 +111,20 @@
       _.set(row, 'overlay.panelVisible', true);
       _.set(row, 'overlay.panelName', panelName);
       _.set(row, 'overlay.state', state);
+    };
+
+    row.getFailedTooltipText = function() {
+      var message = serviceInstanceFailedMessage(row.apiObject);
+      if (!message) {
+        return '';
+      }
+
+      var truncated = truncate(message, 128);
+      if (message.length !== truncated.length) {
+        truncated += '...';
+      }
+
+      return truncated;
     };
 
     row.deprovision = function() {

--- a/app/styles/_instances.less
+++ b/app/styles/_instances.less
@@ -1,0 +1,3 @@
+.service-instance-details .instance-status-message {
+  white-space: pre-line;
+}

--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -29,6 +29,11 @@
     margin-top: 5px;
   }
 }
+.instance-status-message .truncated-content,
+.instance-status-notification .tooltip {
+  // Preserve newlines in broker error messages.
+  white-space: pre-line;
+}
 .instance-status-notification,
 .notification-icon-count {
   display: inline-block;

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -65,3 +65,4 @@
 @import "_builds.less";
 @import "_editor.less";
 @import "_add-config-to-application.less";
+@import "_instances.less";

--- a/app/views/browse/service-instance.html
+++ b/app/views/browse/service-instance.html
@@ -54,7 +54,7 @@
           </div>
         </div>
       </div><!-- /middle-header-->
-      <div class="middle-content" persist-tab-state>
+      <div class="middle-content service-instance-details" persist-tab-state>
         <div class="container-fluid">
           <div class="row" ng-if="serviceInstance">
             <div class="col-md-12">
@@ -78,9 +78,7 @@
                             <span flex>{{serviceInstance | serviceInstanceStatus | sentenceCase}}</span>
                           </dd>
                           <dt ng-if-start="serviceInstance | serviceInstanceConditionMessage">Status Reason:</dt>
-                          <dd ng-if-end>
-                            {{serviceInstance | serviceInstanceConditionMessage}}
-                          </dd>
+                          <dd ng-if-end class="instance-status-message">{{serviceInstance | serviceInstanceConditionMessage}}</dd>
                         </dl>
                         <div class="hidden-lg">
                           <h3 ng-if-start="serviceClass.spec.description || serviceClass.spec.externalMetadata.longDescription">Description</h3>

--- a/app/views/overview/_service-instance-row.html
+++ b/app/views/overview/_service-instance-row.html
@@ -9,13 +9,15 @@
           <a ng-href="{{row.apiObject | navigateResourceURL}}" ng-bind-html="row.displayName | highlightKeywords : row.state.filterKeywords"></a>
           <div ng-bind-html="row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords" class="list-row-longname"></div>
         </h3>
-        <div class="status-icons" ng-if="!row.expanded">
+        <div class="status-icons" ng-if="!row.expanded" ng-init="tooltipID = 'instance-status-tooltip-' + $id">
           <notification-icon alerts="row.notifications"></notification-icon>
-          <div ng-switch="row.instanceStatus" class="instance-status-notification">
+          <div ng-switch="row.instanceStatus" class="instance-status-notification" id="{{tooltipID}}">
+            <!-- Set the tooltip container so we can add write CSS rules that target the message. -->
             <span ng-switch-when="failed"
-                  dynamic-content="{{row.apiObject | serviceInstanceFailedMessage}}"
+                  dynamic-content="{{row.getFailedTooltipText()}}"
                   data-toggle="tooltip"
-                  data-trigger="hover">
+                  data-trigger="hover"
+                  data-container="#{{tooltipID}}">
               <span class="pficon pficon-error-circle-o" aria-hidden="true"></span>
               Error
             </span>
@@ -111,12 +113,16 @@
                 <span class="pficon pficon-error-circle-o" aria-hidden="true"></span>
                 <span class="sr-only">error</span>
                 <span class="strong">The service failed.</span>
-                <span class="mar-right-md">
-                  <truncate-long-text content="row.apiObject | serviceInstanceFailedMessage" limit="265"></truncate-long-text>
+                <span class="instance-status-message">
+                  <truncate-long-text
+                    content="row.apiObject | serviceInstanceFailedMessage"
+                    expandable="true"
+                    limit="265"
+                    newline-limit="4"></truncate-long-text>
                 </span>
-                <span ng-if="row.serviceInstancesVersion | canI : 'delete'" class="nowrap">
+                <div ng-if="row.serviceInstancesVersion | canI : 'delete'">
                   <a href="" ng-click="row.deprovision()">Delete This Service</a>
-                </span>
+                </div>
               </div>
             </div>
           </div>
@@ -126,7 +132,13 @@
                 <span class="pficon pficon-info" aria-hidden="true"></span>
                 <span class="sr-only">info</span>
                 <span class="strong">The service is not yet ready.</span>
-                <truncate-long-text content="row.apiObject | serviceInstanceReadyMessage" limit="265"></truncate-long-text>
+                <span class="instance-status-message">
+                  <truncate-long-text
+                    content="row.apiObject | serviceInstanceReadyMessage"
+                    expandable="true"
+                    limit="265"
+                    newline-limit="4"></truncate-long-text>
+                </span>
               </div>
             </div>
           </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -13838,21 +13838,21 @@ templateUrl: "views/overview/_list-row.html"
 }(), function() {
 angular.module("openshiftConsole").component("serviceInstanceRow", {
 controller: [ "$filter", "APIService", "AuthorizationService", "BindingService", "ListRowUtils", "ServiceInstancesService", function(e, t, n, a, r, o) {
-var i = this, s = e("isBindingFailed"), c = e("isBindingReady");
+var i = this, s = e("isBindingFailed"), c = e("isBindingReady"), l = e("serviceInstanceFailedMessage"), u = e("truncate");
 _.extend(i, r.ui);
-var l = e("serviceInstanceDisplayName");
+var d = e("serviceInstanceDisplayName");
 i.serviceBindingsVersion = t.getPreferredVersion("servicebindings"), i.serviceInstancesVersion = t.getPreferredVersion("serviceinstances");
-var u = function() {
+var m = function() {
 var e = o.getServiceClassNameForInstance(i.apiObject);
 return _.get(i, [ "state", "serviceClasses", e ]);
-}, d = function() {
+}, p = function() {
 var e = o.getServicePlanNameForInstance(i.apiObject);
 return _.get(i, [ "state", "servicePlans", e ]);
-}, m = function() {
+}, f = function() {
 _.get(i.apiObject, "metadata.deletionTimestamp") ? i.instanceStatus = "deleted" : s(i.apiObject) ? i.instanceStatus = "failed" : c(i.apiObject) ? i.instanceStatus = "ready" : i.instanceStatus = "pending";
 };
 i.$doCheck = function() {
-m(), i.notifications = r.getNotifications(i.apiObject, i.state), i.serviceClass = u(), i.servicePlan = d(), i.displayName = l(i.apiObject, i.serviceClass), i.isBindable = a.isServiceBindable(i.apiObject, i.serviceClass, i.servicePlan);
+f(), i.notifications = r.getNotifications(i.apiObject, i.state), i.serviceClass = m(), i.servicePlan = p(), i.displayName = d(i.apiObject, i.serviceClass), i.isBindable = a.isServiceBindable(i.apiObject, i.serviceClass, i.servicePlan);
 }, i.$onChanges = function(e) {
 e.bindings && (i.deleteableBindings = _.reject(i.bindings, "metadata.deletionTimestamp"));
 }, i.getSecretForBinding = function(e) {
@@ -13863,6 +13863,11 @@ return !(_.get(i.apiObject, "metadata.deletionTimestamp") || (!i.isBindable || !
 _.set(i, "overlay.panelVisible", !1);
 }, i.showOverlayPanel = function(e, t) {
 _.set(i, "overlay.panelVisible", !0), _.set(i, "overlay.panelName", e), _.set(i, "overlay.state", t);
+}, i.getFailedTooltipText = function() {
+var e = l(i.apiObject);
+if (!e) return "";
+var t = u(e, 128);
+return e.length !== t.length && (t += "..."), t;
 }, i.deprovision = function() {
 o.deprovision(i.apiObject, i.deleteableBindings);
 };

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3697,7 +3697,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"middle-content\" persist-tab-state>\n" +
+    "<div class=\"middle-content service-instance-details\" persist-tab-state>\n" +
     "<div class=\"container-fluid\">\n" +
     "<div class=\"row\" ng-if=\"serviceInstance\">\n" +
     "<div class=\"col-md-12\">\n" +
@@ -3721,9 +3721,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span flex>{{serviceInstance | serviceInstanceStatus | sentenceCase}}</span>\n" +
     "</dd>\n" +
     "<dt ng-if-start=\"serviceInstance | serviceInstanceConditionMessage\">Status Reason:</dt>\n" +
-    "<dd ng-if-end>\n" +
-    "{{serviceInstance | serviceInstanceConditionMessage}}\n" +
-    "</dd>\n" +
+    "<dd ng-if-end class=\"instance-status-message\">{{serviceInstance | serviceInstanceConditionMessage}}</dd>\n" +
     "</dl>\n" +
     "<div class=\"hidden-lg\">\n" +
     "<h3 ng-if-start=\"serviceClass.spec.description || serviceClass.spec.externalMetadata.longDescription\">Description</h3>\n" +
@@ -12551,10 +12549,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a ng-href=\"{{row.apiObject | navigateResourceURL}}\" ng-bind-html=\"row.displayName | highlightKeywords : row.state.filterKeywords\"></a>\n" +
     "<div ng-bind-html=\"row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords\" class=\"list-row-longname\"></div>\n" +
     "</h3>\n" +
-    "<div class=\"status-icons\" ng-if=\"!row.expanded\">\n" +
+    "<div class=\"status-icons\" ng-if=\"!row.expanded\" ng-init=\"tooltipID = 'instance-status-tooltip-' + $id\">\n" +
     "<notification-icon alerts=\"row.notifications\"></notification-icon>\n" +
-    "<div ng-switch=\"row.instanceStatus\" class=\"instance-status-notification\">\n" +
-    "<span ng-switch-when=\"failed\" dynamic-content=\"{{row.apiObject | serviceInstanceFailedMessage}}\" data-toggle=\"tooltip\" data-trigger=\"hover\">\n" +
+    "<div ng-switch=\"row.instanceStatus\" class=\"instance-status-notification\" id=\"{{tooltipID}}\">\n" +
+    "\n" +
+    "<span ng-switch-when=\"failed\" dynamic-content=\"{{row.getFailedTooltipText()}}\" data-toggle=\"tooltip\" data-trigger=\"hover\" data-container=\"#{{tooltipID}}\">\n" +
     "<span class=\"pficon pficon-error-circle-o\" aria-hidden=\"true\"></span>\n" +
     "Error\n" +
     "</span>\n" +
@@ -12640,12 +12639,12 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"pficon pficon-error-circle-o\" aria-hidden=\"true\"></span>\n" +
     "<span class=\"sr-only\">error</span>\n" +
     "<span class=\"strong\">The service failed.</span>\n" +
-    "<span class=\"mar-right-md\">\n" +
-    "<truncate-long-text content=\"row.apiObject | serviceInstanceFailedMessage\" limit=\"265\"></truncate-long-text>\n" +
+    "<span class=\"instance-status-message\">\n" +
+    "<truncate-long-text content=\"row.apiObject | serviceInstanceFailedMessage\" expandable=\"true\" limit=\"265\" newline-limit=\"4\"></truncate-long-text>\n" +
     "</span>\n" +
-    "<span ng-if=\"row.serviceInstancesVersion | canI : 'delete'\" class=\"nowrap\">\n" +
+    "<div ng-if=\"row.serviceInstancesVersion | canI : 'delete'\">\n" +
     "<a href=\"\" ng-click=\"row.deprovision()\">Delete This Service</a>\n" +
-    "</span>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -12655,7 +12654,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"pficon pficon-info\" aria-hidden=\"true\"></span>\n" +
     "<span class=\"sr-only\">info</span>\n" +
     "<span class=\"strong\">The service is not yet ready.</span>\n" +
-    "<truncate-long-text content=\"row.apiObject | serviceInstanceReadyMessage\" limit=\"265\"></truncate-long-text>\n" +
+    "<span class=\"instance-status-message\">\n" +
+    "<truncate-long-text content=\"row.apiObject | serviceInstanceReadyMessage\" expandable=\"true\" limit=\"265\" newline-limit=\"4\"></truncate-long-text>\n" +
+    "</span>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -404,7 +404,7 @@ dd{margin-left:0}
 @media (min-width:415px){.dl-horizontal dt{float:left;width:160px;clear:left;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .dl-horizontal dd{margin-left:180px}
 }
-.btn-group-vertical>.btn-group:after,.btn-toolbar:after,.clearfix:after,.container-fluid:after,.container:after,.dl-horizontal dd:after,.form-horizontal .form-group:after,.list-view-pf .list-group-item:after,.modal-footer:after,.modal-header:after,.nav:after,.navbar-collapse:after,.navbar-header:after,.navbar:after,.pager:after,.panel-body:after,.row:after{clear:both}
+.btn-group-vertical>.btn-group:after,.btn-toolbar:after,.clearfix:after,.container-fluid:after,.container:after,.dl-horizontal dd:after,.dropdown-menu>li>a,.form-horizontal .form-group:after,.list-view-pf .list-group-item:after,.log-view,.modal-footer:after,.modal-header:after,.nav:after,.navbar-collapse:after,.navbar-header:after,.navbar:after,.pager:after,.panel-body:after,.row:after{clear:both}
 abbr[data-original-title],abbr[title]{cursor:help;border-bottom:1px dotted #9c9c9c}
 .initialism{font-size:90%;text-transform:uppercase}
 blockquote{padding:10.5px 21px;margin:0 0 21px;font-size:16.25px;border-left:5px solid #f1f1f1}
@@ -829,7 +829,7 @@ tbody.collapse.in{display:table-row-group}
 .btn-group>.btn-group:first-child:not(:last-child)>.btn:last-child,.btn-group>.btn-group:first-child:not(:last-child)>.dropdown-toggle,.btn-group>.btn:first-child:not(:last-child):not(.dropdown-toggle){border-bottom-right-radius:0;border-top-right-radius:0}
 .btn-group>.btn-group:last-child:not(:first-child)>.btn:first-child,.btn-group>.btn:last-child:not(:first-child),.btn-group>.dropdown-toggle:not(:first-child){border-bottom-left-radius:0;border-top-left-radius:0}
 .btn-group-vertical>.btn:not(:first-child):not(:last-child),.btn-group>.btn-group:not(:first-child):not(:last-child)>.btn,.btn-group>.btn:not(:first-child):not(:last-child):not(.dropdown-toggle){border-radius:0}
-.dropdown-menu>li>a{display:block;clear:both;font-weight:400;color:#363636}
+.dropdown-menu>li>a{display:block;font-weight:400;color:#363636}
 .dropdown-menu>li>a:focus,.dropdown-menu>li>a:hover{text-decoration:none;color:#4d5258;background-color:#def3ff}
 .dropdown-menu>.active>a,.dropdown-menu>.active>a:focus,.dropdown-menu>.active>a:hover{color:#fff;text-decoration:none;outline:0}
 .dropdown-menu>.disabled>a,.dropdown-menu>.disabled>a:focus,.dropdown-menu>.disabled>a:hover{color:#9c9c9c}
@@ -5019,6 +5019,7 @@ h2+.list-view-pf{margin-top:20px}
 .build-count .running-stage{font-size:84%;color:#9c9c9c}
 @media (max-width:991px){.builds-label{margin-top:5px}
 }
+.instance-status-message .truncated-content,.instance-status-notification .tooltip{white-space:pre-line}
 .instance-status-notification,.notification-icon-count{display:inline-block;margin:5px 5px 0 0}
 @media (min-width:992px){.instance-status-notification,.notification-icon-count{margin-top:0}
 }
@@ -5468,7 +5469,7 @@ dl.secret-data pre{margin-bottom:0}
 .events-sidebar .events-sidebar-collapse a{text-decoration:none}
 .events-sidebar .sidebar-header.right-header{align-items:center;display:flex;justify-content:space-between;margin-top:17.5px}
 .events-sidebar .sidebar-header.right-header h2{font-family:inherit;font-weight:500;line-height:1.1;color:inherit;margin-top:10.5px;margin-bottom:10.5px;font-size:14px;display:inline-block}
-.config-map-table .key,.config-map-table .truncated-content,.log-view{font-family:Menlo,Monaco,Consolas,monospace}
+.config-map-table .key,.config-map-table .truncated-content,.edit-yaml .ace_editor.editor,.log-view{font-family:Menlo,Monaco,Consolas,monospace}
 .events-sidebar .sidebar-header.right-header h2 .small,.events-sidebar .sidebar-header.right-header h2 small{font-weight:400;line-height:1;color:#9c9c9c;font-size:75%}
 .events-sidebar .sidebar-header.right-header .warning-count{white-space:nowrap;margin-left:2px}
 .events-sidebar .sidebar-header.right-header .warning-count .pficon{vertical-align:-1px}
@@ -5718,7 +5719,7 @@ alerts+.chromeless .log-loading-msg{margin-top:130px}
 .log-size-warning{margin:0}
 @media (max-width:991px){.log-size-warning{margin-top:20px}
 }
-.log-view{clear:both;margin-bottom:20px;position:relative}
+.log-view{margin-bottom:20px;position:relative}
 .log-end-msg,.log-view .log-scroll a{font-family:"Open Sans",Helvetica,Arial,sans-serif}
 .chromeless .log-view{margin-bottom:0}
 .log-view pre,.log-view pre code{background-color:transparent;border:0;margin-bottom:0;overflow:visible;padding:0 10px}
@@ -6020,7 +6021,7 @@ notification-drawer-wrapper .expanded-notification.unread .drawer-pf-notificatio
 .ace-inline{height:300px}
 .ace-inline-small{height:200px}
 .ace_editor.dockerfile-mode .ace_constant.ace_numeric,.editor.yaml-mode .ace_constant.ace_numeric{color:inherit}
-.edit-yaml .ace_editor.editor{font-family:Menlo,Monaco,Consolas,monospace;line-height:1.5;width:100%;min-height:140px;height:50vh}
+.edit-yaml .ace_editor.editor{line-height:1.5;width:100%;min-height:140px;height:50vh}
 @media (min-height:700px){.edit-yaml .ace_editor.editor{height:60vh}
 }
 .edit-yaml .ace_editor.editor .ace_gutter{color:#8b8d8f}
@@ -6040,3 +6041,4 @@ notification-drawer-wrapper .expanded-notification.unread .drawer-pf-notificatio
 .add-config-to-application .dialog-body .radio{margin-top:0}
 .add-config-to-application .updating{background-color:#fff;bottom:55px;left:0;padding-top:60px;position:absolute;right:0;top:55px;z-index:1000}
 .add-config-to-application .volume-options{margin-left:20px}
+.service-instance-details .instance-status-message{white-space:pre-line}


### PR DESCRIPTION
Preserve newlines in service instance status messages on the overview
and the provisioned service page. Truncate long message when displayed
in a tooltip.

See #2217

![screen shot 2017-10-30 at 3 44 27 pm](https://user-images.githubusercontent.com/1167259/32192505-bb62ecc8-bd8a-11e7-9531-385f538c3f52.png)

![screen shot 2017-10-30 at 4 11 12 pm](https://user-images.githubusercontent.com/1167259/32193223-fd560b4a-bd8c-11e7-8ae9-1cc37575fcdf.png)

![screen shot 2017-10-30 at 3 46 30 pm](https://user-images.githubusercontent.com/1167259/32192518-c6f75948-bd8a-11e7-8f97-f22e0a5eb258.png)
