### PR TITLE
Bug 1526538 - Allow users to clear edits by uploading same file

### DIFF
--- a/app/scripts/directives/oscFileInput.js
+++ b/app/scripts/directives/oscFileInput.js
@@ -6,14 +6,15 @@ angular.module('openshiftConsole')
       restrict: 'E',
       scope: {
         model: "=",
-        required: "=",
-        disabled: "=ngDisabled",
-        readonly: "=ngReadonly",
-        showTextArea: '=',
+        required: "<",
+        disabled: "<ngDisabled",
+        readonly: "<ngReadonly",
+        showTextArea: '<',
         // Hide the clear value link.
-        hideClear: '=?',
+        hideClear: '<?',
         helpText: "@?",
-        dropZoneId: "@?"
+        dropZoneId: "@?",
+        onFileAdded: "<?"
       },
       templateUrl: 'views/directives/osc-file-input.html',
       link: function(scope, element){
@@ -75,6 +76,12 @@ angular.module('openshiftConsole')
 
         inputFileField.change(function() {
           addFile(inputFileField[0].files[0]);
+          // In some cases, the user might want to load the same file twice.
+          // For instance, the user might want to replace their edits in the
+          // import YAML dialog by loading the same file again. Clear the value
+          // so that the change event is triggered again, even if the same file
+          // is added.
+          inputFileField[0].value = "";
         });
 
         // Add listeners for the dropZone element
@@ -173,6 +180,10 @@ angular.module('openshiftConsole')
             scope.$apply(function(){
               scope.fileName = file.name;
               scope.model = reader.result;
+              var cb = scope.onFileAdded;
+              if (_.isFunction(cb)) {
+                cb(reader.result);
+              }
             });
           };
           reader.onerror = function(e){

--- a/app/scripts/directives/uiAceYaml.js
+++ b/app/scripts/directives/uiAceYaml.js
@@ -96,15 +96,12 @@
 
     };
 
-    $scope.$watch(function() {
-      return ctrl.fileUpload;
-    }, function(content, previous) {
-      if (content === previous) {
-        return;
-      }
-
+    // Use a file added callback instead of just watching for `fileUpload`
+    // changes so that we can replace the editor contents if the user has made
+    // changes when the same file is added again.
+    ctrl.onFileAdded = function(content) {
       ctrl.model = content;
-    });
+    };
 
     ctrl.$onInit = function() {
       if (ctrl.resource) {

--- a/app/views/directives/ui-ace-yaml.html
+++ b/app/views/directives/ui-ace-yaml.html
@@ -6,7 +6,8 @@
       drop-zone-id="yaml-file"
       help-text="Upload a file by dragging & dropping, selecting it, or pasting from the clipboard."
       ng-disabled="false"
-      hide-clear="true"></osc-file-input>
+      hide-clear="true"
+      on-file-added="$ctrl.onFileAdded"></osc-file-input>
 
     <div class="edit-yaml-errors">
       <!--

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -9836,13 +9836,14 @@ return {
 restrict: "E",
 scope: {
 model: "=",
-required: "=",
-disabled: "=ngDisabled",
-readonly: "=ngReadonly",
-showTextArea: "=",
-hideClear: "=?",
+required: "<",
+disabled: "<ngDisabled",
+readonly: "<ngReadonly",
+showTextArea: "<",
+hideClear: "<?",
 helpText: "@?",
-dropZoneId: "@?"
+dropZoneId: "@?",
+onFileAdded: "<?"
 },
 templateUrl: "views/directives/osc-file-input.html",
 link: function(t, n) {
@@ -9851,6 +9852,8 @@ var r = new FileReader();
 r.onloadend = function() {
 t.$apply(function() {
 t.fileName = n.name, t.model = r.result;
+var e = t.onFileAdded;
+_.isFunction(e) && e(r.result);
 });
 }, r.onerror = function(n) {
 t.supportsFileUpload = !1, t.uploadError = !0, e.error("Could not read file", n);
@@ -9910,7 +9913,7 @@ c || n.find(".drag-and-drop-zone").removeClass("show-drag-and-drop-zone");
 }), t.cleanInputValues = function() {
 t.model = "", t.fileName = "", l[0].value = "";
 }, l.change(function() {
-r(l[0].files[0]);
+r(l[0].files[0]), l[0].value = "";
 }), t.$on("$destroy", function() {
 $(i).off(), $(document).off("drop." + o).off("dragenter." + o).off("dragover." + o).off("dragleave." + o);
 });
@@ -14546,11 +14549,9 @@ e.$evalAsync(function() {
 n.form.$setValidity("yamlValid", t);
 });
 };
-e.$watch(function() {
-return n.fileUpload;
-}, function(e, t) {
-e !== t && (n.model = e);
-}), n.$onInit = function() {
+n.onFileAdded = function(e) {
+n.model = e;
+}, n.$onInit = function() {
 n.resource && (n.model = jsyaml.safeDump(n.resource, {
 sortKeys: !0
 }));

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -9382,7 +9382,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   $templateCache.put('views/directives/ui-ace-yaml.html',
     "<ng-form name=\"$ctrl.form\">\n" +
     "<div class=\"form-group\" id=\"yaml-file\">\n" +
-    "<osc-file-input ng-if=\"$ctrl.showFileInput\" model=\"$ctrl.fileUpload\" drop-zone-id=\"yaml-file\" help-text=\"Upload a file by dragging & dropping, selecting it, or pasting from the clipboard.\" ng-disabled=\"false\" hide-clear=\"true\"></osc-file-input>\n" +
+    "<osc-file-input ng-if=\"$ctrl.showFileInput\" model=\"$ctrl.fileUpload\" drop-zone-id=\"yaml-file\" help-text=\"Upload a file by dragging & dropping, selecting it, or pasting from the clipboard.\" ng-disabled=\"false\" hide-clear=\"true\" on-file-added=\"$ctrl.onFileAdded\"></osc-file-input>\n" +
     "<div class=\"edit-yaml-errors\">\n" +
     "\n" +
     "<div ng-if=\"firstError = $ctrl.annotations.error[0]\">\n" +


### PR DESCRIPTION
In the import YAML dialog, let users clear any edits they've made
locally by uploading the same file again.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1526538

/assign @benjaminapetersen 
/kind bug