### PR TITLE
Partial fix for bug 1440004

### DIFF
--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -529,7 +529,7 @@ angular.module('openshiftConsole')
   })
   .filter('isIncompleteBuild', function(ageLessThanFilter) {
     return function(build) {
-      if (!build || !build.status || !build.status.phase) {
+      if (!build || !build.status || !build.status.phase){
         return false;
       }
 
@@ -539,6 +539,9 @@ angular.module('openshiftConsole')
         case 'Running':
           return true;
         default:
+          if (!build.status.completionTimestamp) {
+            return true;
+          }
           return false;
       }
     };

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -15404,7 +15404,7 @@ case "Running":
 return !0;
 
 default:
-return !1;
+return !e.status.completionTimestamp;
 }
 };
 } ]).filter("isRecentBuild", [ "ageLessThanFilter", "isIncompleteBuildFilter", function(e, t) {


### PR DESCRIPTION
When build history bar chart is shown and a new build is added to the chart, sometimes the duration is initially set to 0 until the page is reloaded. This was mostly observed by setting the build config `source` property to an invalid url to generate a failed build with a very short duration.

Added a check for the `completionTimestamp` property in the `isIncompleteBuild` filter to ensure that any build without a completion timestamp is considered incomplete.