### PR TITLE
[3.7] Bug 1526215 - Fix back button behavior in Import YAML dialog

### DIFF
--- a/app/scripts/directives/fromFileDialog.js
+++ b/app/scripts/directives/fromFileDialog.js
@@ -96,6 +96,10 @@
     };
 
     ctrl.stepChanged = function(step) {
+      // Make sure current step is accurate when the back button is clicked.
+      // Otherwise setting it again later to advanced the wizard does nothing
+      // since the value hasn't changed.
+      ctrl.currentStep = step.title;
       if (step.stepId === 'results') {
         ctrl.nextButtonTitle = "Close";
         ctrl.wizardDone = true;

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1,6 +1,6 @@
 "use strict";
 
-function OverviewController(e, t, n, a, r, o, i, s, c, l, u, d, m, p, f, g, v, h, y, b, C, S, w, k, P, j, R, I) {
+function OverviewController(e, t, n, a, r, o, i, s, c, l, u, d, m, p, f, g, v, h, y, b, S, C, w, k, P, j, R, I) {
 var E = this, T = t("isIE")();
 e.projectName = a.project, E.catalogLandingPageEnabled = !u.DISABLE_SERVICE_CATALOG_LANDING_PAGE;
 var N, D, A = t("annotation"), B = t("canI"), L = t("buildConfigForBuild"), U = t("deploymentIsInProgress"), O = t("imageObjectRef"), F = t("isJenkinsPipelineStrategy"), x = t("isNewerResource"), V = t("label"), M = t("podTemplate"), q = o.getPreferredVersion("servicebindings"), z = o.getPreferredVersion("clusterserviceclasses"), H = o.getPreferredVersion("serviceinstances"), G = o.getPreferredVersion("clusterserviceplans"), K = {}, W = {}, Q = {}, J = E.state = {
@@ -157,13 +157,13 @@ J.notificationsByObjectUID[n] = t || {};
 }, be = function(e) {
 var t = X(e);
 return t ? _.get(J, [ "notificationsByObjectUID", t ], {}) : {};
-}, Ce = function(e) {
+}, Se = function(e) {
 if (X(e)) {
 var t = he(e), n = j.getPodAlerts(t, a.project);
 ye(e, n);
 }
-}, Se = function(e) {
-_.each(e, Ce);
+}, Ce = function(e) {
+_.each(e, Se);
 }, _e = function(e) {
 var t = Z(e);
 return t ? Q[t] : null;
@@ -197,7 +197,7 @@ _.assign(t, n);
 }, Ie = function() {
 _.each(E.deployments, Re);
 }, Ee = function() {
-Se(E.replicationControllers), Se(E.replicaSets), Se(E.statefulSets), Se(E.monopods);
+Ce(E.replicationControllers), Ce(E.replicaSets), Ce(E.statefulSets), Ce(E.monopods);
 }, Te = _.debounce(function() {
 e.$evalAsync(function() {
 Ee(), Pe(), Ie();
@@ -238,7 +238,7 @@ if (_.get(e, "status.replicas")) return !0;
 var n = m.getRevision(e);
 return !n || !!t && m.getRevision(t) === n;
 }, Fe = function() {
-E.replicaSets && N && (E.replicaSetsByDeploymentUID = S.groupByControllerUID(E.replicaSets), E.currentByDeploymentUID = {}, _.each(E.replicaSetsByDeploymentUID, function(e, t) {
+E.replicaSets && N && (E.replicaSetsByDeploymentUID = C.groupByControllerUID(E.replicaSets), E.currentByDeploymentUID = {}, _.each(E.replicaSetsByDeploymentUID, function(e, t) {
 if (t) {
 var n = N[t], a = _.filter(e, function(e) {
 return Oe(e, n);
@@ -381,16 +381,16 @@ var r = function() {
 E.pods && g.fetchReferencedImageStreamImages(E.pods, J.imagesByDockerReference, J.imageStreamImageRefByDockerReference, a);
 };
 ot.push(d.watch("pods", a, function(e) {
-E.pods = e.by("metadata.name"), $e(), r(), Te(), Ve(E.monopods), Se(E.monopods), Ne(E.monopods), fe(), y.log("pods (subscribe)", E.pods);
+E.pods = e.by("metadata.name"), $e(), r(), Te(), Ve(E.monopods), Ce(E.monopods), Ne(E.monopods), fe(), y.log("pods (subscribe)", E.pods);
 })), ot.push(d.watch("replicationcontrollers", a, function(e) {
-E.replicationControllers = e.by("metadata.name"), Ue(), Ve(E.vanillaReplicationControllers), Ve(E.monopods), Se(E.vanillaReplicationControllers), Ne(E.vanillaReplicationControllers), at(), fe(), y.log("replicationcontrollers (subscribe)", E.replicationControllers);
+E.replicationControllers = e.by("metadata.name"), Ue(), Ve(E.vanillaReplicationControllers), Ve(E.monopods), Ce(E.vanillaReplicationControllers), Ne(E.vanillaReplicationControllers), at(), fe(), y.log("replicationcontrollers (subscribe)", E.replicationControllers);
 })), ot.push(d.watch("deploymentconfigs", a, function(e) {
 E.deploymentConfigs = e.by("metadata.name"), Ue(), Ve(E.deploymentConfigs), Ve(E.vanillaReplicationControllers), Ne(E.deploymentConfigs), Ie(), Xe(), et(), at(), fe(), y.log("deploymentconfigs (subscribe)", E.deploymentConfigs);
 })), ot.push(d.watch({
 group: "extensions",
 resource: "replicasets"
 }, a, function(e) {
-E.replicaSets = e.by("metadata.name"), Fe(), Ve(E.vanillaReplicaSets), Ve(E.monopods), Se(E.vanillaReplicaSets), Ne(E.vanillaReplicaSets), at(), fe(), y.log("replicasets (subscribe)", E.replicaSets);
+E.replicaSets = e.by("metadata.name"), Fe(), Ve(E.vanillaReplicaSets), Ve(E.monopods), Ce(E.vanillaReplicaSets), Ne(E.vanillaReplicaSets), at(), fe(), y.log("replicasets (subscribe)", E.replicaSets);
 })), ot.push(d.watch({
 group: "apps",
 resource: "deployments"
@@ -402,7 +402,7 @@ J.builds = e.by("metadata.name"), tt(), y.log("builds (subscribe)", J.builds);
 group: "apps",
 resource: "statefulsets"
 }, a, function(e) {
-E.statefulSets = e.by("metadata.name"), Ve(E.statefulSets), Ve(E.monopods), Se(E.statefulSets), Ne(E.statefulSets), at(), fe(), y.log("statefulsets (subscribe)", E.statefulSets);
+E.statefulSets = e.by("metadata.name"), Ve(E.statefulSets), Ve(E.monopods), Ce(E.statefulSets), Ne(E.statefulSets), at(), fe(), y.log("statefulsets (subscribe)", E.statefulSets);
 }, {
 poll: T,
 pollInterval: 6e4
@@ -487,7 +487,7 @@ namespace: m.namespace
 }, {
 errorNotification: !1
 }).then(function(t) {
-E.samplePipelineURL = C.createFromTemplateURL(t, e.projectName);
+E.samplePipelineURL = S.createFromTemplateURL(t, e.projectName);
 }), e.$on("$destroy", function() {
 d.unwatchAll(ot), $(window).off(".overview");
 });
@@ -3558,11 +3558,11 @@ return !0;
 });
 }, y = function(e, t) {
 return e ? "Pod" === e.kind ? h(e, t) : _.has(e, "spec.template") ? h(e.spec.template, t) : t : t;
-}, b = t("humanizeQuotaResource"), C = t("humanizeKind"), S = function(e, t, n) {
+}, b = t("humanizeQuotaResource"), S = t("humanizeKind"), C = function(e, t, n) {
 var a = e.status.total || e.status;
 if (m(a.hard[n]) <= m(a.used[n])) {
 var r, o;
-return r = "Pod" === t.kind ? "You will not be able to create the " + C(t.kind) + " '" + t.metadata.name + "'." : "You can still create " + C(t.kind) + " '" + t.metadata.name + "' but no pods will be created until resources are freed.", o = "pods" === n ? "You are at your quota for pods." : "You are at your quota for " + b(n) + " on pods.", {
+return r = "Pod" === t.kind ? "You will not be able to create the " + S(t.kind) + " '" + t.metadata.name + "'." : "You can still create " + S(t.kind) + " '" + t.metadata.name + "' but no pods will be created until resources are freed.", o = "pods" === n ? "You are at your quota for pods." : "You are at your quota for " + b(n) + " on pods.", {
 type: "Pod" === t.kind ? "error" : "warning",
 message: o,
 details: r,
@@ -3590,7 +3590,7 @@ var t = _.get(e, o);
 t && (i += m(t));
 }), m(r.hard[a]) < m(r.used[a]) + i) {
 var s;
-return s = "Pod" === t.kind ? "You may not be able to create the " + C(t.kind) + " '" + t.metadata.name + "'." : "You can still create " + C(t.kind) + " '" + t.metadata.name + "' but you may not have pods created until resources are freed.", {
+return s = "Pod" === t.kind ? "You may not be able to create the " + S(t.kind) + " '" + t.metadata.name + "'." : "You can still create " + S(t.kind) + " '" + t.metadata.name + "' but you may not have pods created until resources are freed.", {
 type: "warning",
 message: "You are close to your quota for " + b(a) + " on pods.",
 details: s,
@@ -3606,7 +3606,7 @@ var n = [], a = "Pod" === e.kind ? e : _.get(e, "spec.template");
 return a ? (_.each([ "cpu", "memory", "requests.cpu", "requests.memory", "limits.cpu", "limits.memory", "pods" ], function(r) {
 var o = t.status.total || t.status;
 if (("Pod" !== e.kind || "pods" !== r) && _.has(o, [ "hard", r ]) && _.has(o, [ "used", r ])) {
-var i = S(t, e, r);
+var i = C(t, e, r);
 if (i) n.push(i); else if ("pods" !== r) {
 var s = k(t, e, a, r);
 s && n.push(s);
@@ -3618,7 +3618,7 @@ var r = [];
 return t && n ? (_.each(t, function(t) {
 var o = y(t, n), i = y(t, a), s = e.objectToResourceGroupVersion(t);
 if (s) {
-var c = e.kindToResource(t.kind, !0), l = C(t.kind), u = "";
+var c = e.kindToResource(t.kind, !0), l = S(t.kind), u = "";
 s.group && (u = s.group + "/"), u += s.resource;
 var p = function(e) {
 var n = e.status.total || e.status;
@@ -4497,13 +4497,13 @@ s.toProjectMembership(e.metadata.name);
 }, b && (e.startGuidedTour = function() {
 return !d.isWindowBelowBreakpoint(d.WINDOW_SIZE_SM) && (u.startTour(y.steps), !0);
 }), c.clearNotifications();
-var C = function() {
+var S = function() {
 var t = _.get(e, "template.metadata.uid");
 t && l.addItem(t);
-}, S = function(e) {
+}, C = function(e) {
 return "PartialObjectMetadata" === e.kind;
 }, w = function(e) {
-return S(e) ? i.get("templates", e.metadata.name, {
+return C(e) ? i.get("templates", e.metadata.name, {
 namespace: e.metadata.namespace
 }) : p.when(e);
 };
@@ -4512,7 +4512,7 @@ w(t).then(function(t) {
 _.set(e, "ordering.panelName", "template"), e.template = t;
 });
 }, e.closeOrderingPanel = function() {
-e.template && (C(), e.template = null), _.set(e, "ordering.panelName", "");
+e.template && (S(), e.template = null), _.set(e, "ordering.panelName", "");
 }, e.deployImageSelected = function() {
 _.set(e, "ordering.panelName", "deployImage");
 }, e.fromFileSelected = function() {
@@ -4532,7 +4532,7 @@ c.addNotification(a);
 e.catalogItems = t, h();
 }));
 }), e.$on("$destroy", function() {
-C();
+S();
 }), b && e.$on("$locationChangeStart", function(t) {
 g.search().startTour && (e.startGuidedTour(), t.preventDefault());
 });
@@ -4562,7 +4562,7 @@ text: ""
 }, e.limitListTo = 250;
 var v, h = [ "metadata.name", 'metadata.annotations["openshift.io/display-name"]', 'metadata.annotations["openshift.io/description"]', 'metadata.annotations["openshift.io/requester"]' ], y = function() {
 e.projects = s.filterForKeywords(m, h, f);
-}, b = t("displayName"), C = function() {
+}, b = t("displayName"), S = function() {
 var t = _.get(e, "sortConfig.currentField.id");
 v !== t && (e.sortConfig.isAscending = "metadata.creationTimestamp" !== t);
 var n = function(e) {
@@ -4581,8 +4581,8 @@ default:
 m = _.orderBy(d, [ t ], [ a ]);
 }
 v = t;
-}, S = function() {
-C(), y();
+}, C = function() {
+S(), y();
 };
 e.sortConfig = {
 fields: [ {
@@ -4603,10 +4603,10 @@ title: "Creation Date",
 sortType: "alpha"
 } ],
 isAscending: !0,
-onSortChange: S
+onSortChange: C
 };
 var w = function(t) {
-d = _.toArray(t.by("metadata.name")), e.loading = !1, e.showGetStarted = _.isEmpty(d) && !e.isProjectListIncomplete, S();
+d = _.toArray(t.by("metadata.name")), e.loading = !1, e.showGetStarted = _.isEmpty(d) && !e.isProjectListIncomplete, C();
 }, k = function() {
 g || u.list().then(w);
 };
@@ -4631,7 +4631,7 @@ e.keywords = f = s.generateKeywords(t), e.$applyAsync(y);
 u.list().then(function(t) {
 e.isProjectListIncomplete = u.isProjectListIncomplete(), w(t), !e.isProjectListIncomplete && _.size(d) <= 250 && (p.push(u.watch(e, w)), g = !0);
 }, function() {
-e.isProjectListIncomplete = !0, e.loading = !1, d = [], S();
+e.isProjectListIncomplete = !0, e.loading = !1, d = [], C();
 });
 }), u.canCreate().then(function() {
 e.canCreate = !0;
@@ -4736,7 +4736,7 @@ e.isVisible = !1;
 var b = function(e) {
 var t = _.get(e, "state", {});
 return _.head(_.keys(t));
-}, C = function() {
+}, S = function() {
 var t = [];
 _.each(e.pod.spec.containers, function(n) {
 var a = _.find(e.pod.status.containerStatuses, {
@@ -4751,7 +4751,7 @@ containerState: r
 });
 var n = _.head(t);
 return n.isVisible = !0, n.isUsed = !0, e.selectedTerminalContainer = n, t;
-}, S = function(t) {
+}, C = function(t) {
 e.noContainersYet && (e.noContainersYet = 0 === e.containersRunning(t.status.containerStatuses));
 }, w = function(t) {
 _.each(t, function(t) {
@@ -4778,8 +4778,8 @@ errorNotification: !1
 }).then(function(t) {
 P(t);
 var a = {};
-a[t.metadata.name] = t, e.logOptions.container = n.container || t.spec.containers[0].name, e.containerTerminals = C(), S(t), c.fetchReferencedImageStreamImages(a, e.imagesByDockerReference, e.imageStreamImageRefByDockerReference, f), p.push(i.watchObject("pods", n.pod, l, function(t, n) {
-P(t, n), w(e.containerTerminals), S(t);
+a[t.metadata.name] = t, e.logOptions.container = n.container || t.spec.containers[0].name, e.containerTerminals = S(), C(t), c.fetchReferencedImageStreamImages(a, e.imagesByDockerReference, e.imageStreamImageRefByDockerReference, f), p.push(i.watchObject("pods", n.pod, l, function(t, n) {
+P(t, n), w(e.containerTerminals), C(t);
 }));
 }, function(n) {
 e.loaded = !0, e.alerts.load = {
@@ -4951,12 +4951,12 @@ n.filters = {
 hideOlderResources: v(e.hideOlderResources) || "true" === e.hideOlderResources,
 text: ""
 };
-var h, y, b, C;
+var h, y, b, S;
 l.isAvailable().then(function(e) {
 n.metricsAvailable = e;
 });
-var S = a("orderObjectsByDate"), w = [ "metadata.name" ], k = [], P = function() {
-n.filteredPods = s.filterForKeywords(C, w, k), n.filteredReplicationControllers = s.filterForKeywords(y, w, k), n.filteredReplicaSets = s.filterForKeywords(b, w, k), n.filteredBuilds = s.filterForKeywords(h, w, k), n.filteredStatefulSets = s.filterForKeywords(_.values(n.statefulSets), w, k);
+var C = a("orderObjectsByDate"), w = [ "metadata.name" ], k = [], P = function() {
+n.filteredPods = s.filterForKeywords(S, w, k), n.filteredReplicationControllers = s.filterForKeywords(y, w, k), n.filteredReplicaSets = s.filterForKeywords(b, w, k), n.filteredBuilds = s.filterForKeywords(h, w, k), n.filteredStatefulSets = s.filterForKeywords(_.values(n.statefulSets), w, k);
 }, j = function(e) {
 n.logOptions.pods[e.metadata.name] = {
 container: e.spec.containers[0].name
@@ -4970,9 +4970,9 @@ n.logOptions.builds[e.metadata.name] = {}, n.logCanRun.builds[e.metadata.name] =
 }, E = function() {
 n.filteredStatefulSets = s.filterForKeywords(_.values(n.statefulSets), w, k);
 }, T = function() {
-C = _.filter(n.pods, function(e) {
+S = _.filter(n.pods, function(e) {
 return !n.filters.hideOlderResources || "Succeeded" !== e.status.phase && "Failed" !== e.status.phase;
-}), n.filteredPods = s.filterForKeywords(C, w, k);
+}), n.filteredPods = s.filterForKeywords(S, w, k);
 }, N = a("isIncompleteBuild"), D = a("buildConfigForBuild"), A = a("isRecentBuild"), B = function() {
 moment().subtract(5, "m");
 h = _.filter(n.builds, function(e) {
@@ -5033,7 +5033,7 @@ var t = _.get(n, [ "podsByOwnerUID", e.metadata.uid ], []);
 _.isEmpty(t) || u.toPodsForDeployment(e, t);
 }, m.get(e.project).then(_.spread(function(e, a) {
 n.project = e, n.projectContext = a, g.push(o.watch("pods", a, function(e) {
-n.podsByName = e.by("metadata.name"), n.pods = S(n.podsByName, !0), n.podsByOwnerUID = d.groupByOwnerUID(n.pods), n.podsLoaded = !0, _.each(n.pods, j), T(), c.log("pods", n.pods);
+n.podsByName = e.by("metadata.name"), n.pods = C(n.podsByName, !0), n.podsByOwnerUID = d.groupByOwnerUID(n.pods), n.podsLoaded = !0, _.each(n.pods, j), T(), c.log("pods", n.pods);
 })), g.push(o.watch({
 resource: "statefulsets",
 group: "apps",
@@ -5044,14 +5044,14 @@ n.statefulSets = e.by("metadata.name"), n.statefulSetsLoaded = !0, E(), c.log("s
 poll: f,
 pollInterval: 6e4
 })), g.push(o.watch("replicationcontrollers", a, function(e) {
-n.replicationControllers = S(e.by("metadata.name"), !0), n.replicationControllersLoaded = !0, _.each(n.replicationControllers, R), O(), c.log("replicationcontrollers", n.replicationControllers);
+n.replicationControllers = C(e.by("metadata.name"), !0), n.replicationControllersLoaded = !0, _.each(n.replicationControllers, R), O(), c.log("replicationcontrollers", n.replicationControllers);
 })), g.push(o.watch("builds", a, function(e) {
-n.builds = S(e.by("metadata.name"), !0), n.latestBuildByConfig = r.latestBuildByConfig(n.builds), n.buildsLoaded = !0, _.each(n.builds, I), B(), c.log("builds", n.builds);
+n.builds = C(e.by("metadata.name"), !0), n.latestBuildByConfig = r.latestBuildByConfig(n.builds), n.buildsLoaded = !0, _.each(n.builds, I), B(), c.log("builds", n.builds);
 })), g.push(o.watch({
 group: "extensions",
 resource: "replicasets"
 }, a, function(e) {
-n.replicaSets = S(e.by("metadata.name"), !0), n.replicaSetsLoaded = !0, F(), c.log("replicasets", n.replicaSets);
+n.replicaSets = C(e.by("metadata.name"), !0), n.replicaSetsLoaded = !0, F(), c.log("replicasets", n.replicaSets);
 }, {
 poll: f,
 pollInterval: 6e4
@@ -5073,7 +5073,7 @@ e !== t && (localStorage.setItem("monitoring.eventsidebar.collapsed", n.renderOp
 });
 }));
 } ]), angular.module("openshiftConsole").controller("MembershipController", [ "$filter", "$location", "$routeParams", "$scope", "$timeout", "$uibModal", "AuthService", "AuthorizationService", "DataService", "ProjectsService", "MembershipService", "NotificationsService", "RoleBindingsService", "RolesService", function(e, t, n, a, r, o, i, s, c, l, u, d, m, p) {
-var f, g = n.project, v = e("humanizeKind"), h = e("annotation"), y = e("canI"), b = [], C = {
+var f, g = n.project, v = e("humanizeKind"), h = e("annotation"), y = e("canI"), b = [], S = {
 notice: {
 yourLastRole: _.template('Removing the role "<%= roleName %>" may completely remove your ability to see this project.')
 },
@@ -5098,7 +5098,7 @@ exists: _.template('The role "<%= roleName %>" has already been granted to "<%= 
 }
 },
 errorReason: _.template('Reason: "<%= httpErr %>"')
-}, S = function(e, t, n) {
+}, C = function(e, t, n) {
 d.addNotification({
 type: e,
 message: t,
@@ -5130,29 +5130,29 @@ e && (a.roleBindings[e.metadata.name] = e, a.subjectKindsForUI = u.mapRolebindin
 });
 }, j = function(t, n) {
 a.disableAddForm = !0, m.create(t, n, g, f).then(function() {
-P(), S("success", C.update.subject.success({
+P(), C("success", S.update.subject.success({
 roleName: t.metadata.name,
 subjectName: n.name
 }));
 }, function(a) {
-w(), P(), S("error", C.update.subject.error({
+w(), P(), C("error", S.update.subject.error({
 roleName: t.metadata.name,
 subjectName: n.name
-}), C.errorReason({
+}), S.errorReason({
 httpErr: e("getErrorDetails")(a)
 }));
 });
 }, R = function(t, n, r) {
 a.disableAddForm = !0, m.addSubject(t, n, r, f).then(function() {
-P(), S("success", C.update.subject.success({
+P(), C("success", S.update.subject.success({
 roleName: t.roleRef.name,
 subjectName: n.name
 }));
 }, function(a) {
-w(), P(), S("error", C.update.subject.error({
+w(), P(), C("error", S.update.subject.error({
 roleName: t.roleRef.name,
 subjectName: n.name
-}), C.errorReason({
+}), S.errorReason({
 httpErr: e("getErrorDetails")(a)
 }));
 });
@@ -5199,7 +5199,7 @@ return e ? a + (h(e, "description") || "") : "";
 var T = function(e, t, n, r) {
 var o = {
 alerts: {},
-detailsMarkup: C.remove.areYouSure.html.subject({
+detailsMarkup: S.remove.areYouSure.html.subject({
 roleName: n,
 kindName: v(t),
 subjectName: e
@@ -5208,17 +5208,17 @@ okButtonText: "Remove",
 okButtonClass: "btn-danger",
 cancelButtonText: "Cancel"
 };
-return _.isEqual(e, r) && (o.detailsMarkup = C.remove.areYouSure.html.self({
+return _.isEqual(e, r) && (o.detailsMarkup = S.remove.areYouSure.html.self({
 roleName: n,
 subjectName: e
 }), u.isLastRole(a.user.metadata.name, a.roleBindings) && (o.alerts.currentUserLabelRole = {
 type: "error",
-message: C.notice.yourLastRole({
+message: S.notice.yourLastRole({
 roleName: n
 })
 })), _.isEqual(t, "ServiceAccount") && _.startsWith(n, "system:") && (o.alerts.editingServiceAccountRole = {
 type: "error",
-message: C.warning.serviceAccount()
+message: S.warning.serviceAccount()
 }), o;
 };
 i.withUser().then(function(e) {
@@ -5263,15 +5263,15 @@ mode: {
 edit: !!a.mode.edit && t
 }
 });
-}), S("success", C.remove.success({
+}), C("success", S.remove.success({
 roleName: i,
 subjectName: n
 })));
 }, function(t) {
-S("error", C.remove.error({
+C("error", S.remove.error({
 roleName: i,
 subjectName: n
-}), C.errorReason({
+}), S.errorReason({
 httpErr: e("getErrorDetails")(t)
 }));
 });
@@ -5288,7 +5288,7 @@ roleRef: {
 name: n.metadata.name
 }
 });
-i && _.some(i.subjects, o) ? S("error", C.update.subject.exists({
+i && _.some(i.subjects, o) ? C("error", S.update.subject.exists({
 roleName: n.metadata.name,
 subjectName: e
 })) : i ? R(i, o, r) : j(n, o);
@@ -5756,7 +5756,7 @@ title: n.deployment
 } ];
 var v = a.getPreferredVersion("builds"), h = a.getPreferredVersion("replicasets"), y = a.getPreferredVersion("limitranges"), b = a.getPreferredVersion("imagestreams");
 e.deploymentsVersion = a.getPreferredVersion("deployments"), e.eventsVersion = a.getPreferredVersion("events"), e.horizontalPodAutoscalersVersion = a.getPreferredVersion("horizontalpodautoscalers"), e.healthCheckURL = d.healthCheckURL(n.project, "Deployment", n.deployment, e.deploymentsVersion.group);
-var C = [];
+var S = [];
 p.get(n.project).then(_.spread(function(a, d) {
 function p() {
 c.getLabelSelector().isEmpty() || !_.isEmpty(e.replicaSetsForDeployment) || _.isEmpty(e.unfilteredReplicaSetsForDeployment) ? delete e.alerts["filter-hiding-all"] : e.alerts["filter-hiding-all"] = {
@@ -5765,20 +5765,20 @@ details: "The active filters are hiding all rollout history."
 };
 }
 e.project = a, e.projectContext = d;
-var S = {}, w = function() {
-i.getHPAWarnings(e.deployment, e.autoscalers, S, a).then(function(t) {
+var C = {}, w = function() {
+i.getHPAWarnings(e.deployment, e.autoscalers, C, a).then(function(t) {
 e.hpaWarnings = t;
 });
 };
 r.get(e.deploymentsVersion, n.deployment, d, {
 errorNotification: !1
 }).then(function(t) {
-e.loaded = !0, e.deployment = t, w(), C.push(r.watchObject(e.deploymentsVersion, n.deployment, d, function(t, n) {
+e.loaded = !0, e.deployment = t, w(), S.push(r.watchObject(e.deploymentsVersion, n.deployment, d, function(t, n) {
 "DELETED" === n && (e.alerts.deleted = {
 type: "warning",
 message: "This deployment has been deleted."
 }), e.deployment = t, e.updatingPausedState = !1, w(), s.fetchReferencedImageStreamImages([ t.spec.template ], e.imagesByDockerReference, g, d);
-})), C.push(r.watch(h, d, function(n) {
+})), S.push(r.watch(h, d, function(n) {
 e.emptyMessage = "No deployments to show";
 var a = n.by("metadata.name");
 a = m.filterForController(a, t), e.inProgressDeployment = _.chain(a).filter("status.replicas").length > 1, e.unfilteredReplicaSetsForDeployment = o.sortByRevision(a), e.replicaSetsForDeployment = c.getLabelSelector().select(e.unfilteredReplicaSetsForDeployment), p(), c.addLabelSuggestionsFromResources(e.unfilteredReplicaSetsForDeployment, e.labelSuggestions), c.setLabelSuggestions(e.labelSuggestions);
@@ -5790,13 +5790,13 @@ message: 404 === n.status ? "This deployment can not be found, it may have been 
 details: t("getErrorDetails")(n)
 };
 }), r.list(y, d).then(function(e) {
-S = e.by("metadata.name"), w();
-}), C.push(r.watch(b, d, function(t) {
+C = e.by("metadata.name"), w();
+}), S.push(r.watch(b, d, function(t) {
 var n = t.by("metadata.name");
 s.buildDockerRefMapForImageStreams(n, g), e.deployment && s.fetchReferencedImageStreamImages([ e.deployment.spec.template ], e.imagesByDockerReference, g, d), l.log("imagestreams (subscribe)", e.imageStreams);
-})), C.push(r.watch(e.horizontalPodAutoscalersVersion, d, function(t) {
+})), S.push(r.watch(e.horizontalPodAutoscalersVersion, d, function(t) {
 e.autoscalers = i.filterHPA(t.by("metadata.name"), "Deployment", n.deployment), w();
-})), C.push(r.watch(v, d, function(t) {
+})), S.push(r.watch(v, d, function(t) {
 e.builds = t.by("metadata.name"), l.log("builds (subscribe)", e.builds);
 })), c.onActiveFiltersChanged(function(t) {
 e.$evalAsync(function() {
@@ -5831,7 +5831,7 @@ cancelButtonText: "Cancel"
 f.removeVolume(e.deployment, t, d);
 });
 }, e.$on("$destroy", function() {
-r.unwatchAll(C);
+r.unwatchAll(S);
 });
 }));
 } ]), angular.module("openshiftConsole").controller("DeploymentConfigController", [ "$scope", "$filter", "$routeParams", "APIService", "BreadcrumbsService", "DataService", "DeploymentsService", "HPAService", "ImageStreamResolver", "ModalsService", "Navigate", "NotificationsService", "Logger", "ProjectsService", "StorageService", "LabelFilter", "labelNameFilter", function(e, t, n, a, r, o, i, s, c, l, u, d, m, p, f, g, v) {
@@ -5841,7 +5841,7 @@ name: n.deploymentconfig,
 kind: "DeploymentConfig",
 namespace: n.project
 }), e.emptyMessage = "Loading...", e.deploymentConfigsInstantiateVersion = a.getPreferredVersion("deploymentconfigs/instantiate"), e.deploymentConfigsVersion = a.getPreferredVersion("deploymentconfigs"), e.eventsVersion = a.getPreferredVersion("events"), e.horizontalPodAutoscalersVersion = a.getPreferredVersion("horizontalpodautoscalers");
-var y = a.getPreferredVersion("builds"), b = a.getPreferredVersion("imagestreams"), C = a.getPreferredVersion("limitranges"), S = a.getPreferredVersion("replicationcontrollers");
+var y = a.getPreferredVersion("builds"), b = a.getPreferredVersion("imagestreams"), S = a.getPreferredVersion("limitranges"), C = a.getPreferredVersion("replicationcontrollers");
 e.healthCheckURL = u.healthCheckURL(n.project, "DeploymentConfig", n.deploymentconfig, e.deploymentConfigsVersion.group);
 var w = t("mostRecent"), k = t("orderObjectsByDate"), P = [];
 p.get(n.project).then(_.spread(function(a, r) {
@@ -5872,7 +5872,7 @@ type: "error",
 message: 404 === n.status ? "This deployment configuration can not be found, it may have been deleted." : "The deployment configuration details could not be loaded.",
 details: 404 === n.status ? "Any remaining deployment history for this deployment will be shown." : t("getErrorDetails")(n)
 };
-}), P.push(o.watch(S, r, function(a, r, o) {
+}), P.push(o.watch(C, r, function(a, r, o) {
 var s = n.deploymentconfig;
 if (e.emptyMessage = "No deployments to show", r) {
 if (i.deploymentBelongsToConfig(o, n.deploymentconfig)) {
@@ -5900,7 +5900,7 @@ params: {
 labelSelector: v("deploymentConfig") + "=" + e.deploymentConfigName
 }
 }
-})), o.list(C, r).then(function(e) {
+})), o.list(S, r).then(function(e) {
 d = e.by("metadata.name"), p();
 }), P.push(o.watch(b, r, function(t) {
 var n = t.by("metadata.name");
@@ -5958,7 +5958,7 @@ o.unwatchAll(P);
 });
 }));
 } ]), angular.module("openshiftConsole").controller("ReplicaSetController", [ "$scope", "$filter", "$routeParams", "AuthorizationService", "BreadcrumbsService", "DataService", "DeploymentsService", "HPAService", "ImageStreamResolver", "Logger", "MetricsService", "ModalsService", "Navigate", "OwnerReferencesService", "PodsService", "ProjectsService", "StorageService", "keyValueEditorUtils", "kind", function(e, t, n, a, r, o, i, s, c, l, u, d, m, p, f, g, v, h, y) {
-var b = !1, C = t("annotation"), S = t("humanizeKind")(y), w = t("hasDeployment");
+var b = !1, S = t("annotation"), C = t("humanizeKind")(y), w = t("hasDeployment");
 switch (y) {
 case "ReplicaSet":
 e.resource = {
@@ -5993,7 +5993,7 @@ e.autoscalers = e.hpaForRS.concat(a);
 P.push(o.watch(e.resource, g, function(t) {
 var n, a = [];
 angular.forEach(t.by("metadata.name"), function(t) {
-(C(t, "deploymentConfig") || "") === e.deploymentConfigName && a.push(t);
+(S(t, "deploymentConfig") || "") === e.deploymentConfigName && a.push(t);
 }), n = i.getActiveDeployment(a), e.isActive = n && n.metadata.uid === e.replicaSet.metadata.uid, E();
 }));
 }, N = function() {
@@ -6001,10 +6001,10 @@ s.getHPAWarnings(e.replicaSet, e.autoscalers, e.limitRanges, u).then(function(t)
 e.hpaWarnings = t;
 });
 }, D = function(a) {
-var r = C(a, "deploymentConfig");
+var r = S(a, "deploymentConfig");
 if (r) {
 b = !0, e.deploymentConfigName = r;
-var i = C(a, "deploymentVersion");
+var i = S(a, "deploymentVersion");
 i && (e.logOptions.version = i), e.healthCheckURL = m.healthCheckURL(n.project, "DeploymentConfig", r), o.get("deploymentconfigs", r, g, {
 errorNotification: !1
 }).then(function(t) {
@@ -6083,7 +6083,7 @@ object: t
 }), P.push(o.watchObject(e.resource, n.replicaSet, g, function(t, n) {
 "DELETED" === n && (e.alerts.deleted = {
 type: "warning",
-message: "This " + S + " has been deleted."
+message: "This " + C + " has been deleted."
 }), e.replicaSet = t, R(t), N(), U(), e.deployment && A();
 })), e.deploymentConfigName && T(), P.push(o.watch("pods", g, function(t) {
 var n = t.by("metadata.name");
@@ -6092,7 +6092,7 @@ e.podsForDeployment = f.filterForOwner(n, e.replicaSet);
 }, function(a) {
 e.loaded = !0, e.alerts.load = {
 type: "error",
-message: "The " + S + " details could not be loaded.",
+message: "The " + C + " details could not be loaded.",
 details: t("getErrorDetails")(a)
 }, e.breadcrumbs = r.getBreadcrumbs({
 name: n.replicaSet,
@@ -6102,7 +6102,7 @@ namespace: n.project
 }), P.push(o.watch(e.resource, g, function(n, a, r) {
 e.replicaSets = n.by("metadata.name"), "ReplicationController" === y && (e.deploymentsByDeploymentConfig = i.associateDeploymentsToDeploymentConfig(e.replicaSets));
 var o, s;
-r && (o = C(r, "deploymentConfig"), s = r.metadata.name), e.deploymentConfigDeploymentsInProgress = e.deploymentConfigDeploymentsInProgress || {}, a ? "ADDED" === a || "MODIFIED" === a && t("deploymentIsInProgress")(r) ? (e.deploymentConfigDeploymentsInProgress[o] = e.deploymentConfigDeploymentsInProgress[o] || {}, e.deploymentConfigDeploymentsInProgress[o][s] = r) : "MODIFIED" === a && e.deploymentConfigDeploymentsInProgress[o] && delete e.deploymentConfigDeploymentsInProgress[o][s] : e.deploymentConfigDeploymentsInProgress = i.associateRunningDeploymentToDeploymentConfig(e.deploymentsByDeploymentConfig), r ? "DELETED" !== a && (r.causes = t("deploymentCauses")(r)) : angular.forEach(e.replicaSets, function(e) {
+r && (o = S(r, "deploymentConfig"), s = r.metadata.name), e.deploymentConfigDeploymentsInProgress = e.deploymentConfigDeploymentsInProgress || {}, a ? "ADDED" === a || "MODIFIED" === a && t("deploymentIsInProgress")(r) ? (e.deploymentConfigDeploymentsInProgress[o] = e.deploymentConfigDeploymentsInProgress[o] || {}, e.deploymentConfigDeploymentsInProgress[o][s] = r) : "MODIFIED" === a && e.deploymentConfigDeploymentsInProgress[o] && delete e.deploymentConfigDeploymentsInProgress[o][s] : e.deploymentConfigDeploymentsInProgress = i.associateRunningDeploymentToDeploymentConfig(e.deploymentsByDeploymentConfig), r ? "DELETED" !== a && (r.causes = t("deploymentCauses")(r)) : angular.forEach(e.replicaSets, function(e) {
 e.causes = t("deploymentCauses")(e);
 });
 })), P.push(o.watch("imagestreams", g, function(e) {
@@ -6385,7 +6385,7 @@ var b = function() {
 e.breadcrumbs.push({
 title: e.displayName
 });
-}, C = function() {
+}, S = function() {
 if (e.serviceInstance && e.parameterSchema) {
 s.unwatchAll(g), g = [], e.allowParametersReveal = o.canI("secrets", "get", e.projectName), e.parameterData = {}, e.opaqueParameterKeys = [];
 var t = e.allowParametersReveal ? "" : "*****";
@@ -6406,20 +6406,20 @@ c.warn("Unable to load parameters from secret " + _.get(t, "secretKeyRef.name"),
 }));
 });
 }
-}, S = function() {
+}, C = function() {
 if (e.plan && e.serviceClass && e.serviceInstance) {
 var t = _.get(e.plan, "spec.instanceUpdateParameterSchema"), n = _.size(_.get(t, "properties")) > 0 || _.get(e.serviceClass, "spec.planUpdatable") && _.size(e.servicePlans) > 1;
 e.editAvailable = n && !h(e.serviceInstance) && !_.get(e.serviceInstance, "status.asyncOpInProgress") && !_.get(e.serviceInstance, "metadata.deletionTimestamp");
 }
 }, w = function() {
-e.parameterFormDefinition = angular.copy(_.get(e.plan, "spec.externalMetadata.schemas.service_instance.update.openshift_form_definition")), e.parameterSchema = _.get(e.plan, "spec.instanceCreateParameterSchema"), C();
+e.parameterFormDefinition = angular.copy(_.get(e.plan, "spec.externalMetadata.schemas.service_instance.update.openshift_form_definition")), e.parameterSchema = _.get(e.plan, "spec.instanceCreateParameterSchema"), S();
 }, k = function() {
 var t = _.get(e.serviceInstance, "spec.clusterServicePlanRef.name");
 e.plan = _.find(e.servicePlans, {
 metadata: {
 name: t
 }
-}), w(), S();
+}), w(), C();
 }, P = function() {
 e.serviceClass && !p && (e.servicePlans ? k() : p = i.getServicePlansForServiceClass(e.serviceClass).then(function(t) {
 var n = _.get(e.serviceInstance, "spec.clusterServicePlanRef.name");
@@ -6435,7 +6435,7 @@ e.serviceClass = t, e.displayName = v(e.serviceInstance, e.serviceClass), b(), m
 e.loaded = !0, e.serviceInstance = t, "DELETED" === n && (e.alerts.deleted = {
 type: "warning",
 message: "This provisioned service has been deleted."
-}), j(), C(), S();
+}), j(), S(), C();
 };
 l.get(n.project).then(_.spread(function(a, o) {
 e.project = a, e.projectContext = o, s.get(e.serviceInstancesVersion, n.instance, o, {
@@ -7031,7 +7031,7 @@ e.$on("$destroy", b), u.get(a.project).then(_.spread(function(n, r) {
 e.project = n, e.context = r, i.canI("buildconfigs", "update", a.project) ? s.get("buildconfigs", a.buildconfig, r, {
 errorNotification: !1
 }).then(function(t) {
-e.buildConfig = t, f(), e.updatedBuildConfig = angular.copy(e.buildConfig), e.buildStrategy = h(e.updatedBuildConfig), e.strategyType = e.buildConfig.spec.strategy.type, e.envVars = e.buildStrategy.env || [], e.triggers = C(e.triggers, e.buildConfig.spec.triggers), e.sources = I(e.sources, e.buildConfig.spec.source), _.has(t, "spec.strategy.jenkinsPipelineStrategy.jenkinsfile") && (e.jenkinsfileOptions.type = "inline"), s.list("secrets", r).then(function(t) {
+e.buildConfig = t, f(), e.updatedBuildConfig = angular.copy(e.buildConfig), e.buildStrategy = h(e.updatedBuildConfig), e.strategyType = e.buildConfig.spec.strategy.type, e.envVars = e.buildStrategy.env || [], e.triggers = S(e.triggers, e.buildConfig.spec.triggers), e.sources = I(e.sources, e.buildConfig.spec.source), _.has(t, "spec.strategy.jenkinsPipelineStrategy.jenkinsfile") && (e.jenkinsfileOptions.type = "inline"), s.list("secrets", r).then(function(t) {
 var n = m.groupSecretsByType(t), a = _.mapValues(n, function(e) {
 return _.map(e, "metadata.name");
 });
@@ -7082,7 +7082,7 @@ details: "Reason: " + t("getErrorDetails")(n)
 };
 }) : c.toErrorPage("You do not have authority to update build config " + a.buildconfig + ".", "access_denied");
 }));
-var C = function(n, a) {
+var S = function(n, a) {
 function r(n, a) {
 return t("imageObjectRef")(n, e.projectName) === t("imageObjectRef")(a, e.projectName);
 }
@@ -7150,7 +7150,7 @@ e.aceLoaded = function(e) {
 var t = e.getSession();
 t.setOption("tabSize", 2), t.setOption("useSoftTabs", !0), e.$blockScrolling = 1 / 0;
 };
-var S = function(e) {
+var C = function(e) {
 return _.map(p.compactEntries(e), function(e) {
 return {
 sourcePath: e.name,
@@ -7252,7 +7252,7 @@ break;
 case "JenkinsPipeline":
 "path" === e.jenkinsfileOptions.type ? delete e.updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile : delete e.updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath;
 }
-switch (e.sources.images && !_.isEmpty(e.sourceImages) && (e.updatedBuildConfig.spec.source.images[0].paths = S(e.imageSourcePaths), e.updatedBuildConfig.spec.source.images[0].from = w(e.imageOptions.fromSource)), "None" === e.imageOptions.from.type ? delete h(e.updatedBuildConfig).from : h(e.updatedBuildConfig).from = w(e.imageOptions.from), "None" === e.imageOptions.to.type ? delete e.updatedBuildConfig.spec.output.to : e.updatedBuildConfig.spec.output.to = w(e.imageOptions.to), h(e.updatedBuildConfig).env = p.compactEntries(e.envVars), j(e.updatedBuildConfig.spec.source, _.head(e.secrets.picked.gitSecret), "sourceSecret"), j(h(e.updatedBuildConfig), _.head(e.secrets.picked.pullSecret), "pullSecret"), j(e.updatedBuildConfig.spec.output, _.head(e.secrets.picked.pushSecret), "pushSecret"), e.strategyType) {
+switch (e.sources.images && !_.isEmpty(e.sourceImages) && (e.updatedBuildConfig.spec.source.images[0].paths = C(e.imageSourcePaths), e.updatedBuildConfig.spec.source.images[0].from = w(e.imageOptions.fromSource)), "None" === e.imageOptions.from.type ? delete h(e.updatedBuildConfig).from : h(e.updatedBuildConfig).from = w(e.imageOptions.from), "None" === e.imageOptions.to.type ? delete e.updatedBuildConfig.spec.output.to : e.updatedBuildConfig.spec.output.to = w(e.imageOptions.to), h(e.updatedBuildConfig).env = p.compactEntries(e.envVars), j(e.updatedBuildConfig.spec.source, _.head(e.secrets.picked.gitSecret), "sourceSecret"), j(h(e.updatedBuildConfig), _.head(e.secrets.picked.pullSecret), "pullSecret"), j(e.updatedBuildConfig.spec.output, _.head(e.secrets.picked.pushSecret), "pushSecret"), e.strategyType) {
 case "Source":
 case "Docker":
 R(e.updatedBuildConfig.spec.source, e.secrets.picked.sourceSecrets);
@@ -7340,9 +7340,9 @@ type: "error",
 message: t,
 details: n
 };
-}, y = [], b = [], C = [];
+}, y = [], b = [], S = [];
 e.valueFromObjects = [];
-var S = function(e) {
+var C = function(e) {
 switch (e) {
 case "Recreate":
 return "recreateParams";
@@ -7404,18 +7404,18 @@ _.set(a, [ t.name, "triggerData" ], o);
 pullSecrets: angular.copy(e.deploymentConfig.spec.template.spec.imagePullSecrets) || [ {
 name: ""
 } ]
-}, e.volumeNames = _.map(e.deploymentConfig.spec.template.spec.volumes, "name"), e.strategyData = angular.copy(e.deploymentConfig.spec.strategy), e.originalStrategy = e.strategyData.type, e.strategyParamsPropertyName = S(e.strategyData.type), e.triggers.hasConfigTrigger = _.some(e.updatedDeploymentConfig.spec.triggers, {
+}, e.volumeNames = _.map(e.deploymentConfig.spec.template.spec.volumes, "name"), e.strategyData = angular.copy(e.deploymentConfig.spec.strategy), e.originalStrategy = e.strategyData.type, e.strategyParamsPropertyName = C(e.strategyData.type), e.triggers.hasConfigTrigger = _.some(e.updatedDeploymentConfig.spec.triggers, {
 type: "ConfigChange"
 }), "Custom" !== e.strategyData.type || _.has(e.strategyData, "customParams.environment") || (e.strategyData.customParams.environment = []), c.list("configmaps", r, null, {
 errorNotification: !1
 }).then(function(t) {
-b = g(t.by("metadata.name")), e.availableConfigMaps = b, e.valueFromObjects = b.concat(C);
+b = g(t.by("metadata.name")), e.availableConfigMaps = b, e.valueFromObjects = b.concat(S);
 }, function(e) {
 403 !== e.status && h("Could not load config maps", v(e));
 }), c.list("secrets", r, null, {
 errorNotification: !1
 }).then(function(t) {
-C = g(t.by("metadata.name")), e.availableSecrets = C, e.valueFromObjects = b.concat(C);
+S = g(t.by("metadata.name")), e.availableSecrets = S, e.valueFromObjects = b.concat(S);
 var n = p.groupSecretsByType(t), a = _.mapValues(n, function(e) {
 return _.map(e, "metadata.name");
 });
@@ -7461,13 +7461,13 @@ cancelButtonText: "No"
 }
 }
 }).result.then(function() {
-e.strategyData[t] = angular.copy(e.strategyData[S(e.originalStrategy)]);
+e.strategyData[t] = angular.copy(e.strategyData[C(e.originalStrategy)]);
 }, function() {
 e.strategyData[t] = {};
 });
 };
 e.strategyChanged = function() {
-var t = S(e.strategyData.type);
+var t = C(e.strategyData.type);
 w() ? k(t) : _.has(e.strategyData, t) || ("Custom" !== e.strategyData.type ? e.strategyData[t] = {} : e.strategyData[t] = {
 image: "",
 command: [],
@@ -7507,7 +7507,7 @@ if (e.disableInputs = !0, _.each(e.containerConfigByName, function(t, n) {
 _.find(e.updatedDeploymentConfig.spec.template.spec.containers, {
 name: n
 }).env = f.compactEntries(t.env);
-}), w() && delete e.strategyData[S(e.originalStrategy)], "Rolling" === e.strategyData.type) {
+}), w() && delete e.strategyData[C(e.originalStrategy)], "Rolling" === e.strategyData.type) {
 var a = e.strategyData[e.strategyParamsPropertyName].maxSurge, r = Number(a);
 "" === a ? e.strategyData[e.strategyParamsPropertyName].maxSurge = null : _.isFinite(r) && (e.strategyData[e.strategyParamsPropertyName].maxSurge = r);
 var o = e.strategyData[e.strategyParamsPropertyName].maxUnavailable, i = Number(o);
@@ -7907,7 +7907,7 @@ e.projectTemplates = t.by("metadata.name");
 }));
 }))) : l.toErrorPage("Catalog category " + r.category + "/" + r.subcategory + " not found.");
 } else l.toErrorPage("Catalog category " + r.category + " not found.");
-} ]), angular.module("openshiftConsole").controller("CreateFromImageController", [ "$scope", "$filter", "$parse", "$q", "$routeParams", "$uibModal", "APIService", "ApplicationGenerator", "DataService", "HPAService", "ImagesService", "LimitRangesService", "Logger", "MetricsService", "Navigate", "NotificationsService", "ProjectsService", "QuotaService", "SOURCE_URL_PATTERN", "SecretsService", "TaskList", "failureObjectNameFilter", "keyValueEditorUtils", function(e, t, n, a, r, o, i, s, c, l, u, d, m, p, f, g, v, h, y, b, C, S, w) {
+} ]), angular.module("openshiftConsole").controller("CreateFromImageController", [ "$scope", "$filter", "$parse", "$q", "$routeParams", "$uibModal", "APIService", "ApplicationGenerator", "DataService", "HPAService", "ImagesService", "LimitRangesService", "Logger", "MetricsService", "Navigate", "NotificationsService", "ProjectsService", "QuotaService", "SOURCE_URL_PATTERN", "SecretsService", "TaskList", "failureObjectNameFilter", "keyValueEditorUtils", function(e, t, n, a, r, o, i, s, c, l, u, d, m, p, f, g, v, h, y, b, S, C, w) {
 var k = t("displayName"), P = t("humanize");
 e.projectName = r.project, e.sourceURLPattern = y;
 var j = r.imageStream;
@@ -7929,14 +7929,14 @@ e.hideCPU || (e.cpuProblems = d.validatePodLimits(e.limitRanges, "cpu", [ e.cont
 c.list("limitranges", n).then(function(t) {
 e.limitRanges = t.by("metadata.name"), _.isEmpty(e.limitRanges) || e.$watch("container", i, !0);
 });
-var v, y, S = function() {
+var v, y, C = function() {
 e.scaling.autoscale ? e.showCPURequestWarning = !l.hasCPURequest([ e.container ], e.limitRanges, t) : e.showCPURequestWarning = !1;
 };
 c.list("resourcequotas", n).then(function(e) {
 v = e.by("metadata.name"), m.log("quotas", v);
 }), c.list("appliedclusterresourcequotas", n).then(function(e) {
 y = e.by("metadata.name"), m.log("cluster quotas", y);
-}), e.$watch("scaling.autoscale", S), e.$watch("container", S, !0), e.$watch("name", function(e, t) {
+}), e.$watch("scaling.autoscale", C), e.$watch("container", C, !0), e.$watch("name", function(e, t) {
 R.value && R.value !== t || (R.value = e);
 }), function(a) {
 a.name = r.name, a.imageName = j, a.imageTag = r.imageTag, a.namespace = r.namespace, a.buildConfig = {
@@ -8036,7 +8036,7 @@ started: "Creating application " + e.name + " in project " + e.projectDisplayNam
 success: "Created application " + e.name + " in project " + e.projectDisplayName(),
 failure: "Failed to create " + e.name + " in project " + e.projectDisplayName()
 }, o = {};
-C.clear(), C.add(t, o, r.project, function() {
+S.clear(), S.add(t, o, r.project, function() {
 var t = a.defer();
 return c.batch(D, n).then(function(n) {
 var a = [], r = !1;
@@ -8149,12 +8149,12 @@ k = [];
 var t = [], n = {};
 angular.forEach(e.objects, function(e) {
 if ("BuildConfig" === e.kind) {
-var a = S(b(e), h);
+var a = C(b(e), h);
 a && k.push({
 name: a,
 usesParameters: d(a)
 });
-var r = S(C(e), h);
+var r = C(S(e), h);
 r && (n[r] = !0);
 }
 "DeploymentConfig" === e.kind && (t = t.concat(p(e)));
@@ -8171,7 +8171,7 @@ return _.each(r.template.parameters, function(t) {
 e[t.name] = t.value;
 }), e;
 }
-var v = a.template, h = a.namespace || "", y = n("spec.template.spec.containers"), b = n("spec.strategy.sourceStrategy.from || spec.strategy.dockerStrategy.from || spec.strategy.customStrategy.from"), C = n("spec.output.to"), S = e("imageObjectRef");
+var v = a.template, h = a.namespace || "", y = n("spec.template.spec.containers"), b = n("spec.strategy.sourceStrategy.from || spec.strategy.dockerStrategy.from || spec.strategy.customStrategy.from"), S = n("spec.output.to"), C = e("imageObjectRef");
 if (v) {
 a.templateParamsMap && (r.prefillParameters = function() {
 try {
@@ -8557,17 +8557,17 @@ subpage: "Add Storage"
 var h = r.getPreferredVersion("resourcequotas"), y = r.getPreferredVersion("appliedclusterresourcequotas");
 d.get(t.project).then(_.spread(function(r, d) {
 if (n.project = r, o.canI(v, "update", t.project)) {
-var p = e("orderByDisplayName"), f = e("getErrorDetails"), b = e("generateName"), C = function(e, t) {
+var p = e("orderByDisplayName"), f = e("getErrorDetails"), b = e("generateName"), S = function(e, t) {
 n.disableInputs = !0, u.addNotification({
 id: "attach-pvc-error",
 type: "error",
 message: e,
 details: t
 });
-}, S = function() {
+}, C = function() {
 u.hideNotification("attach-pvc-error");
 };
-n.$on("$destroy", S);
+n.$on("$destroy", C);
 var w = function() {
 a.history.back();
 };
@@ -8588,7 +8588,7 @@ subpage: "Add Storage"
 var t = _.get(e, "spec.template");
 n.existingVolumeNames = m.getVolumeNames(t);
 }, function(e) {
-C(t.name + " could not be loaded.", f(e));
+S(t.name + " could not be loaded.", f(e));
 }), s.list(n.pvcVersion, d).then(function(e) {
 n.pvcs = p(e.by("metadata.name")), _.isEmpty(n.pvcs) || n.attach.persistentVolumeClaim || (n.attach.persistentVolumeClaim = _.head(n.pvcs));
 }), s.list(h, {
@@ -8600,7 +8600,7 @@ namespace: n.projectName
 }, function(e) {
 n.clusterQuotas = e.by("metadata.name"), n.outOfClaims = c.isAnyStorageQuotaExceeded(n.quotas, n.clusterQuotas);
 }), n.attachPVC = function() {
-if (n.disableInputs = !0, S(), n.attachPVCForm.$valid) {
+if (n.disableInputs = !0, C(), n.attachPVCForm.$valid) {
 n.attach.volumeName || (n.attach.volumeName = b("volume-"));
 var e = n.attach.resource, a = _.get(e, "spec.template"), r = n.attach.persistentVolumeClaim, o = n.attach.volumeName, i = n.attach.mountPath, c = n.attach.subPath, l = n.attach.readOnly;
 i && angular.forEach(a.spec.containers, function(e) {
@@ -8618,7 +8618,7 @@ message: "Persistent volume claim " + r.metadata.name + " added to " + g(t.kind)
 details: e
 }), w();
 }, function(e) {
-C("An error occurred attaching the persistent volume claim to the " + g(t.kind) + ".", f(e)), n.disableInputs = !1;
+S("An error occurred attaching the persistent volume claim to the " + g(t.kind) + ".", f(e)), n.disableInputs = !1;
 });
 }
 };
@@ -8663,10 +8663,10 @@ type: "error",
 message: e,
 details: t
 });
-}, C = function() {
+}, S = function() {
 u.hideNotification("add-config-volume-error");
 };
-a.$on("$destroy", C), a.addItem = function() {
+a.$on("$destroy", S), a.addItem = function() {
 a.attach.items.push({}), h();
 }, a.removeItem = function(e) {
 a.attach.items.splice(e, 1), h();
@@ -8732,15 +8732,15 @@ secretName: o.metadata.name,
 items: m
 };
 }
-i.spec.volumes = i.spec.volumes || [], i.spec.volumes.push(v), a.disableInputs = !0, C();
-var h = e("humanizeKind"), S = h(o.kind), w = h(n.kind);
+i.spec.volumes = i.spec.volumes || [], i.spec.volumes.push(v), a.disableInputs = !0, S();
+var h = e("humanizeKind"), C = h(o.kind), w = h(n.kind);
 c.update(g, t.metadata.name, a.targetObject, r).then(function() {
 u.addNotification({
 type: "success",
-message: "Successfully added " + S + " " + o.metadata.name + " to " + w + " " + n.name + "."
+message: "Successfully added " + C + " " + o.metadata.name + " to " + w + " " + n.name + "."
 }), y();
 }, function(e) {
-a.disableInputs = !1, b("An error occurred attaching the " + S + " to the " + w + ".", d(e));
+a.disableInputs = !1, b("An error occurred attaching the " + C + " to the " + w + ".", d(e));
 });
 }
 };
@@ -9513,7 +9513,7 @@ var e = p.createResources.length, t = p.updateResources.length;
 if (p.resourceKind.endsWith("List")) {
 var a = [];
 t > 0 && a.push(k()), e > 0 && a.push(w()), n.all(a).then(b);
-} else S();
+} else C();
 }
 function b() {
 var e, n;
@@ -9528,7 +9528,7 @@ resource: p.resource,
 isList: p.isList
 }) : (e = s.projectOverviewURL(p.input.selectedProject.metadata.name), t.url(e));
 }
-function C(e) {
+function S(e) {
 var t = r.objectToResourceGroupVersion(e);
 return t ? r.apiInfo(t) ? i.get(t, e.metadata.name, {
 namespace: p.input.selectedProject.metadata.name
@@ -9545,7 +9545,7 @@ message: r.unsupportedObjectKindOrVersion(e)
 message: r.invalidObjectKindOrVersion(e)
 }));
 }
-function S() {
+function C() {
 var t;
 _.isEmpty(p.createResources) ? (t = _.head(p.updateResources), i.update(r.kindToResource(t.kind), t.metadata.name, t, {
 namespace: p.input.selectedProject.metadata.name
@@ -9723,7 +9723,7 @@ add: !1
 var e = [];
 p.errorOccurred = !1, _.forEach(p.resourceList, function(t) {
 if (!g(t)) return p.errorOccurred = !0, !1;
-e.push(C(t));
+e.push(S(t));
 }), D().then(function(t) {
 p.input.selectedProject = t, n.all(e).then(function() {
 p.errorOccurred || (1 === p.createResources.length && "Template" === p.resourceList[0].kind ? v() : _.isEmpty(p.updateResources) ? l.getLatestQuotaAlerts(p.createResources, {
@@ -10598,15 +10598,15 @@ _.size(l) <= 100 ? (u = e("orderByDisplayName")(l), y = _.map(u, function(e) {
 return n(e, !1);
 })) : y = [ n(l[t], !0) ], h.empty(), h.append(y), h.append($('<option data-divider="true"></option>')), h.append($('<option value="">View All Projects</option>')), h.selectpicker("refresh");
 }
-}, C = function() {
+}, S = function() {
 return s.list().then(function(e) {
 l = e.by("metadata.name");
 });
-}, S = function() {
+}, C = function() {
 var e = a.project;
 r.currentProjectName !== e && (r.currentProjectName = e, r.chromeless = "chromeless" === a.view, e && !r.chromeless ? (_.set(n, "view.hasProject", !0), r.canIAddToProject = !1, o.getProjectRules(e).then(function() {
 r.currentProjectName === e && (r.canIAddToProject = o.canIAddToProject(e));
-}), C().then(function() {
+}), S().then(function() {
 r.currentProjectName && l && (l[r.currentProjectName] || (l[r.currentProjectName] = {
 metadata: {
 name: r.currentProjectName
@@ -10614,7 +10614,7 @@ name: r.currentProjectName
 }), r.currentProject = l[r.currentProjectName], b());
 })) : _.set(n, "view.hasProject", !1));
 };
-S(), r.$on("$routeChangeSuccess", S), h.selectpicker({
+C(), r.$on("$routeChangeSuccess", C), h.selectpicker({
 iconBase: "fa",
 tickIcon: "fa-check"
 }).change(function() {
@@ -11492,12 +11492,12 @@ pod: m.pod,
 containerName: e.containerMetric ? m.options.selectedContainer.name : "pod"
 }) : null;
 }
-function C() {
+function S() {
 A || (U = 0, _.each(m.metrics, function(e) {
 g(e), f(e);
 }));
 }
-function S(e) {
+function C(e) {
 if (!A) if (U++, m.noData) m.metricsError = {
 status: _.get(e, "status", 0),
 details: _.get(e, "data.errorMsg") || _.get(e, "statusText") || "Status code " + _.get(e, "status", 0)
@@ -11549,7 +11549,7 @@ id: e.metricID
 }), e);
 });
 });
-}), r.all(t).then(C, S).finally(function() {
+}), r.all(t).then(S, C).finally(function() {
 m.loaded = !0;
 });
 }
@@ -11721,7 +11721,7 @@ return e[0];
 function u(e) {
 k || (N = 0, t.showAverage = _.size(t.pods) > 5 || w, _.each(t.metrics, function(n) {
 var a, r = o(e, n), i = n.descriptor;
-w && n.compactCombineWith && (i = n.compactCombineWith, n.lastValue && (T[i].lastValue = (T[i].lastValue || 0) + n.lastValue)), C[i] ? (C[i].load(r), t.showAverage ? C[i].legend.hide() : C[i].legend.show()) : ((a = D(n)).data = r, C[i] = c3.generate(a));
+w && n.compactCombineWith && (i = n.compactCombineWith, n.lastValue && (T[i].lastValue = (T[i].lastValue || 0) + n.lastValue)), S[i] ? (S[i].load(r), t.showAverage ? S[i].legend.hide() : S[i].legend.show()) : ((a = D(n)).data = r, S[i] = c3.generate(a));
 }));
 }
 function d() {
@@ -11731,7 +11731,7 @@ function m() {
 return 60 * t.options.timeRange.value * 1e3;
 }
 function p() {
-return w ? "1mn" : Math.floor(m() / S) + "ms";
+return w ? "1mn" : Math.floor(m() / C) + "ms";
 }
 function f() {
 var e = _.find(t.pods, "metadata.namespace");
@@ -11770,7 +11770,7 @@ function h(e, n, a) {
 t.noData = !1;
 var r = _.initial(a), o = _.get(R, [ e, n ]);
 if (o) {
-var i = _.takeRight(o.concat(r), S);
+var i = _.takeRight(o.concat(r), C);
 _.set(R, [ e, n ], i);
 } else _.set(R, [ e, n ], r);
 }
@@ -11783,7 +11783,7 @@ t.loaded = !0;
 });
 }
 }
-var b, C = {}, S = 30, w = "compact" === t.profile, k = !1;
+var b, S = {}, C = 30, w = "compact" === t.profile, k = !1;
 t.uniqueID = s.uniqueID();
 var P, j, R = {}, I = w, E = function(e) {
 return e >= 1024;
@@ -11861,12 +11861,12 @@ R = {}, P = null, delete t.metricsError, y();
 I = !e, e && (!j || Date.now() > j + s.getDefaultUpdateInterval()) && y();
 };
 var A = r.$on("metrics.charts.resize", function() {
-s.redraw(C);
+s.redraw(S);
 });
 t.$on("$destroy", function() {
-b && (e.cancel(b), b = null), A && (A(), A = null), angular.forEach(C, function(e) {
+b && (e.cancel(b), b = null), A && (A(), A = null), angular.forEach(S, function(e) {
 e.destroy();
-}), C = null, k = !0;
+}), S = null, k = !0;
 });
 }
 };
@@ -11903,12 +11903,12 @@ t.$apply(function() {
 var e = l.getBoundingClientRect();
 t.fixedHeight ? t.showScrollLinks = e && e.height > t.fixedHeight : t.showScrollLinks = e && (e.top < 0 || e.bottom > g.clientHeight);
 });
-}, C = !1, S = function() {
-C ? C = !1 : t.$evalAsync(function() {
+}, S = !1, C = function() {
+S ? S = !1 : t.$evalAsync(function() {
 t.autoScrollActive = !1;
 });
 }, w = function() {
-u ? $(u).on("scroll", S) : m.on("scroll", S);
+u ? $(u).on("scroll", C) : m.on("scroll", C);
 }, k = function() {
 t.fixedHeight || p.affix({
 target: window,
@@ -11938,11 +11938,11 @@ n > 10 ? e() : (n++, P().is(":visible") && (j(), e()));
 }, 100);
 }
 }, I = _.debounce(function() {
-j(!0), b(), S();
+j(!0), b(), C();
 }, 100);
 m.on("resize", I);
 var E, T = function() {
-C = !0, d.scrollBottom(u);
+S = !0, d.scrollBottom(u);
 }, N = document.createDocumentFragment(), D = _.debounce(function() {
 l.appendChild(N), N = document.createDocumentFragment(), t.autoScrollActive && T(), t.showScrollLinks || b();
 }, 100, {
@@ -12036,7 +12036,7 @@ t.autoScrollActive = !t.autoScrollActive, t.autoScrollActive && T();
 goChromeless: d.chromelessLink,
 restartLogs: B
 }), t.$on("$destroy", function() {
-A(), m.off("resize", I), m.off("scroll", S), u && $(u).off("scroll", S);
+A(), m.off("resize", I), m.off("scroll", C), u && $(u).off("scroll", C);
 }), "deploymentconfigs/logs" === v && !h) return t.state = "empty", void (t.emptyStateMessage = "Logs are not available for this replication controller because it was not generated from a deployment configuration.");
 t.$watchGroup([ "name", "options.container", "run" ], B);
 } ],
@@ -12931,7 +12931,7 @@ onShow: function() {
 u && (u(), u = void 0), d && (d(), d = void 0), p.nextTitle = "Close", p.wizardComplete = !0, p.bindService();
 }
 };
-var C = function() {
+var S = function() {
 if (p.serviceClasses && p.servicePlans) {
 var e = "ServiceInstance" === p.target.kind ? p.target : p.serviceToBind;
 if (e) {
@@ -12942,15 +12942,15 @@ p.plan = p.servicePlans[n], p.parameterSchema = _.get(p.plan, "spec.serviceBindi
 }
 }
 };
-e.$watch("ctrl.serviceToBind", C), p.$onInit = function() {
+e.$watch("ctrl.serviceToBind", S), p.$onInit = function() {
 p.serviceSelection = {}, p.projectDisplayName = t("displayName")(p.project), p.podPresets = g("pod_presets"), p.parameterData = {}, p.steps = [ s, c, l ], p.hideBack = c.hidden;
 var e = n.getPreferredVersion("clusterserviceclasses");
 o.list(e, {}).then(function(e) {
-p.serviceClasses = e.by("metadata.name"), C(), h();
+p.serviceClasses = e.by("metadata.name"), S(), h();
 });
 var a = n.getPreferredVersion("clusterserviceplans");
 o.list(a, {}).then(function(e) {
-p.servicePlans = e.by("metadata.name"), C();
+p.servicePlans = e.by("metadata.name"), S();
 }), "ServiceInstance" === p.target.kind ? (p.bindType = "secret-only", p.appToBind = null, p.serviceToBind = p.target, p.podPresets && y()) : (p.bindType = "application", p.appToBind = p.target, b());
 }, p.$onChanges = function(e) {
 e.project && !e.project.isFirstChange() && (p.projectDisplayName = t("displayName")(p.project));
@@ -13066,7 +13066,7 @@ v.projectNameTaken = !1;
 v.noProjectsCantCreate = !0;
 }), f();
 };
-var b, C = function() {
+var b, S = function() {
 var e = {
 started: "Creating " + v.templateDisplayName + " in project " + h(v.selectedProject),
 success: "Created " + v.templateDisplayName + " in project " + h(v.selectedProject),
@@ -13099,7 +13099,7 @@ hasErrors: a
 project: v.selectedProject,
 template: v.template
 }) : o.toNextSteps(v.templateDisplayName, v.selectedProject.metadata.name);
-}, S = function(e) {
+}, C = function(e) {
 a.open({
 animation: !0,
 templateUrl: "views/modals/confirm.html",
@@ -13115,7 +13115,7 @@ cancelButtonText: "Cancel"
 };
 }
 }
-}).result.then(C);
+}).result.then(S);
 }, w = {}, k = function() {
 i.hideNotification("process-template-error"), _.each(w, function(e) {
 !e.id || "error" !== e.type && "warning" !== e.type || i.hideNotification(e.id);
@@ -13127,7 +13127,7 @@ w = w.concat(t), _.filter(w, {
 type: "error"
 }).length ? (v.disableInputs = !1, _.each(w, function(e) {
 e.id = _.uniqueId("process-template-alert-"), i.addNotification(e);
-})) : w.length ? (S(w), v.disableInputs = !1) : C();
+})) : w.length ? (C(w), v.disableInputs = !1) : S();
 }, j = function() {
 if (_.has(v.selectedProject, "metadata.uid")) return t.when(v.selectedProject);
 var n = v.selectedProject.metadata.name, a = v.selectedProject.metadata.annotations["new-display-name"], r = e("description")(v.selectedProject);
@@ -13187,7 +13187,7 @@ return -1 !== e.indexOf("icon-") ? "font-icon " + e : e;
 }
 function u() {
 var e = _.get(b, "template.metadata.annotations.iconClass", "fa fa-clone");
-return C(e);
+return S(e);
 }
 function d() {
 b.steps || (b.steps = [ b.selectStep, b.infoStep, b.configStep, b.resultsStep ]);
@@ -13218,7 +13218,7 @@ b.unfilteredProjects = [];
 w();
 });
 }
-var y, b = this, C = t("imageForIconClass"), S = t("annotation");
+var y, b = this, S = t("imageForIconClass"), C = t("annotation");
 b.selectStep = {
 id: "projectTemplates",
 label: "Selection",
@@ -13291,7 +13291,7 @@ appliedFilters: [],
 onFilterChange: g
 }, n.project || (b.showProjectName = !0);
 }, b.$onChanges = function(e) {
-e.template && b.template && (d(), b.iconClass = l(), b.image = u(), b.docUrl = S(b.template, "openshift.io/documentation-url"), b.supportUrl = S(b.template, "openshift.io/support-url"), b.vendor = S(b.template, "openshift.io/provider-display-name")), e.useProjectTemplate && d();
+e.template && b.template && (d(), b.iconClass = l(), b.image = u(), b.docUrl = C(b.template, "openshift.io/documentation-url"), b.supportUrl = C(b.template, "openshift.io/support-url"), b.vendor = C(b.template, "openshift.io/provider-display-name")), e.useProjectTemplate && d();
 }, e.$on("templateInstantiated", function(e, t) {
 b.selectedProject = t.project, b.currentStep = b.resultsStep.label;
 }), b.$onDestroy = function() {
@@ -13304,7 +13304,7 @@ _.isFunction(e) && e();
 }, b.onProjectSelected = function(t) {
 b.selectedProject = t, b.configStep.valid = e.$ctrl.form.$valid && b.selectedProject;
 }, b.templateSelected = function(e) {
-b.selectedTemplate = e, b.template = _.get(e, "resource"), b.selectStep.valid = !!e, b.iconClass = l(), b.image = u(), b.docUrl = S(b.template, "openshift.io/documentation-url"), b.supportUrl = S(b.template, "openshift.io/support-url"), b.vendor = S(b.template, "openshift.io/provider-display-name");
+b.selectedTemplate = e, b.template = _.get(e, "resource"), b.selectStep.valid = !!e, b.iconClass = l(), b.image = u(), b.docUrl = C(b.template, "openshift.io/documentation-url"), b.supportUrl = C(b.template, "openshift.io/support-url"), b.vendor = C(b.template, "openshift.io/provider-display-name");
 }, b.templateProjectChange = function() {
 b.templateProjectName = _.get(b.templateProject, "metadata.name"), b.catalogItems = {}, b.templateSelected(), a.getProjectCatalogItems(b.templateProjectName, !1, !0).then(_.spread(function(e, t) {
 b.catalogItems = e, b.totalCount = b.catalogItems.length, g(), t && i.addNotification({
@@ -13389,7 +13389,7 @@ s.template = null;
 var e = s.onDialogClosed();
 return _.isFunction(e) && e(), s.wizardDone = !1, !0;
 }, s.stepChanged = function(e) {
-"results" === e.stepId ? (s.nextButtonTitle = "Close", s.wizardDone = !0) : s.nextButtonTitle = "Create";
+s.currentStep = e.title, "results" === e.stepId ? (s.nextButtonTitle = "Close", s.wizardDone = !0) : s.nextButtonTitle = "Create";
 }, s.currentStep = "YAML / JSON", s.nextCallback = function(e) {
 return "file" === e.stepId ? (s.importFile(), !1) : "template" === e.stepId ? (s.instantiateTemplate(), !1) : "results" !== e.stepId || (s.close(), !1);
 };
@@ -14038,11 +14038,11 @@ var y = function() {
 if (_.has(n.input.selectedProject, "metadata.uid")) return t.when(n.input.selectedProject);
 var a = n.input.selectedProject.metadata.name, r = n.input.selectedProject.metadata.annotations["new-display-name"], o = e("description")(n.input.selectedProject);
 return l.create(a, r, o);
-}, b = e("stripTag"), C = e("stripSHA"), S = e("humanizeKind"), w = function(e) {
+}, b = e("stripTag"), S = e("stripSHA"), C = e("humanizeKind"), w = function(e) {
 return e.length > 24 ? e.substring(0, 24) : e;
 }, k = function() {
 var e = _.last(n.import.name.split("/"));
-return e = C(e), e = b(e), e = w(e);
+return e = S(e), e = b(e), e = w(e);
 };
 n.findImage = function() {
 n.loading = !0, i.findImage(n.imageName, {
@@ -14130,13 +14130,13 @@ var a, r = !_.isEmpty(t.failure);
 a = r ? (a = _.map(t.failure, function(e) {
 return {
 type: "error",
-message: "Cannot create " + S(e.object.kind).toLowerCase() + ' "' + e.object.metadata.name + '". ',
+message: "Cannot create " + C(e.object.kind).toLowerCase() + ' "' + e.object.metadata.name + '". ',
 details: e.data.message
 };
 })).concat(_.map(t.success, function(e) {
 return {
 type: "success",
-message: "Created " + S(e.kind).toLowerCase() + ' "' + e.metadata.name + '" successfully. '
+message: "Created " + C(e.kind).toLowerCase() + ' "' + e.metadata.name + '" successfully. '
 };
 })) : [ {
 type: "success",
@@ -14503,18 +14503,18 @@ namespace: l.apiObject.metadata.namespace
 }).then(function(e) {
 d = h(e.by("metadata.name")), l.valueFromObjects = d.concat(m);
 });
-}, C = function() {
+}, S = function() {
 f("secrets", "list") && n.list("secrets", {
 namespace: l.apiObject.metadata.namespace
 }).then(function(e) {
 m = h(e.by("metadata.name")), l.valueFromObjects = d.concat(m);
 });
-}, S = function() {
-p || (p = !0, b(), C());
+}, C = function() {
+p || (p = !0, b(), S());
 }, _ = function(e, n) {
 o = v(e.kind), i = e.metadata.name, s = t.objectToResourceGroupVersion(e), l.canIUpdate = f(s, "update"), c ? c.finally(function() {
 y(e, n);
-}) : y(e, n), l.containers = a.getContainers(l.updatedObject), l.disableValueFrom || l.ngReadonly || !l.canIUpdate || S();
+}) : y(e, n), l.containers = a.getContainers(l.updatedObject), l.disableValueFrom || l.ngReadonly || !l.canIUpdate || C();
 };
 l.$onChanges = function(e) {
 e.apiObject && e.apiObject.currentValue && _(e.apiObject.currentValue, e.apiObject.previousValue);
@@ -14620,13 +14620,13 @@ var l, u, d = _.get(i, "DISABLE_GLOBAL_EVENT_WATCH"), m = e("isIE")(), p = this,
 e || (p.drawerHidden = !0);
 }, b = function(e, t) {
 return _.get(e, "params.project") !== _.get(t, "params.project");
-}, C = function(e) {
+}, S = function(e) {
 return s.get("projects", e, {}, {
 errorNotification: !1
 }).then(function(e) {
 return h[e.metadata.name] = e, e;
 });
-}, S = function(t, n) {
+}, C = function(t, n) {
 return {
 heading: e("displayName")(h[t]),
 project: h[t],
@@ -14673,7 +14673,7 @@ return _.assign({}, e[n], t[n]);
 return _.orderBy(e, [ "event.lastTimestamp", "event.metadata.resourceVersion" ], [ "desc", "desc" ]);
 }, D = function() {
 o.$evalAsync(function() {
-p.notificationGroups = [ S(r.project, N(T(g, v))) ], k();
+p.notificationGroups = [ C(r.project, N(T(g, v))) ], k();
 });
 }, A = function() {
 _.each(f, function(e) {
@@ -14709,7 +14709,7 @@ skipDigest: !0
 }, F = _.once(function(e, t) {
 B(), l = o.$on("NotificationsService.onNotificationAdded", t);
 }), x = function() {
-C(r.project).then(function() {
+S(r.project).then(function() {
 O(r.project, L), F(r.project, U), y(r.project), D();
 });
 };


### PR DESCRIPTION
Clicking back from the "Template Configuration" step can prevent the
user from being able to click next again in the wizard in the Import
YAML dialog. This is because the `ctrl.currentStep` value is not reset
to the first step title after the user clicks back. Sine the wizard is
watching for changes to `ctrl.currentStep` and the value never changes
when the user clicks next again, the wizard doesn't advance.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1526215

/kind bug
/assign @benjaminapetersen 