### PR TITLE
Add unit test for underscore filter, split out into separate file

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -394,6 +394,7 @@
         <script src="scripts/filters/resources.js"></script>
         <script src="scripts/filters/canI.js"></script>
         <script src="scripts/filters/util.js"></script>
+        <script src="scripts/filters/underscore.js"></script>
         <script src="scripts/services/logLinks.js"></script>
 
         <!-- add bundled extensions here -->

--- a/app/scripts/filters/underscore.js
+++ b/app/scripts/filters/underscore.js
@@ -1,0 +1,12 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  /**
+   * Replace special chars with underscore (e.g. '.')
+   * @returns {Function}
+   */
+  .filter("underscore", function(){
+    return function(value){
+      return value.replace(/\./g, '_');
+    };
+  });

--- a/app/scripts/filters/util.js
+++ b/app/scripts/filters/util.js
@@ -1,15 +1,6 @@
 'use strict';
 
 angular.module('openshiftConsole')
-  /**
-   * Replace special chars with underscore (e.g. '.')
-   * @returns {Function}
-   */
-  .filter("underscore", function(){
-    return function(value){
-      return value.replace(/\./g, '_');
-    };
-  })
   .filter("defaultIfBlank", function(){
     return function(input, defaultValue){
       if(input === null) {

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -15609,11 +15609,7 @@ return function(t) {
 var a = n.getScaleResource(t);
 return e(a, "update");
 };
-} ]), angular.module("openshiftConsole").filter("underscore", function() {
-return function(e) {
-return e.replace(/\./g, "_");
-};
-}).filter("defaultIfBlank", function() {
+} ]), angular.module("openshiftConsole").filter("defaultIfBlank", function() {
 return function(e, t) {
 return null === e ? t : ("string" != typeof e && (e = String(e)), 0 === e.trim().length ? t : e);
 };
@@ -15901,7 +15897,11 @@ return window.encodeURIComponent;
 return function(t) {
 return _.get(e, [ "ENABLE_TECH_PREVIEW_FEATURE", t ], !1);
 };
-} ]), angular.module("openshiftConsole").factory("logLinks", [ "$anchorScroll", "$document", "$location", "$window", function(e, t, n, a) {
+} ]), angular.module("openshiftConsole").filter("underscore", function() {
+return function(e) {
+return e.replace(/\./g, "_");
+};
+}), angular.module("openshiftConsole").factory("logLinks", [ "$anchorScroll", "$document", "$location", "$window", function(e, t, n, a) {
 var r = _.template([ "/#/discover?", "_g=(", "time:(", "from:now-1w,", "mode:relative,", "to:now", ")", ")", "&_a=(", "columns:!(kubernetes.container_name,message),", "index:'project.<%= namespace %>.<%= namespaceUid %>.*',", "query:(", "query_string:(", "analyze_wildcard:!t,", 'query:\'kubernetes.pod_name:"<%= podname %>" AND kubernetes.namespace_name:"<%= namespace %>"\'', ")", "),", "sort:!('@timestamp',desc)", ")", "#console_container_name=<%= containername %>", "&console_back_url=<%= backlink %>" ].join(""));
 return {
 scrollTop: function(e) {

--- a/test/spec/filters/underscoreSpec.js
+++ b/test/spec/filters/underscoreSpec.js
@@ -1,0 +1,18 @@
+'use strict';
+
+describe('underscoreFilter', function() {
+  var underscore;
+
+  beforeEach(
+    inject(function(underscoreFilter){
+      underscore = underscoreFilter;
+    })
+  );
+
+  it('should return stuff and things', function() {
+    expect(underscore('Foo.bar')).toBe('Foo_bar');
+    expect(underscore('.Foo.bar.')).toBe('_Foo_bar_');
+    expect(underscore('Foo.bar.baz')).toBe('Foo_bar_baz');
+    expect(underscore('a.b-c_d.e()')).toBe('a_b-c_d_e()');
+  });
+});


### PR DESCRIPTION
Improving our test coverage.
Sticking with the pattern of splitting out filters into their own file to match the structure in the unit test directory.