### PR TITLE
Separate out defaultIfBlank filter

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -394,6 +394,7 @@
         <script src="scripts/filters/resources.js"></script>
         <script src="scripts/filters/canI.js"></script>
         <script src="scripts/filters/util.js"></script>
+        <script src="scripts/filters/defaultIfBlank.js"></script>
         <script src="scripts/services/logLinks.js"></script>
 
         <!-- add bundled extensions here -->

--- a/app/scripts/filters/defaultIfBlank.js
+++ b/app/scripts/filters/defaultIfBlank.js
@@ -1,0 +1,17 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .filter("defaultIfBlank", function(){
+    return function(input, defaultValue){
+      if(input === null) {
+        return defaultValue;
+      }
+      if(typeof input !== "string"){
+        input = String(input);
+      }
+      if(input.trim().length === 0){
+        return defaultValue;
+      }
+      return input;
+    };
+  });

--- a/app/scripts/filters/util.js
+++ b/app/scripts/filters/util.js
@@ -10,20 +10,6 @@ angular.module('openshiftConsole')
       return value.replace(/\./g, '_');
     };
   })
-  .filter("defaultIfBlank", function(){
-    return function(input, defaultValue){
-      if(input === null) {
-        return defaultValue;
-      }
-      if(typeof input !== "string"){
-        input = String(input);
-      }
-      if(input.trim().length === 0){
-        return defaultValue;
-      }
-      return input;
-    };
-  })
   .filter('keys', function() {
     return _.keys;
   })

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -15613,10 +15613,6 @@ return e(a, "update");
 return function(e) {
 return e.replace(/\./g, "_");
 };
-}).filter("defaultIfBlank", function() {
-return function(e, t) {
-return null === e ? t : ("string" != typeof e && (e = String(e)), 0 === e.trim().length ? t : e);
-};
 }).filter("keys", function() {
 return _.keys;
 }).filter("usageValue", function() {
@@ -15901,7 +15897,11 @@ return window.encodeURIComponent;
 return function(t) {
 return _.get(e, [ "ENABLE_TECH_PREVIEW_FEATURE", t ], !1);
 };
-} ]), angular.module("openshiftConsole").factory("logLinks", [ "$anchorScroll", "$document", "$location", "$window", function(e, t, n, a) {
+} ]), angular.module("openshiftConsole").filter("defaultIfBlank", function() {
+return function(e, t) {
+return null === e ? t : ("string" != typeof e && (e = String(e)), 0 === e.trim().length ? t : e);
+};
+}), angular.module("openshiftConsole").factory("logLinks", [ "$anchorScroll", "$document", "$location", "$window", function(e, t, n, a) {
 var r = _.template([ "/#/discover?", "_g=(", "time:(", "from:now-1w,", "mode:relative,", "to:now", ")", ")", "&_a=(", "columns:!(kubernetes.container_name,message),", "index:'project.<%= namespace %>.<%= namespaceUid %>.*',", "query:(", "query_string:(", "analyze_wildcard:!t,", 'query:\'kubernetes.pod_name:"<%= podname %>" AND kubernetes.namespace_name:"<%= namespace %>"\'', ")", "),", "sort:!('@timestamp',desc)", ")", "#console_container_name=<%= containername %>", "&console_back_url=<%= backlink %>" ].join(""));
 return {
 scrollTop: function(e) {


### PR DESCRIPTION
Reviewing some test coverage & noticed we have a standalone spec for `defaultIfBlank`.  Breaking the filter out so the file structure matches.