### PR TITLE
Fix console error when drawer.countUnreadNotifications() is called

### DIFF
--- a/app/scripts/directives/notifications/notificationDrawerWrapper.js
+++ b/app/scripts/directives/notifications/notificationDrawerWrapper.js
@@ -342,7 +342,7 @@
         rootScopeWatches.push($rootScope.$on('NotificationDrawerWrapper.clear', function(event, notification) {
           EventsService.markCleared(notification.uid);
           remove(notification);
-          drawer.countUnreadNotifications();
+          countUnreadNotifications();
         }));
       };
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -14878,7 +14878,7 @@ h.drawerHidden = !h.drawerHidden;
 })), y.push(r.$on("NotificationDrawerWrapper.hide", function() {
 h.drawerHidden = !0;
 })), y.push(r.$on("NotificationDrawerWrapper.clear", function(e, t) {
-u.markCleared(t.uid), T(t), h.countUnreadNotifications();
+u.markCleared(t.uid), T(t), R();
 }));
 };
 h.$onInit = function() {


### PR DESCRIPTION
Found this while testing quota in my Openshift Online acct.  Doesn't affect functionality (as the count is updated on markRead already), but is an ugly mark in the dev console.  ☹️ 

![screen shot 2018-01-08 at 4 10 09 pm](https://user-images.githubusercontent.com/280512/34692506-6d91829e-f48e-11e7-804b-9d5d1f43ce67.png)

I should have written tests for this directive.   Boo.