### PR TITLE
prevent wrapping of text in terminal

### DIFF
--- a/app/styles/_container-terminal.less
+++ b/app/styles/_container-terminal.less
@@ -97,4 +97,5 @@ kubernetes-container-terminal {
   font-family: "Monospace Regular", "DejaVu Sans Mono", Menlo, Monaco, Consolas, monospace;
   font-size: 12px;
   line-height: 1em;
+  white-space: nowrap;
 }

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5929,7 +5929,7 @@ alerts+.chromeless .log-loading-msg{margin-top:130px}
 .container-terminal-wrapper .fullscreen-toggle a:active,.container-terminal-wrapper .fullscreen-toggle a:focus,.container-terminal-wrapper .fullscreen-toggle a:hover{color:#fff;text-decoration:none}
 .container-terminal-wrapper .fullscreen-toggle .go-fullscreen{display:block}
 .container-terminal-wrapper .terminal-actions .btn{background:0 0;font-weight:400;border-radius:0;color:#9c9c9c;cursor:pointer;font-size:18px;padding:5px}
-.terminal-font,kubernetes-container-terminal .terminal{font-family:"Monospace Regular","DejaVu Sans Mono",Menlo,Monaco,Consolas,monospace;font-size:12px;line-height:1em}
+.terminal-font,kubernetes-container-terminal .terminal{font-family:"Monospace Regular","DejaVu Sans Mono",Menlo,Monaco,Consolas,monospace;font-size:12px;line-height:1em;white-space:nowrap}
 .container-terminal-wrapper .terminal-actions .btn,.container-terminal-wrapper .terminal-actions .btn.active,.container-terminal-wrapper .terminal-actions .btn:active,.container-terminal-wrapper .terminal-actions .btn[disabled],fieldset[disabled] .container-terminal-wrapper .terminal-actions .btn{background-color:transparent;-webkit-box-shadow:none;box-shadow:none}
 .container-terminal-wrapper .terminal-actions .btn,.container-terminal-wrapper .terminal-actions .btn:active,.container-terminal-wrapper .terminal-actions .btn:focus,.container-terminal-wrapper .terminal-actions .btn:hover{border-color:transparent}
 .container-terminal-wrapper .terminal-actions .btn:focus,.container-terminal-wrapper .terminal-actions .btn:hover{background-color:transparent}


### PR DESCRIPTION
I'm encountering a weird bug with some of our terminals with a big fancy prompts, it basically breaks at a wrong place:

![openshift_web_console](https://user-images.githubusercontent.com/750999/34689912-c8019578-f47c-11e7-8cf6-15ba4a955327.jpg)

see the `$PS1` output, it should not be breaking after `[idg-standard-public-` but somehow it does.

It's clearly the dash that causes the browser to think it should break the line. if I remove the dash it will not break:

![openshift_web_console2](https://user-images.githubusercontent.com/750999/34689981-0acbc2b6-f47d-11e7-9792-99560e016bd9.jpg)

After setting the `white-space: nowrap;` it all works perfectly
![openshift_web_console](https://user-images.githubusercontent.com/750999/34689993-165133d2-f47d-11e7-85e9-e8dee9638f79.jpg)

Browser: Chrome 63
OpenShift Container Platform v3.6.173.0.49