### PR TITLE
[WIP] fix(bug 1525819): Add backdrop static option to fromFile confirmation modal

### DIFF
--- a/app/scripts/directives/fromFile.js
+++ b/app/scripts/directives/fromFile.js
@@ -54,6 +54,7 @@ angular.module("openshiftConsole")
             animation: true,
             templateUrl: 'views/modals/confirm.html',
             controller: 'ConfirmModalController',
+            backdrop: 'static',
             resolve: {
               modalConfig: function() {
                 return {


### PR DESCRIPTION
## Description

uib-modal option `backdrop: "static"` prevents the modal from being
dismissed if user clicks outside of the modal dialog.

Fixes [bugzilla bug 1525819](https://bugzilla.redhat.com/show_bug.cgi?id=1525819) / Issue #2609 

/kind bug