### PR TITLE
Prevent hyphen from wrapping first to new line in drawer

### DIFF
--- a/app/views/directives/notifications/notification-body.html
+++ b/app/views/directives/notifications/notification-body.html
@@ -55,7 +55,7 @@
       <div>
 
         <span ng-if="notification.event.reason">
-          {{notification.event.reason | humanize}} &mdash; <span ng-if="notification.event.involvedObject">{{notification.event.involvedObject.kind | humanizeKind : true}}</span>
+          {{notification.event.reason | humanize}}&nbsp;&mdash; <span ng-if="notification.event.involvedObject">{{notification.event.involvedObject.kind | humanizeKind : true}}</span>
         </span>
 
         <span

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -7937,7 +7937,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"drawer-pf-notification-message word-break\" ng-attr-title=\"{{notification.event.message}}\">\n" +
     "<div>\n" +
     "<span ng-if=\"notification.event.reason\">\n" +
-    "{{notification.event.reason | humanize}} &mdash; <span ng-if=\"notification.event.involvedObject\">{{notification.event.involvedObject.kind | humanizeKind : true}}</span>\n" +
+    "{{notification.event.reason | humanize}}&nbsp;&mdash; <span ng-if=\"notification.event.involvedObject\">{{notification.event.involvedObject.kind | humanizeKind : true}}</span>\n" +
     "</span>\n" +
     "<span ng-if=\"notification.event.involvedObject\" ng-init=\"eventObjUrl = (notification.event | navigateEventInvolvedObjectURL)\">\n" +
     "<a ng-if=\"eventObjUrl\" ng-attr-title=\"Navigate to {{notification.event.involvedObject.name}}\" href=\"{{eventObjUrl}}\" ng-click=\"$ctrl.customScope.close()\">\n" +


### PR DESCRIPTION
In the notification drawer title, prevent the `--` from wrapping by itself to the new line.

Before:

![openshift web console 2017-11-08 14-11-10](https://user-images.githubusercontent.com/1167259/32569556-6c583686-c48f-11e7-9558-93f04788c961.png)

After:

![openshift web console 2017-11-08 14-16-48](https://user-images.githubusercontent.com/1167259/32569578-7b8655de-c48f-11e7-96b3-4f8fa0d91223.png)

/kind bug
/assign @jwforres 