### PR TITLE
Bug 1535374: Add console version to about page

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -38,7 +38,8 @@
 
   window.OPENSHIFT_VERSION = {
     openshift: "dev-mode",
-    kubernetes: "dev-mode"
+    kubernetes: "dev-mode",
+    console: "dev-mode"
   };
 
 })();

--- a/app/scripts/controllers/about.js
+++ b/app/scripts/controllers/about.js
@@ -9,11 +9,12 @@
 angular.module('openshiftConsole')
   .controller('AboutController', function ($scope, AuthService, Constants) {
     AuthService.withUser();
-    
+
     $scope.version = {
       master: {
         openshift: Constants.VERSION.openshift,
         kubernetes: Constants.VERSION.kubernetes,
       },
+      console: Constants.VERSION.console
     };
   });

--- a/app/views/about.html
+++ b/app/views/about.html
@@ -19,6 +19,8 @@
                   <dd>{{version.master.openshift || 'unknown'}}</dd>
                   <dt>Kubernetes Master:</dt>
                   <dd>{{version.master.kubernetes || 'unknown'}}</dd>
+                  <dt>OpenShift Web Console:</dt>
+                  <dd>{{version.console || 'unknown'}}</dd>
                 </dl>
 
                 <p>The <a target="_blank" ng-href="{{'welcome' | helpLink}}">documentation</a> helps you learn about OpenShift and start exploring its features. From getting started with creating your first application to trying out more advanced build and deployment techniques, it provides guidance on setting up and managing your OpenShift environment as an application developer.</p>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8995,7 +8995,8 @@ t.withUser(), e.version = {
 master: {
 openshift: n.VERSION.openshift,
 kubernetes: n.VERSION.kubernetes
-}
+},
+console: n.VERSION.console
 };
 } ]), angular.module("openshiftConsole").controller("CommandLineController", [ "$scope", "DataService", "AuthService", "Constants", function(e, t, n, r) {
 n.withUser(), e.cliDownloadURL = r.CLI, e.cliDownloadURLPresent = e.cliDownloadURL && !_.isEmpty(e.cliDownloadURL), e.loginBaseURL = t.openshiftAPIBaseUrl(), r.DISABLE_COPY_LOGIN_COMMAND || (e.sessionToken = n.UserStore().getToken());

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -722,6 +722,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dd>{{version.master.openshift || 'unknown'}}</dd>\n" +
     "<dt>Kubernetes Master:</dt>\n" +
     "<dd>{{version.master.kubernetes || 'unknown'}}</dd>\n" +
+    "<dt>OpenShift Web Console:</dt>\n" +
+    "<dd>{{version.console || 'unknown'}}</dd>\n" +
     "</dl>\n" +
     "<p>The <a target=\"_blank\" ng-href=\"{{'welcome' | helpLink}}\">documentation</a> helps you learn about OpenShift and start exploring its features. From getting started with creating your first application to trying out more advanced build and deployment techniques, it provides guidance on setting up and managing your OpenShift environment as an application developer.</p>\n" +
     "<p>With the OpenShift command line interface (CLI), you can create applications and manage OpenShift projects from a terminal. To get started using the CLI, visit <a href=\"command-line\">Command Line Tools</a>.\n" +


### PR DESCRIPTION
Now that the console runs in a pod, it has its own version string.

Requires https://github.com/openshift/origin-web-console-server/pull/23
See https://bugzilla.redhat.com/show_bug.cgi?id=1535374

/assign @jwforres 