### PR TITLE
Do not change DC label to "Deployments" on overview

### DIFF
--- a/app/views/deployments.html
+++ b/app/views/deployments.html
@@ -37,7 +37,7 @@
             </div>
           </div>
           <div ng-if="!filterWithZeroResults">
-            <h3 ng-if="showDeploymentConfigTable() && ((deployments | size) || (replicaSets | size) || (replicationControllersByDC[''] | size))">Deployment Configurations</h3>
+            <h3 ng-if="showDeploymentConfigTable() && ((deployments | size) || (replicaSets | size) || (replicationControllersByDC[''] | size))">Deployment Configs</h3>
             <table ng-if="showDeploymentConfigTable() && !showEmptyState" class="table table-bordered table-mobile table-layout-fixed">
               <colgroup>
                 <col class="col-sm-3">

--- a/app/views/overview/_list-row-content.html
+++ b/app/views/overview/_list-row-content.html
@@ -1,12 +1,7 @@
 <div class="list-pf-name">
   <h3>
     <div class="component-label">
-      <span ng-if="row.apiObject.kind === 'DeploymentConfig'">
-        Deployment
-      </span>
-      <span ng-if="row.apiObject.kind !== 'DeploymentConfig'">
-        {{row.apiObject.kind | humanizeKind}}
-      </span>
+      {{row.apiObject.kind | humanizeKind}}
     </div>
     <a ng-href="{{row.apiObject | navigateResourceURL}}"><span ng-bind-html="row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords"></span></a><span ng-if="row.apiObject.kind === 'DeploymentConfig' && row.current">,
       <a ng-href="{{row.current | navigateResourceURL}}">#{{row.current | annotation : 'deploymentVersion'}}</a>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5113,7 +5113,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"!filterWithZeroResults\">\n" +
-    "<h3 ng-if=\"showDeploymentConfigTable() && ((deployments | size) || (replicaSets | size) || (replicationControllersByDC[''] | size))\">Deployment Configurations</h3>\n" +
+    "<h3 ng-if=\"showDeploymentConfigTable() && ((deployments | size) || (replicaSets | size) || (replicationControllersByDC[''] | size))\">Deployment Configs</h3>\n" +
     "<table ng-if=\"showDeploymentConfigTable() && !showEmptyState\" class=\"table table-bordered table-mobile table-layout-fixed\">\n" +
     "<colgroup>\n" +
     "<col class=\"col-sm-3\">\n" +
@@ -12189,12 +12189,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"list-pf-name\">\n" +
     "<h3>\n" +
     "<div class=\"component-label\">\n" +
-    "<span ng-if=\"row.apiObject.kind === 'DeploymentConfig'\">\n" +
-    "Deployment\n" +
-    "</span>\n" +
-    "<span ng-if=\"row.apiObject.kind !== 'DeploymentConfig'\">\n" +
     "{{row.apiObject.kind | humanizeKind}}\n" +
-    "</span>\n" +
     "</div>\n" +
     "<a ng-href=\"{{row.apiObject | navigateResourceURL}}\"><span ng-bind-html=\"row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords\"></span></a><span ng-if=\"row.apiObject.kind === 'DeploymentConfig' && row.current\">,\n" +
     "<a ng-href=\"{{row.current | navigateResourceURL}}\">#{{row.current | annotation : 'deploymentVersion'}}</a>\n" +


### PR DESCRIPTION
And change browse/deployments heading from "Deployment Configurations" to "Deployment Configs" so we're consistent in our labeling.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1488380

<img width="956" alt="screen shot 2018-01-17 at 10 35 02 am" src="https://user-images.githubusercontent.com/895728/35051280-e10b9832-fb72-11e7-88f4-de0cf6845239.PNG">
<img width="974" alt="screen shot 2018-01-17 at 10 36 37 am" src="https://user-images.githubusercontent.com/895728/35051281-e11ab1fa-fb72-11e7-9c92-eafc43018439.PNG">

cc: @ncameronbritt 
