### PR TITLE
Prohibit close of warning dialog by clicking on backdrop

### DIFF
--- a/app/scripts/directives/fromFile.js
+++ b/app/scripts/directives/fromFile.js
@@ -52,6 +52,7 @@ angular.module("openshiftConsole")
         var launchConfirmationDialog = function(alerts) {
           var modalInstance = $uibModal.open({
             animation: true,
+            backdrop: 'static',
             templateUrl: 'views/modals/confirm.html',
             controller: 'ConfirmModalController',
             resolve: {

--- a/app/scripts/directives/processTemplate.js
+++ b/app/scripts/directives/processTemplate.js
@@ -151,6 +151,7 @@
     var launchConfirmationDialog = function(alerts) {
       var modalInstance = $uibModal.open({
         animation: true,
+        backdrop: 'static',
         templateUrl: 'views/modals/confirm.html',
         controller: 'ConfirmModalController',
         resolve: {

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -9770,6 +9770,7 @@ p.projectNameTaken = !1;
 var R = function(e) {
 r.open({
 animation: !0,
+backdrop: "static",
 templateUrl: "views/modals/confirm.html",
 controller: "ConfirmModalController",
 resolve: {
@@ -13216,6 +13217,7 @@ template: v.template
 }, C = function(e) {
 r.open({
 animation: !0,
+backdrop: "static",
 templateUrl: "views/modals/confirm.html",
 controller: "ConfirmModalController",
 resolve: {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1525819

Note:  this PR covers the case listed in the BZ plus a similar case in the process template directive (both include the warning: "We checked your application for potential problems. Please confirm you still want to create this application.").  

Presumably these are the only cases where we want to prohibit closing the modal by clicking in the background.