### PR TITLE
Make warning message more accurate when adding invalid secret/configMap

### DIFF
--- a/app/views/directives/add-config-to-application.html
+++ b/app/views/directives/add-config-to-application.html
@@ -39,7 +39,7 @@
           <div class="has-warning" ng-if="ctrl.hasInvalidEnvVars">
             <div class="help-block">
               <span class="pf-icon pficon-warning-triangle-o" aria-hidden="true"></span>
-              Some of the keys for {{ctrl.apiObject.kind | humanizeKind}} <strong>{{ctrl.apiObject.metadata.name}}</strong> are not valid environment variable names and will not be added.
+              {{ctrl.apiObject.kind | humanizeKind | upperFirst}} <strong>{{ctrl.apiObject.metadata.name}}</strong> contains keys that are not valid environment variable names. Only {{ctrl.apiObject.kind | humanizeKind}} keys with valid names will be added as environment variables.
             </div>
           </div>
           <div class="form-group">

--- a/app/views/directives/edit-environment-from.html
+++ b/app/views/directives/edit-environment-from.html
@@ -62,7 +62,8 @@
             </ui-select>
           </div>
           <div class="has-warning" ng-if="$ctrl.hasInvalidEnvVar(entry.selectedEnvFrom.data)">
-            <div class="help-block">Some of the keys for {{entry.selectedEnvFrom.kind | humanizeKind}} <strong>{{entry.selectedEnvFrom.metadata.name}}</strong> are not valid environment variable names and will not be added.</div>
+            <div class="help-block">{{entry.selectedEnvFrom.kind | humanizeKind | upperFirst}} <strong>{{entry.selectedEnvFrom.metadata.name}}</strong> contains keys that are not valid environment variable names. Only {{entry.selectedEnvFrom.kind | humanizeKind}} keys with valid names will be added as environment variables.
+            </div>
           </div>
         </div>
       </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5758,7 +5758,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"has-warning\" ng-if=\"ctrl.hasInvalidEnvVars\">\n" +
     "<div class=\"help-block\">\n" +
     "<span class=\"pf-icon pficon-warning-triangle-o\" aria-hidden=\"true\"></span>\n" +
-    "Some of the keys for {{ctrl.apiObject.kind | humanizeKind}} <strong>{{ctrl.apiObject.metadata.name}}</strong> are not valid environment variable names and will not be added.\n" +
+    "{{ctrl.apiObject.kind | humanizeKind | upperFirst}} <strong>{{ctrl.apiObject.metadata.name}}</strong> contains keys that are not valid environment variable names. Only {{ctrl.apiObject.kind | humanizeKind}} keys with valid names will be added as environment variables.\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"form-group\">\n" +
@@ -6722,7 +6722,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</ui-select>\n" +
     "</div>\n" +
     "<div class=\"has-warning\" ng-if=\"$ctrl.hasInvalidEnvVar(entry.selectedEnvFrom.data)\">\n" +
-    "<div class=\"help-block\">Some of the keys for {{entry.selectedEnvFrom.kind | humanizeKind}} <strong>{{entry.selectedEnvFrom.metadata.name}}</strong> are not valid environment variable names and will not be added.</div>\n" +
+    "<div class=\"help-block\">{{entry.selectedEnvFrom.kind | humanizeKind | upperFirst}} <strong>{{entry.selectedEnvFrom.metadata.name}}</strong> contains keys that are not valid environment variable names. Only {{entry.selectedEnvFrom.kind | humanizeKind}} keys with valid names will be added as environment variables.\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
This fix is based from https://bugzilla.redhat.com/show_bug.cgi?id=1529467 where we suggested that best fix would be just warn user that the envVar is invalid.
@jwforres @spadgett PTAL