### PR TITLE
Whitelist service catalog resources for templates

### DIFF
--- a/app/scripts/constants.js
+++ b/app/scripts/constants.js
@@ -147,6 +147,8 @@ angular.extend(window.OPENSHIFT_CONSTANTS, {
     {resource: 'routes', group: 'route.openshift.io'},
     {resource: 'secrets', group: ''},
     {resource: 'serviceaccounts', group: ''},
+    {resource: 'servicebindings', group: 'servicecatalog.k8s.io'},
+    {resource: 'serviceinstances', group: 'servicecatalog.k8s.io'},
     {resource: 'services', group: ''},
     {resource: 'statefulsets', group: 'apps'}
   ],

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -701,6 +701,12 @@ group: ""
 resource: "serviceaccounts",
 group: ""
 }, {
+resource: "servicebindings",
+group: "servicecatalog.k8s.io"
+}, {
+resource: "serviceinstances",
+group: "servicecatalog.k8s.io"
+}, {
 resource: "services",
 group: ""
 }, {


### PR DESCRIPTION
Don't warn when users instantiate a template with service instances or
service bindings.

/kind bug
/assign @jwforres 