### PR TITLE
add k8s compliant validation for label

### DIFF
--- a/app/views/directives/osc-persistent-volume-claim.html
+++ b/app/views/directives/osc-persistent-volume-claim.html
@@ -221,8 +221,8 @@
           entries="claim.selectedLabels"
           key-placeholder="label"
           value-placeholder="value"
-          key-validator="[a-zA-Z][a-zA-Z0-9_-]*"
-          key-validator-error-tooltip="A valid label name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores and dashes."
+          key-validator="[a-zA-Z][a-zA-Z0-9_.-\/]*"
+          key-validator-error-tooltip="A valid label name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores, dots and dashes."
           add-row-link="Add Label"></key-value-editor>
       </fieldset>
     </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8323,7 +8323,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a ng-href=\"{{'selector_label' | helpLink}}\" target=\"_blank\">Learn More&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></a>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<key-value-editor entries=\"claim.selectedLabels\" key-placeholder=\"label\" value-placeholder=\"value\" key-validator=\"[a-zA-Z][a-zA-Z0-9_-]*\" key-validator-error-tooltip=\"A valid label name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores and dashes.\" add-row-link=\"Add Label\"></key-value-editor>\n" +
+    "<key-value-editor entries=\"claim.selectedLabels\" key-placeholder=\"label\" value-placeholder=\"value\" key-validator=\"[a-zA-Z][a-zA-Z0-9_.-\\/]*\" key-validator-error-tooltip=\"A valid label name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores, dots and dashes.\" add-row-link=\"Add Label\"></key-value-editor>\n" +
     "</fieldset>\n" +
     "</div>\n" +
     "</fieldset>\n" +


### PR DESCRIPTION
If I have storageclass like this: 
```
kind: StorageClass
apiVersion: storage.k8s.io/v1beta1
metadata:
  name: fast
provisioner: kubernetes.io/mystorageprvider
parameters:
  pool: default
  description: Kubernetes volume
  fsType: ext4
  adminSecretNamespace: default
  adminSecretName: mystorageprvider-secret
```

I want to use UI and create storage claim and provide label selector. As per K8S docs labels can have . and / as keys (https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)

But our validation does not allow this from UI:
![image](https://user-images.githubusercontent.com/3225744/32272069-6bb0b816-bef4-11e7-9a5c-9ec3cf8edba4.png)

We want this to be valid:
![image](https://user-images.githubusercontent.com/3225744/32272119-a030333c-bef4-11e7-8412-8cbdd5b28ed8.png)

