### PR TITLE
[WIP] Append notification drawer kebab menu to body to fix overflow clipping

### DIFF
--- a/app/styles/_notifications.less
+++ b/app/styles/_notifications.less
@@ -2,6 +2,11 @@
 // Notification drawer
 // -----------------------------------------------
 
+// so that .uib-dropdown-menu inside drawer-pf render above the drawer pf
+body > .uib-dropdown-menu {
+  z-index: @zindex-navbar-fixed - 2; // two less than navbar, one less than project-bar, same as drawer-pf
+}
+
 notification-drawer-wrapper {
   .blank-state-pf-title {
     font-size: @font-size-h4;

--- a/app/views/directives/notifications/notification-body.html
+++ b/app/views/directives/notifications/notification-body.html
@@ -12,6 +12,7 @@
   </button>
   <div
     uib-dropdown
+    dropdown-append-to-body
     class="dropdown pull-right dropdown-kebab-pf"
     ng-if="notification.actions.length">
     <button
@@ -25,7 +26,7 @@
       <span class="fa fa-ellipsis-v"></span>
     </button>
     <ul
-      class="dropdown-menu dropdown-menu-right"
+      class="uib-dropdown-menu dropdown-menu dropdown-menu-right"
       aria-labelledby="dropdownKebabRight">
       <li
         ng-repeat="action in notification.actions"

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7894,11 +7894,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"sr-only\">Clear notification</span>\n" +
     "<span aria-hidden=\"true\" class=\"pficon pficon-close\"></span>\n" +
     "</button>\n" +
-    "<div uib-dropdown class=\"dropdown pull-right dropdown-kebab-pf\" ng-if=\"notification.actions.length\">\n" +
+    "<div uib-dropdown dropdown-append-to-body class=\"dropdown pull-right dropdown-kebab-pf\" ng-if=\"notification.actions.length\">\n" +
     "<button uib-dropdown-toggle class=\"btn btn-link dropdown-toggle\" type=\"button\" id=\"dropdownKebabRight-{{$id}}\" data-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"true\">\n" +
     "<span class=\"fa fa-ellipsis-v\"></span>\n" +
     "</button>\n" +
-    "<ul class=\"dropdown-menu dropdown-menu-right\" aria-labelledby=\"dropdownKebabRight\">\n" +
+    "<ul class=\"uib-dropdown-menu dropdown-menu dropdown-menu-right\" aria-labelledby=\"dropdownKebabRight\">\n" +
     "<li ng-repeat=\"action in notification.actions\" role=\"{{action.isSeparator === true ? 'separator' : 'menuitem'}}\" ng-class=\"{'divider': action.isSeparator === true, 'disabled': action.isDisabled === true}\">\n" +
     "<a ng-if=\"!action.isSeparator\" href=\"\" class=\"secondary-action\" title=\"{{action.title}}\" ng-click=\"action.onClick(notification)\">\n" +
     "{{action.name}}\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5974,6 +5974,7 @@ kubernetes-container-terminal .terminal-actions .spinner{top:5px}
 }
 .membership .content-pane .col-add-role,.membership .content-pane .col-heading,.membership .content-pane .col-name,.membership .content-pane .item-row,.membership .content-pane [flex-collapse-fix],.membership .content-pane [flex]{flex-shrink:0;flex-basis:auto}
 .membership .ui-select-bootstrap>.ui-select-choices{max-height:300px}
+body>.uib-dropdown-menu{z-index:1028}
 notification-drawer-wrapper .blank-state-pf-title{font-size:14px}
 notification-drawer-wrapper .drawer-pf{height:calc(100vh - 69px);opacity:1;position:fixed;right:0;top:69px;transition:top 150ms ease-in-out,opacity 150ms;z-index:1028}
 @media (max-width:350px){notification-drawer-wrapper .drawer-pf{left:0;width:100%}


### PR DESCRIPTION
Fixes #2449 

This fix comes with some concessions:

1. The styling of the dropdown no longer includes the caret/arrow and the alignment to the kebab now differs since the rules that provide the styling no longer apply now that the dropdown is appended to body. [1]
1.  The dropdown no longer scrolls with the notification drawer contents. [2]

Upgrading UI Bootstrap to v1.0.0+ should allow us to fix both issues as those versions include a uib-dropdown setting to append the dropdown to an arbitrary element (dropdown-append-to) in addition to the ability to add an optional class to the open dropdown (appendToOpenClass).

Upgrading a dependency is too risky at this point, so it seems like our options are to:

1.  Not merge this PR and let the bug remain unfixed
1.  Merge the PR with the understanding it comes with the above concessions.

[1]
![screen shot 2017-11-06 at 9 17 16 am](https://user-images.githubusercontent.com/895728/32445574-2d30b58a-c2d4-11e7-804d-0af7b1f1a425.PNG)
![screen shot 2017-11-06 at 9 17 25 am](https://user-images.githubusercontent.com/895728/32445575-2d3b826c-c2d4-11e7-8554-4742c398b976.PNG)

[2]
![screen shot 2017-11-06 at 9 24 02 am](https://user-images.githubusercontent.com/895728/32445611-4b7cea40-c2d4-11e7-9dc3-97bae10a5e3e.PNG)
