### PR TITLE
Fix incorrect apiGroup for roles causing dupes on membership page

### DIFF
--- a/app/scripts/services/membership/roles.js
+++ b/app/scripts/services/membership/roles.js
@@ -7,15 +7,15 @@ angular
     APIService,
     DataService) {
 
-    var roleBindingsVersion = APIService.getPreferredVersion('rolebindings');
-    var clusterRoleBindingsVersion = APIService.getPreferredVersion('clusterroles');
+    var rolesVersion = APIService.getPreferredVersion('roles');
+    var clusterRolesVersion = APIService.getPreferredVersion('clusterroles');
 
     var listAllRoles = function(context) {
       return $q.all([
         DataService
-          .list(roleBindingsVersion, context, null),
+          .list(rolesVersion, context, null),
         DataService
-          .list(clusterRoleBindingsVersion, {}, null)
+          .list(clusterRolesVersion, {}, null)
       ]);
     };
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2476,7 +2476,7 @@ return _.sortBy(r, "sortOrder");
 }
 };
 } ]), angular.module("openshiftConsole").factory("RolesService", [ "$q", "APIService", "DataService", function(e, t, n) {
-var r = t.getPreferredVersion("rolebindings"), a = t.getPreferredVersion("clusterroles");
+var r = t.getPreferredVersion("roles"), a = t.getPreferredVersion("clusterroles");
 return {
 listAllRoles: function(t) {
 return e.all([ n.list(r, t, null), n.list(a, {}, null) ]);


### PR DESCRIPTION
Fixes #2619 

I'm surprised the page worked & the bug was this subtle with this error. 

@jwforres @spadgett 
