### PR TITLE
[WIP] Give pod donuts a real href when linking to multiple pods

### DIFF
--- a/app/scripts/controllers/monitoring.js
+++ b/app/scripts/controllers/monitoring.js
@@ -270,10 +270,10 @@ angular.module('openshiftConsole')
     $scope.viewPodsForSet = function(set) {
       var pods = _.get($scope, ['podsByOwnerUID', set.metadata.uid], []);
       if (_.isEmpty(pods)) {
-        return;
+        return "";
       }
 
-      Navigate.toPodsForDeployment(set, pods);
+      return Navigate.podsForDeploymentURL(set, pods);
     };
 
     ProjectsService

--- a/app/scripts/directives/deploymentDonut.js
+++ b/app/scripts/directives/deploymentDonut.js
@@ -102,10 +102,10 @@ angular.module('openshiftConsole')
 
         $scope.viewPodsForDeployment = function(deployment) {
           if (_.isEmpty($scope.pods)) {
-            return;
+            return null;
           }
 
-          Navigate.toPodsForDeployment(deployment, $scope.pods);
+          return Navigate.podsForDeploymentURL(deployment, $scope.pods);
         };
 
         $scope.scaleUp = function() {

--- a/app/scripts/directives/overview/listRow.js
+++ b/app/scripts/directives/overview/listRow.js
@@ -346,12 +346,12 @@
       return Navigate.resourceURL(imageStreamName, 'ImageStream', imageStreamNamespace);
     };
 
-    row.navigateToPods = function() {
+    row.navigateToPodsURL = function() {
       var pods = row.getPods(row.current);
       if (_.isEmpty(pods)) {
-        return;
+        return "";
       }
-      Navigate.toPodsForDeployment(row.current, pods);
+      return Navigate.podsForDeploymentURL(row.current, pods);
     };
 
     row.closeOverlayPanel = function() {

--- a/app/scripts/services/navigate.js
+++ b/app/scripts/services/navigate.js
@@ -128,6 +128,16 @@ angular.module("openshiftConsole")
         $location.path("project/" + encodeURIComponent(projectName) + "/create/next").search(search);
       },
 
+      podsForDeploymentURL: function(deployment, pods) {
+        if (_.size(pods) === 1) {
+          return this.resourceURL(_.sample(pods));
+        }
+
+        var url = URI("project/" + deployment.metadata.namespace + "/browse/pods");
+        url.search(LabelFilter.persistedStateForSelector(new LabelSelector(deployment.spec.selector, true)));
+        return url.toString();
+      },
+
       toPodsForDeployment: function(deployment, pods) {
         if (_.size(pods) === 1) {
           this.toResourceURL(_.sample(pods));

--- a/app/views/directives/deployment-donut.html
+++ b/app/views/directives/deployment-donut.html
@@ -1,21 +1,14 @@
 <div column class="deployment-donut">
   <div row>
     <div column>
-      <pod-donut
-          pods="pods"
-          desired="getDesiredReplicas()"
-          idled="isIdled"
-          ng-click="viewPodsForDeployment(rc)"
-          ng-class="{ clickable: (pods | hashSize) > 0 }">
-      </pod-donut>
-
       <!-- Add a link for screen readers. -->
-      <a href=""
-         class="sr-only"
-         ng-click="viewPodsForDeployment(rc)"
-         ng-if="(pods | hashSize) > 0"
-         role="button">
-         View pods for {{rc | displayName}}
+      <a ng-href="{{viewPodsForDeployment(rc)}}">
+        <pod-donut
+            pods="pods"
+            desired="getDesiredReplicas()"
+            idled="isIdled">
+        </pod-donut>
+        <span class="sr-only">View pods for {{rc | displayName}}</span>
       </a>
     </div>
 

--- a/app/views/monitoring.html
+++ b/app/views/monitoring.html
@@ -175,8 +175,7 @@
                           <small>created <span am-time-ago="replicationController.metadata.creationTimestamp"></span></small>
                         </div>
                         <div class="list-group-item-text">
-                          <a href=""
-                             ng-click="viewPodsForSet(replicationController)"
+                          <a ng-href="{{viewPodsForSet(replicationController)}}"
                              class="mini-donut-link"
                              ng-class="{ 'disabled-link': !(podsByOwnerUID[replicationController.metadata.uid] | size) }">
                             <pod-donut pods="podsByOwnerUID[replicationController.metadata.uid]" mini="true"></pod-donut>
@@ -236,8 +235,7 @@
                           <small>created <span am-time-ago="replicaSet.metadata.creationTimestamp"></span></small>
                         </div>
                         <div class="list-group-item-text">
-                          <a href=""
-                             ng-click="viewPodsForSet(replicaSet)"
+                          <a ng-href="{{viewPodsForSet(replicaSet)}}"
                              class="mini-donut-link"
                              ng-class="{ 'disabled-link': !(podsByOwnerUID[replicaSet.metadata.uid] | size) }">
                             <pod-donut pods="podsByOwnerUID[replicaSet.metadata.uid]" mini="true"></pod-donut>
@@ -259,7 +257,7 @@
                   Logs are not available for replica sets.
                   <span ng-if="podsByOwnerUID[replicaSet.metadata.uid] | hashSize">
                     To see application logs, view the logs for one of the replica set's
-                    <a href="" ng-click="viewPodsForSet(replicaSet)">pods</a>.
+                    <a ng-href="{{viewPodsForSet(replicaSet)}}">pods</a>.
                   </span>
                   <div class="mar-top-lg" ng-if="metricsAvailable">
                     <deployment-metrics
@@ -306,8 +304,7 @@
                           <small>created <span am-time-ago="set.metadata.creationTimestamp"></span></small>
                         </div>
                         <div class="list-group-item-text">
-                          <a href=""
-                             ng-click="viewPodsForSet(set)"
+                          <a ng-href="{{viewPodsForSet(set)}}"
                              class="mini-donut-link"
                              ng-class="{ 'disabled-link': !(podsByOwnerUID[set.metadata.uid] | size) }">
                             <pod-donut pods="podsByOwnerUID[set.metadata.uid]" mini="true"></pod-donut>
@@ -326,7 +323,7 @@
                   Logs are not available for stateful sets.
                   <span ng-if="podsByOwnerUID[set.metadata.uid] | hashSize">
                     To see application logs, view the logs for one of the stateful sets's
-                    <a href="" ng-click="viewPodsForSet(set)">pods</a>.
+                    <a ng-href="{{viewPodsForSet(set)}}">pods</a>.
                   </span>
                   <div class="mar-top-lg" ng-if="metricsAvailable">
                     <deployment-metrics

--- a/app/views/overview/_list-row-content.html
+++ b/app/views/overview/_list-row-content.html
@@ -84,7 +84,7 @@
       </a>
     </div>
     <div ng-if="row.apiObject.kind !== 'Pod'">
-      <a href="" ng-click="row.navigateToPods()" class="mini-donut-link" ng-class="{ 'disabled-link': !(row.getPods(row.current) | size) }">
+      <a ng-href="{{row.navigateToPodsURL()}}" class="mini-donut-link" ng-class="{ 'disabled-link': !(row.getPods(row.current) | size) }">
         <pod-donut pods="row.getPods(row.current)" mini="true"></pod-donut>
       </a>
     </div>


### PR DESCRIPTION
This was the original idea just opening to save the work. We discussed other alternatives because the URLs for this can be very long when using the label filter plus the label filter is no longer 100% accurate since it may select pods from another controller.
1) Add an ownerRef filter - would add the option to view pods for a particular controller from the pod list view which would be handy
2) Go straight to the controllers page and scrollTo the pod list

cc @spadgett 