### PR TITLE
Fix membershipService.mapRolebindingsForUI to properly list custom Roles in the output

### DIFF
--- a/app/scripts/services/membership/membership.js
+++ b/app/scripts/services/membership/membership.js
@@ -2,7 +2,7 @@
 
 angular
   .module('openshiftConsole')
-  .factory('MembershipService', function($filter, Constants) {
+  .factory('MembershipService', function($filter, APIService, Constants) {
 
     var annotation = $filter('annotation');
 
@@ -88,8 +88,8 @@ angular
       var mapForUI = _.reduce(
                       rolebindings,
                       function(result, rolebinding) {
-                        // hmm. dont like this here
-                        var roleKey = uniqueKey(rolebinding.roleRef.namespace ? 'Role' : 'ClusterRole', rolebinding.roleRef.name);
+                        // matched keyedRoles below for lookups
+                        var roleKey = uniqueKey(rolebinding.roleRef.apiGroup, rolebinding.roleRef.kind, rolebinding.roleRef.name);
                         // each subject, (user, bob; group: hobbits)
                         _.each(rolebinding.subjects, function(subject) {
                           var subjectKey = uniqueKey(subject.namespace, subject.name);
@@ -128,7 +128,9 @@ angular
       return _.reduce(
               roles,
               function(result, role) {
-                result[uniqueKey(role.kind, role.metadata.name)] = role;
+                var group = APIService.parseGroupVersion(role.apiVersion).group;
+                var roleKey = uniqueKey(group, role.kind, role.metadata.name);
+                result[roleKey] = role;
                 return result;
               }, {});
     };

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2419,13 +2419,13 @@ t[e.tag] = t[e.tag] || {}, t[e.tag].name = e.tag, t[e.tag].status = angular.copy
 }), t;
 }
 };
-}), angular.module("openshiftConsole").factory("MembershipService", [ "$filter", "Constants", function(e, t) {
+}), angular.module("openshiftConsole").factory("MembershipService", [ "$filter", "APIService", "Constants", function(e, t, n) {
 e("annotation");
-var n = function() {
+var r = function() {
 return _.reduce(_.slice(arguments), function(e, t, n) {
 return t ? _.isEqual(n, 0) ? t : e + "-" + t : e;
 }, "");
-}, r = function() {
+}, a = function() {
 return {
 User: {
 kind: "User",
@@ -2464,9 +2464,10 @@ name: "SystemGroup",
 subjects: {}
 }
 };
-}, a = function(e) {
-return _.reduce(e, function(e, t) {
-return e[n(t.kind, t.metadata.name)] = t, e;
+}, o = function(e) {
+return _.reduce(e, function(e, n) {
+var a = t.parseGroupVersion(n.apiVersion).group;
+return e[r(a, n.kind, n.metadata.name)] = n, e;
 }, {});
 };
 return {
@@ -2475,11 +2476,11 @@ return _.sortBy(e, "metadata.name");
 },
 filterRoles: function(e) {
 return _.filter(e, function(e) {
-return "Role" === e.kind || _.includes(t.MEMBERSHIP_WHITELIST, e.metadata.name);
+return "Role" === e.kind || _.includes(n.MEMBERSHIP_WHITELIST, e.metadata.name);
 });
 },
 mapRolesForUI: function(e, t) {
-return _.merge(a(e), a(t));
+return _.merge(o(e), o(t));
 },
 isLastRole: function(e, t) {
 return 1 === _.filter(t, function(t) {
@@ -2488,16 +2489,16 @@ name: e
 });
 }).length;
 },
-getSubjectKinds: r,
+getSubjectKinds: a,
 mapRolebindingsForUI: function(e, t) {
-var r = _.reduce(e, function(e, r) {
-var a = n(r.roleRef.namespace ? "Role" : "ClusterRole", r.roleRef.name);
-return _.each(r.subjects, function(r) {
-var o = n(r.namespace, r.name);
-e[r.kind].subjects[o] || (e[r.kind].subjects[o] = {
-name: r.name,
+var n = _.reduce(e, function(e, n) {
+var a = r(n.roleRef.apiGroup, n.roleRef.kind, n.roleRef.name);
+return _.each(n.subjects, function(n) {
+var o = r(n.namespace, n.name);
+e[n.kind].subjects[o] || (e[n.kind].subjects[o] = {
+name: n.name,
 roles: {}
-}, r.namespace && (e[r.kind].subjects[o].namespace = r.namespace)), _.includes(e[r.kind].subjects[o].roles, a) || t[a] && (e[r.kind].subjects[o].roles[a] = t[a]);
+}, n.namespace && (e[n.kind].subjects[o].namespace = n.namespace)), _.includes(e[n.kind].subjects[o].roles, a) || t[a] && (e[n.kind].subjects[o].roles[a] = t[a]);
 }), e;
 }, {
 User: {
@@ -2537,7 +2538,7 @@ name: "SystemGroup",
 subjects: {}
 }
 });
-return _.sortBy(r, "sortOrder");
+return _.sortBy(n, "sortOrder");
 }
 };
 } ]), angular.module("openshiftConsole").factory("RolesService", [ "$q", "APIService", "DataService", function(e, t, n) {


### PR DESCRIPTION
Fixes [bugzilla 1533753](https://bugzilla.redhat.com/show_bug.cgi?id=1533753)

- Maps custom `Roles` correctly now by checking the `Role` kind, not just assuming the presence of a `namespace` means the `Role` is not a `ClusterRole`.
- Updates tests to ensure a `Role` is covered
- Fixes (my) poorly written tests that made this harder to debug than it should have been, considering it was such a tiny update.

