### PR TITLE
Fix problems with env valueFrom for DC hooks

### DIFF
--- a/app/scripts/controllers/edit/deploymentConfig.js
+++ b/app/scripts/controllers/edit/deploymentConfig.js
@@ -165,7 +165,7 @@ angular.module('openshiftConsole')
             DataService.list("secrets", context, null, { errorNotification: false }).then(function(secretData) {
               secretDataOrdered = orderByDisplayName(secretData.by("metadata.name"));
               $scope.availableSecrets = secretDataOrdered;
-              $scope.valueFromObjects = secretDataOrdered.concat(configMapDataOrdered);
+              $scope.valueFromObjects = configMapDataOrdered.concat(secretDataOrdered);
               var secretsByType = SecretsService.groupSecretsByType(secretData);
               var secretNamesByType =_.mapValues(secretsByType, function(secretData) {return _.map(secretData, 'metadata.name');});
               // Add empty option to the image/source secrets

--- a/app/scripts/directives/lifecycleHook.js
+++ b/app/scripts/directives/lifecycleHook.js
@@ -123,7 +123,9 @@ angular.module("openshiftConsole")
 
         $scope.valueFromObjects = [];
         $scope.$watchGroup(['availableSecrets', 'availableConfigMaps'], function() {
-          $scope.valueFromObjects = ($scope.availableSecrets || []).concat($scope.availableConfigMaps);
+          var configMaps = $scope.availableConfigMaps || [];
+          var secrets = $scope.availableSecrets || [];
+          $scope.valueFromObjects = configMaps.concat(secrets);
         });
 
         $scope.$watch("istagHook.tagObject.tag", function() {

--- a/app/views/directives/lifecycle-hook.html
+++ b/app/views/directives/lifecycle-hook.html
@@ -33,7 +33,36 @@
       <dt ng-if-start="strategyParams[type].execNewPod.env">Environment Variables:</dt>
       <dd ng-if-end>
         <div ng-repeat="env in strategyParams[type].execNewPod.env">
-          <div class="truncate" ng-attr-title="{{env.value}}">{{env.name}}={{env.value}}</div>
+          <div ng-if="env.valueFrom.configMapKeyRef || env.valueFrom.secretKeyRef">
+            {{env.name}} set to key
+            <span ng-if="env.valueFrom.configMapKeyRef">
+              {{env.valueFrom.configMapKeyRef.key}} in config map
+              <span
+                ng-if="!('configmaps' | canI : 'get')">
+                {{env.valueFrom.configMapKeyRef.name}}
+              </span>
+              <a
+                ng-if="'configmaps' | canI : 'get'"
+                ng-href="{{env.valueFrom.configMapKeyRef.name | navigateResourceURL : 'ConfigMap' : deploymentConfig.metadata.namespace}}">
+                {{env.valueFrom.configMapKeyRef.name}}
+              </a>
+            </span>
+            <span ng-if="env.valueFrom.secretKeyRef">
+              {{env.valueFrom.secretKeyRef.key}} in secret
+              <span
+                ng-if="!('secrets' | canI : 'get')">
+                {{env.valueFrom.secretKeyRef.name}}
+              </span>
+              <a
+                ng-if="'secrets' | canI : 'get'"
+                ng-href="{{env.valueFrom.secretKeyRef.name | navigateResourceURL : 'Secret' : deploymentConfig.metadata.namespace}}">
+                {{env.valueFrom.secretKeyRef.name}}
+              </a>
+            </span>
+          </div>
+          <div ng-if="!env.valueFrom" class="truncate" ng-attr-title="{{env.value}}">
+            {{env.name}}={{env.value}}
+          </div>
         </div>
       </dd>
       <dt ng-if-start="strategyParams[type].execNewPod.volumes">Volumes:</dt>

--- a/app/views/edit/deployment-config.html
+++ b/app/views/edit/deployment-config.html
@@ -229,37 +229,40 @@
                           <div class="lifecycle-hook" id="pre-lifecycle-hook">
 
                             <h3>Pre Lifecycle Hook</h3>
-                            <edit-lifecycle-hook model='strategyData[strategyParamsPropertyName].pre'
-                                              type='pre'
-                                              available-volumes='volumeNames'
-                                              available-containers='containerNames'
-                                              available-secrets='availableSecrets'
-                                              available-configmaps='availableConfigMaps'
-                                              namespace="projectName">
+                            <edit-lifecycle-hook
+                              model="strategyData[strategyParamsPropertyName].pre"
+                              type="pre"
+                              available-volumes="volumeNames"
+                              available-containers="containerNames"
+                              available-secrets="availableSecrets"
+                              available-config-maps="availableConfigMaps"
+                              namespace="projectName">
                             </edit-lifecycle-hook>
                           </div>
 
                           <div ng-if="strategyData.type !== 'Rolling'" class="lifecycle-hook" id="mid-lifecycle-hook" >
                             <h3>Mid Lifecycle Hook</h3>
-                            <edit-lifecycle-hook model='strategyData[strategyParamsPropertyName].mid'
-                                              type='mid'
-                                              available-volumes='volumeNames'
-                                              available-containers='containerNames'
-                                              available-secrets='availableSecrets'
-                                              available-configmaps='availableConfigMaps'
-                                              namespace="projectName">
+                            <edit-lifecycle-hook
+                              model="strategyData[strategyParamsPropertyName].mid"
+                              type="mid"
+                              available-volumes="volumeNames"
+                              available-containers="containerNames"
+                              available-secrets="availableSecrets"
+                              available-config-maps="availableConfigMaps"
+                              namespace="projectName">
                             </edit-lifecycle-hook>
                           </div>
 
                           <div class="lifecycle-hook" id="post-lifecycle-hook" >
                             <h3>Post Lifecycle Hook</h3>
-                            <edit-lifecycle-hook model='strategyData[strategyParamsPropertyName].post'
-                                              type='post'
-                                              available-volumes='volumeNames'
-                                              available-containers='containerNames'
-                                              available-secrets='availableSecrets'
-                                              available-configmaps='availableConfigMaps'
-                                              namespace="projectName">
+                            <edit-lifecycle-hook
+                              model="strategyData[strategyParamsPropertyName].post"
+                              type="post"
+                              available-volumes="volumeNames"
+                              available-containers="containerNames"
+                              available-secrets="availableSecrets"
+                              available-config-maps="availableConfigMaps"
+                              namespace="projectName">
                             </edit-lifecycle-hook>
                           </div>
                         </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7395,7 +7395,7 @@ b = g(t.by("metadata.name")), e.availableConfigMaps = b, e.valueFromObjects = b.
 }), c.list("secrets", r, null, {
 errorNotification: !1
 }).then(function(t) {
-C = g(t.by("metadata.name")), e.availableSecrets = C, e.valueFromObjects = C.concat(b);
+C = g(t.by("metadata.name")), e.availableSecrets = C, e.valueFromObjects = b.concat(C);
 var n = p.groupSecretsByType(t), a = _.mapValues(n, function(e) {
 return _.map(e, "metadata.name");
 });
@@ -11040,7 +11040,8 @@ e.removedHookParams = e.hookParams, delete e.hookParams, e.editForm.$setDirty();
 e.$watchGroup([ "hookParams", "action.type" ], function() {
 e.hookParams && ("execNewPod" === e.action.type ? (e.hookParams.tagImages && (e.removedHookParams.tagImages = e.hookParams.tagImages, delete e.hookParams.tagImages), r()) : "tagImages" === e.action.type && (e.hookParams.execNewPod && (e.removedHookParams.execNewPod = e.hookParams.execNewPod, delete e.hookParams.execNewPod), r()));
 }), e.valueFromObjects = [], e.$watchGroup([ "availableSecrets", "availableConfigMaps" ], function() {
-e.valueFromObjects = (e.availableSecrets || []).concat(e.availableConfigMaps);
+var t = e.availableConfigMaps || [], n = e.availableSecrets || [];
+e.valueFromObjects = t.concat(n);
 }), e.$watch("istagHook.tagObject.tag", function() {
 _.has(e.istagHook, [ "tagObject", "tag" ]) && (_.set(e.hookParams, "tagImages[0].to.kind", "ImageStreamTag"), _.set(e.hookParams, "tagImages[0].to.namespace", e.istagHook.namespace), _.set(e.hookParams, "tagImages[0].to.name", e.istagHook.imageStream + ":" + e.istagHook.tagObject.tag));
 });

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7622,7 +7622,30 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt ng-if-start=\"strategyParams[type].execNewPod.env\">Environment Variables:</dt>\n" +
     "<dd ng-if-end>\n" +
     "<div ng-repeat=\"env in strategyParams[type].execNewPod.env\">\n" +
-    "<div class=\"truncate\" ng-attr-title=\"{{env.value}}\">{{env.name}}={{env.value}}</div>\n" +
+    "<div ng-if=\"env.valueFrom.configMapKeyRef || env.valueFrom.secretKeyRef\">\n" +
+    "{{env.name}} set to key\n" +
+    "<span ng-if=\"env.valueFrom.configMapKeyRef\">\n" +
+    "{{env.valueFrom.configMapKeyRef.key}} in config map\n" +
+    "<span ng-if=\"!('configmaps' | canI : 'get')\">\n" +
+    "{{env.valueFrom.configMapKeyRef.name}}\n" +
+    "</span>\n" +
+    "<a ng-if=\"'configmaps' | canI : 'get'\" ng-href=\"{{env.valueFrom.configMapKeyRef.name | navigateResourceURL : 'ConfigMap' : deploymentConfig.metadata.namespace}}\">\n" +
+    "{{env.valueFrom.configMapKeyRef.name}}\n" +
+    "</a>\n" +
+    "</span>\n" +
+    "<span ng-if=\"env.valueFrom.secretKeyRef\">\n" +
+    "{{env.valueFrom.secretKeyRef.key}} in secret\n" +
+    "<span ng-if=\"!('secrets' | canI : 'get')\">\n" +
+    "{{env.valueFrom.secretKeyRef.name}}\n" +
+    "</span>\n" +
+    "<a ng-if=\"'secrets' | canI : 'get'\" ng-href=\"{{env.valueFrom.secretKeyRef.name | navigateResourceURL : 'Secret' : deploymentConfig.metadata.namespace}}\">\n" +
+    "{{env.valueFrom.secretKeyRef.name}}\n" +
+    "</a>\n" +
+    "</span>\n" +
+    "</div>\n" +
+    "<div ng-if=\"!env.valueFrom\" class=\"truncate\" ng-attr-title=\"{{env.value}}\">\n" +
+    "{{env.name}}={{env.value}}\n" +
+    "</div>\n" +
     "</div>\n" +
     "</dd>\n" +
     "<dt ng-if-start=\"strategyParams[type].execNewPod.volumes\">Volumes:</dt>\n" +
@@ -10127,17 +10150,17 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"lifecycle-hooks\">\n" +
     "<div class=\"lifecycle-hook\" id=\"pre-lifecycle-hook\">\n" +
     "<h3>Pre Lifecycle Hook</h3>\n" +
-    "<edit-lifecycle-hook model=\"strategyData[strategyParamsPropertyName].pre\" type=\"pre\" available-volumes=\"volumeNames\" available-containers=\"containerNames\" available-secrets=\"availableSecrets\" available-configmaps=\"availableConfigMaps\" namespace=\"projectName\">\n" +
+    "<edit-lifecycle-hook model=\"strategyData[strategyParamsPropertyName].pre\" type=\"pre\" available-volumes=\"volumeNames\" available-containers=\"containerNames\" available-secrets=\"availableSecrets\" available-config-maps=\"availableConfigMaps\" namespace=\"projectName\">\n" +
     "</edit-lifecycle-hook>\n" +
     "</div>\n" +
     "<div ng-if=\"strategyData.type !== 'Rolling'\" class=\"lifecycle-hook\" id=\"mid-lifecycle-hook\">\n" +
     "<h3>Mid Lifecycle Hook</h3>\n" +
-    "<edit-lifecycle-hook model=\"strategyData[strategyParamsPropertyName].mid\" type=\"mid\" available-volumes=\"volumeNames\" available-containers=\"containerNames\" available-secrets=\"availableSecrets\" available-configmaps=\"availableConfigMaps\" namespace=\"projectName\">\n" +
+    "<edit-lifecycle-hook model=\"strategyData[strategyParamsPropertyName].mid\" type=\"mid\" available-volumes=\"volumeNames\" available-containers=\"containerNames\" available-secrets=\"availableSecrets\" available-config-maps=\"availableConfigMaps\" namespace=\"projectName\">\n" +
     "</edit-lifecycle-hook>\n" +
     "</div>\n" +
     "<div class=\"lifecycle-hook\" id=\"post-lifecycle-hook\">\n" +
     "<h3>Post Lifecycle Hook</h3>\n" +
-    "<edit-lifecycle-hook model=\"strategyData[strategyParamsPropertyName].post\" type=\"post\" available-volumes=\"volumeNames\" available-containers=\"containerNames\" available-secrets=\"availableSecrets\" available-configmaps=\"availableConfigMaps\" namespace=\"projectName\">\n" +
+    "<edit-lifecycle-hook model=\"strategyData[strategyParamsPropertyName].post\" type=\"post\" available-volumes=\"volumeNames\" available-containers=\"containerNames\" available-secrets=\"availableSecrets\" available-config-maps=\"availableConfigMaps\" namespace=\"projectName\">\n" +
     "</edit-lifecycle-hook>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
![screen shot 2017-11-06 at 8 26 19 am](https://user-images.githubusercontent.com/1167259/32443765-258629d8-c2ce-11e7-91db-47d2e9f91f78.png)

* Avoid adding an `undefined` element to value from array depending on the
  order that config maps and secrets load
* Fix typo passing config maps to edit-lifecycle-hooks
* Show valueFrom values for hooks when viewing the deployment config

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1509842
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1509819
Fixes #2460

/kind bug
/assign @jwforres 