### PR TITLE
Bug 1510786 - Error info should be more precise when create app in project with view role

### DIFF
--- a/app/scripts/controllers/newfromtemplate.js
+++ b/app/scripts/controllers/newfromtemplate.js
@@ -14,6 +14,7 @@ angular.module('openshiftConsole')
                        $parse,
                        $routeParams,
                        $scope,
+                       AuthorizationService,
                        CachedTemplateService,
                        DataService,
                        Navigate,
@@ -162,6 +163,11 @@ angular.module('openshiftConsole')
       .get($routeParams.project)
       .then(_.spread(function(project) {
         $scope.project = project;
+
+        if (!AuthorizationService.canI('processedtemplates', 'create', $routeParams.project)) {
+          Navigate.toErrorPage('You do not have authority to process templates in project ' + $routeParams.project + '.', 'access_denied');
+          return;
+        }
 
         // Missing namespace indicates that the template should be received from from the 'CachedTemplateService'.
         // Otherwise get it via GET call.

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8095,8 +8095,8 @@ e.buildConfigs = t.by("metadata.name"), e.createdBuildConfig = e.buildConfigs[n.
 a.unwatchAll(f);
 });
 }));
-} ]), angular.module("openshiftConsole").controller("NewFromTemplateController", [ "$filter", "$location", "$parse", "$routeParams", "$scope", "CachedTemplateService", "DataService", "Navigate", "NotificationsService", "ProjectsService", function(e, t, n, a, r, o, i, s, c, l) {
-function u(e, t) {
+} ]), angular.module("openshiftConsole").controller("NewFromTemplateController", [ "$filter", "$location", "$parse", "$routeParams", "$scope", "AuthorizationService", "CachedTemplateService", "DataService", "Navigate", "NotificationsService", "ProjectsService", function(e, t, n, a, r, o, i, s, c, l, u) {
+function d(e, t) {
 var n = _.get(e, "spec.triggers", []), a = _.find(n, function(e) {
 if ("ImageChange" !== e.type) return !1;
 var n = _.get(e, "imageChangeParams.containerNames", []);
@@ -8104,62 +8104,62 @@ return _.includes(n, t.name);
 });
 return _.get(a, "imageChangeParams.from.name");
 }
-function d(e) {
-for (var t = [], n = w.exec(e); n; ) t.push(n[1]), n = w.exec(e);
+function m(e) {
+for (var t = [], n = k.exec(e); n; ) t.push(n[1]), n = k.exec(e);
 return t;
 }
-function m() {
-var e = g();
-r.templateImages = _.map(k, function(t) {
+function p() {
+var e = v();
+r.templateImages = _.map(P, function(t) {
 return _.isEmpty(t.usesParameters) ? t : {
 name: _.template(t.name, {
-interpolate: w
+interpolate: k
 })(e),
 usesParameters: t.usesParameters
 };
 });
 }
-function p(e) {
-var t = [], n = y(e);
+function f(e) {
+var t = [], n = b(e);
 return n && angular.forEach(n, function(n) {
-var a = n.image, r = u(e, n);
+var a = n.image, r = d(e, n);
 r && (a = r), a && t.push(a);
 }), t;
 }
-function f(e) {
-k = [];
+function g(e) {
+P = [];
 var t = [], n = {};
 angular.forEach(e.objects, function(e) {
 if ("BuildConfig" === e.kind) {
-var a = C(b(e), h);
-a && k.push({
+var a = w(S(e), y);
+a && P.push({
 name: a,
-usesParameters: d(a)
+usesParameters: m(a)
 });
-var r = C(S(e), h);
+var r = w(C(e), y);
 r && (n[r] = !0);
 }
-"DeploymentConfig" === e.kind && (t = t.concat(p(e)));
+"DeploymentConfig" === e.kind && (t = t.concat(f(e)));
 }), t.forEach(function(e) {
-n[e] || k.push({
+n[e] || P.push({
 name: e,
-usesParameters: d(e)
+usesParameters: m(e)
 });
-}), k = _.uniqBy(k, "name");
+}), P = _.uniqBy(P, "name");
 }
-function g() {
+function v() {
 var e = {};
 return _.each(r.template.parameters, function(t) {
 e[t.name] = t.value;
 }), e;
 }
-var v = a.template, h = a.namespace || "", y = n("spec.template.spec.containers"), b = n("spec.strategy.sourceStrategy.from || spec.strategy.dockerStrategy.from || spec.strategy.customStrategy.from"), S = n("spec.output.to"), C = e("imageObjectRef");
-if (v) {
+var h = a.template, y = a.namespace || "", b = n("spec.template.spec.containers"), S = n("spec.strategy.sourceStrategy.from || spec.strategy.dockerStrategy.from || spec.strategy.customStrategy.from"), C = n("spec.output.to"), w = e("imageObjectRef");
+if (h) {
 a.templateParamsMap && (r.prefillParameters = function() {
 try {
 return JSON.parse(a.templateParamsMap);
 } catch (e) {
-c.addNotification({
+l.addNotification({
 id: "template-params-invalid-json",
 type: "error",
 message: "Could not prefill parameter values.",
@@ -8167,35 +8167,35 @@ details: "The `templateParamsMap` URL parameter is not valid JSON. " + e
 });
 }
 }());
-var w = /\${([a-zA-Z0-9\_]+)}/g, k = [];
-l.get(a.project).then(_.spread(function(e) {
-if (r.project = e, h) i.get("templates", v, {
-namespace: h || r.project.metadata.name
+var k = /\${([a-zA-Z0-9\_]+)}/g, P = [];
+u.get(a.project).then(_.spread(function(e) {
+if (r.project = e, o.canI("processedtemplates", "create", a.project)) if (y) s.get("templates", h, {
+namespace: y || r.project.metadata.name
 }).then(function(e) {
-r.template = e, f(e);
-_.some(k, function(e) {
+r.template = e, g(e);
+_.some(P, function(e) {
 return !_.isEmpty(e.usesParameters);
 }) ? (r.parameterDisplayNames = {}, _.each(e.parameters, function(e) {
 r.parameterDisplayNames[e.name] = e.displayName || e.name;
 }), r.$watch("template.parameters", _.debounce(function() {
-r.$apply(m);
+r.$apply(p);
 }, 50, {
 maxWait: 250
-}), !0)) : r.templateImages = k;
+}), !0)) : r.templateImages = P;
 }, function() {
-s.toErrorPage("Cannot create from template: the specified template could not be retrieved.");
+c.toErrorPage("Cannot create from template: the specified template could not be retrieved.");
 }); else {
-if (r.template = o.getTemplate(), _.isEmpty(r.template)) {
+if (r.template = i.getTemplate(), _.isEmpty(r.template)) {
 var n = URI("error").query({
 error: "not_found",
 error_description: "Template wasn't found in cache."
 }).toString();
 t.url(n);
 }
-o.clearTemplate();
-}
+i.clearTemplate();
+} else c.toErrorPage("You do not have authority to process templates in project " + a.project + ".", "access_denied");
 }));
-} else s.toErrorPage("Cannot create from template: a template name was not specified.");
+} else c.toErrorPage("Cannot create from template: a template name was not specified.");
 } ]), angular.module("openshiftConsole").controller("LabelsController", [ "$scope", function(e) {
 e.expanded = !0, e.toggleExpanded = function() {
 e.expanded = !e.expanded;


### PR DESCRIPTION
Instead of trying to send a request that will fail, we shouldn't show the "Create" button, if he doesn't have the permissions.

![create](https://user-images.githubusercontent.com/1668218/32555206-6d6f1082-c49c-11e7-80cf-4779131a0e93.png)

Not really sure if we shouldn't hide both `Create | Cancel` butwould rather keep the `Cancel` btn for the navigation.

@spadgett PTAL