### PR TITLE
Add track by to container repeat for env vars

### DIFF
--- a/app/views/directives/edit-environment-variables.html
+++ b/app/views/directives/edit-environment-variables.html
@@ -1,6 +1,6 @@
 <form ng-if="$ctrl.apiObject" name="$ctrl.form" class="mar-bottom-xl">
   <confirm-on-exit ng-if="$ctrl.canIUpdate && !$ctrl.ngReadonly" dirty="$ctrl.form.$dirty"></confirm-on-exit>
-  <div ng-repeat="container in $ctrl.containers">
+  <div ng-repeat="container in $ctrl.containers track by container.name">
     <h3>Container {{container.name}}</h3>
 
     <div ng-if="!$ctrl.canIUpdate || $ctrl.ngReadonly">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6811,7 +6811,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   $templateCache.put('views/directives/edit-environment-variables.html',
     "<form ng-if=\"$ctrl.apiObject\" name=\"$ctrl.form\" class=\"mar-bottom-xl\">\n" +
     "<confirm-on-exit ng-if=\"$ctrl.canIUpdate && !$ctrl.ngReadonly\" dirty=\"$ctrl.form.$dirty\"></confirm-on-exit>\n" +
-    "<div ng-repeat=\"container in $ctrl.containers\">\n" +
+    "<div ng-repeat=\"container in $ctrl.containers track by container.name\">\n" +
     "<h3>Container {{container.name}}</h3>\n" +
     "<div ng-if=\"!$ctrl.canIUpdate || $ctrl.ngReadonly\">\n" +
     "<span ng-if=\"!container.env.length\">\n" +


### PR DESCRIPTION
Avoids some issues where the page flickers on updates and prevents the
dropdown from closing when open during a background update.

Fixes one of the flicker problems mentioned in #2182

/kind bug
/assign @jwforres 
cc @cdcabrera 