### PR TITLE
Fix bugzilla 15077030 rolebindings for serviceaccounts

### DIFF
--- a/app/scripts/controllers/membership.js
+++ b/app/scripts/controllers/membership.js
@@ -274,7 +274,8 @@ angular
             project: project,
             subjectKinds: subjectKinds,
             canUpdateRolebindings: canI('rolebindings', 'update', projectName),
-            confirmRemove: function(subjectName, kindName, roleName) {
+            confirmRemove: function(subjectName, kindName, roleName, namespace) {
+
               var redirectToProjectList = null;
               var modalScope = createModalScope(subjectName, kindName, roleName, $scope.user.metadata.name);
               if(_.isEqual(subjectName, $scope.user.metadata.name)) {
@@ -294,7 +295,7 @@ angular
               })
               .result.then(function() {
                 RoleBindingsService
-                  .removeSubject(subjectName, roleName, $scope.roleBindings, requestContext)
+                  .removeSubject(subjectName, roleName, namespace, $scope.roleBindings, requestContext)
                   .then(function(updateRolebinding) {
                     if(redirectToProjectList) {
                       $location.url("./");

--- a/app/views/membership.html
+++ b/app/views/membership.html
@@ -113,7 +113,7 @@
                     key="role.metadata.name"
                     key-help="roleHelp(role)"
                     show-action="mode.edit"
-                    action="confirmRemove(subject.name, subjectKind.name, role.metadata.name)"
+                    action="confirmRemove(subject.name, subjectKind.name, role.metadata.name, subject.namespace)"
                     action-title="Remove role {{role.metadata.name}} from {{subject.name}}"></action-chip>
                 </div>
                 <div

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2514,17 +2514,19 @@ l.subjects.push(n);
 } else l.subjects = [ n ];
 return i(l), t.update("rolebindings", l.metadata.name, l, s);
 },
-removeSubject: function(n, a, o, s) {
-var c = _.filter(o, {
+removeSubject: function(n, a, o, s, c) {
+var l = _.filter(s, {
 roleRef: {
 name: a
 }
 });
-return e.all(_.map(c, function(e) {
+return e.all(_.map(l, function(e) {
 var a = r();
-return e = _.extend(a, e), i(e), e.subjects = _.reject(e.subjects, {
+e = _.extend(a, e), i(e);
+var s = {
 name: n
-}), e.subjects.length ? t.update("rolebindings", e.metadata.name, e, s) : t.delete("rolebindings", e.metadata.name, s).then(function() {
+};
+return o && (s.namespace = o), e.subjects = _.reject(e.subjects, s), e.subjects.length ? t.update("rolebindings", e.metadata.name, e, c) : t.delete("rolebindings", e.metadata.name, c).then(function() {
 return e;
 });
 }));
@@ -5222,20 +5224,20 @@ f = r, P(), k(f), angular.extend(a, {
 project: n,
 subjectKinds: E,
 canUpdateRolebindings: y("rolebindings", "update", g),
-confirmRemove: function(n, r, i) {
-var c = null, l = T(n, r, i, a.user.metadata.name);
-_.isEqual(n, a.user.metadata.name) && u.isLastRole(a.user.metadata.name, a.roleBindings) && (c = !0), o.open({
+confirmRemove: function(n, r, i, c) {
+var l = null, d = T(n, r, i, a.user.metadata.name);
+_.isEqual(n, a.user.metadata.name) && u.isLastRole(a.user.metadata.name, a.roleBindings) && (l = !0), o.open({
 animation: !0,
 templateUrl: "views/modals/confirm.html",
 controller: "ConfirmModalController",
 resolve: {
 modalConfig: function() {
-return l;
+return d;
 }
 }
 }).result.then(function() {
-m.removeSubject(n, i, a.roleBindings, f).then(function(e) {
-c ? t.url("./") : (s.getProjectRules(g, !0).then(function() {
+m.removeSubject(n, i, c, a.roleBindings, f).then(function(e) {
+l ? t.url("./") : (s.getProjectRules(g, !0).then(function() {
 P(e[0]);
 var t = y("rolebindings", "update", g);
 angular.extend(a, {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -10702,7 +10702,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"action-set\">\n" +
     "<div class=\"col-roles\">\n" +
-    "<action-chip ng-repeat=\"role in subject.roles\" key=\"role.metadata.name\" key-help=\"roleHelp(role)\" show-action=\"mode.edit\" action=\"confirmRemove(subject.name, subjectKind.name, role.metadata.name)\" action-title=\"Remove role {{role.metadata.name}} from {{subject.name}}\"></action-chip>\n" +
+    "<action-chip ng-repeat=\"role in subject.roles\" key=\"role.metadata.name\" key-help=\"roleHelp(role)\" show-action=\"mode.edit\" action=\"confirmRemove(subject.name, subjectKind.name, role.metadata.name, subject.namespace)\" action-title=\"Remove role {{role.metadata.name}} from {{subject.name}}\"></action-chip>\n" +
     "</div>\n" +
     "<div ng-if=\"mode.edit\" class=\"col-add-role\">\n" +
     "<div row>\n" +


### PR DESCRIPTION
Fix bugzilla 15077030 where deleting a rolebinding for a serviceaccount can delete additional rolebindings for serviceaccounts from another namespace.

Hopefully will follow-up with some tests soon.  Time elapse is def showing some subtle bugs here.