### PR TITLE
[WIP] Fix bug 1529045: Editing buildConfig env vars can incorrectly display error messages

### DIFF
--- a/app/scripts/controllers/buildConfig.js
+++ b/app/scripts/controllers/buildConfig.js
@@ -98,6 +98,7 @@ angular.module('openshiftConsole')
       NotificationsService.hideNotification("save-bc-env-error");
       $scope.envVars = _.filter($scope.envVars, 'name');
       buildStrategy($scope.updatedBuildConfig).env = keyValueEditorUtils.compactEntries(angular.copy($scope.envVars));
+      $scope.forms.bcEnvVars.$setPristine();
       DataService
         .update($scope.buildConfigsVersion, $routeParams.buildconfig, $scope.updatedBuildConfig, $scope.projectContext)
         .then(function success() {
@@ -105,8 +106,8 @@ angular.module('openshiftConsole')
             type: "success",
             message: "Environment variables for build config " + $scope.buildConfigName + " were successfully updated."
           });
-          $scope.forms.bcEnvVars.$setPristine();
         }, function error(e) {
+          $scope.forms.bcEnvVars.$setDirty();
           NotificationsService.addNotification({
             id: "save-bc-env-error",
             type: "error",

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5451,13 +5451,13 @@ e.updatedBuildConfig = angular.copy(t), e.envVars = f(e.updatedBuildConfig).env 
 e.compareTriggers = function(e, t) {
 return _.isNumber(e.value) ? -1 : "ConfigChange" === e.value ? -1 : "ConfigChange" === t.value ? 1 : "ImageChange" === e.value ? -1 : "ImageChange" === t.value ? 1 : e.value.localeCompare(t.value);
 }, e.saveEnvVars = function() {
-l.hideNotification("save-bc-env-error"), e.envVars = _.filter(e.envVars, "name"), f(e.updatedBuildConfig).env = m.compactEntries(angular.copy(e.envVars)), i.update(e.buildConfigsVersion, n.buildconfig, e.updatedBuildConfig, e.projectContext).then(function() {
+l.hideNotification("save-bc-env-error"), e.envVars = _.filter(e.envVars, "name"), f(e.updatedBuildConfig).env = m.compactEntries(angular.copy(e.envVars)), e.forms.bcEnvVars.$setPristine(), i.update(e.buildConfigsVersion, n.buildconfig, e.updatedBuildConfig, e.projectContext).then(function() {
 l.addNotification({
 type: "success",
 message: "Environment variables for build config " + e.buildConfigName + " were successfully updated."
-}), e.forms.bcEnvVars.$setPristine();
+});
 }, function(n) {
-l.addNotification({
+e.forms.bcEnvVars.$setDirty(), l.addNotification({
 id: "save-bc-env-error",
 type: "error",
 message: "An error occurred updating environment variables for build config " + e.buildConfigName + ".",


### PR DESCRIPTION
This bug appears to be a race condition associated with slow internet connections.  The `update` response and `webSocket` data may hit the browser inconsistently, causing the reported problem.

The fix here is to immediately declare the form `$pristine` and submit the update, backing out & setting the form back to `$dirty` only if the update fails.

