### PR TITLE
Bug 1507753 - Make config page and environment tab actions consistent

### DIFF
--- a/app/views/create/fromimage.html
+++ b/app/views/create/fromimage.html
@@ -283,8 +283,8 @@
                                 value-from-selector-options="valueFromObjects"
                                 key-validator="[a-zA-Z_][a-zA-Z0-9_]*"
                                 key-validator-error-tooltip="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."
-                                add-row-link="Add Environment Variable"
-                                add-row-with-selectors-link="Add Environment Variable Using a Config Map or Secret"></key-value-editor>
+                                add-row-link="Add Value"
+                                add-row-with-selectors-link="Add Value from Config Map or Secret"></key-value-editor>
                             </div>
                           </div>
                         </osc-form-section>

--- a/app/views/directives/deploy-image.html
+++ b/app/views/directives/deploy-image.html
@@ -167,8 +167,8 @@
             key-validator-error="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."
             value-placeholder="Value"
             value-from-selector-options="input.selectedProject.metadata.uid && valueFromNamespace[input.selectedProject.metadata.name]"
-            add-row-link="Add Environment Variable"
-            add-row-with-selectors-link="Add Environment Variable Using a Config Map or Secret"></key-value-editor>
+            add-row-link="Add Value"
+            add-row-with-selectors-link="Add Value from Config Map or Secret"></key-value-editor>
         </osc-form-section>
 
         <label-editor

--- a/app/views/directives/edit-lifecycle-hook.html
+++ b/app/views/directives/edit-lifecycle-hook.html
@@ -58,8 +58,8 @@
             key-validator="[a-zA-Z_][a-zA-Z0-9_]*"
             key-validator-error-tooltip="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."
             value-from-selector-options="valueFromObjects"
-            add-row-with-selectors-link="Add Environment Variable Using a Config Map or Secret"
-            add-row-link="Add Environment Variable"></key-value-editor>
+            add-row-with-selectors-link="Add Value from Config Map or Secret"
+            add-row-link="Add Value"></key-value-editor>
           <div class="help-block">
             Environment variables to supply to the hook pod's container.
           </div>

--- a/app/views/edit/deployment-config.html
+++ b/app/views/edit/deployment-config.html
@@ -71,8 +71,8 @@
                           key-validator="[a-zA-Z_][a-zA-Z0-9_]*"
                           key-validator-error-tooltip="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."
                           value-from-selector-options="valueFromObjects"
-                          add-row-link="Add Environment Variable"
-                          add-row-with-selectors-link="Add Environment Variable Using a Config Map or Secret"></key-value-editor>
+                          add-row-link="Add Value"
+                          add-row-with-selectors-link="Add Value from Config Map or Secret"></key-value-editor>
                       </div>
                     </div>
                     <div ng-if="strategyData.type !== 'Custom'" >
@@ -356,8 +356,8 @@
                       value-from-selector-options="valueFromObjects"
                       key-validator="[a-zA-Z_][a-zA-Z0-9_]*"
                       key-validator-error-tooltip="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."
-                      add-row-link="Add Environment Variable"
-                      add-row-with-selectors-link="Add Environment Variable Using a Config Map or Secret"></key-value-editor>
+                      add-row-link="Add Value"
+                      add-row-with-selectors-link="Add Value from Config Map or Secret"></key-value-editor>
                   </div>
                 </div>
 

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4985,7 +4985,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<key-value-editor entries=\"DCEnvVarsFromImage\" is-readonly cannot-add cannot-sort cannot-delete></key-value-editor>\n" +
     "</div>\n" +
-    "<key-value-editor entries=\"DCEnvVarsFromUser\" key-placeholder=\"name\" value-placeholder=\"value\" value-from-selector-options=\"valueFromObjects\" key-validator=\"[a-zA-Z_][a-zA-Z0-9_]*\" key-validator-error-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" add-row-link=\"Add Environment Variable\" add-row-with-selectors-link=\"Add Environment Variable Using a Config Map or Secret\"></key-value-editor>\n" +
+    "<key-value-editor entries=\"DCEnvVarsFromUser\" key-placeholder=\"name\" value-placeholder=\"value\" value-from-selector-options=\"valueFromObjects\" key-validator=\"[a-zA-Z_][a-zA-Z0-9_]*\" key-validator-error-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" add-row-link=\"Add Value\" add-row-with-selectors-link=\"Add Value from Config Map or Secret\"></key-value-editor>\n" +
     "</div>\n" +
     "</div>\n" +
     "</osc-form-section>\n" +
@@ -6452,7 +6452,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "<osc-form-section header=\"Environment Variables\" about-title=\"Environment Variables\" about=\"Environment variables are used to configure and pass information to running containers.\" expand=\"true\" can-toggle=\"false\" class=\"first-section\">\n" +
-    "<key-value-editor entries=\"env\" key-placeholder=\"Name\" key-validator=\"[A-Za-z_][A-Za-z0-9_]*\" key-validator-error=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" value-placeholder=\"Value\" value-from-selector-options=\"input.selectedProject.metadata.uid && valueFromNamespace[input.selectedProject.metadata.name]\" add-row-link=\"Add Environment Variable\" add-row-with-selectors-link=\"Add Environment Variable Using a Config Map or Secret\"></key-value-editor>\n" +
+    "<key-value-editor entries=\"env\" key-placeholder=\"Name\" key-validator=\"[A-Za-z_][A-Za-z0-9_]*\" key-validator-error=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" value-placeholder=\"Value\" value-from-selector-options=\"input.selectedProject.metadata.uid && valueFromNamespace[input.selectedProject.metadata.name]\" add-row-link=\"Add Value\" add-row-with-selectors-link=\"Add Value from Config Map or Secret\"></key-value-editor>\n" +
     "</osc-form-section>\n" +
     "<label-editor labels=\"labels\" expand=\"true\" can-toggle=\"false\" help-text=\"Each label is applied to each created resource.\">\n" +
     "</label-editor>\n" +
@@ -6877,7 +6877,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"form-group\">\n" +
     "<label>Environment Variables</label>\n" +
-    "<key-value-editor entries=\"hookParams.execNewPod.env\" key-validator=\"[a-zA-Z_][a-zA-Z0-9_]*\" key-validator-error-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" value-from-selector-options=\"valueFromObjects\" add-row-with-selectors-link=\"Add Environment Variable Using a Config Map or Secret\" add-row-link=\"Add Environment Variable\"></key-value-editor>\n" +
+    "<key-value-editor entries=\"hookParams.execNewPod.env\" key-validator=\"[a-zA-Z_][a-zA-Z0-9_]*\" key-validator-error-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" value-from-selector-options=\"valueFromObjects\" add-row-with-selectors-link=\"Add Value from Config Map or Secret\" add-row-link=\"Add Value\"></key-value-editor>\n" +
     "<div class=\"help-block\">\n" +
     "Environment variables to supply to the hook pod's container.\n" +
     "</div>\n" +
@@ -10026,7 +10026,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"form-group\">\n" +
     "<label>Environment Variables</label>\n" +
-    "<key-value-editor entries=\"strategyData.customParams.environment\" key-validator=\"[a-zA-Z_][a-zA-Z0-9_]*\" key-validator-error-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" value-from-selector-options=\"valueFromObjects\" add-row-link=\"Add Environment Variable\" add-row-with-selectors-link=\"Add Environment Variable Using a Config Map or Secret\"></key-value-editor>\n" +
+    "<key-value-editor entries=\"strategyData.customParams.environment\" key-validator=\"[a-zA-Z_][a-zA-Z0-9_]*\" key-validator-error-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" value-from-selector-options=\"valueFromObjects\" add-row-link=\"Add Value\" add-row-with-selectors-link=\"Add Value from Config Map or Secret\"></key-value-editor>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"strategyData.type !== 'Custom'\">\n" +
@@ -10206,7 +10206,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-name\">\n" +
     "<h4>Container {{containerName}}</h4>\n" +
     "</div>\n" +
-    "<key-value-editor ng-if=\"containerConfig\" entries=\"containerConfig.env\" value-from-selector-options=\"valueFromObjects\" key-validator=\"[a-zA-Z_][a-zA-Z0-9_]*\" key-validator-error-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" add-row-link=\"Add Environment Variable\" add-row-with-selectors-link=\"Add Environment Variable Using a Config Map or Secret\"></key-value-editor>\n" +
+    "<key-value-editor ng-if=\"containerConfig\" entries=\"containerConfig.env\" value-from-selector-options=\"valueFromObjects\" key-validator=\"[a-zA-Z_][a-zA-Z0-9_]*\" key-validator-error-tooltip=\"A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores.\" add-row-link=\"Add Value\" add-row-with-selectors-link=\"Add Value from Config Map or Secret\"></key-value-editor>\n" +
     "</div>\n" +
     "</div>\n" +
     "<pause-rollouts-checkbox deployment=\"updatedDeploymentConfig\" always-visible=\"true\">\n" +


### PR DESCRIPTION
When editing DC environment variables the action links are following: 
![current-env](https://user-images.githubusercontent.com/1668218/32218021-f1019e98-be29-11e7-87af-5ebe8f497740.png)

But the DC's Environment tab actions links are:
![old-env](https://user-images.githubusercontent.com/1668218/32218143-519da1b6-be2a-11e7-9a00-492aabc7c27d.png)

To be consistent (eg BC editor and BC Environment tab)  the action links wording in the DC env tab should be:
![new-env](https://user-images.githubusercontent.com/1668218/32218198-79e64952-be2a-11e7-8a8f-96fbd1993c26.png)
 
@spadgett PTAL