### PR TITLE
Allow editing service instances again if previous update failed

### DIFF
--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -6359,7 +6359,7 @@ e.showParameterValues = !e.showParameterValues;
 }, e.closeEditDialog = function() {
 e.editDialogShown = !1;
 };
-var m, p, f = [], g = [], v = t("serviceInstanceDisplayName"), h = t("isServiceInstanceReady"), y = a.getPreferredVersion("servicebindings");
+var m, p, f = [], g = [], v = t("serviceInstanceDisplayName"), h = t("isServiceInstanceFailed"), y = a.getPreferredVersion("servicebindings");
 e.serviceInstancesVersion = a.getPreferredVersion("serviceinstances");
 var b = function() {
 e.breadcrumbs.push({
@@ -6389,7 +6389,7 @@ c.warn("Unable to load parameters from secret " + _.get(t, "secretKeyRef.name"),
 }, S = function() {
 if (e.plan && e.serviceClass && e.serviceInstance) {
 var t = _.get(e.plan, "spec.instanceUpdateParameterSchema"), n = _.size(_.get(t, "properties")) > 0 || _.get(e.serviceClass, "spec.planUpdatable") && _.size(e.servicePlans) > 1;
-e.editAvailable = n && h(e.serviceInstance) && !_.get(e.serviceInstance, "metadata.deletionTimestamp");
+e.editAvailable = n && !h(e.serviceInstance) && !_.get(e.serviceInstance, "status.asyncOpInProgress") && !_.get(e.serviceInstance, "metadata.deletionTimestamp");
 }
 }, w = function() {
 e.parameterFormDefinition = angular.copy(_.get(e.plan, "spec.externalMetadata.schemas.service_instance.update.openshift_form_definition")), e.parameterSchema = _.get(e.plan, "spec.instanceCreateParameterSchema"), C();


### PR DESCRIPTION
Service catalog now allows users to edit a service instance if the previous
update failed. We were incorrectly blocking it in the UI since we check for
readiness instead of failure.

/kind bug
/assign @jwforres @jeff-phillips-18 