### PR TITLE
[3.7] Bug 1532182 - Handle missing service class for instance

### DIFF
--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -1343,6 +1343,9 @@ function OverviewController($scope,
       // Get the service class for this instance. Returns a promise.
       fetchServiceClass = function(instance) {
         var serviceClassName = ServiceInstancesService.getServiceClassNameForInstance(instance);
+        if (!serviceClassName) {
+          return $q.when();
+        }
 
         var serviceClass = _.get(state, ['serviceClasses', serviceClassName]);
         if (serviceClass) {
@@ -1365,6 +1368,9 @@ function OverviewController($scope,
       // Get the service plan for this instance. Returns a promise.
       fetchServicePlan = function(instance) {
         var servicePlanName = ServiceInstancesService.getServicePlanNameForInstance(instance);
+        if (!servicePlanName) {
+          return $q.when();
+        }
 
         // Check if we already have the service plan or if a request is already in flight.
         var servicePlan = _.get(state, ['servicePlans', servicePlanName]);

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -448,14 +448,18 @@ pollInterval: 6e4
 }));
 var o, i, s = {}, c = {};
 l.SERVICE_CATALOG_ENABLED && B(H, "watch") && (o = function(e) {
-var t = I.getServiceClassNameForInstance(e), a = _.get(J, [ "serviceClasses", t ]);
+var t = I.getServiceClassNameForInstance(e);
+if (!t) return n.when();
+var a = _.get(J, [ "serviceClasses", t ]);
 return a ? n.when(a) : (s[t] || (s[t] = d.get(z, t, {}).then(function(e) {
 return J.serviceClasses[t] = e, e;
 }).finally(function() {
 delete c[t];
 })), s[t]);
 }, i = function(e) {
-var t = I.getServicePlanNameForInstance(e), a = _.get(J, [ "servicePlans", t ]);
+var t = I.getServicePlanNameForInstance(e);
+if (!t) return n.when();
+var a = _.get(J, [ "servicePlans", t ]);
 return a ? n.when(a) : (c[t] || (c[t] = d.get(G, t, {}).then(function(e) {
 return J.servicePlans[t] = e, e;
 }).finally(function() {


### PR DESCRIPTION
Avoid display problems on the overview when a service instance
references a non-existent service class or service plan.

/kind bug
/assign @jwforres 

3.7 backport of #2635