### PR TITLE
Bug 1506998 - DC's environment tab not showing image secrets properly

### DIFF
--- a/app/scripts/directives/editEnvironmentFrom.js
+++ b/app/scripts/directives/editEnvironmentFrom.js
@@ -24,13 +24,23 @@
     var canI = $filter('canI');
     var humanizeKind = $filter('humanizeKind');
     var uniqueId = _.uniqueId();
+    var keyValidator = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
     ctrl.setFocusClass = 'edit-environment-from-set-focus-' + uniqueId;
+
+    ctrl.isEnvVarInvalid = function(keyName) {
+      return !keyValidator.test(keyName);
+    };
+
+    ctrl.hasInvalidEnvVar = function(secret) {
+      return _.some(secret, function(value, key) {
+        return ctrl.isEnvVarInvalid(key);
+      });
+    };
 
     ctrl.viewOverlayPanel = function(entry) {
       ctrl.decodedData = entry.data;
       ctrl.overlayPaneEntryDetails = entry;
-
       if (entry.kind === 'Secret') {
         ctrl.decodedData = SecretsService.decodeSecretData(entry.data);
       }

--- a/app/styles/_kve.less
+++ b/app/styles/_kve.less
@@ -156,6 +156,9 @@
         float: left;
         width: 100%;
       }
+      .has-warning {
+        display: inline-block;
+      }
     }
     .environment-from-view-details {
       float: left;

--- a/app/views/directives/edit-environment-from.html
+++ b/app/views/directives/edit-environment-from.html
@@ -61,6 +61,9 @@
               </ui-select-choices>
             </ui-select>
           </div>
+          <div class="has-warning" ng-if="$ctrl.hasInvalidEnvVar(entry.selectedEnvFrom.data)">
+            <div class="help-block">Some of the keys for {{entry.selectedEnvFrom.kind | humanizeKind}} <strong>{{entry.selectedEnvFrom.metadata.name}}</strong> are not valid environment variable names and will not be added.</div>
+          </div>
         </div>
       </div>
 
@@ -149,8 +152,11 @@
       <div ng-if="$ctrl.overlayPaneEntryDetails.data | size" class="table-responsive scroll-shadows-horizontal">
         <table class="table table-bordered table-bordered-columns config-map-table key-value-table">
           <tbody>
-            <tr ng-repeat="(prop, value) in $ctrl.decodedData">
-              <td class="key">{{prop}}</td>
+            <tr ng-repeat="(key, value) in $ctrl.decodedData">
+              <td class="key">
+                {{key}}
+                <span ng-if="$ctrl.isEnvVarInvalid(key)" class="pficon pficon-warning-triangle-o tooltip-default-icon" data-toggle="popover" data-trigger="hover" dynamic-content="{{key}} is not a valid environment variable name and will not be added."></span>
+              </td>
               <td class="value">
                 <truncate-long-text
                   ng-if="$ctrl.overlayPaneEntryDetails.kind === 'ConfigMap'"
@@ -168,7 +174,7 @@
                     newline-limit="2"
                     expandable="true">
                   </truncate-long-text>
-                  <div ng-if="decodedData.$$nonprintable[prop]" class="help-block">
+                  <div ng-if="decodedData.$$nonprintable[key]" class="help-block">
                     This secret value contains non-printable characters and is displayed as a Base64-encoded string.
                   </div>
                 </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -9218,19 +9218,25 @@ n[e.key] = e.value;
 } ]), function() {
 angular.module("openshiftConsole").component("editEnvironmentFrom", {
 controller: [ "$attrs", "$filter", "keyValueEditorUtils", "SecretsService", function(e, t, n, a) {
-var r = this, o = t("canI"), i = t("humanizeKind"), s = _.uniqueId();
-r.setFocusClass = "edit-environment-from-set-focus-" + s, r.viewOverlayPanel = function(e) {
+var r = this, o = t("canI"), i = t("humanizeKind"), s = _.uniqueId(), c = /^[A-Za-z_][A-Za-z0-9_]*$/;
+r.setFocusClass = "edit-environment-from-set-focus-" + s, r.isEnvVarInvalid = function(e) {
+return !c.test(e);
+}, r.hasInvalidEnvVar = function(e) {
+return _.some(e, function(e, t) {
+return r.isEnvVarInvalid(t);
+});
+}, r.viewOverlayPanel = function(e) {
 r.decodedData = e.data, r.overlayPaneEntryDetails = e, "Secret" === e.kind && (r.decodedData = a.decodeSecretData(e.data)), r.overlayPanelVisible = !0;
 }, r.closeOverlayPanel = function() {
 r.showSecret = !1, r.overlayPanelVisible = !1;
 };
-var c = function(e, t) {
+var l = function(e, t) {
 e && e.push(t || {});
 };
 r.onAddRow = function() {
-c(r.envFromEntries), n.setFocusOn("." + r.setFocusClass);
+l(r.envFromEntries), n.setFocusOn("." + r.setFocusClass);
 }, r.deleteEntry = function(e, t) {
-r.envFromEntries && !r.envFromEntries.length || (r.envFromEntries.splice(e, t), r.envFromEntries.length || c(r.envFromEntries), r.updateEntries(r.envFromEntries), r.editEnvironmentFromForm.$setDirty());
+r.envFromEntries && !r.envFromEntries.length || (r.envFromEntries.splice(e, t), r.envFromEntries.length || l(r.envFromEntries), r.updateEntries(r.envFromEntries), r.editEnvironmentFromForm.$setDirty());
 }, r.hasOptions = function() {
 return !_.isEmpty(r.envFromSelectorOptions);
 }, r.hasEntries = function() {
@@ -9268,9 +9274,9 @@ r.entries = _.filter(e, function(e) {
 return e.secretRef || e.configMapRef;
 });
 };
-var l = function() {
+var u = function() {
 var e = {}, t = {};
-r.envFromEntries = r.entries || [], r.envFromEntries.length || c(r.envFromEntries), _.each(r.envFromSelectorOptions, function(n) {
+r.envFromEntries = r.entries || [], r.envFromEntries.length || l(r.envFromEntries), _.each(r.envFromSelectorOptions, function(n) {
 switch (n.kind) {
 case "ConfigMap":
 e[n.metadata.name] = n;
@@ -9288,9 +9294,9 @@ n.configMapRef && i in e && (n.selectedEnvFrom = e[i]), n.secretRef && i in t &&
 });
 };
 r.$onInit = function() {
-l(), "cannotDelete" in e && (r.cannotDeleteAny = !0), "cannotSort" in e && (r.cannotSort = !0), "showHeader" in e && (r.showHeader = !0), r.envFromEntries && !r.envFromEntries.length && c(r.envFromEntries);
+u(), "cannotDelete" in e && (r.cannotDeleteAny = !0), "cannotSort" in e && (r.cannotSort = !0), "showHeader" in e && (r.showHeader = !0), r.envFromEntries && !r.envFromEntries.length && l(r.envFromEntries);
 }, r.$onChanges = function(e) {
-(e.entries || e.envFromSelectorOptions) && l();
+(e.entries || e.envFromSelectorOptions) && u();
 };
 } ],
 bindings: {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6735,6 +6735,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
     "</div>\n" +
+    "<div class=\"has-warning\" ng-if=\"$ctrl.hasInvalidEnvVar(entry.selectedEnvFrom.data)\">\n" +
+    "<div class=\"help-block\">Some of the keys for {{entry.selectedEnvFrom.kind | humanizeKind}} <strong>{{entry.selectedEnvFrom.metadata.name}}</strong> are not valid environment variable names and will not be added.</div>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"environment-from-input prefix\">\n" +
@@ -6780,8 +6783,11 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"$ctrl.overlayPaneEntryDetails.data | size\" class=\"table-responsive scroll-shadows-horizontal\">\n" +
     "<table class=\"table table-bordered table-bordered-columns config-map-table key-value-table\">\n" +
     "<tbody>\n" +
-    "<tr ng-repeat=\"(prop, value) in $ctrl.decodedData\">\n" +
-    "<td class=\"key\">{{prop}}</td>\n" +
+    "<tr ng-repeat=\"(key, value) in $ctrl.decodedData\">\n" +
+    "<td class=\"key\">\n" +
+    "{{key}}\n" +
+    "<span ng-if=\"$ctrl.isEnvVarInvalid(key)\" class=\"pficon pficon-warning-triangle-o tooltip-default-icon\" data-toggle=\"popover\" data-trigger=\"hover\" dynamic-content=\"{{key}} is not a valid environment variable name and will not be added.\"></span>\n" +
+    "</td>\n" +
     "<td class=\"value\">\n" +
     "<truncate-long-text ng-if=\"$ctrl.overlayPaneEntryDetails.kind === 'ConfigMap'\" content=\"value\" limit=\"50\" newline-limit=\"2\" expandable=\"true\">\n" +
     "</truncate-long-text>\n" +
@@ -6789,7 +6795,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"$ctrl.showSecret && $ctrl.overlayPaneEntryDetails.kind === 'Secret'\">\n" +
     "<truncate-long-text content=\"value\" limit=\"50\" newline-limit=\"2\" expandable=\"true\">\n" +
     "</truncate-long-text>\n" +
-    "<div ng-if=\"decodedData.$$nonprintable[prop]\" class=\"help-block\">\n" +
+    "<div ng-if=\"decodedData.$$nonprintable[key]\" class=\"help-block\">\n" +
     "This secret value contains non-printable characters and is displayed as a Base64-encoded string.\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -766,7 +766,6 @@ select[multiple].input-lg,textarea.input-lg{height:auto}
 .form-horizontal .form-group-sm .control-label{padding-top:3px;font-size:11px}
 }
 .btn{display:inline-block;margin-bottom:0;font-weight:600;text-align:center;vertical-align:middle;touch-action:manipulation;cursor:pointer;border:1px solid transparent;white-space:nowrap;padding:2px 6px;font-size:13px;line-height:1.66666667;border-radius:1px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-.bootstrap-switch,.datepicker table{-webkit-user-select:none;-moz-user-select:none}
 .btn.active.focus,.btn.active:focus,.btn.focus,.btn:active.focus,.btn:active:focus,.btn:focus{outline:dotted thin!important;outline:-webkit-focus-ring-color auto 5px!important;outline-offset:-2px!important}
 .btn.focus,.btn:focus,.btn:hover{color:#4d5258;text-decoration:none}
 .btn.active,.btn:active{outline:0;-webkit-box-shadow:inset 0 3px 5px rgba(0,0,0,.125);box-shadow:inset 0 3px 5px rgba(0,0,0,.125)}
@@ -2374,7 +2373,7 @@ td>.progress:first-child:last-child{margin-bottom:0;margin-top:3px}
 .datepicker-dropdown.datepicker-orient-bottom:after{top:-6px}
 .datepicker-dropdown.datepicker-orient-top:before{bottom:-7px;border-bottom:0;border-top:7px solid #bbb}
 .datepicker-dropdown.datepicker-orient-top:after{bottom:-6px;border-bottom:0;border-top:6px solid #fff}
-.datepicker table{margin:0;-webkit-touch-callout:none;-khtml-user-select:none;-ms-user-select:none;user-select:none}
+.datepicker table{margin:0;-webkit-touch-callout:none;-webkit-user-select:none;-khtml-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
 .datepicker table tr td,.datepicker table tr th{text-align:center;width:30px;height:30px;border:none}
 .datepicker table tr td.new,.datepicker table tr td.old{color:#9c9c9c}
 .datepicker table tr td.day:hover,.datepicker table tr td.focused{background:#f1f1f1;cursor:pointer}
@@ -2510,8 +2509,7 @@ select.bs-select-hidden,select.selectpicker{display:none!important}
 .bs-donebutton .btn-group button{width:100%}
 .bs-searchbox+.bs-actionsbox{padding:0 8px 4px}
 .bs-searchbox .form-control{margin-bottom:0;width:100%;float:none}
-.bootstrap-switch{display:inline-block;direction:ltr;cursor:pointer;border-radius:1px;border:1px solid #bbb;position:relative;text-align:left;overflow:hidden;line-height:8px;z-index:0;-ms-user-select:none;user-select:none;vertical-align:middle;-webkit-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;-o-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s}
-.c3 text,.log-line-number{-moz-user-select:none;-webkit-user-select:none}
+.bootstrap-switch{display:inline-block;direction:ltr;cursor:pointer;border-radius:1px;border:1px solid #bbb;position:relative;text-align:left;overflow:hidden;line-height:8px;z-index:0;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;vertical-align:middle;-webkit-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;-o-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s}
 .bootstrap-switch .bootstrap-switch-container{display:inline-block;top:0;border-radius:1px;-webkit-transform:translate3d(0,0,0);transform:translate3d(0,0,0)}
 .bootstrap-switch .bootstrap-switch-handle-off,.bootstrap-switch .bootstrap-switch-handle-on,.bootstrap-switch .bootstrap-switch-label{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;cursor:pointer;display:inline-block!important;height:100%;padding:2px 6px;font-size:13px;line-height:21px}
 .ie9.layout-pf-alt-fixed .nav-pf-vertical-alt,.ie9.layout-pf-fixed .nav-pf-secondary-nav,.ie9.layout-pf-fixed .nav-pf-tertiary-nav,.ie9.layout-pf-fixed .nav-pf-vertical,.list-group-item-header{box-sizing:content-box}
@@ -2545,7 +2543,7 @@ select.bs-select-hidden,select.selectpicker{display:none!important}
 .bootstrap-touchspin .input-group-btn-vertical i{position:absolute;font-weight:400}
 .c3 svg{font:10px sans-serif}
 .c3 line,.c3 path{fill:none;stroke:#000}
-.c3 text{user-select:none}
+.c3 text{-webkit-user-select:none;-moz-user-select:none;user-select:none}
 .c3-bars path,.c3-event-rect,.c3-legend-item-tile,.c3-xgrid-focus,.c3-ygrid{shape-rendering:crispEdges}
 .c3-chart-arc text{fill:#fff;font-size:13px}
 .c3-grid text{fill:#aaa}
@@ -4142,7 +4140,6 @@ body>.ui-select-bootstrap.open{z-index:1050}
 .landing-search-form .search-pf-input-group .pficon-close{font-size:17px;padding-top:.3em}
 .landing-search-form .dropdown-menu{margin-top:0;width:100%}
 .landing-search-form .dropdown-menu>li>a.catalog-search-match{display:flex;line-height:1.5;padding:3px 10px 3px 5px;white-space:normal}
-.order-service-details .order-service-description-block .description,.pre-wrap{white-space:pre-wrap}
 .landing-search-form .dropdown-menu .active>a.catalog-search-match,.landing-search-form .dropdown-menu :focus{background-color:#def3ff!important;border-color:#bee1f4!important;color:inherit!important}
 .landing-search-form .dropdown-menu .active>a.catalog-search-match.no-matches{background-color:transparent!important;border-color:transparent!important}
 .landing-side-bar{background-color:#292e34;color:#fff;z-index:1029}
@@ -4178,6 +4175,7 @@ body>.ui-select-bootstrap.open{z-index:1050}
 .order-service-details .order-service-details-top .service-vendor{margin-top:5px}
 .order-service-details .order-service-details-top .sub-title{color:#72767b;font-size:20px;font-weight:600}
 .order-service-details .order-service-description-block{margin-top:15px}
+.order-service-details .order-service-description-block .description{white-space:pre-wrap}
 .order-service-details .order-service-description-block .learn-more-link{font-size:11px;white-space:nowrap}
 .order-service-details .order-service-description-block .order-service-dependent-image{margin-bottom:5px;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .order-service-details .order-service-description-block .order-service-dependent-image .pficon{margin-right:5px;vertical-align:-1px}
@@ -4430,6 +4428,7 @@ body.overlay-open,body.overlay-open .landing,body.overlay-open .landing-side-bar
 .services-view .services-view-container .services-categories>li>a .services-sub-category-tab-icon,.services-view .services-view-container .services-categories>li>a .services-sub-category-tab-image,.services-view .services-view-container .services-sub-categories>li>a .services-sub-category-tab-icon,.services-view .services-view-container .services-sub-categories>li>a .services-sub-category-tab-image{display:none!important}
 }
 .services-view .spinner-container{background:#fff;display:flex;flex:1 1 auto;padding-top:100px;padding-bottom:100px}
+.pre-wrap{white-space:pre-wrap}
 .visible-xlg-inline-block{display:none!important}
 @media (max-width:767px){.td-long-string{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 }
@@ -4969,7 +4968,6 @@ h2+.list-view-pf{margin-top:20px}
 .list-view-pf .list-group-item:first-child{border-top-color:#eaeaea}
 .list-view-pf .list-group-item:hover{background-color:#edf8ff}
 .list-view-pf .list-group-item-expandable{cursor:pointer;border:1px solid #eaeaea;border-left-color:transparent;border-right-color:transparent}
-.build-count .icon-count,.build-count .icon-count [data-toggle=tooltip],.instance-status-notification [data-toggle=tooltip],.notification-icon-count [data-toggle=tooltip]{cursor:help}
 .list-view-pf .list-group-item-expandable.expanded{border-color:#d1d1d1}
 .list-view-pf .list-group-item-expandable.expanded,.list-view-pf .list-group-item-expandable.expanded:hover{background-color:#ededed}
 .list-view-pf .list-group-item-expandable.expanded .list-view-pf-checkbox{border-right-color:#d1d1d1}
@@ -5025,6 +5023,7 @@ h2+.list-view-pf{margin-top:20px}
 .landing-page .wizard-pf-main .deploy-image .empty-state-message{margin-top:50px}
 }
 .build-count .builds,.build-count .pipelines{display:block}
+.build-count .icon-count,.build-count .icon-count [data-toggle=tooltip]{cursor:help}
 .build-count .running-stage{font-size:84%;color:#9c9c9c}
 @media (max-width:991px){.builds-label{margin-top:5px}
 }
@@ -5032,6 +5031,7 @@ h2+.list-view-pf{margin-top:20px}
 .instance-status-notification,.notification-icon-count{display:inline-block;margin:5px 5px 0 0}
 @media (min-width:992px){.instance-status-notification,.notification-icon-count{margin-top:0}
 }
+.instance-status-notification [data-toggle=tooltip],.notification-icon-count [data-toggle=tooltip]{cursor:help}
 .mini-donut-link{color:#252525}
 .mini-donut-link:active,.mini-donut-link:focus,.mini-donut-link:hover{color:#0088ce;text-decoration:none}
 .mini-donut-link.disabled-link,.mini-donut-link.disabled-link:active,.mini-donut-link.disabled-link:focus,.mini-donut-link.disabled-link:hover{color:#252525;opacity:1}
@@ -5759,7 +5759,7 @@ alerts+.chromeless .log-loading-msg{margin-top:130px}
 .log-line{color:#d1d1d1}
 .log-line:hover{background-color:#22262b;color:#ededed}
 .log-line-number:before{content:attr(data-line-number)}
-.log-line-number{-ms-user-select:none;border-right:1px #272b30 solid;padding-right:10px;vertical-align:top;white-space:nowrap;width:60px;color:#72767b}
+.log-line-number{-moz-user-select:none;-webkit-user-select:none;-ms-user-select:none;border-right:1px #272b30 solid;padding-right:10px;vertical-align:top;white-space:nowrap;width:60px;color:#72767b}
 .log-line-text{padding:0 10px;white-space:pre-wrap;width:100%}
 .appended-icon,.project-date [am-time-ago],.projects-list [am-time-ago]{white-space:nowrap}
 .log-line-text::-moz-selection{color:#101214;background:#e5e5e5}
@@ -5925,6 +5925,7 @@ kubernetes-container-terminal .terminal-actions .spinner{top:5px}
 @media (max-width:479px){.environment-from-editor .environment-from-entry .environment-from-input.prefix,.key-value-editor .environment-from-entry .environment-from-input.prefix{margin-top:5px;width:100%}
 }
 .environment-from-editor .environment-from-entry .environment-from-input .faux-input-group,.environment-from-editor .environment-from-entry .environment-from-input .ui-select,.key-value-editor .environment-from-entry .environment-from-input .faux-input-group,.key-value-editor .environment-from-entry .environment-from-input .ui-select{float:left;width:100%}
+.environment-from-editor .environment-from-entry .environment-from-input .has-warning,.key-value-editor .environment-from-entry .environment-from-input .has-warning{display:inline-block}
 .environment-from-editor .environment-from-entry .environment-from-view-details,.key-value-editor .environment-from-entry .environment-from-view-details{float:left;line-height:1;padding:6px 0 0}
 .environment-from-editor .key-value-editor-entry,.key-value-editor .key-value-editor-entry{display:table;margin-bottom:15px;padding-right:52px;position:relative;table-layout:fixed;width:100%}
 .environment-from-editor .key-value-editor-input .ui-select+.ui-select,.key-value-editor .key-value-editor-input .ui-select+.ui-select{padding-top:5px}


### PR DESCRIPTION
Image secrets of `kubernetes/dockercfg` and `kubernetes/dockerconfigjson` havent been shown properly on the DC's environment tab.

Screen:
![dc_page 1](https://user-images.githubusercontent.com/1668218/32627180-e448e91c-c591-11e7-8d33-8fd1b20d0bf7.png)


After fix:
![dc_page](https://user-images.githubusercontent.com/1668218/32627189-e929eb0c-c591-11e7-8071-1a0c078c63be.png)


@spadgett PTAL