### PR TITLE
Fix storage nav highlighting

### DIFF
--- a/app/scripts/constants.js
+++ b/app/scripts/constants.js
@@ -382,6 +382,7 @@ angular.extend(window.OPENSHIFT_CONSTANTS, {
       href: "/browse/storage",
       prefixes: [
         "/browse/storage/",
+        "/browse/persistentvolumeclaims/",
         "/create-pvc"
       ]
     },

--- a/app/scripts/controllers/persistentVolumeClaim.js
+++ b/app/scripts/controllers/persistentVolumeClaim.js
@@ -22,7 +22,7 @@ angular.module('openshiftConsole')
     $scope.renderOptions.hideFilterWidget = true;
     $scope.breadcrumbs = [
       {
-        title: "Persistent Volume Claims",
+        title: "Storage",
         link: "project/" + $routeParams.project + "/browse/storage"
       },
       {

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -839,7 +839,7 @@ href: "/browse/other"
 label: "Storage",
 iconClass: "pficon pficon-container-node",
 href: "/browse/storage",
-prefixes: [ "/browse/storage/", "/create-pvc" ]
+prefixes: [ "/browse/storage/", "/browse/persistentvolumeclaims/", "/create-pvc" ]
 }, {
 label: "Monitoring",
 iconClass: "pficon pficon-screen",
@@ -6824,7 +6824,7 @@ n.resources = e.select(n.unfilteredResources), u();
 });
 } ]), angular.module("openshiftConsole").controller("PersistentVolumeClaimController", [ "$filter", "$scope", "$routeParams", "APIService", "DataService", "ProjectsService", function(e, t, n, a, r, o) {
 t.projectName = n.project, t.pvc = null, t.alerts = {}, t.renderOptions = t.renderOptions || {}, t.renderOptions.hideFilterWidget = !0, t.breadcrumbs = [ {
-title: "Persistent Volume Claims",
+title: "Storage",
 link: "project/" + n.project + "/browse/storage"
 }, {
 title: n.pvc


### PR DESCRIPTION
* Highlight the storage vertical nav item as selected when looking at a PVC
* Change breadcrumb to "Storage" to be consistent with the PVC list and
   nav label

Before:

![image 2017-12-01 15-18-53](https://user-images.githubusercontent.com/1167259/33501584-17fa1a54-d6ab-11e7-82f0-bca1454655b8.png)

After:

![image 2017-12-01 15-19-58](https://user-images.githubusercontent.com/1167259/33501599-2756d00a-d6ab-11e7-9df3-5437c721f38f.png)

/kind bug
/assign @jwforres 
/area usability
/cc @ncameronbritt 