### PR TITLE
[enterprise-3.7] Bump origin-web-catalog to 0.0.66

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -47,7 +47,7 @@
     "angular-utf8-base64": "0.0.5",
     "file-saver": "1.3.3",
     "origin-web-common": "0.0.74",
-    "origin-web-catalog": "0.0.65"
+    "origin-web-catalog": "0.0.66"
   },
   "devDependencies": {
     "angular-mocks": "1.5.11",

--- a/dist/scripts/vendor.js
+++ b/dist/scripts/vendor.js
@@ -77644,7 +77644,7 @@ tags: [ "mongodb" ],
 icon: "icon-mongodb"
 }, {
 id: "mysql",
-label: "mySQL",
+label: "MySQL",
 tags: [ "mysql" ],
 icon: "icon-mysql-database"
 }, {


### PR DESCRIPTION
https://github.com/openshift/origin-web-catalog/releases/tag/v0.0.66
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1512461

/kind bug
/assign @jwforres 
cc @jhadvig 