### PR TITLE
Bug 1510346 - Don't let users copy empty secret value

### DIFF
--- a/app/views/browse/secret.html
+++ b/app/views/browse/secret.html
@@ -72,7 +72,8 @@
                   </div>
                   <div ng-switch-default>
                     <dt ng-attr-title="{{secretDataName}}">{{secretDataName}}</dt>
-                    <dd ng-if="view.showSecret">
+                    <dd ng-if="view.showSecret && !secretData"><em>No value</em></dd>
+                    <dd ng-if="view.showSecret && secretData">
                       <copy-to-clipboard
                           clipboard-text="secretData"
                           multiline="secretData | isMultiline : true"

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3620,7 +3620,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div ng-switch-default>\n" +
     "<dt ng-attr-title=\"{{secretDataName}}\">{{secretDataName}}</dt>\n" +
-    "<dd ng-if=\"view.showSecret\">\n" +
+    "<dd ng-if=\"view.showSecret && !secretData\"><em>No value</em></dd>\n" +
+    "<dd ng-if=\"view.showSecret && secretData\">\n" +
     "<copy-to-clipboard clipboard-text=\"secretData\" multiline=\"secretData | isMultiline : true\" display-wide=\"true\">\n" +
     "</copy-to-clipboard>\n" +
     "<div ng-if=\"decodedSecretData.$$nonprintable[secretDataName]\" class=\"help-block\">\n" +


### PR DESCRIPTION
Instead of using copy-to-clipboard with an empty value, show "No value" when a
secret value is null.

Follow on fix for https://bugzilla.redhat.com/show_bug.cgi?id=1510346

/kind bug
/assign @jwforres 