### PR TITLE
Fix deploy button on deployment page

### DIFF
--- a/app/scripts/services/deployments.js
+++ b/app/scripts/services/deployments.js
@@ -22,7 +22,7 @@ angular.module("openshiftConsole")
       // increase latest version by one so starts new deployment based on latest
       var req = {
         kind: "DeploymentRequest",
-        apiVersion: "v1",
+        apiVersion: deploymentConfig.apiVersion,
         name: deploymentConfig.metadata.name,
         latest: true,
         force: true

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2131,7 +2131,7 @@ var s = n.getPreferredVersion("deploymentconfigs/instantiate"), c = n.getPreferr
 i.prototype.startLatestDeployment = function(t, n) {
 var a = {
 kind: "DeploymentRequest",
-apiVersion: "v1",
+apiVersion: t.apiVersion,
 name: t.metadata.name,
 latest: !0,
 force: !0


### PR DESCRIPTION
So this update works, but the Q here is:

```JavaScript 
// the request payload to startLatestDeployment
apiVersion: "apps.openshift.io/v1",
force: true,
kind: "DeploymentRequest",
latest: true,
name: "mongodb"

// the resource, group, version
group: "apps.openshift.io",
resource: "deploymentconfigs/instantiate",
version: "v1"
```
Does it work because these two objects happen to be compatible, but I should further adjust this to ensure they are long term compatible?