### PR TITLE
Bug 1526215 - Fix back button behavior in Import YAML dialog

### DIFF
--- a/app/scripts/directives/fromFileDialog.js
+++ b/app/scripts/directives/fromFileDialog.js
@@ -96,6 +96,10 @@
     };
 
     ctrl.stepChanged = function(step) {
+      // Make sure current step is accurate when the back button is clicked.
+      // Otherwise setting it again later to advanced the wizard does nothing
+      // since the value hasn't changed.
+      ctrl.currentStep = step.title;
       if (step.stepId === 'results') {
         ctrl.nextButtonTitle = "Close";
         ctrl.wizardDone = true;

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -13498,7 +13498,7 @@ s.template = null;
 var e = s.onDialogClosed();
 return _.isFunction(e) && e(), s.wizardDone = !1, !0;
 }, s.stepChanged = function(e) {
-"results" === e.stepId ? (s.nextButtonTitle = "Close", s.wizardDone = !0) : s.nextButtonTitle = "Create";
+s.currentStep = e.title, "results" === e.stepId ? (s.nextButtonTitle = "Close", s.wizardDone = !0) : s.nextButtonTitle = "Create";
 }, s.currentStep = "YAML / JSON", s.nextCallback = function(e) {
 return "file" === e.stepId ? (s.importFile(), !1) : "template" === e.stepId ? (s.instantiateTemplate(), !1) : "results" !== e.stepId || (s.close(), !1);
 };


### PR DESCRIPTION
Clicking back from the "Template Configuration" step can prevent the
user from being able to click next again in the wizard in the Import
YAML dialog. This is because the `ctrl.currentStep` value is not reset
to the first step title after the user clicks back. Sine the wizard is
watching for changes to `ctrl.currentStep` and the value never changes
when the user clicks next again, the wizard doesn't advance.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1526215

/kind bug
/assign @benjaminapetersen 