### PR TITLE
Create dockercodnfigjson as default secret

### DIFF
--- a/app/scripts/directives/createSecret.js
+++ b/app/scripts/directives/createSecret.js
@@ -49,11 +49,14 @@ angular.module("openshiftConsole")
             label: "Image Secret",
             authTypes: [
               {
-                id: "kubernetes.io/dockercfg",
+                id: "kubernetes.io/dockerconfigjson",
                 label: "Image Registry Credentials"
               },
+              // User can paste content of his docker configuration file, which could be either in old
+              // '.dockercfg' format, or new '.docker/config.json' format. Because of that the secret type
+              // is determined upon creating the secret, where we scan for the type of format.
               {
-                id: "kubernetes.io/dockerconfigjson",
+                id: "kubernetes.io/dockercfg",
                 label: "Configuration File"
               }
             ]
@@ -164,23 +167,23 @@ angular.module("openshiftConsole")
               }
               break;
             case "kubernetes.io/dockerconfigjson":
+              var auth = window.btoa(data.dockerUsername + ":" + data.dockerPassword);
+              var configData = {auths: {}};
+              configData.auths[data.dockerServer] = {
+                username: data.dockerUsername,
+                password: data.dockerPassword,
+                email: data.dockerMail,
+                auth: auth
+              };
+              secret.stringData['.dockerconfigjson'] = JSON.stringify(configData);
+              break;
+            case "kubernetes.io/dockercfg":
               var configType = ".dockerconfigjson";
               if (!JSON.parse(data.dockerConfig).auths) {
                 secret.type = "kubernetes.io/dockercfg";
                 configType = ".dockercfg";
               }
               secret.stringData[configType] = data.dockerConfig;
-              break;
-            case "kubernetes.io/dockercfg":
-              var auth = window.btoa(data.dockerUsername + ":" + data.dockerPassword);
-              var configData = {};
-              configData[data.dockerServer] = {
-                username: data.dockerUsername,
-                password: data.dockerPassword,
-                email: data.dockerMail,
-                auth: auth
-              };
-              secret.stringData['.dockercfg'] = JSON.stringify(configData);
               break;
             case "Opaque":
               if (data.webhookSecretKey) {

--- a/app/scripts/services/secrets.js
+++ b/app/scripts/services/secrets.js
@@ -64,11 +64,9 @@ angular.module("openshiftConsole")
     // decodeDockerConfig handles both Docker configuration file formats, which are:
     //  - .dockercfg
     //    {
-    //      "auths": {
-    //        "https://index.docker.io/v1/": {
-    //          "auth": "dGVzdHVzZXI6dGVzdHB3",
-    //          "email": "jhadvig@test.com"
-    //        }
+    //      "https://index.docker.io/v1/": {
+    //        "auth": "dGVzdHVzZXI6dGVzdHB3",
+    //        "email": "mail@test.com"
     //      }
     //    }
     //

--- a/app/views/directives/create-secret.html
+++ b/app/views/directives/create-secret.html
@@ -214,7 +214,7 @@
         </div>
       </div>
 
-      <div ng-if="newSecret.authType === 'kubernetes.io/dockercfg'">
+      <div ng-if="newSecret.authType === 'kubernetes.io/dockerconfigjson'">
         <div class="form-group" ng-class="{ 'has-error' : secretForm.dockerServer.$invalid && secretForm.dockerServer.$touched }">
           <label for="docker-server" class="required">Image Registry Server Address</label>
           <div>
@@ -298,7 +298,7 @@
         </div>
       </div>
 
-      <div ng-if="newSecret.authType === 'kubernetes.io/dockerconfigjson'">
+      <div ng-if="newSecret.authType === 'kubernetes.io/dockercfg'">
         <div class="form-group" id="docker-config">
           <label for="dockerConfig" class="required">Configuration File</label>
           <osc-file-input

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -9171,10 +9171,10 @@ label: "Generic Secret"
 image: {
 label: "Image Secret",
 authTypes: [ {
-id: "kubernetes.io/dockercfg",
+id: "kubernetes.io/dockerconfigjson",
 label: "Image Registry Credentials"
 }, {
-id: "kubernetes.io/dockerconfigjson",
+id: "kubernetes.io/dockercfg",
 label: "Configuration File"
 } ]
 },
@@ -9237,18 +9237,20 @@ r.stringData["ssh-privatekey"] = e.privateKey, e.gitconfig && (r.stringData[".gi
 break;
 
 case "kubernetes.io/dockerconfigjson":
-var a = ".dockerconfigjson";
-JSON.parse(e.dockerConfig).auths || (r.type = "kubernetes.io/dockercfg", a = ".dockercfg"), r.stringData[a] = e.dockerConfig;
-break;
-
-case "kubernetes.io/dockercfg":
-var o = window.btoa(e.dockerUsername + ":" + e.dockerPassword), i = {};
-i[e.dockerServer] = {
+var a = window.btoa(e.dockerUsername + ":" + e.dockerPassword), o = {
+auths: {}
+};
+o.auths[e.dockerServer] = {
 username: e.dockerUsername,
 password: e.dockerPassword,
 email: e.dockerMail,
-auth: o
-}, r.stringData[".dockercfg"] = JSON.stringify(i);
+auth: a
+}, r.stringData[".dockerconfigjson"] = JSON.stringify(o);
+break;
+
+case "kubernetes.io/dockercfg":
+var i = ".dockerconfigjson";
+JSON.parse(e.dockerConfig).auths || (r.type = "kubernetes.io/dockercfg", i = ".dockercfg"), r.stringData[i] = e.dockerConfig;
 break;
 
 case "Opaque":

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6243,7 +6243,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "          }\" ng-model=\"newSecret.data.gitconfig\" class=\"create-secret-editor ace-bordered\" id=\"gitconfig-editor\" required></div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-if=\"newSecret.authType === 'kubernetes.io/dockercfg'\">\n" +
+    "<div ng-if=\"newSecret.authType === 'kubernetes.io/dockerconfigjson'\">\n" +
     "<div class=\"form-group\" ng-class=\"{ 'has-error' : secretForm.dockerServer.$invalid && secretForm.dockerServer.$touched }\">\n" +
     "<label for=\"docker-server\" class=\"required\">Image Registry Server Address</label>\n" +
     "<div>\n" +
@@ -6292,7 +6292,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-if=\"newSecret.authType === 'kubernetes.io/dockerconfigjson'\">\n" +
+    "<div ng-if=\"newSecret.authType === 'kubernetes.io/dockercfg'\">\n" +
     "<div class=\"form-group\" id=\"docker-config\">\n" +
     "<label for=\"dockerConfig\" class=\"required\">Configuration File</label>\n" +
     "<osc-file-input id=\"dockercfg-file-input\" model=\"newSecret.data.dockerConfig\" drop-zone-id=\"docker-config\" help-text=\"Upload a .dockercfg or .docker/config.json file\" required=\"true\"></osc-file-input>\n" +


### PR DESCRIPTION
When creating secret we should start defaulting to the new file type and format which is `docker/config.json`
```
{
        "auths": {
                "registryaddress": {
                        "auth": "auth string",
                        "email": "email@domain.com"
                }
        }
}
```

So when selecting an `Image registry Credentials` Authentication Type on the create-secret page, it shall create secret of `kubernetes/dockerconfigjson` type, that is in the mentioned format.

`Image registry Credentials` Authentication Type will create a `kubernetes/dockercfg` type of secret with the old format, unless user provides a config in a new format that contains `auths` as a root field in the object, in that case `kubernetes/dockerconfigjson` type of a secret is created.

@jwforres @spadgett PTAL