### PR TITLE
Show existing git settings by default in BC editor

### DIFF
--- a/app/scripts/controllers/edit/buildConfig.js
+++ b/app/scripts/controllers/edit/buildConfig.js
@@ -268,6 +268,9 @@ angular.module('openshiftConsole')
             $scope.triggers = getTriggerMap($scope.triggers, $scope.buildConfig.spec.triggers);
             $scope.sources = getSourceMap($scope.sources, $scope.buildConfig.spec.source);
 
+            var gitRef = _.get(buildConfig, 'spec.source.git.ref');
+            $scope.view.showGitReference = gitRef && gitRef !== 'master';
+
             if (_.has(buildConfig, 'spec.strategy.jenkinsPipelineStrategy.jenkinsfile')) {
               $scope.jenkinsfileOptions.type = 'inline';
             }

--- a/app/views/edit/build-config.html
+++ b/app/views/edit/build-config.html
@@ -18,8 +18,9 @@
                   <div ng-if="sources.git">
                     <div class="row">
                       <div ng-class="{
-                        'col-lg-8': view.advancedOptions,
-                        'col-lg-12': !view.advancedOptions}">
+                        'col-lg-8': view.advancedOptions || view.showGitReference,
+                        'col-lg-12': !view.advancedOptions && !view.showGitReference
+                      }">
                         <div class="form-group">
                           <label for="sourceUrl" class="required">Git Repository URL</label>
                           <div ng-class="{
@@ -40,7 +41,11 @@
                           </div>
                           <div class="help-block" id="source-url-help">
                             Git URL of the source code to build.
-                            <span ng-if="!view.advancedOptions">If your Git repository is private, view the <a href="" ng-click="view.advancedOptions = true">advanced options</a> to set up authentication.</span>
+                            <span ng-if="!view.advancedOptions && !buildConfig.spec.source.sourceSecret">
+                              If your Git repository is private, view the
+                              <a href="" ng-click="view.advancedOptions = true">advanced options</a>
+                              to set up authentication.
+                            </span>
                           </div>
                           <div class="has-error" ng-if="form.sourceUrl.$touched && form.sourceUrl.$error.required">
                             <span class="help-block">A Git repository URL is required.</span>
@@ -51,7 +56,7 @@
                         </div>
 
                       </div>
-                      <div class="col-lg-4" ng-if="view.advancedOptions">
+                      <div class="col-lg-4" ng-if="view.advancedOptions || view.showGitReference">
                         <div class="form-group editor">
                           <label for="sourceRef">Git Reference</label>
                           <div>
@@ -71,33 +76,31 @@
                       </div>
                     </div>
 
-                    <div ng-if="view.advancedOptions">
-                      <div class="form-group">
-                        <label for="sourceContextDir">Context Dir</label>
-                        <div>
-                          <input class="form-control"
-                            id="sourceContextDir"
-                            name="sourceContextDir"
-                            type="text"
-                            ng-model="updatedBuildConfig.spec.source.contextDir"
-                            placeholder="/"
-                            autocorrect="off"
-                            autocapitalize="none"
-                            spellcheck="false"
-                            aria-describedby="context-dir-help">
-                        </div>
-                        <div class="help-block" id="context-dir-help">Optional subdirectory for the application source code, used as the context directory for the build.</div>
+                    <div class="form-group" ng-if="view.advancedOptions || buildConfig.spec.source.contextDir">
+                      <label for="sourceContextDir">Context Dir</label>
+                      <div>
+                        <input class="form-control"
+                          id="sourceContextDir"
+                          name="sourceContextDir"
+                          type="text"
+                          ng-model="updatedBuildConfig.spec.source.contextDir"
+                          placeholder="/"
+                          autocorrect="off"
+                          autocapitalize="none"
+                          spellcheck="false"
+                          aria-describedby="context-dir-help">
                       </div>
-                      <div class="form-group">
-                        <osc-secrets model="secrets.picked.gitSecret"
-                                    namespace="projectName"
-                                    display-type="source"
-                                    type="source"
-                                    service-account-to-link="builder"
-                                    secrets-by-type="secrets.secretsByType"
-                                    alerts="alerts">
-                        </osc-secrets>
-                      </div>
+                      <div class="help-block" id="context-dir-help">Optional subdirectory for the application source code, used as the context directory for the build.</div>
+                    </div>
+                    <div class="form-group" ng-if="view.advancedOptions || buildConfig.spec.source.sourceSecret">
+                      <osc-secrets model="secrets.picked.gitSecret"
+                                  namespace="projectName"
+                                  display-type="source"
+                                  type="source"
+                                  service-account-to-link="builder"
+                                  secrets-by-type="secrets.secretsByType"
+                                  alerts="alerts">
+                      </osc-secrets>
                     </div>
                   </div>
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7013,7 +7013,9 @@ e.$on("$destroy", b), u.get(a.project).then(_.spread(function(n, r) {
 e.project = n, e.context = r, i.canI("buildconfigs", "update", a.project) ? s.get("buildconfigs", a.buildconfig, r, {
 errorNotification: !1
 }).then(function(t) {
-e.buildConfig = t, f(), e.updatedBuildConfig = angular.copy(e.buildConfig), e.buildStrategy = h(e.updatedBuildConfig), e.strategyType = e.buildConfig.spec.strategy.type, e.envVars = e.buildStrategy.env || [], e.triggers = S(e.triggers, e.buildConfig.spec.triggers), e.sources = I(e.sources, e.buildConfig.spec.source), _.has(t, "spec.strategy.jenkinsPipelineStrategy.jenkinsfile") && (e.jenkinsfileOptions.type = "inline"), s.list("secrets", r).then(function(t) {
+e.buildConfig = t, f(), e.updatedBuildConfig = angular.copy(e.buildConfig), e.buildStrategy = h(e.updatedBuildConfig), e.strategyType = e.buildConfig.spec.strategy.type, e.envVars = e.buildStrategy.env || [], e.triggers = S(e.triggers, e.buildConfig.spec.triggers), e.sources = I(e.sources, e.buildConfig.spec.source);
+var n = _.get(t, "spec.source.git.ref");
+e.view.showGitReference = n && "master" !== n, _.has(t, "spec.strategy.jenkinsPipelineStrategy.jenkinsfile") && (e.jenkinsfileOptions.type = "inline"), s.list("secrets", r).then(function(t) {
 var n = m.groupSecretsByType(t), a = _.mapValues(n, function(e) {
 return _.map(e, "metadata.name");
 });
@@ -7021,7 +7023,7 @@ e.secrets.secretsByType = _.each(a, function(e) {
 e.unshift("");
 }), P();
 });
-var n = function(e, n) {
+var o = function(e, n) {
 e.type = n && n.kind ? n.kind : "None";
 var a = {}, r = "", o = "";
 a = "ImageStreamTag" === e.type ? {
@@ -7038,7 +7040,7 @@ tag: ""
 }
 }, r = "ImageStreamImage" === e.type ? (n.namespace || t.metadata.namespace) + "/" + n.name : "", o = "DockerImage" === e.type ? n.name : "", e.imageStreamTag = a, e.imageStreamImage = r, e.dockerImage = o;
 };
-n(e.imageOptions.from, e.buildStrategy.from), n(e.imageOptions.to, e.updatedBuildConfig.spec.output.to), e.sources.images && (e.sourceImages = e.buildConfig.spec.source.images, 1 === _.size(e.sourceImages) ? (e.imageSourceTypes = angular.copy(e.buildFromTypes), n(e.imageOptions.fromSource, e.sourceImages[0].from), e.imageSourcePaths = _.map(e.sourceImages[0].paths, function(e) {
+o(e.imageOptions.from, e.buildStrategy.from), o(e.imageOptions.to, e.updatedBuildConfig.spec.output.to), e.sources.images && (e.sourceImages = e.buildConfig.spec.source.images, 1 === _.size(e.sourceImages) ? (e.imageSourceTypes = angular.copy(e.buildFromTypes), o(e.imageOptions.fromSource, e.sourceImages[0].from), e.imageSourcePaths = _.map(e.sourceImages[0].paths, function(e) {
 return {
 name: e.sourcePath,
 value: e.destinationDir

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -9506,8 +9506,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"sources.git\">\n" +
     "<div class=\"row\">\n" +
     "<div ng-class=\"{\n" +
-    "                        'col-lg-8': view.advancedOptions,\n" +
-    "                        'col-lg-12': !view.advancedOptions}\">\n" +
+    "                        'col-lg-8': view.advancedOptions || view.showGitReference,\n" +
+    "                        'col-lg-12': !view.advancedOptions && !view.showGitReference\n" +
+    "                      }\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"sourceUrl\" class=\"required\">Git Repository URL</label>\n" +
     "<div ng-class=\"{\n" +
@@ -9519,7 +9520,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"help-block\" id=\"source-url-help\">\n" +
     "Git URL of the source code to build.\n" +
-    "<span ng-if=\"!view.advancedOptions\">If your Git repository is private, view the <a href=\"\" ng-click=\"view.advancedOptions = true\">advanced options</a> to set up authentication.</span>\n" +
+    "<span ng-if=\"!view.advancedOptions && !buildConfig.spec.source.sourceSecret\">\n" +
+    "If your Git repository is private, view the\n" +
+    "<a href=\"\" ng-click=\"view.advancedOptions = true\">advanced options</a>\n" +
+    "to set up authentication.\n" +
+    "</span>\n" +
     "</div>\n" +
     "<div class=\"has-error\" ng-if=\"form.sourceUrl.$touched && form.sourceUrl.$error.required\">\n" +
     "<span class=\"help-block\">A Git repository URL is required.</span>\n" +
@@ -9529,7 +9534,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"col-lg-4\" ng-if=\"view.advancedOptions\">\n" +
+    "<div class=\"col-lg-4\" ng-if=\"view.advancedOptions || view.showGitReference\">\n" +
     "<div class=\"form-group editor\">\n" +
     "<label for=\"sourceRef\">Git Reference</label>\n" +
     "<div>\n" +
@@ -9539,18 +9544,16 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-if=\"view.advancedOptions\">\n" +
-    "<div class=\"form-group\">\n" +
+    "<div class=\"form-group\" ng-if=\"view.advancedOptions || buildConfig.spec.source.contextDir\">\n" +
     "<label for=\"sourceContextDir\">Context Dir</label>\n" +
     "<div>\n" +
     "<input class=\"form-control\" id=\"sourceContextDir\" name=\"sourceContextDir\" type=\"text\" ng-model=\"updatedBuildConfig.spec.source.contextDir\" placeholder=\"/\" autocorrect=\"off\" autocapitalize=\"none\" spellcheck=\"false\" aria-describedby=\"context-dir-help\">\n" +
     "</div>\n" +
     "<div class=\"help-block\" id=\"context-dir-help\">Optional subdirectory for the application source code, used as the context directory for the build.</div>\n" +
     "</div>\n" +
-    "<div class=\"form-group\">\n" +
+    "<div class=\"form-group\" ng-if=\"view.advancedOptions || buildConfig.spec.source.sourceSecret\">\n" +
     "<osc-secrets model=\"secrets.picked.gitSecret\" namespace=\"projectName\" display-type=\"source\" type=\"source\" service-account-to-link=\"builder\" secrets-by-type=\"secrets.secretsByType\" alerts=\"alerts\">\n" +
     "</osc-secrets>\n" +
-    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"sources.dockerfile\">\n" +


### PR DESCRIPTION
If git reference, context dir, or source secret are set for a build config,
show them by default when opening the build config editor. Don't make the user
click "advanced options" to see that values are already set.

Fixes #1910 

/kind bug
/assign @jwforres 