### PR TITLE
Fix bug 14400044: Build chart legend hover issue

### DIFF
--- a/app/scripts/directives/buildTrendsChart.js
+++ b/app/scripts/directives/buildTrendsChart.js
@@ -135,6 +135,7 @@ angular.module('openshiftConsole')
             selection: {
               enabled: true
             },
+            order: null,
             type: 'bar'
           }
         };

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12859,6 +12859,7 @@ t.path(o);
 selection: {
 enabled: !0
 },
+order: null,
 type: "bar"
 }
 }, p = function() {


### PR DESCRIPTION
Add `order: null` config option to build history chart to prevent C3 from sorting legend items when `load()` API function is used.

[C3js Issue](https://github.com/c3js/c3/issues/1945)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1440004.