### PR TITLE
Add link to re-enable percentage slider when editing service weights on the create route page

### DIFF
--- a/app/scripts/directives/oscRouting.js
+++ b/app/scripts/directives/oscRouting.js
@@ -292,6 +292,13 @@ angular.module("openshiftConsole")
           }
         });
 
+        scope.$watch('controls.hideSlider', function(hideSlider){
+          if(!hideSlider && scope.route.alternateServices.length === 1){
+            initializingSlider = true;
+            scope.controls.rangeSlider = scope.weightAsPercentage(scope.route.to.weight);
+          }
+        });
+
         scope.$watch('controls.rangeSlider', function(weight, previous) {
           // Don't update the routes if we're setting the initial slider value.
           if (initializingSlider) {

--- a/app/views/directives/osc-routing.html
+++ b/app/views/directives/osc-routing.html
@@ -160,19 +160,27 @@
           </div>
         </div>
       </div>
-
+      
       <div ng-repeat="alternate in route.alternateServices" class="form-group">
-        <osc-routing-service model="alternate"
-                             service-options="alternateServiceOptions"
-                             all-services="servicesByName"
-                             is-alternate="true"
-                             show-weight="route.alternateServices.length > 1 || controls.hideSlider">
+        <osc-routing-service 
+          model="alternate"
+          service-options="alternateServiceOptions"
+          all-services="servicesByName"
+          is-alternate="true"
+          show-weight="route.alternateServices.length > 1 || controls.hideSlider">
         </osc-routing-service>
-        <a href="" ng-click="route.alternateServices.splice($index, 1)">Remove Service</a>
-        <span ng-if="$last && route.alternateServices.length < alternateServiceOptions.length">
-          <span class="action-divider">|</span>
-          <a href="" ng-click="addAlternateService()">Add Another Service</a>
-        </span>
+        <div class="row">
+          <div class="col-sm-6">
+            <button type="button" class="btn btn-link" ng-click="route.alternateServices.splice($index, 1)">Remove Service</button>
+            <span ng-if="$last && route.alternateServices.length < alternateServiceOptions.length">
+              <span class="action-divider">|</span>
+              <button type="button" class="btn btn-link" ng-click="addAlternateService()">Add Another Service</button>
+            </span>
+          </div>
+          <div ng-if="route.alternateServices.length === 1 && controls.hideSlider" class="col-sm-6">
+            <button type="button" class="btn btn-link" ng-click="controls.hideSlider = false">Edit Weights Using Percentage Slider</button>
+          </div>
+        </div>
       </div>
       <div ng-repeat="duplicate in duplicateServices" class="has-error mar-bottom-lg">
         <span class="help-block">
@@ -216,7 +224,7 @@
         </datalist>
         <div class="help-block" id="weight-slider-help">
           Percentage of traffic sent to each service. Drag the slider to adjust the values or
-          <a href="" ng-click="controls.hideSlider = true">edit weights as integers</a>.
+          <button type="button" class="btn btn-link" ng-click="controls.hideSlider = true">edit weights as integers</button>.
         </div>
       </div>
     </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10144,6 +10144,8 @@ if (0 === e && _.has(r, "route.to.weight") && delete r.route.to.weight, 1 === e)
 if (0 === r.route.to.weight && 0 === r.route.alternateServices[0].weight) return void (r.controls.hideSlider = !0);
 m = !0, r.controls.rangeSlider = r.weightAsPercentage(r.route.to.weight);
 }
+}), r.$watch("controls.hideSlider", function(e) {
+e || 1 !== r.route.alternateServices.length || (m = !0, r.controls.rangeSlider = r.weightAsPercentage(r.route.to.weight));
 }), r.$watch("controls.rangeSlider", function(e, t) {
 m ? m = !1 : e !== t && (e = parseInt(e, 10), _.set(r, "route.to.weight", e), _.set(r, "route.alternateServices[0].weight", 100 - e));
 });

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8522,11 +8522,18 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-repeat=\"alternate in route.alternateServices\" class=\"form-group\">\n" +
     "<osc-routing-service model=\"alternate\" service-options=\"alternateServiceOptions\" all-services=\"servicesByName\" is-alternate=\"true\" show-weight=\"route.alternateServices.length > 1 || controls.hideSlider\">\n" +
     "</osc-routing-service>\n" +
-    "<a href=\"\" ng-click=\"route.alternateServices.splice($index, 1)\">Remove Service</a>\n" +
+    "<div class=\"row\">\n" +
+    "<div class=\"col-sm-6\">\n" +
+    "<button type=\"button\" class=\"btn btn-link\" ng-click=\"route.alternateServices.splice($index, 1)\">Remove Service</button>\n" +
     "<span ng-if=\"$last && route.alternateServices.length < alternateServiceOptions.length\">\n" +
     "<span class=\"action-divider\">|</span>\n" +
-    "<a href=\"\" ng-click=\"addAlternateService()\">Add Another Service</a>\n" +
+    "<button type=\"button\" class=\"btn btn-link\" ng-click=\"addAlternateService()\">Add Another Service</button>\n" +
     "</span>\n" +
+    "</div>\n" +
+    "<div ng-if=\"route.alternateServices.length === 1 && controls.hideSlider\" class=\"col-sm-6\">\n" +
+    "<button type=\"button\" class=\"btn btn-link\" ng-click=\"controls.hideSlider = false\">Edit Weights Using Percentage Slider</button>\n" +
+    "</div>\n" +
+    "</div>\n" +
     "</div>\n" +
     "<div ng-repeat=\"duplicate in duplicateServices\" class=\"has-error mar-bottom-lg\">\n" +
     "<span class=\"help-block\">\n" +
@@ -8560,7 +8567,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</datalist>\n" +
     "<div class=\"help-block\" id=\"weight-slider-help\">\n" +
     "Percentage of traffic sent to each service. Drag the slider to adjust the values or\n" +
-    "<a href=\"\" ng-click=\"controls.hideSlider = true\">edit weights as integers</a>.\n" +
+    "<button type=\"button\" class=\"btn btn-link\" ng-click=\"controls.hideSlider = true\">edit weights as integers</button>.\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +


### PR DESCRIPTION
A link now appears next to the alternate service action links to re-enable the slider once it is disabled. Fixes [Bugzilla Bug 1533818](https://bugzilla.redhat.com/show_bug.cgi?id=1533818)

![screenshot-localhost-9000-2018-01-12-17-31-45-372](https://user-images.githubusercontent.com/22625502/34897938-8ec75762-f7be-11e7-813f-0b6fb2946b71.png)
