### PR TITLE
Webhook trigger editor should behave like envVar editor

### DIFF
--- a/app/components/copy-webhook-url/copy-webhook-url.component.js
+++ b/app/components/copy-webhook-url/copy-webhook-url.component.js
@@ -1,20 +1,23 @@
 'use strict';
-
-angular.module('openshiftConsole')
-  .component('copyWebhookUrl', {
+(function() {
+  angular.module('openshiftConsole').component('copyWebhookUrl', {
+    controller: CopyWebhookUrl,
+    controllerAs: '$ctrl',
     bindings: {
-      buildConfigName: "=",
-      triggerType: "=",
-      projectName: "=",
-      secret: "=",
-      webhookSecrets: "="
+      buildConfigName: "<",
+      triggerType: "<",
+      projectName: "<",
+      secret: "<",
+      webhookSecrets: "<"
     },
-    templateUrl: 'components/copy-webhook-url/copy-webhook-url.html',
-    controller: function() {
-      var ctrl = this;
-
-      ctrl.showSecretsWarning = function() {
-        return _.get(ctrl.secret, 'secretReference.name') && !ctrl.webhookSecrets;
-      };
-    }
+    templateUrl: 'components/copy-webhook-url/copy-webhook-url.html'
   });
+
+  function CopyWebhookUrl() {
+    var ctrl = this;
+
+    ctrl.showSecretsWarning = function() {
+      return _.get(ctrl.secret, 'secretReference.name') && !ctrl.webhookSecrets;
+    };
+  }
+})();

--- a/app/components/osc-webhook-triggers/osc-webhook-triggers.component.js
+++ b/app/components/osc-webhook-triggers/osc-webhook-triggers.component.js
@@ -1,138 +1,148 @@
 'use strict';
-
-angular.module('openshiftConsole')
-  .component('oscWebhookTriggers', {
+(function() {
+  angular.module('openshiftConsole').component('oscWebhookTriggers', {
+    controller: [
+      '$scope',
+      '$uibModal',
+      '$filter',
+      'APIService',
+      OscWebhookTriggers
+    ],
+    controllerAs: '$ctrl',
     bindings: {
-      webhookSecrets: '=',
-      namespace: '=',
+      webhookSecrets: '<',
+      namespace: '<',
       type: '@',
       webhookTriggers: '=',
       form: '='
     },
-    templateUrl: 'components/osc-webhook-triggers/osc-webhook-triggers.html',
-    controller: function($scope, $uibModal, $filter, APIService) {
-      var ctrl = this;
-
-      ctrl.$onInit = function() {
-        $scope.namespace = ctrl.namespace;
-        $scope.type = ctrl.type;
-        ctrl.secretsVersion = APIService.getPreferredVersion('secrets');
-        ctrl.webhookTypesOptions = [{
-          type: 'github',
-          label: 'GitHub'
-        }, {
-          type: 'gitlab',
-          label: 'GitLab'
-        }, {
-          type: 'bitbucket',
-          label: 'Bitbucket'
-        }, {
-          type: 'generic',
-          label: 'Generic'
-        }];
-      };
-
-      // Check if the webhook trigger contains only deprecated secret format.
-      ctrl.isDeprecated = function(trigger) {
-        var triggerSecretData = $filter('getWebhookSecretData')(trigger);
-        return _.has(triggerSecretData, 'secret') && !_.has(triggerSecretData, 'secretReference.name');
-      };
-
-      ctrl.toggleSecretInputType = function(trigger) {
-        trigger.secretInputType = trigger.secretInputType === 'password' ? 'text' : 'password';
-      };
-
-      // Check if new or modified webhook trigger is a duplicate. If so, show a warning under the appropriate trigger
-      var checkDuplicates = function(trigger) {
-        var matchingTriggers = _.filter(ctrl.webhookTriggers, function(wehbookTrigger) {
-          return _.isEqual(wehbookTrigger.data, trigger.data);
-        });
-
-        // Mark all except the first as duplicates.
-        _.each(matchingTriggers, function(trigger, i) {
-          var first = i === 0;
-          trigger.isDuplicate = !first;
-        });
-      };
-
-      ctrl.removeWebhookTrigger = function(trigger, index) {
-        var removedTrigger = _.clone(trigger);
-        if (ctrl.webhookTriggers.length === 1) {
-          var lonelyTrigger = _.first(ctrl.webhookTriggers);
-          lonelyTrigger.lastTriggerType = "";
-          lonelyTrigger.data = {
-            type: ""
-          };
-        } else {
-          ctrl.webhookTriggers.splice(index,1);
-        }
-        ctrl.form.$setDirty();
-        checkDuplicates(removedTrigger);
-      };
-
-      // When user changes the webhook trigger type move the secret data from the old one to the new one.
-      ctrl.triggerTypeChange = function(trigger) {
-        var lastTriggerType = _.toLower(trigger.lastTriggerType);
-        var newTriggerType = _.toLower(trigger.data.type);
-
-        trigger.data[newTriggerType] = trigger.data[lastTriggerType];
-        delete trigger.data[lastTriggerType];
-        trigger.lastTriggerType = trigger.data.type;
-        checkDuplicates(trigger);
-      };
-
-      ctrl.triggerSecretChange = function(trigger) {
-        checkDuplicates(trigger);
-      };
-
-      var addEmptyWebhookTrigger = function() {
-        ctrl.webhookTriggers.push({
-          lastTriggerType: "",
-          data: {
-            type: ""
-          }
-        });
-      };
-
-      // Check last trigger if it's type and secret are selected.
-      ctrl.checkLastAndAddNew = function() {
-        var lastTrigger = _.last(ctrl.webhookTriggers);
-        var lastTriggerSecretData = $filter('getWebhookSecretData')(lastTrigger);
-        if (lastTrigger.data.type && (_.has(lastTriggerSecretData, 'secret') || _.has(lastTriggerSecretData, 'secretReference.name'))) {
-          addEmptyWebhookTrigger();
-        }
-      };
-
-      // If there are no webhook triggers create empty one, otherwise check for duplicates.
-      // In case of deprecated secret format add a `secretInputType` field to the object so we can toggle secret visibility.
-      if (_.isEmpty(ctrl.webhookTriggers)) {
-        addEmptyWebhookTrigger();
-      } else {
-        // Uncomment in case we want to notify user that he has deprecated embedded secrets in his BC
-        // ctrl.hasWebhookWithDeprecatedSecret = _.some(ctrl.webhookTriggers, function(trigger) {return ctrl.isDeprecated(trigger)});
-        _.each(ctrl.webhookTriggers, function(trigger) {
-          if (ctrl.isDeprecated(trigger)) {
-            trigger.secretInputType = "password";
-          }
-          if (trigger.isDuplicate) {
-            return;
-          }
-          checkDuplicates(trigger);
-        });
-      }
-
-      ctrl.openCreateWebhookSecretModal = function() {
-        var modalInstance = $uibModal.open({
-          animation: true,
-          templateUrl: 'views/modals/create-secret.html',
-          controller: 'CreateSecretModalController',
-          scope: $scope
-        });
-
-        modalInstance.result.then(function(newSecret) {
-          // Add the created secret into the webhook secret array
-          ctrl.webhookSecrets.push(newSecret);
-        });
-      };
-    }
+    templateUrl: 'components/osc-webhook-triggers/osc-webhook-triggers.html'
   });
+
+
+  function OscWebhookTriggers($scope, $uibModal, $filter, APIService) {
+    var ctrl = this;
+
+    ctrl.$onInit = function() {
+      $scope.namespace = ctrl.namespace;
+      $scope.type = ctrl.type;
+      ctrl.secretsVersion = APIService.getPreferredVersion('secrets');
+      ctrl.webhookTypesOptions = [{
+        type: 'github',
+        label: 'GitHub'
+      }, {
+        type: 'gitlab',
+        label: 'GitLab'
+      }, {
+        type: 'bitbucket',
+        label: 'Bitbucket'
+      }, {
+        type: 'generic',
+        label: 'Generic'
+      }];
+    };
+
+    // Check if the webhook trigger contains only deprecated secret format.
+    ctrl.isDeprecated = function(trigger) {
+      var triggerSecretData = $filter('getWebhookSecretData')(trigger);
+      return _.has(triggerSecretData, 'secret') && !_.has(triggerSecretData, 'secretReference.name');
+    };
+
+    ctrl.toggleSecretInputType = function(trigger) {
+      trigger.secretInputType = trigger.secretInputType === 'password' ? 'text' : 'password';
+    };
+
+    // Check if new or modified webhook trigger is a duplicate. If so, show a warning under the appropriate trigger
+    var checkDuplicates = function(trigger) {
+      var matchingTriggers = _.filter(ctrl.webhookTriggers, function(wehbookTrigger) {
+        return _.isEqual(wehbookTrigger.data, trigger.data);
+      });
+
+      // Mark all except the first as duplicates.
+      _.each(matchingTriggers, function(trigger, i) {
+        var first = i === 0;
+        trigger.isDuplicate = !first;
+      });
+    };
+
+    ctrl.removeWebhookTrigger = function(trigger, index) {
+      var removedTrigger = _.clone(trigger);
+      if (ctrl.webhookTriggers.length === 1) {
+        var lonelyTrigger = _.first(ctrl.webhookTriggers);
+        lonelyTrigger.lastTriggerType = "";
+        lonelyTrigger.data = {
+          type: ""
+        };
+      } else {
+        ctrl.webhookTriggers.splice(index,1);
+      }
+      ctrl.form.$setDirty();
+      checkDuplicates(removedTrigger);
+    };
+
+    // When user changes the webhook trigger type move the secret data from the old one to the new one.
+    ctrl.triggerTypeChange = function(trigger) {
+      var lastTriggerType = _.toLower(trigger.lastTriggerType);
+      var newTriggerType = _.toLower(trigger.data.type);
+
+      trigger.data[newTriggerType] = trigger.data[lastTriggerType];
+      delete trigger.data[lastTriggerType];
+      trigger.lastTriggerType = trigger.data.type;
+      checkDuplicates(trigger);
+    };
+
+    ctrl.triggerSecretChange = function(trigger) {
+      checkDuplicates(trigger);
+    };
+
+    var addEmptyWebhookTrigger = function() {
+      ctrl.webhookTriggers.push({
+        lastTriggerType: "",
+        data: {
+          type: ""
+        }
+      });
+    };
+
+    // Check last trigger if it's type and secret are selected.
+    ctrl.checkLastAndAddNew = function() {
+      var lastTrigger = _.last(ctrl.webhookTriggers);
+      var lastTriggerSecretData = $filter('getWebhookSecretData')(lastTrigger);
+      if (lastTrigger.data.type && (_.has(lastTriggerSecretData, 'secret') || _.has(lastTriggerSecretData, 'secretReference.name'))) {
+        addEmptyWebhookTrigger();
+      }
+    };
+
+    // If there are no webhook triggers create empty one, otherwise check for duplicates.
+    // In case of deprecated secret format add a `secretInputType` field to the object so we can toggle secret visibility.
+    if (_.isEmpty(ctrl.webhookTriggers)) {
+      addEmptyWebhookTrigger();
+    } else {
+      // Uncomment in case we want to notify user that he has deprecated embedded secrets in his BC
+      // ctrl.hasWebhookWithDeprecatedSecret = _.some(ctrl.webhookTriggers, function(trigger) {return ctrl.isDeprecated(trigger)});
+      _.each(ctrl.webhookTriggers, function(trigger) {
+        if (ctrl.isDeprecated(trigger)) {
+          trigger.secretInputType = "password";
+        }
+        if (trigger.isDuplicate) {
+          return;
+        }
+        checkDuplicates(trigger);
+      });
+    }
+
+    ctrl.openCreateWebhookSecretModal = function() {
+      var modalInstance = $uibModal.open({
+        animation: true,
+        templateUrl: 'views/modals/create-secret.html',
+        controller: 'CreateSecretModalController',
+        scope: $scope
+      });
+
+      modalInstance.result.then(function(newSecret) {
+        // Add the created secret into the webhook secret array
+        ctrl.webhookSecrets.push(newSecret);
+      });
+    };
+  }
+})();

--- a/app/components/osc-webhook-triggers/osc-webhook-triggers.html
+++ b/app/components/osc-webhook-triggers/osc-webhook-triggers.html
@@ -71,7 +71,7 @@
   </div>
 
   <div class="add-webhook-action-btns">
-    <button class="btn btn-link" type="button" ng-click="$ctrl.checkLastAndAddNew()">Add Webhook</button>
+    <button class="btn btn-link pad-left-none" type="button" ng-click="$ctrl.checkLastAndAddNew()">Add Webhook</button>
     <span ng-if="$ctrl.secretsVersion | canI : 'create'">
       <span class="action-divider" aria-hidden="true"> | </span>
       <button class="btn btn-link" href="" type="button" ng-click="$ctrl.openCreateWebhookSecretModal()">Create New Webhook Secret</button>

--- a/app/scripts/controllers/edit/buildConfig.js
+++ b/app/scripts/controllers/edit/buildConfig.js
@@ -486,6 +486,12 @@ angular.module('openshiftConsole')
       return imageObject;
     };
 
+    // Return only webhook triggers that have defined type and their type object. 
+    var filterValidWebhookTriggers = function(triggers) {
+      return _.filter(triggers, function(trigger) {
+        return (!_.isEmpty(trigger.data.type) && !_.isEmpty(trigger.data[_.toLower(trigger.data.type)]));
+      });
+    };
 
     var updateTriggers = function() {
       var triggers = [].concat($scope.triggers.imageChangeTriggers,
@@ -496,7 +502,7 @@ angular.module('openshiftConsole')
         // The condition has to check if the value exist and  is set to 'false' in case of webhook triggers and 'true' in case of imageChange and configChange triggers.
         return (_.has(trigger, 'disabled') && !trigger.disabled) || trigger.present;
       });
-      triggers = triggers.concat($scope.triggers.webhookTriggers);
+      triggers = triggers.concat(filterValidWebhookTriggers($scope.triggers.webhookTriggers));
       triggers = _.map(triggers, 'data');
       return triggers;
     };

--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -1104,7 +1104,7 @@ a.disabled-link {
       }
     }
     .add-webhook-action-btns {
-        margin-top: 15px;
+      margin-top: 15px;
     }
   }
 

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1,6 +1,6 @@
 "use strict";
 
-function OverviewController(e, t, n, r, a, o, i, s, c, l, u, d, m, p, f, g, v, h, y, b, S, C, w, P, j, k, I, R, T, E) {
+function OverviewController(e, t, n, r, a, o, i, s, c, l, u, d, m, p, f, g, v, h, y, b, S, C, w, P, j, k, I, R, E, T) {
 var N = this, D = t("isIE")();
 e.projectName = a.project;
 var A = a.isHomePage;
@@ -70,7 +70,7 @@ return s.groupByApp(e, "metadata.name");
 }, de = function(e) {
 var t = null;
 return _.each(e, function(e) {
-t = t ? T.getPreferredDisplayRoute(t, e) : e;
+t = t ? E.getPreferredDisplayRoute(t, e) : e;
 }), t;
 }, me = _.debounce(function() {
 e.$evalAsync(function() {
@@ -168,21 +168,21 @@ je(e, n);
 }
 }, Re = function(e) {
 _.each(e, Ie);
-}, Te = function(e) {
+}, Ee = function(e) {
 var t = oe(e);
 return t ? ne[t] : null;
-}, Ee = function(e) {
+}, Te = function(e) {
 var t = oe(e);
 return t ? _.get(N, [ "replicationControllersByDeploymentConfig", t ]) : [];
 };
 N.getPreviousReplicationController = function(e) {
-var t = Ee(e);
+var t = Te(e);
 return _.size(t) < 2 ? null : t[1];
 };
 var Ne = function(e) {
-var t = {}, n = Te(e);
+var t = {}, n = Ee(e);
 _.assign(t, R.getDeploymentStatusAlerts(e, n), R.getPausedDeploymentAlerts(e));
-var r = Ee(e);
+var r = Te(e);
 _.each(r, function(e) {
 var n = ke(e);
 _.assign(t, n);
@@ -266,8 +266,8 @@ var e = [ N.deploymentConfigs, N.vanillaReplicationControllers, N.deployments, N
 _.each(e, We), me();
 }
 }, Je = function() {
-var e = T.groupByService(N.routes, !0);
-re.routesByService = _.mapValues(e, T.sortRoutesByScore), me();
+var e = E.groupByService(N.routes, !0);
+re.routesByService = _.mapValues(e, E.sortRoutesByScore), me();
 }, Ye = function() {
 re.hpaByResource = g.groupHPAs(N.horizontalPodAutoscalers);
 }, Ze = function(e) {
@@ -443,7 +443,7 @@ pollInterval: 6e4
 }));
 var o, i, s = {}, c = {};
 u.SERVICE_CATALOG_ENABLED && L(W, "watch") && (o = function(e) {
-var t = E.getServiceClassNameForInstance(e);
+var t = T.getServiceClassNameForInstance(e);
 if (!t) return n.when();
 var r = _.get(re, [ "serviceClasses", t ]);
 return r ? n.when(r) : (s[t] || (s[t] = m.get(K, t, {}).then(function(e) {
@@ -452,7 +452,7 @@ return re.serviceClasses[t] = e, e;
 delete c[t];
 })), s[t]);
 }, i = function(e) {
-var t = E.getServicePlanNameForInstance(e);
+var t = T.getServicePlanNameForInstance(e);
 if (!t) return n.when();
 var r = _.get(re, [ "servicePlans", t ]);
 return r ? n.when(r) : (c[t] || (c[t] = m.get(Q, t, {}).then(function(e) {
@@ -3739,9 +3739,9 @@ target: "_blank"
 _.each(a, d), _.each(i, d);
 }
 }), r) : r;
-}, T = [ "cpu", "requests.cpu", "memory", "requests.memory", "limits.cpu", "limits.memory" ], E = function(e, t, n, r, a) {
+}, E = [ "cpu", "requests.cpu", "memory", "requests.memory", "limits.cpu", "limits.memory" ], T = function(e, t, n, r, a) {
 var o, s = "Your project is " + (r < t ? "over" : "at") + " quota. ";
-return o = _.includes(T, a) ? s + "It is using " + v(t / r, 0) + " of " + g(n, a) + " " + C(a) + "." : s + "It is using " + t + " of " + r + " " + C(a) + ".", o = _.escape(o), i.QUOTA_NOTIFICATION_MESSAGE && i.QUOTA_NOTIFICATION_MESSAGE[a] && (o += " " + i.QUOTA_NOTIFICATION_MESSAGE[a]), o;
+return o = _.includes(E, a) ? s + "It is using " + v(t / r, 0) + " of " + g(n, a) + " " + C(a) + "." : s + "It is using " + t + " of " + r + " " + C(a) + ".", o = _.escape(o), i.QUOTA_NOTIFICATION_MESSAGE && i.QUOTA_NOTIFICATION_MESSAGE[a] && (o += " " + i.QUOTA_NOTIFICATION_MESSAGE[a]), o;
 }, N = function(e, t, n) {
 var r = function(e) {
 var t = e.status.total || e.status;
@@ -3798,7 +3798,7 @@ var c = f(e), l = _.get(a, [ "used", s ]), d = f(l);
 id: o + "/quota-limit-reached-" + s,
 namespace: o,
 type: c < d ? "warning" : "info",
-message: E(0, d, e, c, s),
+message: T(0, d, e, c, s),
 isHTML: !0,
 skipToast: !0,
 showInDrawer: !0,
@@ -5102,9 +5102,9 @@ var t = r("annotation")(e, "deploymentVersion");
 t && (n.logOptions.replicationControllers[e.metadata.name].version = t), n.logCanRun.replicationControllers[e.metadata.name] = !_.includes([ "New", "Pending" ], r("deploymentStatus")(e));
 }, R = function(e) {
 n.logOptions.builds[e.metadata.name] = {}, n.logCanRun.builds[e.metadata.name] = !_.includes([ "New", "Pending", "Error" ], e.status.phase);
-}, T = function() {
-n.filteredStatefulSets = s.filterForKeywords(_.values(n.statefulSets), w, P);
 }, E = function() {
+n.filteredStatefulSets = s.filterForKeywords(_.values(n.statefulSets), w, P);
+}, T = function() {
 S = _.filter(n.pods, function(e) {
 return !n.filters.hideOlderResources || "Succeeded" !== e.status.phase && "Failed" !== e.status.phase;
 }), n.filteredPods = s.filterForKeywords(S, w, P);
@@ -5168,13 +5168,13 @@ var t = _.get(n, [ "podsByOwnerUID", e.metadata.uid ], []);
 _.isEmpty(t) || u.toPodsForDeployment(e, t);
 }, m.get(e.project).then(_.spread(function(e, r) {
 n.project = e, n.projectContext = r, g.push(o.watch("pods", r, function(e) {
-n.podsByName = e.by("metadata.name"), n.pods = C(n.podsByName, !0), n.podsByOwnerUID = d.groupByOwnerUID(n.pods), n.podsLoaded = !0, _.each(n.pods, k), E(), c.log("pods", n.pods);
+n.podsByName = e.by("metadata.name"), n.pods = C(n.podsByName, !0), n.podsByOwnerUID = d.groupByOwnerUID(n.pods), n.podsLoaded = !0, _.each(n.pods, k), T(), c.log("pods", n.pods);
 })), g.push(o.watch({
 resource: "statefulsets",
 group: "apps",
 version: "v1beta1"
 }, r, function(e) {
-n.statefulSets = e.by("metadata.name"), n.statefulSetsLoaded = !0, T(), c.log("statefulSets", n.statefulSets);
+n.statefulSets = e.by("metadata.name"), n.statefulSetsLoaded = !0, E(), c.log("statefulSets", n.statefulSets);
 }, {
 poll: f,
 pollInterval: 6e4
@@ -5193,7 +5193,7 @@ pollInterval: 6e4
 })), n.$on("$destroy", function() {
 o.unwatchAll(g);
 }), n.$watch("filters.hideOlderResources", function() {
-E(), B(), O(), U(), T();
+T(), B(), O(), U(), E();
 var e = t.search();
 e.hideOlderResources = n.filters.hideOlderResources ? "true" : "false", t.replace().search(e);
 }), n.$watch("kindSelector.selected.kind", function() {
@@ -5279,7 +5279,7 @@ subjectName: n.name
 httpErr: e("getErrorDetails")(r)
 }));
 });
-}, T = function(t, n, a) {
+}, E = function(t, n, a) {
 r.disableAddForm = !0, p.addSubject(t, n, a, g).then(function() {
 I(), P("success", w.update.subject.success({
 roleName: t.roleRef.name,
@@ -5293,11 +5293,11 @@ subjectName: n.name
 httpErr: e("getErrorDetails")(r)
 }));
 });
-}, E = {};
-n.tab && (E[n.tab] = !0);
+}, T = {};
+n.tab && (T[n.tab] = !0);
 var N = d.getSubjectKinds();
 angular.extend(r, {
-selectedTab: E,
+selectedTab: T,
 projectName: v,
 forms: {},
 subjectKinds: N,
@@ -5428,7 +5428,7 @@ name: n.metadata.name
 i && _.some(i.subjects, o) ? P("error", w.update.subject.exists({
 roleName: n.metadata.name,
 subjectName: e
-})) : i ? T(i, o, a) : R(n, o);
+})) : i ? E(i, o, a) : R(n, o);
 }
 }), f.listAllRoles(g, {
 errorNotification: !1
@@ -6135,7 +6135,7 @@ e.resource = "replicationcontrollers", e.healthCheckURL = g.healthCheckURL(n.pro
 }
 var j = {};
 e.projectName = n.project, e.kind = d, e.replicaSet = null, e.deploymentConfig = null, e.deploymentConfigMissing = !1, e.imagesByDockerReference = {}, e.builds = {}, e.alerts = {}, e.renderOptions = e.renderOptions || {}, e.renderOptions.hideFilterWidget = !0, e.forms = {}, e.logOptions = {};
-var k = r.getPreferredVersion("builds"), I = r.getPreferredVersion("imagestreams"), R = r.getPreferredVersion("horizontalpodautoscalers"), T = r.getPreferredVersion("limitranges"), E = r.getPreferredVersion("pods"), N = r.getPreferredVersion("replicasets"), D = r.getPreferredVersion("resourcequotas"), A = r.getPreferredVersion("appliedclusterresourcequotas");
+var k = r.getPreferredVersion("builds"), I = r.getPreferredVersion("imagestreams"), R = r.getPreferredVersion("horizontalpodautoscalers"), E = r.getPreferredVersion("limitranges"), T = r.getPreferredVersion("pods"), N = r.getPreferredVersion("replicasets"), D = r.getPreferredVersion("resourcequotas"), A = r.getPreferredVersion("appliedclusterresourcequotas");
 e.deploymentsVersion = r.getPreferredVersion("deployments"), e.deploymentConfigsVersion = r.getPreferredVersion("deploymentconfigs"), e.eventsVersion = r.getPreferredVersion("events"), e.deploymentConfigsLogVersion = "deploymentconfigs/log";
 var $ = [];
 p.isAvailable().then(function(t) {
@@ -6241,7 +6241,7 @@ object: t
 type: "warning",
 message: "This " + w + " has been deleted."
 }), e.replicaSet = t, L(t), U(), H(), e.deployment && x();
-})), e.deploymentConfigName && O(), $.push(i.watch(E, u, function(t) {
+})), e.deploymentConfigName && O(), $.push(i.watch(T, u, function(t) {
 var n = t.by("metadata.name");
 e.podsForDeployment = h.filterForOwner(n, e.replicaSet);
 }));
@@ -6271,7 +6271,7 @@ p = e.by("metadata.name"), y(), U();
 }, {
 poll: V,
 pollInterval: 6e4
-})), i.list(T, u).then(function(t) {
+})), i.list(E, u).then(function(t) {
 e.limitRanges = t.by("metadata.name"), U();
 });
 $.push(i.watch(D, u, function(t) {
@@ -7177,13 +7177,13 @@ e.$on("$destroy", k), u.get(r.project).then(_.spread(function(n, a) {
 e.project = n, e.context = a, i.canI("buildconfigs", "update", r.project) ? (s.get(v, r.buildconfig, a, {
 errorNotification: !1
 }).then(function(t) {
-e.buildConfig = t, f(), e.updatedBuildConfig = angular.copy(e.buildConfig), e.buildStrategy = b(e.updatedBuildConfig), e.strategyType = e.buildConfig.spec.strategy.type, e.envVars = e.buildStrategy.env || [], e.triggers = I(e.triggers, e.buildConfig.spec.triggers), e.sources = $(e.sources, e.buildConfig.spec.source), _.has(t, "spec.strategy.jenkinsPipelineStrategy.jenkinsfile") && (e.jenkinsfileOptions.type = "inline"), i.canI(h, "list", r.project) && s.list(h, a).then(function(t) {
+e.buildConfig = t, f(), e.updatedBuildConfig = angular.copy(e.buildConfig), e.buildStrategy = b(e.updatedBuildConfig), e.strategyType = e.buildConfig.spec.strategy.type, e.envVars = e.buildStrategy.env || [], e.triggers = I(e.triggers, e.buildConfig.spec.triggers), e.sources = B(e.sources, e.buildConfig.spec.source), _.has(t, "spec.strategy.jenkinsPipelineStrategy.jenkinsfile") && (e.jenkinsfileOptions.type = "inline"), i.canI(h, "list", r.project) && s.list(h, a).then(function(t) {
 var n = m.groupSecretsByType(t), r = _.mapValues(n, function(e) {
 return _.map(e, "metadata.name");
 });
 e.webhookSecrets = m.groupSecretsByType(t).webhook, e.secrets.secretsByType = _.each(r, function(e) {
 e.unshift("");
-}), N(), P = S(t.by("metadata.name")), e.valueFromObjects = w.concat(P);
+}), D(), P = S(t.by("metadata.name")), e.valueFromObjects = w.concat(P);
 });
 var n = function(e, n) {
 e.type = n && n.kind ? n.kind : "None";
@@ -7296,7 +7296,7 @@ sourcePath: e.name,
 destinationDir: e.value
 };
 });
-}, T = function(t) {
+}, E = function(t) {
 var n = {};
 switch (t.type) {
 case "ImageStreamTag":
@@ -7321,12 +7321,16 @@ name: _.last(r)
 }).namespace = 1 !== _.size(r) ? _.head(r) : e.buildConfig.metadata.namespace;
 }
 return n;
-}, E = function() {
+}, T = function(e) {
+return _.filter(e, function(e) {
+return !_.isEmpty(e.data.type) && !_.isEmpty(e.data[_.toLower(e.data.type)]);
+});
+}, N = function() {
 var t = [].concat(e.triggers.imageChangeTriggers, e.triggers.builderImageChangeTrigger, e.triggers.configChangeTrigger);
 return t = _.filter(t, function(e) {
 return _.has(e, "disabled") && !e.disabled || e.present;
-}), t = t.concat(e.triggers.webhookTriggers), t = _.map(t, "data");
-}, N = function() {
+}), t = t.concat(T(e.triggers.webhookTriggers)), t = _.map(t, "data");
+}, D = function() {
 switch (e.secrets.picked = {
 gitSecret: e.buildConfig.spec.source.sourceSecret ? [ e.buildConfig.spec.source.sourceSecret ] : [ {
 name: ""
@@ -7356,14 +7360,14 @@ name: ""
 mountPath: ""
 } ];
 }
-}, D = function(e, t, n) {
+}, A = function(e, t, n) {
 t.name ? e[n] = t : delete e[n];
-}, A = function(t, n) {
+}, $ = function(t, n) {
 var r = "Custom" === e.strategyType ? "secretSource" : "secret", a = _.filter(n, function(e) {
 return e[r].name;
 });
 _.isEmpty(a) ? delete t.secrets : t.secrets = a;
-}, $ = function(e, t) {
+}, B = function(e, t) {
 return "None" === t.type ? e : (e.none = !1, angular.forEach(t, function(t, n) {
 e[n] = !0;
 }), e);
@@ -7377,16 +7381,16 @@ break;
 case "JenkinsPipeline":
 "path" === e.jenkinsfileOptions.type ? delete e.updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile : delete e.updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath;
 }
-switch (e.sources.images && !_.isEmpty(e.sourceImages) && (e.updatedBuildConfig.spec.source.images[0].paths = R(e.imageSourcePaths), e.updatedBuildConfig.spec.source.images[0].from = T(e.imageOptions.fromSource)), "None" === e.imageOptions.from.type ? delete b(e.updatedBuildConfig).from : b(e.updatedBuildConfig).from = T(e.imageOptions.from), "None" === e.imageOptions.to.type ? delete e.updatedBuildConfig.spec.output.to : e.updatedBuildConfig.spec.output.to = T(e.imageOptions.to), b(e.updatedBuildConfig).env = p.compactEntries(e.envVars), D(e.updatedBuildConfig.spec.source, _.head(e.secrets.picked.gitSecret), "sourceSecret"), D(b(e.updatedBuildConfig), _.head(e.secrets.picked.pullSecret), "pullSecret"), D(e.updatedBuildConfig.spec.output, _.head(e.secrets.picked.pushSecret), "pushSecret"), e.strategyType) {
+switch (e.sources.images && !_.isEmpty(e.sourceImages) && (e.updatedBuildConfig.spec.source.images[0].paths = R(e.imageSourcePaths), e.updatedBuildConfig.spec.source.images[0].from = E(e.imageOptions.fromSource)), "None" === e.imageOptions.from.type ? delete b(e.updatedBuildConfig).from : b(e.updatedBuildConfig).from = E(e.imageOptions.from), "None" === e.imageOptions.to.type ? delete e.updatedBuildConfig.spec.output.to : e.updatedBuildConfig.spec.output.to = E(e.imageOptions.to), b(e.updatedBuildConfig).env = p.compactEntries(e.envVars), A(e.updatedBuildConfig.spec.source, _.head(e.secrets.picked.gitSecret), "sourceSecret"), A(b(e.updatedBuildConfig), _.head(e.secrets.picked.pullSecret), "pullSecret"), A(e.updatedBuildConfig.spec.output, _.head(e.secrets.picked.pushSecret), "pushSecret"), e.strategyType) {
 case "Source":
 case "Docker":
-A(e.updatedBuildConfig.spec.source, e.secrets.picked.sourceSecrets);
+$(e.updatedBuildConfig.spec.source, e.secrets.picked.sourceSecrets);
 break;
 
 case "Custom":
-A(b(e.updatedBuildConfig), e.secrets.picked.sourceSecrets);
+$(b(e.updatedBuildConfig), e.secrets.picked.sourceSecrets);
 }
-e.updatedBuildConfig.spec.triggers = E(), k(), s.update(v, e.updatedBuildConfig.metadata.name, e.updatedBuildConfig, e.context).then(function() {
+e.updatedBuildConfig.spec.triggers = N(), k(), s.update(v, e.updatedBuildConfig.metadata.name, e.updatedBuildConfig, e.context).then(function() {
 l.addNotification({
 type: "success",
 message: "Build config " + e.updatedBuildConfig.metadata.name + " was successfully updated."
@@ -7601,7 +7605,7 @@ command: [],
 environment: []
 }), e.strategyParamsPropertyName = t;
 };
-var T = function(e, t, n, r) {
+var E = function(e, t, n, r) {
 var a = {
 kind: "ImageStreamTag",
 namespace: t.namespace,
@@ -7615,12 +7619,12 @@ containerNames: [ e ],
 from: a
 }
 }, n;
-}, E = function() {
+}, T = function() {
 var t = _.reject(e.updatedDeploymentConfig.spec.triggers, function(e) {
 return "ImageChange" === e.type || "ConfigChange" === e.type;
 });
 return _.each(e.containerConfigByName, function(n, r) {
-n.hasDeploymentTrigger ? t.push(T(r, n.triggerData.istag, n.triggerData.data, n.triggerData.automatic)) : _.find(e.updatedDeploymentConfig.spec.template.spec.containers, {
+n.hasDeploymentTrigger ? t.push(E(r, n.triggerData.istag, n.triggerData.data, n.triggerData.automatic)) : _.find(e.updatedDeploymentConfig.spec.template.spec.containers, {
 name: r
 }).image = n.image;
 }), e.triggers.hasConfigTrigger && t.push({
@@ -7642,7 +7646,7 @@ var o = e.strategyData[e.strategyParamsPropertyName].maxUnavailable, i = Number(
 }
 "Custom" !== e.strategyData.type && _.each([ "pre", "mid", "post" ], function(t) {
 _.has(e.strategyData, [ e.strategyParamsPropertyName, t, "execNewPod", "env" ]) && (e.strategyData[e.strategyParamsPropertyName][t].execNewPod.env = g.compactEntries(e.strategyData[e.strategyParamsPropertyName][t].execNewPod.env));
-}), _.has(e, "strategyData.customParams.environment") && (e.strategyData.customParams.environment = g.compactEntries(e.strategyData.customParams.environment)), e.updatedDeploymentConfig.spec.template.spec.imagePullSecrets = _.filter(e.secrets.pullSecrets, "name"), e.updatedDeploymentConfig.spec.strategy = e.strategyData, e.updatedDeploymentConfig.spec.triggers = E(), N(), l.update(b, e.updatedDeploymentConfig.metadata.name, e.updatedDeploymentConfig, e.context).then(function() {
+}), _.has(e, "strategyData.customParams.environment") && (e.strategyData.customParams.environment = g.compactEntries(e.strategyData.customParams.environment)), e.updatedDeploymentConfig.spec.template.spec.imagePullSecrets = _.filter(e.secrets.pullSecrets, "name"), e.updatedDeploymentConfig.spec.strategy = e.strategyData, e.updatedDeploymentConfig.spec.triggers = T(), N(), l.update(b, e.updatedDeploymentConfig.metadata.name, e.updatedDeploymentConfig, e.context).then(function() {
 m.addNotification({
 type: "success",
 message: "Deployment config " + e.updatedDeploymentConfig.metadata.name + " was successfully updated."
@@ -8041,8 +8045,8 @@ e.displayName = a.displayName, e.advancedOptions = "true" === a.advanced;
 var I = {
 name: "app",
 value: ""
-}, R = t("orderByDisplayName"), T = t("getErrorDetails"), E = {}, N = function() {
-g.hideNotification("create-builder-list-config-maps-error"), g.hideNotification("create-builder-list-secrets-error"), _.each(E, function(e) {
+}, R = t("orderByDisplayName"), E = t("getErrorDetails"), T = {}, N = function() {
+g.hideNotification("create-builder-list-config-maps-error"), g.hideNotification("create-builder-list-secrets-error"), _.each(T, function(e) {
 !e.id || "error" !== e.type && "warning" !== e.type || g.hideNotification(e.id);
 });
 };
@@ -8114,7 +8118,7 @@ o = R(t.by("metadata.name")), e.valueFromObjects = o.concat(i);
 id: "create-builder-list-config-maps-error",
 type: "error",
 message: "Could not load config maps.",
-details: T(e)
+details: E(e)
 });
 }), c.list(L, n, null, {
 errorNotification: !1
@@ -8131,7 +8135,7 @@ e.unshift("");
 id: "create-builder-list-secrets-error",
 type: "error",
 message: "Could not load secrets.",
-details: T(e)
+details: E(e)
 });
 }), c.get($, r.imageName, {
 namespace: r.namespace || a.project
@@ -8207,11 +8211,11 @@ cancelButtonText: "Cancel"
 }
 }).result.then(F);
 }, M = function(t) {
-N(), E = t.quotaAlerts || [], e.nameTaken || _.some(E, {
+N(), T = t.quotaAlerts || [], e.nameTaken || _.some(T, {
 type: "error"
-}) ? (e.disableInputs = !1, _.each(E, function(e) {
+}) ? (e.disableInputs = !1, _.each(T, function(e) {
 e.id = _.uniqueId("create-builder-alert-"), g.addNotification(e);
-})) : _.isEmpty(E) ? F() : (x(E), e.disableInputs = !1);
+})) : _.isEmpty(T) ? F() : (x(T), e.disableInputs = !1);
 };
 e.projectDisplayName = function() {
 return P(this.project) || this.projectName;
@@ -9702,7 +9706,7 @@ t > 0 && r.push(P()), e > 0 && r.push(w()), n.all(r).then(b);
 }
 function b() {
 var e, n;
-E(), "Template" === p.resourceKind && p.templateOptions.process && !p.errorOccurred ? p.isDialog ? p.$emit("fileImportedFromYAMLOrJSON", {
+T(), "Template" === p.resourceKind && p.templateOptions.process && !p.errorOccurred ? p.isDialog ? p.$emit("fileImportedFromYAMLOrJSON", {
 project: p.input.selectedProject,
 template: p.resource
 }) : (n = p.templateOptions.add || p.updateResources.length > 0 ? p.input.selectedProject.metadata.name : "", e = s.createFromTemplateURL(p.resource, p.input.selectedProject.metadata.name, {
@@ -9883,18 +9887,18 @@ cancelButtonText: "Cancel"
 }
 }
 }).result.then(y);
-}, T = {}, E = function() {
-c.hideNotification("from-file-error"), _.each(T, function(e) {
+}, E = {}, T = function() {
+c.hideNotification("from-file-error"), _.each(E, function(e) {
 !e.id || "error" !== e.type && "warning" !== e.type || c.hideNotification(e.id);
 });
 }, N = function(e) {
-E(), T = u.getSecurityAlerts(p.createResources, p.input.selectedProject.metadata.name);
+T(), E = u.getSecurityAlerts(p.createResources, p.input.selectedProject.metadata.name);
 var t = e.quotaAlerts || [];
-T = T.concat(t), _.filter(T, {
+E = E.concat(t), _.filter(E, {
 type: "error"
-}).length ? (_.each(T, function(e) {
+}).length ? (_.each(E, function(e) {
 e.id = _.uniqueId("from-file-alert-"), c.addNotification(e);
-}), p.disableInputs = !1) : T.length ? (R(T), p.disableInputs = !1) : y();
+}), p.disableInputs = !1) : E.length ? (R(E), p.disableInputs = !1) : y();
 }, D = function() {
 if (_.has(p.input.selectedProject, "metadata.uid")) return n.when(p.input.selectedProject);
 var t = p.input.selectedProject.metadata.name, r = p.input.selectedProject.metadata.annotations["new-display-name"], a = e("description")(p.input.selectedProject);
@@ -9926,10 +9930,10 @@ details: I(e)
 });
 }
 }, p.cancel = function() {
-E(), s.toProjectOverview(p.input.selectedProject.metadata.name);
+T(), s.toProjectOverview(p.input.selectedProject.metadata.name);
 };
 var A = e("displayName");
-p.$on("importFileFromYAMLOrJSON", p.create), p.$on("$destroy", E);
+p.$on("importFileFromYAMLOrJSON", p.create), p.$on("$destroy", T);
 } ]
 };
 } ]), angular.module("openshiftConsole").directive("oscFileInput", [ "Logger", function(e) {
@@ -10772,17 +10776,17 @@ _.size(h) <= 100 ? (y = e("orderByDisplayName")(h), I = _.map(y, function(e) {
 return n(e, !1);
 })) : I = [ n(h[t], !0) ], k.empty(), k.append(I), k.append($('<option data-divider="true"></option>')), k.append($('<option value="">View All Projects</option>')), k.selectpicker("refresh");
 }
-}, T = function() {
+}, E = function() {
 return f.list().then(function(e) {
 h = e.by("metadata.name");
 });
-}, E = function() {
+}, T = function() {
 var e = a.project;
 i.currentProjectName !== e && (i.currentProjectName = e, i.chromeless = "chromeless" === a.view, e && !i.chromeless ? (_.set(r, "view.hasProject", !0), i.canIAddToProject = !1, s.getProjectRules(e).then(function() {
 i.currentProjectName === e && (i.canIAddToProject = s.canIAddToProject(e), i.canIAddToProject && l.getCatalogItems().then(function(e) {
 i.catalogItems = e;
 }));
-}), T().then(function() {
+}), E().then(function() {
 i.currentProjectName && h && (h[i.currentProjectName] || (h[i.currentProjectName] = {
 metadata: {
 name: i.currentProjectName
@@ -10821,7 +10825,7 @@ m.toProjectCatalog(i.currentProjectName, n);
 });
 i.closeOrderingPanel = function() {
 v.addItem(_.get(i.selectedItem, "resource.metadata.uid")), i.orderingPanelVisible = !1;
-}, E(), i.$on("$routeChangeSuccess", E), k.selectpicker({
+}, T(), i.$on("$routeChangeSuccess", T), k.selectpicker({
 iconBase: "fa",
 tickIcon: "fa-check"
 }).change(function() {
@@ -10921,16 +10925,9 @@ e.hidden = !0, _.isFunction(e.onClose) && e.onClose();
 _.isFunction(n.onClick) && n.onClick() && e.close(t);
 };
 }
-}), angular.module("openshiftConsole").component("oscWebhookTriggers", {
-bindings: {
-webhookSecrets: "=",
-namespace: "=",
-type: "@",
-webhookTriggers: "=",
-form: "="
-},
-templateUrl: "components/osc-webhook-triggers/osc-webhook-triggers.html",
-controller: function(e, t, n, r) {
+}), function() {
+angular.module("openshiftConsole").component("oscWebhookTriggers", {
+controller: [ "$scope", "$uibModal", "$filter", "APIService", function(e, t, n, r) {
 var a = this;
 a.$onInit = function() {
 e.namespace = a.namespace, e.type = a.type, a.secretsVersion = r.getPreferredVersion("secrets"), a.webhookTypesOptions = [ {
@@ -10999,23 +10996,36 @@ scope: e
 a.webhookSecrets.push(e);
 });
 };
-}
-}), angular.module("openshiftConsole").component("copyWebhookUrl", {
+} ],
+controllerAs: "$ctrl",
 bindings: {
-buildConfigName: "=",
-triggerType: "=",
-projectName: "=",
-secret: "=",
-webhookSecrets: "="
+webhookSecrets: "<",
+namespace: "<",
+type: "@",
+webhookTriggers: "=",
+form: "="
 },
-templateUrl: "components/copy-webhook-url/copy-webhook-url.html",
+templateUrl: "components/osc-webhook-triggers/osc-webhook-triggers.html"
+});
+}(), function() {
+angular.module("openshiftConsole").component("copyWebhookUrl", {
 controller: function() {
 var e = this;
 e.showSecretsWarning = function() {
 return _.get(e.secret, "secretReference.name") && !e.webhookSecrets;
 };
-}
-}), angular.module("openshiftConsole").directive("parseError", function() {
+},
+controllerAs: "$ctrl",
+bindings: {
+buildConfigName: "<",
+triggerType: "<",
+projectName: "<",
+secret: "<",
+webhookSecrets: "<"
+},
+templateUrl: "components/copy-webhook-url/copy-webhook-url.html"
+});
+}(), angular.module("openshiftConsole").directive("parseError", function() {
 return {
 restrict: "E",
 scope: {
@@ -11744,7 +11754,7 @@ if (!m.pod) return null;
 var t = m.options.selectedContainer;
 switch (e) {
 case "memory/usage":
-var n = E(t);
+var n = T(t);
 if (n) return s.bytesToMiB(d(n));
 break;
 
@@ -11779,10 +11789,10 @@ _.each(e.datasets, function(e) {
 t[e.id] = e.data;
 });
 var n, a = c.getSparklineData(t), o = e.chartPrefix + "sparkline";
-T[o] ? T[o].load(a) : ((n = L(e)).data = a, e.chartDataColors && (n.color = {
+E[o] ? E[o].load(a) : ((n = L(e)).data = a, e.chartDataColors && (n.color = {
 pattern: e.chartDataColors
 }), r(function() {
-A || (T[o] = c3.generate(n));
+A || (E[o] = c3.generate(n));
 }));
 }
 }
@@ -11870,7 +11880,7 @@ m.loaded = !0;
 }
 }
 m.includedMetrics = m.includedMetrics || [ "cpu", "memory", "network" ];
-var I, R = {}, T = {}, E = n("resources.limits.memory"), N = n("resources.limits.cpu"), D = 30, A = !1;
+var I, R = {}, E = {}, T = n("resources.limits.memory"), N = n("resources.limits.cpu"), D = 30, A = !1;
 m.uniqueID = c.uniqueID(), m.metrics = [], _.includes(m.includedMetrics, "memory") && m.metrics.push({
 label: "Memory",
 units: "MiB",
@@ -11967,14 +11977,14 @@ delete e.data;
 }, !0), I = t(k, c.getDefaultUpdateInterval(), !1);
 });
 var O = o.$on("metrics.charts.resize", function() {
-c.redraw(R), c.redraw(T);
+c.redraw(R), c.redraw(E);
 });
 m.$on("$destroy", function() {
 I && (t.cancel(I), I = null), O && (O(), O = null), angular.forEach(R, function(e) {
 e.destroy();
-}), R = null, angular.forEach(T, function(e) {
+}), R = null, angular.forEach(E, function(e) {
 e.destroy();
-}), T = null, A = !0;
+}), E = null, A = !0;
 });
 }
 };
@@ -12036,7 +12046,7 @@ return e[0];
 function u(e) {
 P || (N = 0, t.showAverage = _.size(t.pods) > 5 || w, _.each(t.metrics, function(n) {
 var r, a = o(e, n), i = n.descriptor;
-w && n.compactCombineWith && (i = n.compactCombineWith, n.lastValue && (E[i].lastValue = (E[i].lastValue || 0) + n.lastValue)), S[i] ? (S[i].load(a), t.showAverage ? S[i].legend.hide() : S[i].legend.show()) : ((r = D(n)).data = a, S[i] = c3.generate(r));
+w && n.compactCombineWith && (i = n.compactCombineWith, n.lastValue && (T[i].lastValue = (T[i].lastValue || 0) + n.lastValue)), S[i] ? (S[i].load(a), t.showAverage ? S[i].legend.hide() : S[i].legend.show()) : ((r = D(n)).data = a, S[i] = c3.generate(r));
 }));
 }
 function d() {
@@ -12100,7 +12110,7 @@ t.loaded = !0;
 }
 var b, S = {}, C = 30, w = "compact" === t.profile, P = !1;
 t.uniqueID = s.uniqueID();
-var j, k, I = {}, R = w, T = function(e) {
+var j, k, I = {}, R = w, E = function(e) {
 return e >= 1024;
 };
 t.metrics = [ {
@@ -12108,10 +12118,10 @@ label: "Memory",
 units: "MiB",
 convert: i.bytesToMiB,
 formatUsage: function(e) {
-return T(e) && (e /= 1024), s.formatUsage(e);
+return E(e) && (e /= 1024), s.formatUsage(e);
 },
 usageUnits: function(e) {
-return T(e) ? "GiB" : "MiB";
+return E(e) ? "GiB" : "MiB";
 },
 descriptor: "memory/usage",
 type: "pod_container",
@@ -12156,7 +12166,7 @@ compactDatasetLabel: "Received",
 compactType: "spline",
 chartID: "network-rx-" + t.uniqueID
 } ];
-var E = _.keyBy(t.metrics, "descriptor");
+var T = _.keyBy(t.metrics, "descriptor");
 t.loaded = !1, t.noData = !0, t.showComputeUnitsHelp = function() {
 l.showComputeUnitsHelp();
 };
@@ -12256,17 +12266,17 @@ n > 10 ? e() : (n++, j().is(":visible") && (k(), e()));
 k(!0), b(), C();
 }, 100);
 m.on("resize", R);
-var T, E = function() {
+var E, T = function() {
 S = !0, d.scrollBottom(u);
 }, N = document.createDocumentFragment(), D = _.debounce(function() {
-l.appendChild(N), N = document.createDocumentFragment(), t.autoScrollActive && E(), t.showScrollLinks || b();
+l.appendChild(N), N = document.createDocumentFragment(), t.autoScrollActive && T(), t.showScrollLinks || b();
 }, 100, {
 maxWait: 300
 }), A = function(e) {
 var t = a.defer();
-return T ? (T.onClose(function() {
+return E ? (E.onClose(function() {
 t.resolve();
-}), T.stop()) : t.resolve(), e || (D.cancel(), l && (l.innerHTML = ""), N = document.createDocumentFragment()), t.promise;
+}), E.stop()) : t.resolve(), e || (D.cancel(), l && (l.innerHTML = ""), N = document.createDocumentFragment()), t.promise;
 }, B = function() {
 A().then(function() {
 t.$evalAsync(function() {
@@ -12286,7 +12296,7 @@ limitBytes: 10485760
 }, t.options), n = 0, r = function(e) {
 n++, N.appendChild(f(n, e)), D();
 };
-(T = c.createStream(v, h, t.context, e)).onMessage(function(a, o, i) {
+(E = c.createStream(v, h, t.context, e)).onMessage(function(a, o, i) {
 t.$evalAsync(function() {
 t.empty = !1, "logs" !== t.state && (t.state = "logs", I());
 }), a && (e.limitBytes && i >= e.limitBytes && (t.$evalAsync(function() {
@@ -12294,18 +12304,18 @@ t.limitReached = !0, t.loading = !1;
 }), A(!0)), r(a), !t.largeLog && n >= e.tailLines && t.$evalAsync(function() {
 t.largeLog = !0;
 }));
-}), T.onClose(function() {
-T = null, t.$evalAsync(function() {
+}), E.onClose(function() {
+E = null, t.$evalAsync(function() {
 t.loading = !1, t.autoScrollActive = !1, 0 !== n || t.emptyStateMessage || (t.state = "empty", t.emptyStateMessage = "The logs are no longer available or could not be loaded.");
 });
-}), T.onError(function() {
-T = null, t.$evalAsync(function() {
+}), E.onError(function() {
+E = null, t.$evalAsync(function() {
 angular.extend(t, {
 loading: !1,
 autoScrollActive: !1
 }), 0 === n ? (t.state = "empty", t.emptyStateMessage = "The logs are no longer available or could not be loaded.") : t.errorWhileRunning = !0;
 });
-}), T.start();
+}), E.start();
 }
 });
 });
@@ -12346,7 +12356,7 @@ onScrollTop: function() {
 t.autoScrollActive = !1, d.scrollTop(u), $("#" + t.logViewerID + "-affixedFollow").affix("checkPosition");
 },
 toggleAutoScroll: function() {
-t.autoScrollActive = !t.autoScrollActive, t.autoScrollActive && E();
+t.autoScrollActive = !t.autoScrollActive, t.autoScrollActive && T();
 },
 goChromeless: d.chromelessLink,
 restartLogs: B
@@ -13361,7 +13371,7 @@ return {
 name: t,
 value: e
 };
-}), T() && h.labels.push({
+}), E() && h.labels.push({
 name: "app",
 value: h.template.metadata.name
 });
@@ -13477,7 +13487,7 @@ details: t
 }, h.cancel = function() {
 j(), i.toProjectOverview(h.project.metadata.name);
 }, n.$on("instantiateTemplate", h.createFromTemplate), n.$on("$destroy", j);
-var T = function() {
+var E = function() {
 return !_.get(h.template, "labels.app") && !_.some(h.template.objects, "metadata.labels.app");
 };
 } ],
@@ -14432,11 +14442,11 @@ details: y(e)
 }
 } else n.mode = "istag";
 });
-var R, T = e("displayName"), E = function() {
+var R, E = e("displayName"), T = function() {
 var e = {
-started: "Deploying image " + n.app.name + " to project " + T(n.input.selectedProject),
-success: "Deployed image " + n.app.name + " to project " + T(n.input.selectedProject),
-failure: "Failed to deploy image " + n.app.name + " to project " + T(n.input.selectedProject)
+started: "Deploying image " + n.app.name + " to project " + E(n.input.selectedProject),
+success: "Deployed image " + n.app.name + " to project " + E(n.input.selectedProject),
+failure: "Failed to deploy image " + n.app.name + " to project " + E(n.input.selectedProject)
 };
 m.clear(), m.add(e, {}, n.input.selectedProject.metadata.name, function() {
 var e = t.defer();
@@ -14483,7 +14493,7 @@ cancelButtonText: "Cancel"
 };
 }
 }
-}).result.then(E);
+}).result.then(T);
 }, D = function(e) {
 b = e.quotaAlerts || [];
 var t = _.filter(b, {
@@ -14491,7 +14501,7 @@ type: "error"
 });
 n.nameTaken || t.length ? (n.disableInputs = !1, _.each(b, function(e) {
 e.id = _.uniqueId("deploy-image-alert-"), l.addNotification(e);
-})) : b.length ? (N(b), n.disableInputs = !1) : E();
+})) : b.length ? (N(b), n.disableInputs = !1) : T();
 };
 n.create = function() {
 n.disableInputs = !0, S(), C().then(function(e) {
@@ -14953,15 +14963,15 @@ return _.filter(e, "unread");
 _.each(h.notificationGroups, function(e) {
 e.totalUnread = I(e.notifications).length, e.hasUnread = !!e.totalUnread, r.$emit("NotificationDrawerWrapper.onUnreadNotifications", e.totalUnread);
 });
-}, T = function(e) {
+}, E = function(e) {
 _.each(h.notificationGroups, function(t) {
 _.remove(t.notifications, {
 uid: e.uid,
 namespace: e.namespace
 });
 });
-}, E = function(e) {
-S[a.project] && delete S[a.project][e.uid], b[a.project] && delete b[a.project][e.uid], T(e);
+}, T = function(e) {
+S[a.project] && delete S[a.project][e.uid], b[a.project] && delete b[a.project][e.uid], E(e);
 }, N = function() {
 b[a.project] = {}, S[a.project] = {};
 }, D = function(e) {
@@ -15054,7 +15064,7 @@ headingInclude: "views/directives/notifications/header.html",
 notificationBodyInclude: "views/directives/notifications/notification-body.html",
 customScope: {
 clear: function(e, t, n) {
-u.markRead(e.uid), u.markCleared(e.uid), n.notifications.splice(t, 1), E(e), L();
+u.markRead(e.uid), u.markCleared(e.uid), n.notifications.splice(t, 1), T(e), L();
 },
 markRead: function(e) {
 e.unread = !1, u.markRead(e.uid), L();
@@ -15078,7 +15088,7 @@ h.drawerHidden = !h.drawerHidden;
 })), y.push(r.$on("NotificationDrawerWrapper.hide", function() {
 h.drawerHidden = !0;
 })), y.push(r.$on("NotificationDrawerWrapper.clear", function(e, t) {
-u.markCleared(t.uid), E(t), R();
+u.markCleared(t.uid), T(t), R();
 }));
 };
 h.$onInit = function() {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -13942,7 +13942,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "<div class=\"add-webhook-action-btns\">\n" +
-    "<button class=\"btn btn-link\" type=\"button\" ng-click=\"$ctrl.checkLastAndAddNew()\">Add Webhook</button>\n" +
+    "<button class=\"btn btn-link pad-left-none\" type=\"button\" ng-click=\"$ctrl.checkLastAndAddNew()\">Add Webhook</button>\n" +
     "<span ng-if=\"$ctrl.secretsVersion | canI : 'create'\">\n" +
     "<span class=\"action-divider\" aria-hidden=\"true\"> | </span>\n" +
     "<button class=\"btn btn-link\" href=\"\" type=\"button\" ng-click=\"$ctrl.openCreateWebhookSecretModal()\">Create New Webhook Secret</button>\n" +


### PR DESCRIPTION
Updated the webhook trigger editor behavior to be the same as the one in envVar editor, which means that user can add as many triggers as he wants, but only those that have filled trigger type and secret will be save, rest wont be saved.

Will add the dist after review.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1535402

@jwforres PTAL 