### PR TITLE
Use new clusterResourceOverridesEnabled flag

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -456,7 +456,6 @@ angular
   })
   .constant("LOGGING_URL", _.get(window.OPENSHIFT_CONFIG, "loggingURL"))
   .constant("METRICS_URL", _.get(window.OPENSHIFT_CONFIG, "metricsURL"))
-  .constant("LIMIT_REQUEST_OVERRIDES", _.get(window.OPENSHIFT_CONFIG, "limitRequestOverrides"))
   // A (very) basic regex to determine if a URL is an absolute URL, enough to
   // warn the user the Git URL probably won't work. This should only be used
   // as a sanity test and shouldn't block submitting the form. Rely on the API
@@ -553,8 +552,8 @@ angular
     };
     // Show inactivity logout modal.
     // Before the the modal is shown the handler for checking the changes in local storage is detached.
-    // After the the modal is closed or dismissed the handler will be attached again. This is because of 
-    // the fact that the handler is attached 
+    // After the the modal is closed or dismissed the handler will be attached again. This is because of
+    // the fact that the handler is attached
     function showLogoutModal() {
       if (isLocalLogoutModalShown) {
         return false;
@@ -580,7 +579,7 @@ angular
       });
     }
 
-    // Need to check for changes in last interaction so the interval can be restarted. 
+    // Need to check for changes in last interaction so the interval can be restarted.
     $(window).on('storage', function (event) {
       if (event.originalEvent.key === lastInteractionKey) {
         restartCheckInteractionInterval();

--- a/app/scripts/constants.js
+++ b/app/scripts/constants.js
@@ -60,13 +60,17 @@ angular.extend(window.OPENSHIFT_CONSTANTS, {
     // default should remain last, add new links above
     "default":                 "welcome/index.html"
   },
+
   // Maps links names to URL's where the CLI tools can be downloaded, may point directly to files or to external pages in a CDN, for example.
   CLI: {
     "Latest Release":          "https://github.com/openshift/origin/releases/latest"
   },
-  // The default CPU target percentage for horizontal pod autoscalers created or edited in the web console.
-  // This value is set in the HPA when the input is left blank.
-  DEFAULT_HPA_CPU_TARGET_PERCENT: 80,
+
+  // Optional default CPU target percentage for horizontal pod autoscalers
+  // created in the web console. This value is prefilled in the HPA form. No
+  // value is prefilled by default. Should be an integer value if specified
+  // (for instance, `80`).
+  DEFAULT_HPA_CPU_TARGET_PERCENT: null,
 
   // true indicates that deployment metrics should be disabled on the web console overview
   DISABLE_OVERVIEW_METRICS: false,
@@ -111,7 +115,7 @@ angular.extend(window.OPENSHIFT_CONSTANTS, {
 
 
   // Set to number of minutes after which a modal with countdown should appear.
-  // When set to anything else then positive integer the inactivity timeout won't be enable. 
+  // When set to anything else then positive integer the inactivity timeout won't be enable.
   INACTIVITY_TIMEOUT_PERIOD: 0,
 
   // only resources from the namespaces listed below can be utilized with create from url (/create)
@@ -666,5 +670,17 @@ angular.extend(window.OPENSHIFT_CONSTANTS, {
     'icon-wildfly': 'wildfly.svg',
     'icon-wordpress': 'wordpress.svg',
     'icon-zend': 'zend.svg'
-  }
+  },
+
+  CLUSTER_RESOURCE_OVERRIDES_EXEMPT_PROJECT_NAMES: [
+    'openshift',
+    'kubernetes',
+    'kube'
+  ],
+
+  CLUSTER_RESOURCE_OVERRIDES_EXEMPT_PROJECT_PREFIXES: [
+    'openshift-',
+    'kubernetes-',
+    'kube-'
+  ]
 });

--- a/app/scripts/controllers/create/createFromImage.js
+++ b/app/scripts/controllers/create/createFromImage.js
@@ -76,6 +76,7 @@ angular.module("openshiftConsole")
         if($routeParams.sourceURI) {
           $scope.sourceURIinParams = true;
         }
+        $scope.hasClusterResourceOverrides = LimitRangesService.hasClusterResourceOverrides(project);
         function initAndValidate(scope){
 
           scope.name = $routeParams.name;
@@ -225,9 +226,7 @@ angular.module("openshiftConsole")
         }
 
         var validatePodLimits = function() {
-          if (!$scope.hideCPU) {
-            $scope.cpuProblems = LimitRangesService.validatePodLimits($scope.limitRanges, 'cpu', [$scope.container], project);
-          }
+          $scope.cpuProblems = LimitRangesService.validatePodLimits($scope.limitRanges, 'cpu', [$scope.container], project);
           $scope.memoryProblems = LimitRangesService.validatePodLimits($scope.limitRanges, 'memory', [$scope.container], project);
         };
 
@@ -239,7 +238,7 @@ angular.module("openshiftConsole")
         });
 
         var checkCPURequest = function() {
-          if (!$scope.scaling.autoscale) {
+          if (!$scope.scaling.autoscale || $scope.hasClusterResourceOverrides) {
             $scope.showCPURequestWarning = false;
             return;
           }

--- a/app/scripts/controllers/edit/autoscaler.js
+++ b/app/scripts/controllers/edit/autoscaler.js
@@ -109,7 +109,7 @@ angular.module('openshiftConsole')
               },
               minReplicas: $scope.autoscaling.minReplicas,
               maxReplicas: $scope.autoscaling.maxReplicas,
-              targetCPUUtilizationPercentage: $scope.autoscaling.targetCPU || $scope.autoscaling.defaultTargetCPU || null
+              targetCPUUtilizationPercentage: $scope.autoscaling.targetCPU
             }
           };
 
@@ -139,7 +139,7 @@ angular.module('openshiftConsole')
           hpa.metadata.labels = keyValueEditorUtils.mapEntries(keyValueEditorUtils.compactEntries($scope.labels));
           hpa.spec.minReplicas = $scope.autoscaling.minReplicas;
           hpa.spec.maxReplicas = $scope.autoscaling.maxReplicas;
-          hpa.spec.targetCPUUtilizationPercentage = $scope.autoscaling.targetCPU || $scope.autoscaling.defaultTargetCPU || null;
+          hpa.spec.targetCPUUtilizationPercentage = $scope.autoscaling.targetCPU;
 
           DataService.update(horizontalPodAutoscalerVersion, hpa.metadata.name, hpa, context)
             .then(function(hpa) { // Success

--- a/app/scripts/controllers/setLimits.js
+++ b/app/scripts/controllers/setLimits.js
@@ -85,6 +85,7 @@ angular.module('openshiftConsole')
     ProjectsService
       .get($routeParams.project)
       .then(_.spread(function(project, context) {
+        $scope.hideCPU = LimitRangesService.hasClusterResourceOverrides(project);
 
         var resourceGroupVersion = {
           resource: APIService.kindToResource($routeParams.kind),

--- a/app/scripts/directives/oscAutoscaling.js
+++ b/app/scripts/directives/oscAutoscaling.js
@@ -5,15 +5,13 @@ angular.module("openshiftConsole")
    * Widget for entering autoscaling information
    */
   .directive("oscAutoscaling",
-             function(HPAService,
-                      LimitRangesService,
+             function(Constants,
+                      HPAService,
                       DNS1123_SUBDOMAIN_VALIDATION) {
     return {
       restrict: 'E',
       scope: {
         autoscaling: "=model",
-        // Needed to determine if limit/request overrides are set. Required.
-        project: "=",
         showNameInput: "=?",
         nameReadOnly: "=?"
       },
@@ -21,70 +19,13 @@ angular.module("openshiftConsole")
       link: function(scope) {
         scope.nameValidation = DNS1123_SUBDOMAIN_VALIDATION;
 
-        // Wait for project to be set.
-        scope.$watch('project', function() {
-          if (!scope.project) {
-            return;
-          }
-
-          // The HPA targetCPU percentage always is against CPU request. If
-          // request/limit overrides are in place, we ask for the percentage
-          // against limit, however.
-          scope.isRequestCalculated = LimitRangesService.isRequestCalculated('cpu', scope.project);
-
-          // Set a default value in the model to include if the HPA if the field is empty.
-          var defaultTargetCPU = window.OPENSHIFT_CONSTANTS.DEFAULT_HPA_CPU_TARGET_PERCENT;
-          if (scope.isRequestCalculated) {
-            // Convert to percent of request to set in the HPA resource.
-            defaultTargetCPU = HPAService.convertLimitPercentToRequest(defaultTargetCPU, scope.project);
-          }
-          _.set(scope, 'autoscaling.defaultTargetCPU', defaultTargetCPU);
-
-          // Default percent for display in the view as a placeholder and in help
-          // text. Don't convert this value since the field will prompt for
-          // limit instead when a request/limit override is in place and we want
-          // to show default percent of limit.
-          scope.defaultTargetCPUDisplayValue = window.OPENSHIFT_CONSTANTS.DEFAULT_HPA_CPU_TARGET_PERCENT;
-
-          // Keep the input value and model value separate in the scope so we can
-          // convert between them on changes.
-          var inputValueChanged = false;
-          var updateTargetCPUInput = function(targetCPU) {
-            if (inputValueChanged) {
-              // Don't update the input in response to the user typing. Only
-              // update the input value when the target CPU changes outside the
-              // directive.
-              inputValueChanged = false;
-              return;
-            }
-
-            if (targetCPU && scope.isRequestCalculated) {
-              // Convert this to a limit value for the target CPU input.
-              targetCPU = HPAService.convertRequestPercentToLimit(targetCPU, scope.project);
-            }
-            _.set(scope, 'targetCPUInput.percent', targetCPU);
-          };
-          scope.$watch('autoscaling.targetCPU', updateTargetCPUInput);
-
-          // Update the model with the target CPU request percentage when the input value changes.
-          var updateTargetCPUModel = function(targetCPU) {
-            if (targetCPU && scope.isRequestCalculated) {
-              targetCPU = HPAService.convertLimitPercentToRequest(targetCPU, scope.project);
-            }
-
-            inputValueChanged = true;
-            _.set(scope, 'autoscaling.targetCPU', targetCPU);
-          };
-
-          // Watch changes to the target CPU input to set values back in the model.
-          scope.$watch('targetCPUInput.percent', function(newValue, oldValue) {
-            if (newValue === oldValue) {
-              return;
-            }
-
-            updateTargetCPUModel(newValue);
-          });
-        });
+        // Prefill a default value if DEFAULT_HPA_CPU_TARGET_PERCENT is set and
+        // there is no previous value.
+        var defaultTargetCPU = Constants.DEFAULT_HPA_CPU_TARGET_PERCENT;
+        var targetCPU = _.get(scope, 'autoscaling.targetCPU');
+        if (_.isNil(targetCPU) && defaultTargetCPU) {
+          _.set(scope, 'autoscaling.targetCPU', defaultTargetCPU);
+        }
       }
     };
   });

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -188,7 +188,7 @@ angular.module('openshiftConsole')
         // In case user wont have permissions to list Secrets, an incomplaete URL will be build, similar to the one from CLI:
         //
         // https://127.0.0.1:8443/apis/build.openshift.io/v1/namespaces/myproject/buildconfigs/test-build/webhooks/<secret>/github
-        // 
+        //
         var webhookURL = DataService.url({
           resource: "buildconfigs/webhooks/",
           name: buildConfig,
@@ -1128,22 +1128,6 @@ angular.module('openshiftConsole')
   .filter('isLimitCalculated', function(LimitRangesService) {
     return function(computeResource, project) {
       return LimitRangesService.isLimitCalculated(computeResource, project);
-    };
-  })
-  .filter('hpaCPUPercent', function(HPAService, LimitRangesService) {
-    // Convert between CPU request percentage and CPU limit percentage if
-    // necessary to display an HPA value. Values are shown as percentages
-    // of CPU limit if a request/limit override is set.
-    return function(targetCPU, project) {
-      if (!targetCPU) {
-        return targetCPU;
-      }
-
-      if (!LimitRangesService.isRequestCalculated('cpu', project)) {
-        return targetCPU;
-      }
-
-      return HPAService.convertRequestPercentToLimit(targetCPU, project);
     };
   })
   .filter('podTemplate', function() {

--- a/app/scripts/services/applicationGenerator.js
+++ b/app/scripts/services/applicationGenerator.js
@@ -275,7 +275,7 @@ angular.module("openshiftConsole")
           },
           minReplicas: input.scaling.minReplicas,
           maxReplicas: input.scaling.maxReplicas,
-          targetCPUUtilizationPercentage: input.scaling.targetCPU || input.scaling.defaultTargetCPU || null
+          targetCPUUtilizationPercentage: input.scaling.targetCPU
         }
       };
 

--- a/app/scripts/services/hpa.js
+++ b/app/scripts/services/hpa.js
@@ -1,47 +1,7 @@
 'use strict';
 
 angular.module("openshiftConsole")
-  .factory("HPAService", function($filter, $q, LimitRangesService, MetricsService, Logger) {
-    var getCPURequestToLimitPercent = function(project) {
-      return LimitRangesService.getRequestToLimitPercent('cpu', project);
-    };
-
-    // Converts a percentage of request to a percentage of the limit based on
-    // the request-to-limit ratio.
-    // If CPU request percent is 120% and CPU request-to-limit percent is 50%, returns 60%
-    var convertRequestPercentToLimit = function(requestPercent, project) {
-      var cpuRequestToLimitPercent = getCPURequestToLimitPercent(project);
-      if (!cpuRequestToLimitPercent) {
-        Logger.warn('convertRequestPercentToLimit called, but no request/limit ratio defined.');
-        return NaN;
-      }
-
-      if (!requestPercent) {
-        return requestPercent;
-      }
-
-      var limitPercent = (cpuRequestToLimitPercent / 100) * requestPercent;
-      return Math.round(limitPercent);
-    };
-
-    // Converts a percentage of limit to a percentage of the request based on
-    // the request-to-limit ratio.
-    // If CPU limit percent is 60% and CPU request-to-limit percent is 50%, returns 120%
-    var convertLimitPercentToRequest = function(limitPercent, project) {
-      var cpuRequestToLimitPercent = getCPURequestToLimitPercent(project);
-      if (!cpuRequestToLimitPercent) {
-        Logger.warn('convertLimitPercentToRequest called, but no request/limit ratio defined.');
-        return NaN;
-      }
-
-      if (!limitPercent) {
-        return limitPercent;
-      }
-
-      var requestPercent = limitPercent / (cpuRequestToLimitPercent / 100);
-      return Math.round(requestPercent);
-    };
-
+  .factory("HPAService", function($filter, $q, LimitRangesService, MetricsService) {
     // Checks if all containers have a value set for the compute resource request or limit.
     //
     // computeResource  - 'cpu' or 'memory'
@@ -66,17 +26,17 @@ angular.module("openshiftConsole")
     // computeResource  - 'cpu' or 'memory'
     // defaultType      - 'defaultRequest' or 'defaultLimit'
     // limitRanges     - collection of LimitRange objects (hash or array)
-    var hasDefault = function(computeResource, defaultType, limitRanges, project) {
-      var effectiveLimits = LimitRangesService.getEffectiveLimitRange(limitRanges, computeResource, 'Container', project);
+    var hasDefault = function(computeResource, defaultType, limitRanges) {
+      var effectiveLimits = LimitRangesService.getEffectiveLimitRange(limitRanges, computeResource, 'Container');
       return !!effectiveLimits[defaultType];
     };
 
-    var hasDefaultRequest = function(computeResource, limitRanges, project) {
-      return hasDefault(computeResource, 'defaultRequest', limitRanges, project);
+    var hasDefaultRequest = function(computeResource, limitRanges) {
+      return hasDefault(computeResource, 'defaultRequest', limitRanges);
     };
 
-    var hasDefaultLimit = function(computeResource, limitRanges, project) {
-      return hasDefault(computeResource, 'defaultLimit', limitRanges, project);
+    var hasDefaultLimit = function(computeResource, limitRanges) {
+      return hasDefault(computeResource, 'defaultLimit', limitRanges);
     };
 
     // Checks if a CPU request is currently set or will be defaulted for any
@@ -84,24 +44,20 @@ angular.module("openshiftConsole")
     //
     // containers       - array of containters from a deployment config or replication controller
     // limitRanges      - collection of LimitRange objects (hash or array)
-    // project          - the project to determine if a request/limit ratio is set
+    // project          - the project to determine if cluster resource overrides are enabled
     var hasCPURequest = function(containers, limitRanges, project) {
-      if (hasRequestSet('cpu', containers) ||
-          hasDefaultRequest('cpu', limitRanges, project)) {
+      // If CRO is enabled, don't try to validate CPU request.
+      if (LimitRangesService.hasClusterResourceOverrides(project)) {
+        return true;
+      }
+
+      if (hasRequestSet('cpu', containers) || hasDefaultRequest('cpu', limitRanges)) {
         return true;
       }
 
       // The request will be defaulted from the limit when the pod is created.
-      if (hasLimitSet('cpu', containers) ||
-          hasDefaultLimit('cpu', limitRanges, containers)) {
+      if (hasLimitSet('cpu', containers) || hasDefaultLimit('cpu', limitRanges, containers)) {
         return true;
-      }
-
-      // Even if CPU limit is not set, it might be calculated. Check if the CPU
-      // limit will be set as a ratio of the memory limit.
-      if (LimitRangesService.isLimitCalculated('cpu', project)) {
-        return hasLimitSet('memory', containers) ||
-               hasDefaultLimit('memory', limitRanges, project);
       }
 
       return false;
@@ -141,22 +97,12 @@ angular.module("openshiftConsole")
         }
 
         var containers = _.get(scaleTarget, 'spec.template.spec.containers', []);
-        var kind, cpuRequestMessage;
+        var kind;
         if (!hasCPURequest(containers, limitRanges, project)) {
           kind = humanizeKind(scaleTarget.kind);
-          if (LimitRangesService.isRequestCalculated('cpu', project)) {
-            cpuRequestMessage = 'This ' + kind + ' does not have any containers with a CPU limit set. ' +
-                      'Autoscaling will not work without a CPU limit.';
-            if (LimitRangesService.isLimitCalculated('cpu', project)) {
-              cpuRequestMessage += ' The CPU limit will be automatically calculated from the container memory limit.';
-            }
-          } else {
-            cpuRequestMessage = 'This ' + kind + ' does not have any containers with a CPU request set. ' +
-                      'Autoscaling will not work without a CPU request.';
-          }
-
           warnings.push({
-            message: cpuRequestMessage,
+            message: 'This ' + kind + ' does not have any containers with a CPU request set. ' +
+                     'Autoscaling will not work without a CPU request.',
             reason: 'NoCPURequest'
           });
         }
@@ -224,8 +170,6 @@ angular.module("openshiftConsole")
     };
 
     return {
-      convertRequestPercentToLimit: convertRequestPercentToLimit,
-      convertLimitPercentToRequest: convertLimitPercentToRequest,
       hasCPURequest: hasCPURequest,
       filterHPA: filterHPA,
       getHPAWarnings: getHPAWarnings,

--- a/app/views/create/fromimage.html
+++ b/app/views/create/fromimage.html
@@ -342,21 +342,12 @@
                             </div>
                           </div>
 
-                          <osc-autoscaling
-                              ng-if="scaling.autoscale"
-                              model="scaling"
-                              project="project">
-                          </osc-autoscaling>
+                          <osc-autoscaling ng-if="scaling.autoscale" model="scaling"></osc-autoscaling>
 
                           <div class="has-warning" ng-if="showCPURequestWarning">
                             <span class="help-block">
                               You should configure resource limits below for autoscaling.
-                              Autoscaling will not work without a CPU
-                              <span ng-if="'cpu' | isRequestCalculated : project">limit.</span>
-                              <span ng-if="!('cpu' | isRequestCalculated : project)">request.</span>
-                              <span ng-if="'cpu' | isLimitCalculated : project">
-                                The CPU limit will be automatically calculated from the container memory limit.
-                              </span>
+                              Autoscaling will not work without a CPU request.
                             </span>
                           </div>
 

--- a/app/views/directives/hpa.html
+++ b/app/views/directives/hpa.html
@@ -17,7 +17,7 @@
     </delete-link>
   </span>
 </h4>
-<dl class="dl-horizontal left" style="margin-bottom: 10px;">
+<dl class="dl-horizontal left mar-top-md">
   <dt ng-if-start="showScaleTarget && hpa.spec.scaleTargetRef.kind && hpa.spec.scaleTargetRef.name">{{hpa.spec.scaleTargetRef.kind | humanizeKind : true}}:</dt>
   <dd ng-if-end>
     <a ng-href="{{hpa.spec.scaleTargetRef.name | navigateResourceURL : hpa.spec.scaleTargetRef.kind : hpa.metadata.namespace}}">{{hpa.spec.scaleTargetRef.name}}</a>
@@ -27,12 +27,9 @@
   <dt>Max Pods:</dt>
   <dd>{{hpa.spec.maxReplicas}}</dd>
   <dt ng-if-start="hpa.spec.targetCPUUtilizationPercentage">
-      CPU
-      <span ng-if="'cpu' | isRequestCalculated : project">Limit</span>
-      <span ng-if="!('cpu' | isRequestCalculated : project)">Request</span>
-      Target:
+      CPU Request
   </dt>
-  <dd ng-if-end>{{hpa.spec.targetCPUUtilizationPercentage | hpaCPUPercent : project}}%</dd>
+  <dd ng-if-end>{{hpa.spec.targetCPUUtilizationPercentage}}%</dd>
   <dt>
     Current Usage:
   </dt>
@@ -40,7 +37,7 @@
     <em>Not available</em>
   </dd>
   <dd ng-if="!(hpa.status.currentCPUUtilizationPercentage | isNil)">
-    {{hpa.status.currentCPUUtilizationPercentage | hpaCPUPercent : project}}%
+    {{hpa.status.currentCPUUtilizationPercentage}}%
   </dd>
   <dt ng-if-start="hpa.status.lastScaleTime">Last Scaled:</dt>
   <dd ng-if-end><span am-time-ago="hpa.status.lastScaleTime"></span></dd>

--- a/app/views/directives/osc-autoscaling.html
+++ b/app/views/directives/osc-autoscaling.html
@@ -101,35 +101,29 @@
   </div>
   <div class="form-group">
     <label>
-      CPU
-      <span ng-if="isRequestCalculated">Limit</span>
-      <span ng-if="!isRequestCalculated">Request</span>
-      Target
+      CPU Request Target
     </label>
     <div class="input-group" ng-class="{ 'has-error': form.targetCPU.$invalid && form.targetCPU.$touched }">
       <input type="number"
              class="form-control"
              min="1"
              name="targetCPU"
-             ng-model="targetCPUInput.percent"
+             ng-model="autoscaling.targetCPU"
              pattern="\d*"
              select-on-focus
              aria-describedby="target-cpu-help">
       <span class="input-group-addon">%</span>
     </div>
     <div id="target-cpu-help" class="help-block">
-      The percentage of the CPU
-      <span ng-if="isRequestCalculated">limit</span>
-      <span ng-if="!isRequestCalculated">request</span>
-      that each pod should ideally be using. Pods will be added or removed
-      periodically when CPU usage exceeds or drops below this target value.
-      <span ng-if="defaultTargetCPUDisplayValue">Defaults to {{defaultTargetCPUDisplayValue}}%.</span>
+      The percentage of the CPU request that each pod should ideally be using.
+      Pods will be added or removed periodically when CPU usage exceeds or
+      drops below this target value.
     </div>
     <div class="learn-more-block">
-      <a href="{{'compute_resources' | helpLink}}" target="_blank">Learn More&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></a>
+      <a ng-href="{{'compute_resources' | helpLink}}" target="_blank">Learn More&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></a>
     </div>
     <!-- Add extra top margin for the learn more block -->
-    <div class="has-error" style="margin-top: 10px;" ng-show="form.targetCPU.$touched && form.targetCPU.$invalid">
+    <div class="has-error mar-top-md" ng-show="form.targetCPU.$touched && form.targetCPU.$invalid">
       <span ng-if="form.targetCPU.$error.number" class="help-block">
         Target CPU percentage must be a number.
       </span>

--- a/app/views/edit/autoscaler.html
+++ b/app/views/edit/autoscaler.html
@@ -41,7 +41,6 @@
             <fieldset ng-disabled="disableInputs" class="gutter-top">
               <osc-autoscaling
                   model="autoscaling"
-                  project="project"
                   show-name-input="true"
                   name-read-only="kind === 'HorizontalPodAutoscaler'">
               </osc-autoscaling>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1,11 +1,11 @@
 "use strict";
 
-function OverviewController(e, t, n, r, a, o, i, s, c, l, u, d, m, p, f, g, v, h, y, b, S, C, w, P, j, k, I, R, T, E) {
+function OverviewController(e, t, n, r, a, o, i, s, c, l, u, d, m, p, f, g, v, h, y, b, S, C, w, P, j, k, I, R, E, T) {
 var N = this, D = t("isIE")();
 e.projectName = a.project;
 var A = a.isHomePage;
 N.catalogLandingPageEnabled = !d.DISABLE_SERVICE_CATALOG_LANDING_PAGE;
-var B = t("annotation"), L = t("canI"), V = t("buildConfigForBuild"), U = t("deploymentIsInProgress"), O = t("imageObjectRef"), F = t("isJenkinsPipelineStrategy"), x = t("isNewerResource"), M = t("label"), q = t("podTemplate"), z = i.getPreferredVersion("deployments"), H = i.getPreferredVersion("horizontalpodautoscalers"), G = i.getPreferredVersion("servicebindings"), K = i.getPreferredVersion("clusterserviceclasses"), W = i.getPreferredVersion("serviceinstances"), Q = i.getPreferredVersion("clusterserviceplans"), J = i.getPreferredVersion("statefulsets"), Y = i.getPreferredVersion("replicasets");
+var B = t("annotation"), L = t("canI"), V = t("buildConfigForBuild"), O = t("deploymentIsInProgress"), U = t("imageObjectRef"), F = t("isJenkinsPipelineStrategy"), x = t("isNewerResource"), M = t("label"), q = t("podTemplate"), z = i.getPreferredVersion("deployments"), H = i.getPreferredVersion("horizontalpodautoscalers"), G = i.getPreferredVersion("servicebindings"), K = i.getPreferredVersion("clusterserviceclasses"), W = i.getPreferredVersion("serviceinstances"), Q = i.getPreferredVersion("clusterserviceplans"), J = i.getPreferredVersion("statefulsets"), Y = i.getPreferredVersion("replicasets");
 N.buildConfigsInstantiateVersion = i.getPreferredVersion("buildconfigs/instantiate");
 var Z, X, ee = {}, te = {}, ne = {}, re = N.state = {
 alerts: {},
@@ -70,7 +70,7 @@ return s.groupByApp(e, "metadata.name");
 }, de = function(e) {
 var t = null;
 return _.each(e, function(e) {
-t = t ? T.getPreferredDisplayRoute(t, e) : e;
+t = t ? E.getPreferredDisplayRoute(t, e) : e;
 }), t;
 }, me = _.debounce(function() {
 e.$evalAsync(function() {
@@ -168,21 +168,21 @@ je(e, n);
 }
 }, Re = function(e) {
 _.each(e, Ie);
-}, Te = function(e) {
+}, Ee = function(e) {
 var t = oe(e);
 return t ? ne[t] : null;
-}, Ee = function(e) {
+}, Te = function(e) {
 var t = oe(e);
 return t ? _.get(N, [ "replicationControllersByDeploymentConfig", t ]) : [];
 };
 N.getPreviousReplicationController = function(e) {
-var t = Ee(e);
+var t = Te(e);
 return _.size(t) < 2 ? null : t[1];
 };
 var Ne = function(e) {
-var t = {}, n = Te(e);
+var t = {}, n = Ee(e);
 _.assign(t, R.getDeploymentStatusAlerts(e, n), R.getPausedDeploymentAlerts(e));
-var r = Ee(e);
+var r = Te(e);
 _.each(r, function(e) {
 var n = ke(e);
 _.assign(t, n);
@@ -206,16 +206,16 @@ Re(N.replicationControllers), Re(N.replicaSets), Re(N.statefulSets), Re(N.monopo
 e.$evalAsync(function() {
 Le(), De(), Be();
 });
-}, 500), Ue = function(e) {
+}, 500), Oe = function(e) {
 _.isEmpty(e) || (b.addLabelSuggestionsFromResources(e, ee), "pipeline" !== N.viewBy && b.setLabelSuggestions(ee));
-}, Oe = function(e) {
+}, Ue = function(e) {
 _.isEmpty(e) || (b.addLabelSuggestionsFromResources(e, te), "pipeline" === N.viewBy && b.setLabelSuggestions(te));
 }, Fe = function(e) {
 return "Succeeded" !== e.status.phase && "Failed" !== e.status.phase && (!M(e, "openshift.io/deployer-pod-for.name") && (!B(e, "openshift.io/build.name") && "slave" !== M(e, "jenkins")));
 }, xe = function() {
 re.podsByOwnerUID = j.groupByOwnerUID(N.pods), N.monopods = _.filter(re.podsByOwnerUID[""], Fe);
 }, Me = function(e) {
-return !!_.get(e, "status.replicas") || (!B(e, "deploymentConfig") || U(e));
+return !!_.get(e, "status.replicas") || (!B(e, "deploymentConfig") || O(e));
 }, qe = function(e) {
 return B(e, "deploymentConfig");
 }, ze = function() {
@@ -266,8 +266,8 @@ var e = [ N.deploymentConfigs, N.vanillaReplicationControllers, N.deployments, N
 _.each(e, We), me();
 }
 }, Je = function() {
-var e = T.groupByService(N.routes, !0);
-re.routesByService = _.mapValues(e, T.sortRoutesByScore), me();
+var e = E.groupByService(N.routes, !0);
+re.routesByService = _.mapValues(e, E.sortRoutesByScore), me();
 }, Ye = function() {
 re.hpaByResource = g.groupHPAs(N.horizontalPodAutoscalers);
 }, Ze = function(e) {
@@ -305,14 +305,14 @@ _.set(N, [ "deploymentConfigsByPipeline", r ], n), _.each(n, function(e) {
 re.pipelinesByDeploymentConfig[e] = re.pipelinesByDeploymentConfig[e] || [], re.pipelinesByDeploymentConfig[e].push(t);
 });
 }
-}), N.pipelineBuildConfigs = _.sortBy(e, "metadata.name"), fe(), Oe(N.pipelineBuildConfigs), ge();
+}), N.pipelineBuildConfigs = _.sortBy(e, "metadata.name"), fe(), Ue(N.pipelineBuildConfigs), ge();
 }, ot = function() {
 re.buildConfigsByObjectUID = {}, _.each(N.deploymentConfigs, function(e) {
 var t = [], n = _.get(e, "spec.triggers");
 _.each(n, function(n) {
 var r = _.get(n, "imageChangeParams.from");
 if (r) {
-var a = O(r, e.metadata.namespace), o = Xe[a];
+var a = U(r, e.metadata.namespace), o = Xe[a];
 _.isEmpty(o) || (t = t.concat(o));
 }
 }), t = _.sortBy(t, "metadata.name"), rt(t, e), nt(e);
@@ -389,19 +389,19 @@ var a = function() {
 N.pods && h.fetchReferencedImageStreamImages(N.pods, re.imagesByDockerReference, re.imageStreamImageRefByDockerReference, r);
 };
 mt.push(m.watch("pods", r, function(e) {
-N.pods = e.by("metadata.name"), xe(), a(), Ve(), We(N.monopods), Re(N.monopods), Ue(N.monopods), Ce(), S.log("pods (subscribe)", N.pods);
+N.pods = e.by("metadata.name"), xe(), a(), Ve(), We(N.monopods), Re(N.monopods), Oe(N.monopods), Ce(), S.log("pods (subscribe)", N.pods);
 })), mt.push(m.watch("replicationcontrollers", r, function(e) {
-N.replicationControllers = e.by("metadata.name"), ze(), We(N.vanillaReplicationControllers), We(N.monopods), Re(N.vanillaReplicationControllers), Ue(N.vanillaReplicationControllers), ut(), Ce(), S.log("replicationcontrollers (subscribe)", N.replicationControllers);
+N.replicationControllers = e.by("metadata.name"), ze(), We(N.vanillaReplicationControllers), We(N.monopods), Re(N.vanillaReplicationControllers), Oe(N.vanillaReplicationControllers), ut(), Ce(), S.log("replicationcontrollers (subscribe)", N.replicationControllers);
 })), mt.push(m.watch("deploymentconfigs", r, function(e) {
-N.deploymentConfigs = e.by("metadata.name"), ze(), We(N.deploymentConfigs), We(N.vanillaReplicationControllers), Ue(N.deploymentConfigs), Be(), it(), st(), ut(), Ce(), S.log("deploymentconfigs (subscribe)", N.deploymentConfigs);
+N.deploymentConfigs = e.by("metadata.name"), ze(), We(N.deploymentConfigs), We(N.vanillaReplicationControllers), Oe(N.deploymentConfigs), Be(), it(), st(), ut(), Ce(), S.log("deploymentconfigs (subscribe)", N.deploymentConfigs);
 })), mt.push(m.watch(Y, r, function(e) {
-N.replicaSets = e.by("metadata.name"), Ge(), We(N.vanillaReplicaSets), We(N.monopods), Re(N.vanillaReplicaSets), Ue(N.vanillaReplicaSets), ut(), Ce(), S.log("replicasets (subscribe)", N.replicaSets);
+N.replicaSets = e.by("metadata.name"), Ge(), We(N.vanillaReplicaSets), We(N.monopods), Re(N.vanillaReplicaSets), Oe(N.vanillaReplicaSets), ut(), Ce(), S.log("replicasets (subscribe)", N.replicaSets);
 })), mt.push(m.watch(z, r, function(e) {
-Z = e.by("metadata.uid"), N.deployments = _.sortBy(Z, "metadata.name"), Ge(), We(N.deployments), We(N.vanillaReplicaSets), Ue(N.deployments), ut(), Ce(), S.log("deployments (subscribe)", N.deploymentsByUID);
+Z = e.by("metadata.uid"), N.deployments = _.sortBy(Z, "metadata.name"), Ge(), We(N.deployments), We(N.vanillaReplicaSets), Oe(N.deployments), ut(), Ce(), S.log("deployments (subscribe)", N.deploymentsByUID);
 })), mt.push(m.watch("builds", r, function(e) {
 re.builds = e.by("metadata.name"), ct(), S.log("builds (subscribe)", re.builds);
 })), mt.push(m.watch(J, r, function(e) {
-N.statefulSets = e.by("metadata.name"), We(N.statefulSets), We(N.monopods), Re(N.statefulSets), Ue(N.statefulSets), ut(), Ce(), S.log("statefulsets (subscribe)", N.statefulSets);
+N.statefulSets = e.by("metadata.name"), We(N.statefulSets), We(N.monopods), Re(N.statefulSets), Oe(N.statefulSets), ut(), Ce(), S.log("statefulsets (subscribe)", N.statefulSets);
 }, {
 poll: D,
 pollInterval: 6e4
@@ -443,7 +443,7 @@ pollInterval: 6e4
 }));
 var o, i, s = {}, c = {};
 u.SERVICE_CATALOG_ENABLED && L(W, "watch") && (o = function(e) {
-var t = E.getServiceClassNameForInstance(e);
+var t = T.getServiceClassNameForInstance(e);
 if (!t) return n.when();
 var r = _.get(re, [ "serviceClasses", t ]);
 return r ? n.when(r) : (s[t] || (s[t] = m.get(K, t, {}).then(function(e) {
@@ -452,7 +452,7 @@ return re.serviceClasses[t] = e, e;
 delete c[t];
 })), s[t]);
 }, i = function(e) {
-var t = E.getServicePlanNameForInstance(e);
+var t = T.getServicePlanNameForInstance(e);
 if (!t) return n.when();
 var r = _.get(re, [ "servicePlans", t ]);
 return r ? n.when(r) : (c[t] || (c[t] = m.get(Q, t, {}).then(function(e) {
@@ -468,7 +468,7 @@ var n = R.getServiceInstanceAlerts(e);
 je(e, n), t.push(o(e)), t.push(i(e));
 }), I.waitForAll(t).finally(function() {
 dt(), Ce();
-}), Ue(re.serviceInstances);
+}), Oe(re.serviceInstances);
 }, {
 poll: D,
 pollInterval: 6e4
@@ -595,7 +595,7 @@ default: "welcome/index.html"
 CLI: {
 "Latest Release": "https://github.com/openshift/origin/releases/latest"
 },
-DEFAULT_HPA_CPU_TARGET_PERCENT: 80,
+DEFAULT_HPA_CPU_TARGET_PERCENT: null,
 DISABLE_OVERVIEW_METRICS: !1,
 DISABLE_CUSTOM_METRICS: !1,
 DISABLE_WILDCARD_ROUTES: !0,
@@ -1044,7 +1044,9 @@ LOGOS: {
 "icon-wildfly": "wildfly.svg",
 "icon-wordpress": "wordpress.svg",
 "icon-zend": "zend.svg"
-}
+},
+CLUSTER_RESOURCE_OVERRIDES_EXEMPT_PROJECT_NAMES: [ "openshift", "kubernetes", "kube" ],
+CLUSTER_RESOURCE_OVERRIDES_EXEMPT_PROJECT_PREFIXES: [ "openshift-", "kubernetes-", "kube-" ]
 }), angular.module("openshiftConsole", [ "ngAnimate", "ngCookies", "ngResource", "ngRoute", "ngSanitize", "kubernetesUI", "registryUI.images", "ui.bootstrap", "patternfly.charts", "patternfly.navigation", "patternfly.sort", "patternfly.notification", "openshiftConsoleTemplates", "ui.ace", "extension-registry", "as.sortable", "ui.select", "angular-inview", "angularMoment", "ab-base64", "openshiftCommonServices", "openshiftCommonUI", "webCatalog" ]).config([ "$routeProvider", "HomePagePreferenceServiceProvider", function(e, t) {
 var n, r = {
 templateUrl: "views/projects.html",
@@ -1357,7 +1359,7 @@ redirectTo: "/project/:project/browse/rc/:rc"
 }).otherwise({
 redirectTo: "/"
 });
-} ]).constant("LOGGING_URL", _.get(window.OPENSHIFT_CONFIG, "loggingURL")).constant("METRICS_URL", _.get(window.OPENSHIFT_CONFIG, "metricsURL")).constant("LIMIT_REQUEST_OVERRIDES", _.get(window.OPENSHIFT_CONFIG, "limitRequestOverrides")).constant("SOURCE_URL_PATTERN", /^[a-z][a-z0-9+.-@]*:(\/\/)?[0-9a-z_-]+/i).constant("RELATIVE_PATH_PATTERN", /^(?!\/)(?!\.\.(\/|$))(?!.*\/\.\.(\/|$)).*$/).constant("IS_SAFARI", /Version\/[\d\.]+.*Safari/.test(navigator.userAgent)).constant("amTimeAgoConfig", {
+} ]).constant("LOGGING_URL", _.get(window.OPENSHIFT_CONFIG, "loggingURL")).constant("METRICS_URL", _.get(window.OPENSHIFT_CONFIG, "metricsURL")).constant("SOURCE_URL_PATTERN", /^[a-z][a-z0-9+.-@]*:(\/\/)?[0-9a-z_-]+/i).constant("RELATIVE_PATH_PATTERN", /^(?!\/)(?!\.\.(\/|$))(?!.*\/\.\.(\/|$)).*$/).constant("IS_SAFARI", /Version\/[\d\.]+.*Safari/.test(navigator.userAgent)).constant("amTimeAgoConfig", {
 titleFormat: "LLL"
 }).config([ "kubernetesContainerSocketProvider", function(e) {
 e.WebSocketFactory = "ContainerWebSocket";
@@ -1588,7 +1590,7 @@ subresource: "scale"
 },
 minReplicas: e.scaling.minReplicas,
 maxReplicas: e.scaling.maxReplicas,
-targetCPUUtilizationPercentage: e.scaling.targetCPU || e.scaling.defaultTargetCPU || null
+targetCPUUtilizationPercentage: e.scaling.targetCPU
 }
 };
 }, o._generateBuildConfig = function(e, t) {
@@ -2955,59 +2957,55 @@ details: a(t)
 });
 }
 };
-} ]), angular.module("openshiftConsole").factory("LimitRangesService", [ "$filter", "LIMIT_REQUEST_OVERRIDES", function(e, t) {
-var n = e("usageValue"), r = e("usageWithUnits"), a = e("amountAndUnit"), o = function(e, t) {
-return !!e && (!t || n(e) < n(t));
-}, i = function(e, t) {
-return !!e && (!t || n(e) > n(t));
-}, s = function(n) {
-if (!t) return !1;
-var r = e("annotation")(n, "quota.openshift.io/cluster-resource-override-enabled");
-return !r || "true" === r;
-}, c = function(e, n) {
-if (!s(n)) return null;
-switch (e) {
-case "cpu":
-return t.cpuRequestToLimitPercent;
-
-case "memory":
-return t.memoryRequestToLimitPercent;
-
-default:
-return null;
-}
-}, l = function(e, t) {
-return !!c(e, t);
-}, u = function(e, n) {
-return s(n) && "cpu" === e && !!t.limitCPUToMemoryPercent;
-}, d = function(e, t, n, r) {
-var s = {};
-angular.forEach(e, function(e) {
+} ]), angular.module("openshiftConsole").factory("LimitRangesService", [ "$filter", "$window", "Constants", function(e, t, n) {
+var r = e("annotation"), a = e("usageValue"), o = e("usageWithUnits"), i = function(e, t) {
+return !!e && (!t || a(e) < a(t));
+}, s = function(e, t) {
+return !!e && (!t || a(e) > a(t));
+}, c = function(e) {
+return _.includes(n.CLUSTER_RESOURCE_OVERRIDES_EXEMPT_PROJECT_NAMES, e);
+}, l = function(e) {
+return _.some(n.CLUSTER_RESOURCE_OVERRIDES_EXEMPT_PROJECT_PREFIXES, function(t) {
+return _.startsWith(e, t);
+});
+}, u = function(e) {
+var t = r(e, "quota.openshift.io/cluster-resource-override-enabled");
+return !!t && "true" !== t;
+}, d = function(e) {
+var t = _.get(e, "metadata.name");
+return c(t) || l(t) || u(e);
+}, m = function(e) {
+return !!_.get(t, "OPENSHIFT_CONFIG.clusterResourceOverridesEnabled") && !d(e);
+}, p = function(e, t) {
+return m(t);
+}, f = function(e, t) {
+return "cpu" === e && m(t);
+}, g = function(e, t, n) {
+var r = {};
+return angular.forEach(e, function(e) {
 angular.forEach(e.spec.limits, function(e) {
 if (e.type === n) {
-e.min && i(e.min[t], s.min) && (s.min = e.min[t]), e.max && o(e.max[t], s.max) && (s.max = e.max[t]), e.default && (s.defaultLimit = e.default[t] || s.defaultLimit), e.defaultRequest && (s.defaultRequest = e.defaultRequest[t] || s.defaultRequest);
-var r;
-e.maxLimitRequestRatio && (r = e.maxLimitRequestRatio[t]) && (!s.maxLimitRequestRatio || r < s.maxLimitRequestRatio) && (s.maxLimitRequestRatio = r);
+e.min && s(e.min[t], r.min) && (r.min = e.min[t]), e.max && i(e.max[t], r.max) && (r.max = e.max[t]), e.default && (r.defaultLimit = e.default[t] || r.defaultLimit), e.defaultRequest && (r.defaultRequest = e.defaultRequest[t] || r.defaultRequest);
+var a;
+e.maxLimitRequestRatio && (a = e.maxLimitRequestRatio[t]) && (!r.maxLimitRequestRatio || a < r.maxLimitRequestRatio) && (r.maxLimitRequestRatio = a);
 }
 });
-});
-var l, u, d, m;
-return s.min && (l = c(t, r)) && (u = a(s.min), d = Math.ceil(u[0] / (l / 100)), m = u[1] || "", s.min = "" + d + m), s;
+}), r;
 };
 return {
-getEffectiveLimitRange: d,
-getRequestToLimitPercent: c,
-isRequestCalculated: l,
-isLimitCalculated: u,
-validatePodLimits: function(t, a, o, i) {
-if (!o || !o.length) return [];
-var s = d(t, a, "Pod", i), c = d(t, a, "Container", i), m = 0, p = 0, f = s.min && n(s.min), g = s.max && n(s.max), v = [], h = e("computeResourceLabel")(a, !0);
-return angular.forEach(o, function(e) {
-var t = e.resources || {}, r = t.requests && t.requests[a] || c.defaultRequest;
-r && (m += n(r));
-var o = t.limits && t.limits[a] || c.defaultLimit;
-o && (p += n(o));
-}), l(a, i) || (f && m < f && v.push(h + " request total for all containers is less than pod minimum (" + r(s.min, a) + ")."), g && m > g && v.push(h + " request total for all containers is greater than pod maximum (" + r(s.max, a) + ").")), u(a, i) || (f && p < f && v.push(h + " limit total for all containers is less than pod minimum (" + r(s.min, a) + ")."), g && p > g && v.push(h + " limit total for all containers is greater than pod maximum (" + r(s.max, a) + ").")), v;
+getEffectiveLimitRange: g,
+hasClusterResourceOverrides: m,
+isRequestCalculated: p,
+isLimitCalculated: f,
+validatePodLimits: function(t, n, r, i) {
+if (!r || !r.length) return [];
+var s = g(t, n, "Pod"), c = g(t, n, "Container"), l = 0, u = 0, d = s.min && a(s.min), m = s.max && a(s.max), v = [], h = e("computeResourceLabel")(n, !0);
+return angular.forEach(r, function(e) {
+var t = e.resources || {}, r = t.requests && t.requests[n] || c.defaultRequest;
+r && (l += a(r));
+var o = t.limits && t.limits[n] || c.defaultLimit;
+o && (u += a(o));
+}), p(0, i) || (d && l < d && v.push(h + " request total for all containers is less than pod minimum (" + o(s.min, n) + ")."), m && l > m && v.push(h + " request total for all containers is greater than pod maximum (" + o(s.max, n) + ").")), f(n, i) || (d && u < d && v.push(h + " limit total for all containers is less than pod minimum (" + o(s.min, n) + ")."), m && u > m && v.push(h + " limit total for all containers is greater than pod maximum (" + o(s.max, n) + ").")), v;
 }
 };
 } ]), angular.module("openshiftConsole").factory("RoutesService", [ "$filter", function(e) {
@@ -3151,63 +3149,47 @@ controller: "SetHomePageModalController"
 });
 }
 };
-} ]), angular.module("openshiftConsole").factory("HPAService", [ "$filter", "$q", "LimitRangesService", "MetricsService", "Logger", function(e, t, n, r, a) {
-var o = function(e) {
-return n.getRequestToLimitPercent("cpu", e);
-}, i = function(e, t, n) {
+} ]), angular.module("openshiftConsole").factory("HPAService", [ "$filter", "$q", "LimitRangesService", "MetricsService", function(e, t, n, r) {
+var a = function(e, t, n) {
 return _.every(n, function(n) {
 return _.get(n, [ "resources", t, e ]);
 });
-}, s = function(e, t) {
-return i(e, "requests", t);
+}, o = function(e, t) {
+return a(e, "requests", t);
+}, i = function(e, t) {
+return a(e, "limits", t);
+}, s = function(e, t, r) {
+return !!n.getEffectiveLimitRange(r, e, "Container")[t];
 }, c = function(e, t) {
-return i(e, "limits", t);
-}, l = function(e, t, r, a) {
-return !!n.getEffectiveLimitRange(r, e, "Container", a)[t];
-}, u = function(e, t, n) {
-return l(e, "defaultRequest", t, n);
-}, d = function(e, t, n) {
-return l(e, "defaultLimit", t, n);
-}, m = function(e, t, r) {
-return !(!s("cpu", e) && !u("cpu", t, r)) || (!(!c("cpu", e) && !d("cpu", t, e)) || !!n.isLimitCalculated("cpu", r) && (c("memory", e) || d("memory", t, r)));
-}, p = e("humanizeKind"), f = e("hasDeploymentConfig");
+return s(e, "defaultRequest", t);
+}, l = function(e, t) {
+return s(e, "defaultLimit", t);
+}, u = function(e, t, r) {
+return !!n.hasClusterResourceOverrides(r) || (!(!o("cpu", e) && !c("cpu", t)) || !(!i("cpu", e) && !l("cpu", t)));
+}, d = e("humanizeKind"), m = e("hasDeploymentConfig");
 return {
-convertRequestPercentToLimit: function(e, t) {
-var n = o(t);
-if (!n) return a.warn("convertRequestPercentToLimit called, but no request/limit ratio defined."), NaN;
-if (!e) return e;
-var r = n / 100 * e;
-return Math.round(r);
-},
-convertLimitPercentToRequest: function(e, t) {
-var n = o(t);
-if (!n) return a.warn("convertLimitPercentToRequest called, but no request/limit ratio defined."), NaN;
-if (!e) return e;
-var r = e / (n / 100);
-return Math.round(r);
-},
-hasCPURequest: m,
+hasCPURequest: u,
 filterHPA: function(e, t, n) {
 return _.filter(e, function(e) {
 return e.spec.scaleTargetRef.kind === t && e.spec.scaleTargetRef.name === n;
 });
 },
-getHPAWarnings: function(e, a, o, i) {
-return !e || _.isEmpty(a) ? t.when([]) : r.isAvailable().then(function(t) {
+getHPAWarnings: function(e, n, a, o) {
+return !e || _.isEmpty(n) ? t.when([]) : r.isAvailable().then(function(t) {
 var r = [];
 t || r.push({
 message: "Metrics might not be configured by your cluster administrator. Metrics are required for autoscaling.",
 reason: "MetricsNotAvailable"
 });
-var s, c, l = _.get(e, "spec.template.spec.containers", []);
-return m(l, o, i) || (s = p(e.kind), n.isRequestCalculated("cpu", i) ? (c = "This " + s + " does not have any containers with a CPU limit set. Autoscaling will not work without a CPU limit.", n.isLimitCalculated("cpu", i) && (c += " The CPU limit will be automatically calculated from the container memory limit.")) : c = "This " + s + " does not have any containers with a CPU request set. Autoscaling will not work without a CPU request.", r.push({
-message: c,
+var i, s = _.get(e, "spec.template.spec.containers", []);
+return u(s, a, o) || (i = d(e.kind), r.push({
+message: "This " + i + " does not have any containers with a CPU request set. Autoscaling will not work without a CPU request.",
 reason: "NoCPURequest"
-})), _.size(a) > 1 && r.push({
+})), _.size(n) > 1 && r.push({
 message: "More than one autoscaler is scaling this resource. This is not recommended because they might compete with each other. Consider removing all but one autoscaler.",
 reason: "MultipleHPA"
-}), "ReplicationController" === e.kind && f(e) && _.some(a, function() {
-return _.some(a, function(e) {
+}), "ReplicationController" === e.kind && m(e) && _.some(n, function() {
+return _.some(n, function(e) {
 return "ReplicationController" === _.get(e, "spec.scaleTargetRef.kind");
 });
 }) && r.push({
@@ -3758,9 +3740,9 @@ target: "_blank"
 _.each(a, d), _.each(i, d);
 }
 }), r) : r;
-}, T = [ "cpu", "requests.cpu", "memory", "requests.memory", "limits.cpu", "limits.memory" ], E = function(e, t, n, r, a) {
+}, E = [ "cpu", "requests.cpu", "memory", "requests.memory", "limits.cpu", "limits.memory" ], T = function(e, t, n, r, a) {
 var o, s = "Your project is " + (r < t ? "over" : "at") + " quota. ";
-return o = _.includes(T, a) ? s + "It is using " + v(t / r, 0) + " of " + g(n, a) + " " + C(a) + "." : s + "It is using " + t + " of " + r + " " + C(a) + ".", o = _.escape(o), i.QUOTA_NOTIFICATION_MESSAGE && i.QUOTA_NOTIFICATION_MESSAGE[a] && (o += " " + i.QUOTA_NOTIFICATION_MESSAGE[a]), o;
+return o = _.includes(E, a) ? s + "It is using " + v(t / r, 0) + " of " + g(n, a) + " " + C(a) + "." : s + "It is using " + t + " of " + r + " " + C(a) + ".", o = _.escape(o), i.QUOTA_NOTIFICATION_MESSAGE && i.QUOTA_NOTIFICATION_MESSAGE[a] && (o += " " + i.QUOTA_NOTIFICATION_MESSAGE[a]), o;
 }, N = function(e, t, n) {
 var r = function(e) {
 var t = e.status.total || e.status;
@@ -3817,7 +3799,7 @@ var c = f(e), l = _.get(a, [ "used", s ]), d = f(l);
 id: o + "/quota-limit-reached-" + s,
 namespace: o,
 type: c < d ? "warning" : "info",
-message: E(0, d, e, c, s),
+message: T(0, d, e, c, s),
 isHTML: !0,
 skipToast: !0,
 showInDrawer: !0,
@@ -5121,9 +5103,9 @@ var t = r("annotation")(e, "deploymentVersion");
 t && (n.logOptions.replicationControllers[e.metadata.name].version = t), n.logCanRun.replicationControllers[e.metadata.name] = !_.includes([ "New", "Pending" ], r("deploymentStatus")(e));
 }, R = function(e) {
 n.logOptions.builds[e.metadata.name] = {}, n.logCanRun.builds[e.metadata.name] = !_.includes([ "New", "Pending", "Error" ], e.status.phase);
-}, T = function() {
-n.filteredStatefulSets = s.filterForKeywords(_.values(n.statefulSets), w, P);
 }, E = function() {
+n.filteredStatefulSets = s.filterForKeywords(_.values(n.statefulSets), w, P);
+}, T = function() {
 S = _.filter(n.pods, function(e) {
 return !n.filters.hideOlderResources || "Succeeded" !== e.status.phase && "Failed" !== e.status.phase;
 }), n.filteredPods = s.filterForKeywords(S, w, P);
@@ -5135,11 +5117,11 @@ if (N(e)) return !0;
 var t = D(e);
 return t ? n.latestBuildByConfig[t].metadata.name === e.metadata.name : A(e);
 }), n.filteredBuilds = s.filterForKeywords(h, w, P);
-}, L = r("deploymentStatus"), V = r("deploymentIsInProgress"), U = function() {
+}, L = r("deploymentStatus"), V = r("deploymentIsInProgress"), O = function() {
 y = _.filter(n.replicationControllers, function(e) {
 return !n.filters.hideOlderResources || (V(e) || "Active" === L(e));
 }), n.filteredReplicationControllers = s.filterForKeywords(y, w, P);
-}, O = function() {
+}, U = function() {
 b = _.filter(n.replicaSets, function(e) {
 return !n.filters.hideOlderResources || _.get(e, "status.replicas");
 }), n.filteredReplicaSets = s.filterForKeywords(b, w, P);
@@ -5187,32 +5169,32 @@ var t = _.get(n, [ "podsByOwnerUID", e.metadata.uid ], []);
 _.isEmpty(t) || u.toPodsForDeployment(e, t);
 }, m.get(e.project).then(_.spread(function(e, r) {
 n.project = e, n.projectContext = r, g.push(o.watch("pods", r, function(e) {
-n.podsByName = e.by("metadata.name"), n.pods = C(n.podsByName, !0), n.podsByOwnerUID = d.groupByOwnerUID(n.pods), n.podsLoaded = !0, _.each(n.pods, k), E(), c.log("pods", n.pods);
+n.podsByName = e.by("metadata.name"), n.pods = C(n.podsByName, !0), n.podsByOwnerUID = d.groupByOwnerUID(n.pods), n.podsLoaded = !0, _.each(n.pods, k), T(), c.log("pods", n.pods);
 })), g.push(o.watch({
 resource: "statefulsets",
 group: "apps",
 version: "v1beta1"
 }, r, function(e) {
-n.statefulSets = e.by("metadata.name"), n.statefulSetsLoaded = !0, T(), c.log("statefulSets", n.statefulSets);
+n.statefulSets = e.by("metadata.name"), n.statefulSetsLoaded = !0, E(), c.log("statefulSets", n.statefulSets);
 }, {
 poll: f,
 pollInterval: 6e4
 })), g.push(o.watch("replicationcontrollers", r, function(e) {
-n.replicationControllers = C(e.by("metadata.name"), !0), n.replicationControllersLoaded = !0, _.each(n.replicationControllers, I), U(), c.log("replicationcontrollers", n.replicationControllers);
+n.replicationControllers = C(e.by("metadata.name"), !0), n.replicationControllersLoaded = !0, _.each(n.replicationControllers, I), O(), c.log("replicationcontrollers", n.replicationControllers);
 })), g.push(o.watch("builds", r, function(e) {
 n.builds = C(e.by("metadata.name"), !0), n.latestBuildByConfig = a.latestBuildByConfig(n.builds), n.buildsLoaded = !0, _.each(n.builds, R), B(), c.log("builds", n.builds);
 })), g.push(o.watch({
 group: "extensions",
 resource: "replicasets"
 }, r, function(e) {
-n.replicaSets = C(e.by("metadata.name"), !0), n.replicaSetsLoaded = !0, O(), c.log("replicasets", n.replicaSets);
+n.replicaSets = C(e.by("metadata.name"), !0), n.replicaSetsLoaded = !0, U(), c.log("replicasets", n.replicaSets);
 }, {
 poll: f,
 pollInterval: 6e4
 })), n.$on("$destroy", function() {
 o.unwatchAll(g);
 }), n.$watch("filters.hideOlderResources", function() {
-E(), B(), U(), O(), T();
+T(), B(), O(), U(), E();
 var e = t.search();
 e.hideOlderResources = n.filters.hideOlderResources ? "true" : "false", t.replace().search(e);
 }), n.$watch("kindSelector.selected.kind", function() {
@@ -5298,7 +5280,7 @@ subjectName: n.name
 httpErr: e("getErrorDetails")(r)
 }));
 });
-}, T = function(t, n, a) {
+}, E = function(t, n, a) {
 r.disableAddForm = !0, p.addSubject(t, n, a, g).then(function() {
 I(), P("success", w.update.subject.success({
 roleName: t.roleRef.name,
@@ -5312,11 +5294,11 @@ subjectName: n.name
 httpErr: e("getErrorDetails")(r)
 }));
 });
-}, E = {};
-n.tab && (E[n.tab] = !0);
+}, T = {};
+n.tab && (T[n.tab] = !0);
 var N = d.getSubjectKinds();
 angular.extend(r, {
-selectedTab: E,
+selectedTab: T,
 projectName: v,
 forms: {},
 subjectKinds: N,
@@ -5447,7 +5429,7 @@ name: n.metadata.name
 i && _.some(i.subjects, o) ? P("error", w.update.subject.exists({
 roleName: n.metadata.name,
 subjectName: e
-})) : i ? T(i, o, a) : R(n, o);
+})) : i ? E(i, o, a) : R(n, o);
 }
 }), f.listAllRoles(g, {
 errorNotification: !1
@@ -6154,7 +6136,7 @@ e.resource = "replicationcontrollers", e.healthCheckURL = g.healthCheckURL(n.pro
 }
 var j = {};
 e.projectName = n.project, e.kind = d, e.replicaSet = null, e.deploymentConfig = null, e.deploymentConfigMissing = !1, e.imagesByDockerReference = {}, e.builds = {}, e.alerts = {}, e.renderOptions = e.renderOptions || {}, e.renderOptions.hideFilterWidget = !0, e.forms = {}, e.logOptions = {};
-var k = r.getPreferredVersion("builds"), I = r.getPreferredVersion("imagestreams"), R = r.getPreferredVersion("horizontalpodautoscalers"), T = r.getPreferredVersion("limitranges"), E = r.getPreferredVersion("pods"), N = r.getPreferredVersion("replicasets"), D = r.getPreferredVersion("resourcequotas"), A = r.getPreferredVersion("appliedclusterresourcequotas");
+var k = r.getPreferredVersion("builds"), I = r.getPreferredVersion("imagestreams"), R = r.getPreferredVersion("horizontalpodautoscalers"), E = r.getPreferredVersion("limitranges"), T = r.getPreferredVersion("pods"), N = r.getPreferredVersion("replicasets"), D = r.getPreferredVersion("resourcequotas"), A = r.getPreferredVersion("appliedclusterresourcequotas");
 e.deploymentsVersion = r.getPreferredVersion("deployments"), e.deploymentConfigsVersion = r.getPreferredVersion("deploymentconfigs"), e.eventsVersion = r.getPreferredVersion("events"), e.deploymentConfigsLogVersion = "deploymentconfigs/log";
 var $ = [];
 p.isAvailable().then(function(t) {
@@ -6173,14 +6155,14 @@ e.autoscalers = e.hpaForRS.concat(t);
 var r = c.filterHPA(p, "Deployment", e.deployment.metadata.name);
 e.autoscalers = e.hpaForRS.concat(r);
 } else e.autoscalers = e.hpaForRS;
-}, U = function() {
+}, O = function() {
 $.push(i.watch(e.resource, u, function(t) {
 var n, r = [];
 angular.forEach(t.by("metadata.name"), function(t) {
 (C(t, "deploymentConfig") || "") === e.deploymentConfigName && r.push(t);
 }), n = s.getActiveDeployment(r), e.isActive = n && n.metadata.uid === e.replicaSet.metadata.uid, y();
 }));
-}, O = function() {
+}, U = function() {
 c.getHPAWarnings(e.replicaSet, e.autoscalers, e.limitRanges, r).then(function(t) {
 e.hpaWarnings = t;
 });
@@ -6253,14 +6235,14 @@ break;
 case "ReplicaSet":
 z();
 }
-O(), e.breadcrumbs = o.getBreadcrumbs({
+U(), e.breadcrumbs = o.getBreadcrumbs({
 object: t
 }), $.push(i.watchObject(e.resource, n.replicaSet, u, function(t, n) {
 "DELETED" === n && (e.alerts.deleted = {
 type: "warning",
 message: "This " + w + " has been deleted."
-}), e.replicaSet = t, L(t), O(), H(), e.deployment && x();
-})), e.deploymentConfigName && U(), $.push(i.watch(E, u, function(t) {
+}), e.replicaSet = t, L(t), U(), H(), e.deployment && x();
+})), e.deploymentConfigName && O(), $.push(i.watch(T, u, function(t) {
 var n = t.by("metadata.name");
 e.podsForDeployment = h.filterForOwner(n, e.replicaSet);
 }));
@@ -6286,12 +6268,12 @@ l.buildDockerRefMapForImageStreams(t, j), H(), m.log("imagestreams (subscribe)",
 })), $.push(i.watch(k, u, function(t) {
 e.builds = t.by("metadata.name"), m.log("builds (subscribe)", e.builds);
 })), $.push(i.watch(R, u, function(e) {
-p = e.by("metadata.name"), y(), O();
+p = e.by("metadata.name"), y(), U();
 }, {
 poll: V,
 pollInterval: 6e4
-})), i.list(T, u).then(function(t) {
-e.limitRanges = t.by("metadata.name"), O();
+})), i.list(E, u).then(function(t) {
+e.limitRanges = t.by("metadata.name"), U();
 });
 $.push(i.watch(D, u, function(t) {
 e.quotas = t.by("metadata.name");
@@ -7041,6 +7023,7 @@ d.hideNotification("set-compute-limits-error");
 a.cancel = y, a.$on("$destroy", b);
 var S = o.getPreferredVersion("limitranges");
 m.get(r.project).then(_.spread(function(e, t) {
+a.hideCPU = l.hasClusterResourceOverrides(e);
 var n = {
 resource: o.kindToResource(r.kind),
 group: r.group
@@ -7314,7 +7297,7 @@ sourcePath: e.name,
 destinationDir: e.value
 };
 });
-}, T = function(t) {
+}, E = function(t) {
 var n = {};
 switch (t.type) {
 case "ImageStreamTag":
@@ -7339,7 +7322,7 @@ name: _.last(r)
 }).namespace = 1 !== _.size(r) ? _.head(r) : e.buildConfig.metadata.namespace;
 }
 return n;
-}, E = function() {
+}, T = function() {
 var t = [].concat(e.triggers.imageChangeTriggers, e.triggers.builderImageChangeTrigger, e.triggers.configChangeTrigger);
 return t = _.filter(t, function(e) {
 return _.has(e, "disabled") && !e.disabled || e.present;
@@ -7395,7 +7378,7 @@ break;
 case "JenkinsPipeline":
 "path" === e.jenkinsfileOptions.type ? delete e.updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile : delete e.updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath;
 }
-switch (e.sources.images && !_.isEmpty(e.sourceImages) && (e.updatedBuildConfig.spec.source.images[0].paths = R(e.imageSourcePaths), e.updatedBuildConfig.spec.source.images[0].from = T(e.imageOptions.fromSource)), "None" === e.imageOptions.from.type ? delete b(e.updatedBuildConfig).from : b(e.updatedBuildConfig).from = T(e.imageOptions.from), "None" === e.imageOptions.to.type ? delete e.updatedBuildConfig.spec.output.to : e.updatedBuildConfig.spec.output.to = T(e.imageOptions.to), b(e.updatedBuildConfig).env = p.compactEntries(e.envVars), D(e.updatedBuildConfig.spec.source, _.head(e.secrets.picked.gitSecret), "sourceSecret"), D(b(e.updatedBuildConfig), _.head(e.secrets.picked.pullSecret), "pullSecret"), D(e.updatedBuildConfig.spec.output, _.head(e.secrets.picked.pushSecret), "pushSecret"), e.strategyType) {
+switch (e.sources.images && !_.isEmpty(e.sourceImages) && (e.updatedBuildConfig.spec.source.images[0].paths = R(e.imageSourcePaths), e.updatedBuildConfig.spec.source.images[0].from = E(e.imageOptions.fromSource)), "None" === e.imageOptions.from.type ? delete b(e.updatedBuildConfig).from : b(e.updatedBuildConfig).from = E(e.imageOptions.from), "None" === e.imageOptions.to.type ? delete e.updatedBuildConfig.spec.output.to : e.updatedBuildConfig.spec.output.to = E(e.imageOptions.to), b(e.updatedBuildConfig).env = p.compactEntries(e.envVars), D(e.updatedBuildConfig.spec.source, _.head(e.secrets.picked.gitSecret), "sourceSecret"), D(b(e.updatedBuildConfig), _.head(e.secrets.picked.pullSecret), "pullSecret"), D(e.updatedBuildConfig.spec.output, _.head(e.secrets.picked.pushSecret), "pushSecret"), e.strategyType) {
 case "Source":
 case "Docker":
 A(e.updatedBuildConfig.spec.source, e.secrets.picked.sourceSecrets);
@@ -7404,7 +7387,7 @@ break;
 case "Custom":
 A(b(e.updatedBuildConfig), e.secrets.picked.sourceSecrets);
 }
-e.updatedBuildConfig.spec.triggers = E(), k(), s.update(v, e.updatedBuildConfig.metadata.name, e.updatedBuildConfig, e.context).then(function() {
+e.updatedBuildConfig.spec.triggers = T(), k(), s.update(v, e.updatedBuildConfig.metadata.name, e.updatedBuildConfig, e.context).then(function() {
 l.addNotification({
 type: "success",
 message: "Build config " + e.updatedBuildConfig.metadata.name + " was successfully updated."
@@ -7619,7 +7602,7 @@ command: [],
 environment: []
 }), e.strategyParamsPropertyName = t;
 };
-var T = function(e, t, n, r) {
+var E = function(e, t, n, r) {
 var a = {
 kind: "ImageStreamTag",
 namespace: t.namespace,
@@ -7633,12 +7616,12 @@ containerNames: [ e ],
 from: a
 }
 }, n;
-}, E = function() {
+}, T = function() {
 var t = _.reject(e.updatedDeploymentConfig.spec.triggers, function(e) {
 return "ImageChange" === e.type || "ConfigChange" === e.type;
 });
 return _.each(e.containerConfigByName, function(n, r) {
-n.hasDeploymentTrigger ? t.push(T(r, n.triggerData.istag, n.triggerData.data, n.triggerData.automatic)) : _.find(e.updatedDeploymentConfig.spec.template.spec.containers, {
+n.hasDeploymentTrigger ? t.push(E(r, n.triggerData.istag, n.triggerData.data, n.triggerData.automatic)) : _.find(e.updatedDeploymentConfig.spec.template.spec.containers, {
 name: r
 }).image = n.image;
 }), e.triggers.hasConfigTrigger && t.push({
@@ -7660,7 +7643,7 @@ var o = e.strategyData[e.strategyParamsPropertyName].maxUnavailable, i = Number(
 }
 "Custom" !== e.strategyData.type && _.each([ "pre", "mid", "post" ], function(t) {
 _.has(e.strategyData, [ e.strategyParamsPropertyName, t, "execNewPod", "env" ]) && (e.strategyData[e.strategyParamsPropertyName][t].execNewPod.env = g.compactEntries(e.strategyData[e.strategyParamsPropertyName][t].execNewPod.env));
-}), _.has(e, "strategyData.customParams.environment") && (e.strategyData.customParams.environment = g.compactEntries(e.strategyData.customParams.environment)), e.updatedDeploymentConfig.spec.template.spec.imagePullSecrets = _.filter(e.secrets.pullSecrets, "name"), e.updatedDeploymentConfig.spec.strategy = e.strategyData, e.updatedDeploymentConfig.spec.triggers = E(), N(), l.update(b, e.updatedDeploymentConfig.metadata.name, e.updatedDeploymentConfig, e.context).then(function() {
+}), _.has(e, "strategyData.customParams.environment") && (e.strategyData.customParams.environment = g.compactEntries(e.strategyData.customParams.environment)), e.updatedDeploymentConfig.spec.template.spec.imagePullSecrets = _.filter(e.secrets.pullSecrets, "name"), e.updatedDeploymentConfig.spec.strategy = e.strategyData, e.updatedDeploymentConfig.spec.triggers = T(), N(), l.update(b, e.updatedDeploymentConfig.metadata.name, e.updatedDeploymentConfig, e.context).then(function() {
 m.addNotification({
 type: "success",
 message: "Deployment config " + e.updatedDeploymentConfig.metadata.name + " was successfully updated."
@@ -7723,7 +7706,7 @@ subresource: "scale"
 },
 minReplicas: e.autoscaling.minReplicas,
 maxReplicas: e.autoscaling.maxReplicas,
-targetCPUUtilizationPercentage: e.autoscaling.targetCPU || e.autoscaling.defaultTargetCPU || null
+targetCPUUtilizationPercentage: e.autoscaling.targetCPU
 }
 };
 s.create(y, null, t, r).then(function(e) {
@@ -7740,7 +7723,7 @@ details: g(t)
 });
 });
 }, f = function(t) {
-e.disableInputs = !0, (t = angular.copy(t)).metadata.labels = p.mapEntries(p.compactEntries(e.labels)), t.spec.minReplicas = e.autoscaling.minReplicas, t.spec.maxReplicas = e.autoscaling.maxReplicas, t.spec.targetCPUUtilizationPercentage = e.autoscaling.targetCPU || e.autoscaling.defaultTargetCPU || null, s.update(y, t.metadata.name, t, r).then(function(e) {
+e.disableInputs = !0, (t = angular.copy(t)).metadata.labels = p.mapEntries(p.compactEntries(e.labels)), t.spec.minReplicas = e.autoscaling.minReplicas, t.spec.maxReplicas = e.autoscaling.maxReplicas, t.spec.targetCPUUtilizationPercentage = e.autoscaling.targetCPU, s.update(y, t.metadata.name, t, r).then(function(e) {
 d.addNotification({
 type: "success",
 message: "Horizontal pod autoscaler " + e.metadata.name + " successfully updated."
@@ -8059,27 +8042,27 @@ e.displayName = a.displayName, e.advancedOptions = "true" === a.advanced;
 var I = {
 name: "app",
 value: ""
-}, R = t("orderByDisplayName"), T = t("getErrorDetails"), E = {}, N = function() {
-g.hideNotification("create-builder-list-config-maps-error"), g.hideNotification("create-builder-list-secrets-error"), _.each(E, function(e) {
+}, R = t("orderByDisplayName"), E = t("getErrorDetails"), T = {}, N = function() {
+g.hideNotification("create-builder-list-config-maps-error"), g.hideNotification("create-builder-list-secrets-error"), _.each(T, function(e) {
 !e.id || "error" !== e.type && "warning" !== e.type || g.hideNotification(e.id);
 });
 };
 e.$on("$destroy", N);
-var D = i.getPreferredVersion("configmaps"), A = i.getPreferredVersion("limitranges"), $ = i.getPreferredVersion("imagestreams"), B = i.getPreferredVersion("imagestreamtags"), L = i.getPreferredVersion("secrets"), V = i.getPreferredVersion("resourcequotas"), U = i.getPreferredVersion("appliedclusterresourcequotas");
+var D = i.getPreferredVersion("configmaps"), A = i.getPreferredVersion("limitranges"), $ = i.getPreferredVersion("imagestreams"), B = i.getPreferredVersion("imagestreamtags"), L = i.getPreferredVersion("secrets"), V = i.getPreferredVersion("resourcequotas"), O = i.getPreferredVersion("appliedclusterresourcequotas");
 v.get(a.project).then(_.spread(function(t, n) {
-e.project = t, a.sourceURI && (e.sourceURIinParams = !0);
+e.project = t, a.sourceURI && (e.sourceURIinParams = !0), e.hasClusterResourceOverrides = d.hasClusterResourceOverrides(t);
 var i = function() {
-e.hideCPU || (e.cpuProblems = d.validatePodLimits(e.limitRanges, "cpu", [ e.container ], t)), e.memoryProblems = d.validatePodLimits(e.limitRanges, "memory", [ e.container ], t);
+e.cpuProblems = d.validatePodLimits(e.limitRanges, "cpu", [ e.container ], t), e.memoryProblems = d.validatePodLimits(e.limitRanges, "memory", [ e.container ], t);
 };
 c.list(A, n).then(function(t) {
 e.limitRanges = t.by("metadata.name"), _.isEmpty(e.limitRanges) || e.$watch("container", i, !0);
 });
 var v, y, C = function() {
-e.scaling.autoscale ? e.showCPURequestWarning = !l.hasCPURequest([ e.container ], e.limitRanges, t) : e.showCPURequestWarning = !1;
+e.scaling.autoscale && !e.hasClusterResourceOverrides ? e.showCPURequestWarning = !l.hasCPURequest([ e.container ], e.limitRanges, t) : e.showCPURequestWarning = !1;
 };
 c.list(V, n).then(function(e) {
 v = e.by("metadata.name"), m.log("quotas", v);
-}), c.list(U, n).then(function(e) {
+}), c.list(O, n).then(function(e) {
 y = e.by("metadata.name"), m.log("cluster quotas", y);
 }), e.$watch("scaling.autoscale", C), e.$watch("container", C, !0), e.$watch("name", function(e, t) {
 I.value && I.value !== t || (I.value = e);
@@ -8132,7 +8115,7 @@ o = R(t.by("metadata.name")), e.valueFromObjects = o.concat(i);
 id: "create-builder-list-config-maps-error",
 type: "error",
 message: "Could not load config maps.",
-details: T(e)
+details: E(e)
 });
 }), c.list(L, n, null, {
 errorNotification: !1
@@ -8149,7 +8132,7 @@ e.unshift("");
 id: "create-builder-list-secrets-error",
 type: "error",
 message: "Could not load secrets.",
-details: T(e)
+details: E(e)
 });
 }), c.get($, r.imageName, {
 namespace: r.namespace || a.project
@@ -8175,7 +8158,7 @@ f.toErrorPage("Cannot create from source: the specified image could not be retri
 f.toErrorPage("Cannot create from source: the specified image could not be retrieved.");
 });
 }(e);
-var O, F = function() {
+var U, F = function() {
 var t = {
 started: "Creating application " + e.name + " in project " + e.projectDisplayName(),
 success: "Created application " + e.name + " in project " + e.projectDisplayName(),
@@ -8183,7 +8166,7 @@ failure: "Failed to create " + e.name + " in project " + e.projectDisplayName()
 }, o = {};
 S.clear(), S.add(t, o, a.project, function() {
 var t = r.defer();
-return c.batch(O, n).then(function(n) {
+return c.batch(U, n).then(function(n) {
 var r = [], a = !1;
 _.isEmpty(n.failure) ? r.push({
 type: "success",
@@ -8225,21 +8208,21 @@ cancelButtonText: "Cancel"
 }
 }).result.then(F);
 }, M = function(t) {
-N(), E = t.quotaAlerts || [], e.nameTaken || _.some(E, {
+N(), T = t.quotaAlerts || [], e.nameTaken || _.some(T, {
 type: "error"
-}) ? (e.disableInputs = !1, _.each(E, function(e) {
+}) ? (e.disableInputs = !1, _.each(T, function(e) {
 e.id = _.uniqueId("create-builder-alert-"), g.addNotification(e);
-})) : _.isEmpty(E) ? F() : (x(E), e.disableInputs = !1);
+})) : _.isEmpty(T) ? F() : (x(T), e.disableInputs = !1);
 };
 e.projectDisplayName = function() {
 return P(this.project) || this.projectName;
 }, e.createApp = function() {
 e.disableInputs = !0, N(), e.buildConfig.envVars = w.compactEntries(e.buildConfigEnvVars), e.deploymentConfig.envVars = w.compactEntries(e.DCEnvVarsFromUser), e.labels = w.mapEntries(w.compactEntries(e.labelArray));
 var t = s.generate(e);
-O = [], angular.forEach(t, function(e) {
-null !== e && (m.debug("Generated resource definition:", e), O.push(e));
+U = [], angular.forEach(t, function(e) {
+null !== e && (m.debug("Generated resource definition:", e), U.push(e));
 });
-var r = s.ifResourcesDontExist(O, e.projectName), a = h.getLatestQuotaAlerts(O, n), o = function(t) {
+var r = s.ifResourcesDontExist(U, e.projectName), a = h.getLatestQuotaAlerts(U, n), o = function(t) {
 return e.nameTaken = t.nameTaken, a;
 };
 r.then(o, o).then(M, M);
@@ -9720,7 +9703,7 @@ t > 0 && r.push(P()), e > 0 && r.push(w()), n.all(r).then(b);
 }
 function b() {
 var e, n;
-E(), "Template" === p.resourceKind && p.templateOptions.process && !p.errorOccurred ? p.isDialog ? p.$emit("fileImportedFromYAMLOrJSON", {
+T(), "Template" === p.resourceKind && p.templateOptions.process && !p.errorOccurred ? p.isDialog ? p.$emit("fileImportedFromYAMLOrJSON", {
 project: p.input.selectedProject,
 template: p.resource
 }) : (n = p.templateOptions.add || p.updateResources.length > 0 ? p.input.selectedProject.metadata.name : "", e = s.createFromTemplateURL(p.resource, p.input.selectedProject.metadata.name, {
@@ -9901,18 +9884,18 @@ cancelButtonText: "Cancel"
 }
 }
 }).result.then(y);
-}, T = {}, E = function() {
-c.hideNotification("from-file-error"), _.each(T, function(e) {
+}, E = {}, T = function() {
+c.hideNotification("from-file-error"), _.each(E, function(e) {
 !e.id || "error" !== e.type && "warning" !== e.type || c.hideNotification(e.id);
 });
 }, N = function(e) {
-E(), T = u.getSecurityAlerts(p.createResources, p.input.selectedProject.metadata.name);
+T(), E = u.getSecurityAlerts(p.createResources, p.input.selectedProject.metadata.name);
 var t = e.quotaAlerts || [];
-T = T.concat(t), _.filter(T, {
+E = E.concat(t), _.filter(E, {
 type: "error"
-}).length ? (_.each(T, function(e) {
+}).length ? (_.each(E, function(e) {
 e.id = _.uniqueId("from-file-alert-"), c.addNotification(e);
-}), p.disableInputs = !1) : T.length ? (R(T), p.disableInputs = !1) : y();
+}), p.disableInputs = !1) : E.length ? (R(E), p.disableInputs = !1) : y();
 }, D = function() {
 if (_.has(p.input.selectedProject, "metadata.uid")) return n.when(p.input.selectedProject);
 var t = p.input.selectedProject.metadata.name, r = p.input.selectedProject.metadata.annotations["new-display-name"], a = e("description")(p.input.selectedProject);
@@ -9944,10 +9927,10 @@ details: I(e)
 });
 }
 }, p.cancel = function() {
-E(), s.toProjectOverview(p.input.selectedProject.metadata.name);
+T(), s.toProjectOverview(p.input.selectedProject.metadata.name);
 };
 var A = e("displayName");
-p.$on("importFileFromYAMLOrJSON", p.create), p.$on("$destroy", E);
+p.$on("importFileFromYAMLOrJSON", p.create), p.$on("$destroy", T);
 } ]
 };
 } ]), angular.module("openshiftConsole").directive("oscFileInput", [ "Logger", function(e) {
@@ -10316,34 +10299,19 @@ t.clusterQuotas = e.by("metadata.name");
 });
 }
 };
-} ]), angular.module("openshiftConsole").directive("oscAutoscaling", [ "HPAService", "LimitRangesService", "DNS1123_SUBDOMAIN_VALIDATION", function(e, t, n) {
+} ]), angular.module("openshiftConsole").directive("oscAutoscaling", [ "Constants", "HPAService", "DNS1123_SUBDOMAIN_VALIDATION", function(e, t, n) {
 return {
 restrict: "E",
 scope: {
 autoscaling: "=model",
-project: "=",
 showNameInput: "=?",
 nameReadOnly: "=?"
 },
 templateUrl: "views/directives/osc-autoscaling.html",
-link: function(r) {
-r.nameValidation = n, r.$watch("project", function() {
-if (r.project) {
-r.isRequestCalculated = t.isRequestCalculated("cpu", r.project);
-var n = window.OPENSHIFT_CONSTANTS.DEFAULT_HPA_CPU_TARGET_PERCENT;
-r.isRequestCalculated && (n = e.convertLimitPercentToRequest(n, r.project)), _.set(r, "autoscaling.defaultTargetCPU", n), r.defaultTargetCPUDisplayValue = window.OPENSHIFT_CONSTANTS.DEFAULT_HPA_CPU_TARGET_PERCENT;
-var a = !1;
-r.$watch("autoscaling.targetCPU", function(t) {
-a ? a = !1 : (t && r.isRequestCalculated && (t = e.convertRequestPercentToLimit(t, r.project)), _.set(r, "targetCPUInput.percent", t));
-});
-var o = function(t) {
-t && r.isRequestCalculated && (t = e.convertLimitPercentToRequest(t, r.project)), a = !0, _.set(r, "autoscaling.targetCPU", t);
-};
-r.$watch("targetCPUInput.percent", function(e, t) {
-e !== t && o(e);
-});
-}
-});
+link: function(t) {
+t.nameValidation = n;
+var r = e.DEFAULT_HPA_CPU_TARGET_PERCENT, a = _.get(t, "autoscaling.targetCPU");
+_.isNil(a) && r && _.set(t, "autoscaling.targetCPU", r);
 }
 };
 } ]), angular.module("openshiftConsole").directive("oscSecrets", [ "$uibModal", "$filter", "APIService", "DataService", "SecretsService", function(e, t, n, r, a) {
@@ -10805,17 +10773,17 @@ _.size(h) <= 100 ? (y = e("orderByDisplayName")(h), I = _.map(y, function(e) {
 return n(e, !1);
 })) : I = [ n(h[t], !0) ], k.empty(), k.append(I), k.append($('<option data-divider="true"></option>')), k.append($('<option value="">View All Projects</option>')), k.selectpicker("refresh");
 }
-}, T = function() {
+}, E = function() {
 return f.list().then(function(e) {
 h = e.by("metadata.name");
 });
-}, E = function() {
+}, T = function() {
 var e = a.project;
 i.currentProjectName !== e && (i.currentProjectName = e, i.chromeless = "chromeless" === a.view, e && !i.chromeless ? (_.set(r, "view.hasProject", !0), i.canIAddToProject = !1, s.getProjectRules(e).then(function() {
 i.currentProjectName === e && (i.canIAddToProject = s.canIAddToProject(e), i.canIAddToProject && l.getCatalogItems().then(function(e) {
 i.catalogItems = e;
 }));
-}), T().then(function() {
+}), E().then(function() {
 i.currentProjectName && h && (h[i.currentProjectName] || (h[i.currentProjectName] = {
 metadata: {
 name: i.currentProjectName
@@ -10854,7 +10822,7 @@ m.toProjectCatalog(i.currentProjectName, n);
 });
 i.closeOrderingPanel = function() {
 v.addItem(_.get(i.selectedItem, "resource.metadata.uid")), i.orderingPanelVisible = !1;
-}, E(), i.$on("$routeChangeSuccess", E), k.selectpicker({
+}, T(), i.$on("$routeChangeSuccess", T), k.selectpicker({
 iconBase: "fa",
 tickIcon: "fa-check"
 }).change(function() {
@@ -11777,7 +11745,7 @@ if (!m.pod) return null;
 var t = m.options.selectedContainer;
 switch (e) {
 case "memory/usage":
-var n = E(t);
+var n = T(t);
 if (n) return s.bytesToMiB(d(n));
 break;
 
@@ -11812,10 +11780,10 @@ _.each(e.datasets, function(e) {
 t[e.id] = e.data;
 });
 var n, a = c.getSparklineData(t), o = e.chartPrefix + "sparkline";
-T[o] ? T[o].load(a) : ((n = L(e)).data = a, e.chartDataColors && (n.color = {
+E[o] ? E[o].load(a) : ((n = L(e)).data = a, e.chartDataColors && (n.color = {
 pattern: e.chartDataColors
 }), r(function() {
-A || (T[o] = c3.generate(n));
+A || (E[o] = c3.generate(n));
 }));
 }
 }
@@ -11903,7 +11871,7 @@ m.loaded = !0;
 }
 }
 m.includedMetrics = m.includedMetrics || [ "cpu", "memory", "network" ];
-var I, R = {}, T = {}, E = n("resources.limits.memory"), N = n("resources.limits.cpu"), D = 30, A = !1;
+var I, R = {}, E = {}, T = n("resources.limits.memory"), N = n("resources.limits.cpu"), D = 30, A = !1;
 m.uniqueID = c.uniqueID(), m.metrics = [], _.includes(m.includedMetrics, "memory") && m.metrics.push({
 label: "Memory",
 units: "MiB",
@@ -11999,15 +11967,15 @@ delete e.data;
 }), delete m.metricsError, k();
 }, !0), I = t(k, c.getDefaultUpdateInterval(), !1);
 });
-var U = o.$on("metrics.charts.resize", function() {
-c.redraw(R), c.redraw(T);
+var O = o.$on("metrics.charts.resize", function() {
+c.redraw(R), c.redraw(E);
 });
 m.$on("$destroy", function() {
-I && (t.cancel(I), I = null), U && (U(), U = null), angular.forEach(R, function(e) {
+I && (t.cancel(I), I = null), O && (O(), O = null), angular.forEach(R, function(e) {
 e.destroy();
-}), R = null, angular.forEach(T, function(e) {
+}), R = null, angular.forEach(E, function(e) {
 e.destroy();
-}), T = null, A = !0;
+}), E = null, A = !0;
 });
 }
 };
@@ -12069,7 +12037,7 @@ return e[0];
 function u(e) {
 P || (N = 0, t.showAverage = _.size(t.pods) > 5 || w, _.each(t.metrics, function(n) {
 var r, a = o(e, n), i = n.descriptor;
-w && n.compactCombineWith && (i = n.compactCombineWith, n.lastValue && (E[i].lastValue = (E[i].lastValue || 0) + n.lastValue)), S[i] ? (S[i].load(a), t.showAverage ? S[i].legend.hide() : S[i].legend.show()) : ((r = D(n)).data = a, S[i] = c3.generate(r));
+w && n.compactCombineWith && (i = n.compactCombineWith, n.lastValue && (T[i].lastValue = (T[i].lastValue || 0) + n.lastValue)), S[i] ? (S[i].load(a), t.showAverage ? S[i].legend.hide() : S[i].legend.show()) : ((r = D(n)).data = a, S[i] = c3.generate(r));
 }));
 }
 function d() {
@@ -12133,7 +12101,7 @@ t.loaded = !0;
 }
 var b, S = {}, C = 30, w = "compact" === t.profile, P = !1;
 t.uniqueID = s.uniqueID();
-var j, k, I = {}, R = w, T = function(e) {
+var j, k, I = {}, R = w, E = function(e) {
 return e >= 1024;
 };
 t.metrics = [ {
@@ -12141,10 +12109,10 @@ label: "Memory",
 units: "MiB",
 convert: i.bytesToMiB,
 formatUsage: function(e) {
-return T(e) && (e /= 1024), s.formatUsage(e);
+return E(e) && (e /= 1024), s.formatUsage(e);
 },
 usageUnits: function(e) {
-return T(e) ? "GiB" : "MiB";
+return E(e) ? "GiB" : "MiB";
 },
 descriptor: "memory/usage",
 type: "pod_container",
@@ -12189,7 +12157,7 @@ compactDatasetLabel: "Received",
 compactType: "spline",
 chartID: "network-rx-" + t.uniqueID
 } ];
-var E = _.keyBy(t.metrics, "descriptor");
+var T = _.keyBy(t.metrics, "descriptor");
 t.loaded = !1, t.noData = !0, t.showComputeUnitsHelp = function() {
 l.showComputeUnitsHelp();
 };
@@ -12289,17 +12257,17 @@ n > 10 ? e() : (n++, j().is(":visible") && (k(), e()));
 k(!0), b(), C();
 }, 100);
 m.on("resize", R);
-var T, E = function() {
+var E, T = function() {
 S = !0, d.scrollBottom(u);
 }, N = document.createDocumentFragment(), D = _.debounce(function() {
-l.appendChild(N), N = document.createDocumentFragment(), t.autoScrollActive && E(), t.showScrollLinks || b();
+l.appendChild(N), N = document.createDocumentFragment(), t.autoScrollActive && T(), t.showScrollLinks || b();
 }, 100, {
 maxWait: 300
 }), A = function(e) {
 var t = a.defer();
-return T ? (T.onClose(function() {
+return E ? (E.onClose(function() {
 t.resolve();
-}), T.stop()) : t.resolve(), e || (D.cancel(), l && (l.innerHTML = ""), N = document.createDocumentFragment()), t.promise;
+}), E.stop()) : t.resolve(), e || (D.cancel(), l && (l.innerHTML = ""), N = document.createDocumentFragment()), t.promise;
 }, B = function() {
 A().then(function() {
 t.$evalAsync(function() {
@@ -12319,7 +12287,7 @@ limitBytes: 10485760
 }, t.options), n = 0, r = function(e) {
 n++, N.appendChild(f(n, e)), D();
 };
-(T = c.createStream(v, h, t.context, e)).onMessage(function(a, o, i) {
+(E = c.createStream(v, h, t.context, e)).onMessage(function(a, o, i) {
 t.$evalAsync(function() {
 t.empty = !1, "logs" !== t.state && (t.state = "logs", I());
 }), a && (e.limitBytes && i >= e.limitBytes && (t.$evalAsync(function() {
@@ -12327,18 +12295,18 @@ t.limitReached = !0, t.loading = !1;
 }), A(!0)), r(a), !t.largeLog && n >= e.tailLines && t.$evalAsync(function() {
 t.largeLog = !0;
 }));
-}), T.onClose(function() {
-T = null, t.$evalAsync(function() {
+}), E.onClose(function() {
+E = null, t.$evalAsync(function() {
 t.loading = !1, t.autoScrollActive = !1, 0 !== n || t.emptyStateMessage || (t.state = "empty", t.emptyStateMessage = "The logs are no longer available or could not be loaded.");
 });
-}), T.onError(function() {
-T = null, t.$evalAsync(function() {
+}), E.onError(function() {
+E = null, t.$evalAsync(function() {
 angular.extend(t, {
 loading: !1,
 autoScrollActive: !1
 }), 0 === n ? (t.state = "empty", t.emptyStateMessage = "The logs are no longer available or could not be loaded.") : t.errorWhileRunning = !0;
 });
-}), T.start();
+}), E.start();
 }
 });
 });
@@ -12379,7 +12347,7 @@ onScrollTop: function() {
 t.autoScrollActive = !1, d.scrollTop(u), $("#" + t.logViewerID + "-affixedFollow").affix("checkPosition");
 },
 toggleAutoScroll: function() {
-t.autoScrollActive = !t.autoScrollActive, t.autoScrollActive && E();
+t.autoScrollActive = !t.autoScrollActive, t.autoScrollActive && T();
 },
 goChromeless: d.chromelessLink,
 restartLogs: B
@@ -13394,7 +13362,7 @@ return {
 name: t,
 value: e
 };
-}), T() && h.labels.push({
+}), E() && h.labels.push({
 name: "app",
 value: h.template.metadata.name
 });
@@ -13510,7 +13478,7 @@ details: t
 }, h.cancel = function() {
 j(), i.toProjectOverview(h.project.metadata.name);
 }, n.$on("instantiateTemplate", h.createFromTemplate), n.$on("$destroy", j);
-var T = function() {
+var E = function() {
 return !_.get(h.template, "labels.app") && !_.some(h.template.objects, "metadata.labels.app");
 };
 } ],
@@ -14465,11 +14433,11 @@ details: y(e)
 }
 } else n.mode = "istag";
 });
-var R, T = e("displayName"), E = function() {
+var R, E = e("displayName"), T = function() {
 var e = {
-started: "Deploying image " + n.app.name + " to project " + T(n.input.selectedProject),
-success: "Deployed image " + n.app.name + " to project " + T(n.input.selectedProject),
-failure: "Failed to deploy image " + n.app.name + " to project " + T(n.input.selectedProject)
+started: "Deploying image " + n.app.name + " to project " + E(n.input.selectedProject),
+success: "Deployed image " + n.app.name + " to project " + E(n.input.selectedProject),
+failure: "Failed to deploy image " + n.app.name + " to project " + E(n.input.selectedProject)
 };
 m.clear(), m.add(e, {}, n.input.selectedProject.metadata.name, function() {
 var e = t.defer();
@@ -14516,7 +14484,7 @@ cancelButtonText: "Cancel"
 };
 }
 }
-}).result.then(E);
+}).result.then(T);
 }, D = function(e) {
 b = e.quotaAlerts || [];
 var t = _.filter(b, {
@@ -14524,7 +14492,7 @@ type: "error"
 });
 n.nameTaken || t.length ? (n.disableInputs = !1, _.each(b, function(e) {
 e.id = _.uniqueId("deploy-image-alert-"), l.addNotification(e);
-})) : b.length ? (N(b), n.disableInputs = !1) : E();
+})) : b.length ? (N(b), n.disableInputs = !1) : T();
 };
 n.create = function() {
 n.disableInputs = !0, S(), C().then(function(e) {
@@ -14986,15 +14954,15 @@ return _.filter(e, "unread");
 _.each(h.notificationGroups, function(e) {
 e.totalUnread = I(e.notifications).length, e.hasUnread = !!e.totalUnread, r.$emit("NotificationDrawerWrapper.onUnreadNotifications", e.totalUnread);
 });
-}, T = function(e) {
+}, E = function(e) {
 _.each(h.notificationGroups, function(t) {
 _.remove(t.notifications, {
 uid: e.uid,
 namespace: e.namespace
 });
 });
-}, E = function(e) {
-S[a.project] && delete S[a.project][e.uid], b[a.project] && delete b[a.project][e.uid], T(e);
+}, T = function(e) {
+S[a.project] && delete S[a.project][e.uid], b[a.project] && delete b[a.project][e.uid], E(e);
 }, N = function() {
 b[a.project] = {}, S[a.project] = {};
 }, D = function(e) {
@@ -15027,9 +14995,9 @@ h.notificationGroups = [ k(a.project, B($(b, S))) ], R();
 _.each(y, function(e) {
 e();
 }), y = [];
-}, U = function() {
-m && (l.unwatch(m), m = null);
 }, O = function() {
+m && (l.unwatch(m), m = null);
+}, U = function() {
 d && d(), d = null;
 }, F = function(e) {
 b[a.project] = D(A(e.by("metadata.name"))), L();
@@ -15049,13 +15017,13 @@ namespace: n,
 links: t.links
 }, L());
 }, M = function(e, t) {
-U(), e && (m = l.watch(p, {
+O(), e && (m = l.watch(p, {
 namespace: e
 }, _.debounce(t, 400), {
 skipDigest: !0
 }));
 }, q = _.once(function(e, t) {
-O(), d = r.$on("NotificationsService.onNotificationAdded", t);
+U(), d = r.$on("NotificationsService.onNotificationAdded", t);
 }), z = function() {
 j(a.project).then(function() {
 M(a.project, F), q(a.project, x), w(a.project), L();
@@ -15087,7 +15055,7 @@ headingInclude: "views/directives/notifications/header.html",
 notificationBodyInclude: "views/directives/notifications/notification-body.html",
 customScope: {
 clear: function(e, t, n) {
-u.markRead(e.uid), u.markCleared(e.uid), n.notifications.splice(t, 1), E(e), L();
+u.markRead(e.uid), u.markCleared(e.uid), n.notifications.splice(t, 1), T(e), L();
 },
 markRead: function(e) {
 e.unread = !1, u.markRead(e.uid), L();
@@ -15111,13 +15079,13 @@ h.drawerHidden = !h.drawerHidden;
 })), y.push(r.$on("NotificationDrawerWrapper.hide", function() {
 h.drawerHidden = !0;
 })), y.push(r.$on("NotificationDrawerWrapper.clear", function(e, t) {
-u.markCleared(t.uid), E(t), R();
+u.markCleared(t.uid), T(t), R();
 }));
 };
 h.$onInit = function() {
 g || v || H();
 }, h.$onDestroy = function() {
-O(), U(), V();
+U(), O(), V();
 };
 } ]
 });
@@ -15767,10 +15735,6 @@ return e.isRequestCalculated(t, n);
 } ]).filter("isLimitCalculated", [ "LimitRangesService", function(e) {
 return function(t, n) {
 return e.isLimitCalculated(t, n);
-};
-} ]).filter("hpaCPUPercent", [ "HPAService", "LimitRangesService", function(e, t) {
-return function(n, r) {
-return n && t.isRequestCalculated("cpu", r) ? e.convertRequestPercentToLimit(n, r) : n;
 };
 } ]).filter("podTemplate", function() {
 return function(e) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5009,16 +5009,10 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"help-block\">Replicas must be an integer value greater than or equal to 0.</span>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<osc-autoscaling ng-if=\"scaling.autoscale\" model=\"scaling\" project=\"project\">\n" +
-    "</osc-autoscaling>\n" +
+    "<osc-autoscaling ng-if=\"scaling.autoscale\" model=\"scaling\"></osc-autoscaling>\n" +
     "<div class=\"has-warning\" ng-if=\"showCPURequestWarning\">\n" +
     "<span class=\"help-block\">\n" +
-    "You should configure resource limits below for autoscaling. Autoscaling will not work without a CPU\n" +
-    "<span ng-if=\"'cpu' | isRequestCalculated : project\">limit.</span>\n" +
-    "<span ng-if=\"!('cpu' | isRequestCalculated : project)\">request.</span>\n" +
-    "<span ng-if=\"'cpu' | isLimitCalculated : project\">\n" +
-    "The CPU limit will be automatically calculated from the container memory limit.\n" +
-    "</span>\n" +
+    "You should configure resource limits below for autoscaling. Autoscaling will not work without a CPU request.\n" +
     "</span>\n" +
     "</div>\n" +
     "</osc-form-section>\n" +
@@ -7359,7 +7353,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</delete-link>\n" +
     "</span>\n" +
     "</h4>\n" +
-    "<dl class=\"dl-horizontal left\" style=\"margin-bottom: 10px\">\n" +
+    "<dl class=\"dl-horizontal left mar-top-md\">\n" +
     "<dt ng-if-start=\"showScaleTarget && hpa.spec.scaleTargetRef.kind && hpa.spec.scaleTargetRef.name\">{{hpa.spec.scaleTargetRef.kind | humanizeKind : true}}:</dt>\n" +
     "<dd ng-if-end>\n" +
     "<a ng-href=\"{{hpa.spec.scaleTargetRef.name | navigateResourceURL : hpa.spec.scaleTargetRef.kind : hpa.metadata.namespace}}\">{{hpa.spec.scaleTargetRef.name}}</a>\n" +
@@ -7369,12 +7363,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt>Max Pods:</dt>\n" +
     "<dd>{{hpa.spec.maxReplicas}}</dd>\n" +
     "<dt ng-if-start=\"hpa.spec.targetCPUUtilizationPercentage\">\n" +
-    "CPU\n" +
-    "<span ng-if=\"'cpu' | isRequestCalculated : project\">Limit</span>\n" +
-    "<span ng-if=\"!('cpu' | isRequestCalculated : project)\">Request</span>\n" +
-    "Target:\n" +
+    "CPU Request\n" +
     "</dt>\n" +
-    "<dd ng-if-end>{{hpa.spec.targetCPUUtilizationPercentage | hpaCPUPercent : project}}%</dd>\n" +
+    "<dd ng-if-end>{{hpa.spec.targetCPUUtilizationPercentage}}%</dd>\n" +
     "<dt>\n" +
     "Current Usage:\n" +
     "</dt>\n" +
@@ -7382,7 +7373,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<em>Not available</em>\n" +
     "</dd>\n" +
     "<dd ng-if=\"!(hpa.status.currentCPUUtilizationPercentage | isNil)\">\n" +
-    "{{hpa.status.currentCPUUtilizationPercentage | hpaCPUPercent : project}}%\n" +
+    "{{hpa.status.currentCPUUtilizationPercentage}}%\n" +
     "</dd>\n" +
     "<dt ng-if-start=\"hpa.status.lastScaleTime\">Last Scaled:</dt>\n" +
     "<dd ng-if-end><span am-time-ago=\"hpa.status.lastScaleTime\"></span></dd>\n" +
@@ -8067,27 +8058,20 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"form-group\">\n" +
     "<label>\n" +
-    "CPU\n" +
-    "<span ng-if=\"isRequestCalculated\">Limit</span>\n" +
-    "<span ng-if=\"!isRequestCalculated\">Request</span>\n" +
-    "Target\n" +
+    "CPU Request Target\n" +
     "</label>\n" +
     "<div class=\"input-group\" ng-class=\"{ 'has-error': form.targetCPU.$invalid && form.targetCPU.$touched }\">\n" +
-    "<input type=\"number\" class=\"form-control\" min=\"1\" name=\"targetCPU\" ng-model=\"targetCPUInput.percent\" pattern=\"\\d*\" select-on-focus aria-describedby=\"target-cpu-help\">\n" +
+    "<input type=\"number\" class=\"form-control\" min=\"1\" name=\"targetCPU\" ng-model=\"autoscaling.targetCPU\" pattern=\"\\d*\" select-on-focus aria-describedby=\"target-cpu-help\">\n" +
     "<span class=\"input-group-addon\">%</span>\n" +
     "</div>\n" +
     "<div id=\"target-cpu-help\" class=\"help-block\">\n" +
-    "The percentage of the CPU\n" +
-    "<span ng-if=\"isRequestCalculated\">limit</span>\n" +
-    "<span ng-if=\"!isRequestCalculated\">request</span>\n" +
-    "that each pod should ideally be using. Pods will be added or removed periodically when CPU usage exceeds or drops below this target value.\n" +
-    "<span ng-if=\"defaultTargetCPUDisplayValue\">Defaults to {{defaultTargetCPUDisplayValue}}%.</span>\n" +
+    "The percentage of the CPU request that each pod should ideally be using. Pods will be added or removed periodically when CPU usage exceeds or drops below this target value.\n" +
     "</div>\n" +
     "<div class=\"learn-more-block\">\n" +
-    "<a href=\"{{'compute_resources' | helpLink}}\" target=\"_blank\">Learn More&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></a>\n" +
+    "<a ng-href=\"{{'compute_resources' | helpLink}}\" target=\"_blank\">Learn More&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></a>\n" +
     "</div>\n" +
     "\n" +
-    "<div class=\"has-error\" style=\"margin-top: 10px\" ng-show=\"form.targetCPU.$touched && form.targetCPU.$invalid\">\n" +
+    "<div class=\"has-error mar-top-md\" ng-show=\"form.targetCPU.$touched && form.targetCPU.$invalid\">\n" +
     "<span ng-if=\"form.targetCPU.$error.number\" class=\"help-block\">\n" +
     "Target CPU percentage must be a number.\n" +
     "</span>\n" +
@@ -9474,7 +9458,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"!('cpu' | isRequestCalculated : project)\">request.</span>\n" +
     "</div>\n" +
     "<fieldset ng-disabled=\"disableInputs\" class=\"gutter-top\">\n" +
-    "<osc-autoscaling model=\"autoscaling\" project=\"project\" show-name-input=\"true\" name-read-only=\"kind === 'HorizontalPodAutoscaler'\">\n" +
+    "<osc-autoscaling model=\"autoscaling\" show-name-input=\"true\" name-read-only=\"kind === 'HorizontalPodAutoscaler'\">\n" +
     "</osc-autoscaling>\n" +
     "<label-editor labels=\"labels\" expand=\"true\" can-toggle=\"false\"></label-editor>\n" +
     "<div class=\"buttons gutter-top gutter-bottom\">\n" +

--- a/test/spec/services/limitsRangesServiceSpec.js
+++ b/test/spec/services/limitsRangesServiceSpec.js
@@ -1,0 +1,292 @@
+"use strict";
+
+describe("LimitRangesService", function() {
+  var LimitRangesService, $window, OPENSHIFT_CONFIG, previousConfig;
+
+  beforeEach(function() {
+    inject(function(_LimitRangesService_) {
+      LimitRangesService = _LimitRangesService_;
+    });
+  });
+
+  beforeEach(function() {
+    inject(function (_LimitRangesService_, _$window_) {
+      LimitRangesService = _LimitRangesService_;
+      $window = _$window_;
+    });
+
+    OPENSHIFT_CONFIG = $window.OPENSHIFT_CONFIG;
+
+    // Make a copy so we can modify the config and then restore the previous values.
+    previousConfig = angular.copy(OPENSHIFT_CONFIG);
+
+    // Make sure this defaults to false for all tests regardless of what is set
+    // in config.local.js.
+    OPENSHIFT_CONFIG.clusterResourceOverridesEnabled = false;
+  });
+
+  afterEach(function () {
+    // Restore original constants value.
+    $window.OPENSHIFT_CONFIG = previousConfig;
+  });
+
+  var mockProject = {
+    metadata: {
+      name: 'my-project',
+      annotations: {}
+    }
+  };
+
+  describe("#hasClusterResourceOverrides", function() {
+    it("should return false if clusterResourceOverridesEnabled is false", function() {
+      expect(LimitRangesService.hasClusterResourceOverrides(mockProject)).toBe(false);
+    });
+
+    it("should return true if clusterResourceOverridesEnabled is true", function() {
+      OPENSHIFT_CONFIG.clusterResourceOverridesEnabled = true;
+      expect(LimitRangesService.hasClusterResourceOverrides(mockProject)).toBe(true);
+    });
+
+    it("should return false if clusterResourceOverridesEnabled is undefined", function() {
+      delete OPENSHIFT_CONFIG.clusterResourceOverridesEnabled;
+      expect(LimitRangesService.hasClusterResourceOverrides(mockProject)).toBe(false);
+    });
+
+    it("should return false if the project name is exempt", function() {
+      OPENSHIFT_CONFIG.clusterResourceOverridesEnabled = true;
+      var project = angular.copy(mockProject);
+      project.metadata.name = "openshift";
+      expect(LimitRangesService.hasClusterResourceOverrides(project)).toBe(false);
+    });
+
+    it("should return false if the project prefix is exempt", function() {
+      OPENSHIFT_CONFIG.clusterResourceOverridesEnabled = true;
+      var project = angular.copy(mockProject);
+      project.metadata.name = "openshift-web-console";
+      expect(LimitRangesService.hasClusterResourceOverrides(project)).toBe(false);
+    });
+
+    it("should return false if the project has the exempt annotation", function() {
+      OPENSHIFT_CONFIG.clusterResourceOverridesEnabled = true;
+      var project = angular.copy(mockProject);
+      project.metadata.annotations['quota.openshift.io/cluster-resource-override-enabled'] = "false";
+      expect(LimitRangesService.hasClusterResourceOverrides(project)).toBe(false);
+    });
+  });
+
+  describe("#validatePodLimits", function() {
+    var mockLimitRanges = [{
+      metadata: {
+        name: 'resource-limits',
+        namespace: 'limits',
+        selfLink: '/api/v1/namespaces/limits/limitranges/resource-limits',
+        uid: '423bc6ef-faf8-11e7-94c1-025000000001',
+        resourceVersion: '18632',
+        creationTimestamp: '2018-01-16T20:03:02Z'
+      },
+      spec: {
+        limits: [
+          {
+            type: 'Pod',
+            max: {
+              cpu: '2',
+              memory: '1Gi'
+            },
+            min: {
+              cpu: '19m',
+              memory: '100Mi'
+            }
+          },
+          {
+            type: 'Container',
+            max: {
+              cpu: '2',
+              memory: '1Gi'
+            },
+            min: {
+              cpu: '19m',
+              memory: '100Mi'
+            },
+            'default': {
+              cpu: '1',
+              memory: '512Mi'
+            },
+            defaultRequest: {
+              cpu: '50m',
+              memory: '256Mi'
+            }
+          },
+          {
+            type: 'PersistentVolumeClaim',
+            max: {
+              storage: '1Gi'
+            },
+            min: {
+              storage: '1Gi'
+            }
+          }
+        ]
+      }
+    }];
+
+    var memoryTooLow = {
+      memory: '50Mi'
+    };
+
+    var memoryTooHigh = {
+      memory: '2Gi'
+    };
+
+    var cpuTooLow = {
+      cpu: '10m'
+    };
+
+    var cpuTooHigh = {
+      cpu: '3'
+    };
+
+    var mockContainersWithResources = function(resources) {
+      return [{
+        name: 'my-container',
+        resources: resources
+      }];
+    };
+
+    var mockContainersWithRequests = function(requests) {
+      return mockContainersWithResources({
+        requests: requests
+      });
+    };
+
+    var mockContainersWithLimits = function(limits) {
+      return mockContainersWithResources({
+        limits: limits
+      });
+    };
+
+    it("should respect limit range defaults", function() {
+      var containers = [{
+        name: 'my-container'
+      }];
+
+      var cpuProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'cpu', containers, mockProject);
+      expect(cpuProblems.length).toBe(0);
+
+      var memoryProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'memory', containers, mockProject);
+      expect(memoryProblems.length).toBe(0);
+    });
+
+    it("should report problems when memory request is too low", function() {
+      var containers = mockContainersWithRequests(memoryTooLow);
+      var memoryProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'memory', containers, mockProject);
+      expect(memoryProblems.length).toBeGreaterThan(0);
+    });
+
+    it("should report problems when memory request is too high", function() {
+      var containers = mockContainersWithRequests(memoryTooHigh);
+      var memoryProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'memory', containers, mockProject);
+      expect(memoryProblems.length).toBeGreaterThan(0);
+    });
+
+    it("should report problems when memory limit is too low", function() {
+      var containers = mockContainersWithLimits(memoryTooLow);
+      var memoryProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'memory', containers, mockProject);
+      expect(memoryProblems.length).toBeGreaterThan(0);
+    });
+
+    it("should report problems when memory limit is too high", function() {
+      var containers = mockContainersWithLimits(memoryTooHigh);
+      var memoryProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'memory', containers, mockProject);
+      expect(memoryProblems.length).toBeGreaterThan(0);
+    });
+
+    it("should report problems when cpu request is too low", function() {
+      var containers = mockContainersWithRequests(cpuTooLow);
+      var cpuProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'cpu', containers, mockProject);
+      expect(cpuProblems.length).toBeGreaterThan(0);
+    });
+
+    it("should report problems when cpu request is too high", function() {
+      var containers = mockContainersWithRequests(cpuTooHigh);
+      var cpuProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'cpu', containers, mockProject);
+      expect(cpuProblems.length).toBeGreaterThan(0);
+    });
+
+    it("should report problems when cpu limit is too low", function() {
+      var containers = mockContainersWithLimits(cpuTooLow);
+      var cpuProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'cpu', containers, mockProject);
+      expect(cpuProblems.length).toBeGreaterThan(0);
+    });
+
+    it("should report problems when cpu limit is too high", function() {
+      var containers = mockContainersWithLimits(cpuTooHigh);
+      var cpuProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'cpu', containers, mockProject);
+      expect(cpuProblems.length).toBeGreaterThan(0);
+    });
+
+    it("should ignore cpu limit problems when cluster resource overrides are enabled", function() {
+      OPENSHIFT_CONFIG.clusterResourceOverridesEnabled = true;
+      var containers, cpuProblems;
+
+      containers = mockContainersWithLimits(cpuTooHigh);
+      cpuProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'cpu', containers, mockProject);
+      expect(cpuProblems.length).toBe(0);
+
+      containers = mockContainersWithLimits(cpuTooLow);
+      cpuProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'cpu', containers, mockProject);
+      expect(cpuProblems.length).toBe(0);
+    });
+
+    it("should ignore cpu request problems when cluster resource overrides are enabled", function() {
+      OPENSHIFT_CONFIG.clusterResourceOverridesEnabled = true;
+      var containers, cpuProblems;
+
+      containers = mockContainersWithRequests(cpuTooLow);
+      cpuProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'cpu', containers, mockProject);
+      expect(cpuProblems.length).toBe(0);
+
+      containers = mockContainersWithRequests(cpuTooHigh);
+      cpuProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'cpu', containers, mockProject);
+      expect(cpuProblems.length).toBe(0);
+    });
+
+    it("should ignore cpu limit problems when cluster resource overrides are enabled", function() {
+      OPENSHIFT_CONFIG.clusterResourceOverridesEnabled = true;
+      var containers, cpuProblems;
+
+      containers = mockContainersWithLimits(cpuTooLow);
+      cpuProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'cpu', containers, mockProject);
+      expect(cpuProblems.length).toBe(0);
+
+      containers = mockContainersWithLimits(cpuTooHigh);
+      cpuProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'cpu', containers, mockProject);
+      expect(cpuProblems.length).toBe(0);
+    });
+
+    it("should ignore memory request problems when cluster resource overrides are enabled", function() {
+      OPENSHIFT_CONFIG.clusterResourceOverridesEnabled = true;
+      var containers, memoryProblems;
+
+      containers = mockContainersWithRequests(memoryTooLow);
+      memoryProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'memory', containers, mockProject);
+      expect(memoryProblems.length).toBe(0);
+
+      containers = mockContainersWithRequests(memoryTooHigh);
+      memoryProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'memory', containers, mockProject);
+      expect(memoryProblems.length).toBe(0);
+    });
+
+    it("should NOT ignore memory limit problems when cluster resource overrides are enabled", function() {
+      OPENSHIFT_CONFIG.clusterResourceOverridesEnabled = true;
+      var containers, memoryProblems;
+
+      containers = mockContainersWithLimits(memoryTooLow);
+      memoryProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'memory', containers, mockProject);
+      expect(memoryProblems.length).toBeGreaterThan(0);
+
+      containers = mockContainersWithLimits(memoryTooHigh);
+      memoryProblems = LimitRangesService.validatePodLimits(mockLimitRanges, 'memory', containers, mockProject);
+      expect(memoryProblems.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
If `clusterResourceOverridesEnabled` in the web console config is set,
assume that CPU request, CPU limit, and memory request are all
calculated. Don't try to validate these fields. Also remove request to
limit conversions for HPAs. A default DEFAULT_HPA_CPU_TARGET_PERCENT can
still be set by an extension if needed.