### PR TITLE
Remove System User, System Group from Membership page

### DIFF
--- a/app/scripts/services/membership/membership.js
+++ b/app/scripts/services/membership/membership.js
@@ -60,26 +60,6 @@ angular
             "subjects":{
 
             }
-         },
-         "SystemUser":{
-            "kind":"SystemUser",
-            "sortOrder":4,
-            "description":"System users are virtual users automatically provisioned by the system.",
-            "helpLinkKey":"users_and_groups",
-            "name":"SystemUser",
-            "subjects":{
-
-            }
-         },
-         "SystemGroup":{
-            "kind":"SystemGroup",
-            "sortOrder":5,
-            "description":"System groups are virtual groups automatically provisioned by the system.",
-            "helpLinkKey":"users_and_groups",
-            "name":"SystemGroup",
-            "subjects":{
-
-            }
          }
       };
     };

--- a/app/scripts/services/membership/roleBindings.js
+++ b/app/scripts/services/membership/roleBindings.js
@@ -6,11 +6,6 @@ angular
     $q,
     APIService,
     DataService) {
-    // some API constraints worth nothing:
-    // ServiceAccountUsernamePrefix    = "system:serviceaccount:"
-    // ServiceAccountUsernameSeparator = ":"
-    // ServiceAccountGroupPrefix       = "system:serviceaccounts:"
-    // AllServiceAccountsGroup         = "system:serviceaccounts"
 
     var roleBindingsVersion = APIService.getPreferredVersion('rolebindings');
 
@@ -48,21 +43,10 @@ angular
     };
 
     var qualifySubject = function(subject, namespace) {
-      // NOTE: so far, SAs are the only ones that need tweaking
       if(_.isEqual(subject.kind, 'ServiceAccount')) {
         subject.namespace = subject.namespace || namespace;
-      } else if(_.isEqual(subject.kind, 'SystemUser') || _.isEqual(subject.kind, 'SystemGroup')) {
-        if(!_.startsWith(subject.name, 'system:')) {
-          subject.name = 'system:'+subject.name;
-        }
       }
       return subject;
-    };
-
-    var cleanBinding = function(binding) {
-      // These generated lists must be removed to be regenerated
-      binding.userNames = null;
-      binding.groupNames = null;
     };
 
     var create = function(role, subject, namespace, context) {
@@ -89,7 +73,6 @@ angular
       } else {
         binding.subjects = [subject];
       }
-      cleanBinding(binding);
       return DataService.update(rgv, binding.metadata.name, binding, context);
     };
 
@@ -101,7 +84,6 @@ angular
         _.map(matchingBindings, function(binding) {
           var tpl = bindingTPL();
           binding = _.extend(tpl, binding);
-          cleanBinding(binding);
           var toMatch = { name: subjectName };
           if(namespace) {
             toMatch.namespace = namespace;

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2446,22 +2446,6 @@ description: "Service accounts provide a flexible way to control API access with
 helpLinkKey: "service_accounts",
 name: "ServiceAccount",
 subjects: {}
-},
-SystemUser: {
-kind: "SystemUser",
-sortOrder: 4,
-description: "System users are virtual users automatically provisioned by the system.",
-helpLinkKey: "users_and_groups",
-name: "SystemUser",
-subjects: {}
-},
-SystemGroup: {
-kind: "SystemGroup",
-sortOrder: 5,
-description: "System groups are virtual groups automatically provisioned by the system.",
-helpLinkKey: "users_and_groups",
-name: "SystemGroup",
-subjects: {}
 }
 };
 }, o = function(e) {
@@ -2520,22 +2504,6 @@ description: "Service accounts provide a flexible way to control API access with
 helpLinkKey: "service_accounts",
 name: "ServiceAccount",
 subjects: {}
-},
-SystemUser: {
-kind: "SystemUser",
-sortOrder: 4,
-description: "System users are virtual users automatically provisioned by the system.",
-helpLinkKey: "users_and_groups",
-name: "SystemUser",
-subjects: {}
-},
-SystemGroup: {
-kind: "SystemGroup",
-sortOrder: 5,
-description: "System groups are virtual groups automatically provisioned by the system.",
-helpLinkKey: "users_and_groups",
-name: "SystemGroup",
-subjects: {}
 }
 });
 return _.sortBy(n, "sortOrder");
@@ -2568,9 +2536,7 @@ namespace: _.get(e, "metadata.namespace")
 subjects: []
 };
 }, s = function(e, t) {
-return _.isEqual(e.kind, "ServiceAccount") ? e.namespace = e.namespace || t : (_.isEqual(e.kind, "SystemUser") || _.isEqual(e.kind, "SystemGroup")) && (_.startsWith(e.name, "system:") || (e.name = "system:" + e.name)), e;
-}, c = function(e) {
-e.userNames = null, e.groupNames = null;
+return _.isEqual(e.kind, "ServiceAccount") && (e.namespace = e.namespace || t), e;
 };
 return {
 list: function(e, t, o) {
@@ -2583,27 +2549,27 @@ var c = i(e, a), l = t.objectToResourceGroupVersion(c);
 return r = s(r, a), c.subjects.push(angular.copy(r)), n.create(l, null, c, o);
 },
 addSubject: function(e, r, a, o) {
-var l = i(), u = _.extend(l, e), d = t.objectToResourceGroupVersion(u);
-if (!r) return u;
-if (r = s(r, a), _.isArray(u.subjects)) {
-if (_.includes(u.subjects, r)) return;
-u.subjects.push(r);
-} else u.subjects = [ r ];
-return c(u), n.update(d, u.metadata.name, u, o);
+var c = i(), l = _.extend(c, e), u = t.objectToResourceGroupVersion(l);
+if (!r) return l;
+if (r = s(r, a), _.isArray(l.subjects)) {
+if (_.includes(l.subjects, r)) return;
+l.subjects.push(r);
+} else l.subjects = [ r ];
+return n.update(u, l.metadata.name, l, o);
 },
-removeSubject: function(t, a, o, s, l) {
-var u = _.filter(s, {
+removeSubject: function(t, a, o, s, c) {
+var l = _.filter(s, {
 roleRef: {
 name: a
 }
 });
-return e.all(_.map(u, function(e) {
+return e.all(_.map(l, function(e) {
 var a = i();
-e = _.extend(a, e), c(e);
+e = _.extend(a, e);
 var s = {
 name: t
 };
-return o && (s.namespace = o), e.subjects = _.reject(e.subjects, s), e.subjects.length ? n.update(r, e.metadata.name, e, l) : n.delete(r, e.metadata.name, l).then(function() {
+return o && (s.namespace = o), e.subjects = _.reject(e.subjects, s), e.subjects.length ? n.update(r, e.metadata.name, e, c) : n.delete(r, e.metadata.name, c).then(function() {
 return e;
 });
 }));

--- a/test/spec/services/membership/membershipSpec.js
+++ b/test/spec/services/membership/membershipSpec.js
@@ -231,30 +231,21 @@ describe('MembershipService', function() {
       expect(kinds['User'].sortOrder).toEqual(1);
       expect(kinds['Group'].sortOrder).toEqual(2);
       expect(kinds['ServiceAccount'].sortOrder).toEqual(3);
-      expect(kinds['SystemUser'].sortOrder).toEqual(4);
-      expect(kinds['SystemGroup'].sortOrder).toEqual(5);
 
       expect(kinds['User'].kind).toEqual('User');
       expect(kinds['Group'].kind).toEqual('Group');
       expect(kinds['ServiceAccount'].kind).toEqual('ServiceAccount');
-      expect(kinds['SystemUser'].kind).toEqual('SystemUser');
-      expect(kinds['SystemGroup'].kind).toEqual('SystemGroup');
-
-      expect(kinds['SystemUser'].helpLinkKey).toEqual('users_and_groups');
-      expect(kinds['SystemGroup'].helpLinkKey).toEqual('users_and_groups');
     });
   });
 
   describe('#mapRolebindingsForUI', function() {
-    it('Should return rolebindings in the following order: User, Group, ServiceAccount, SystemUser, SystemGroup', function() {
+    it('Should return rolebindings in the following order: User, Group, ServiceAccount', function() {
       var mappedRoles = MembershipService.mapRolesForUI(roles, clusterRoles);
       var mappedRolebindings = MembershipService.mapRolebindingsForUI(roleBindings, mappedRoles);
       var orderedKinds = _.map(mappedRolebindings, 'kind');
       expect(orderedKinds[0]).toEqual('User');
       expect(orderedKinds[1]).toEqual('Group');
       expect(orderedKinds[2]).toEqual('ServiceAccount');
-      expect(orderedKinds[3]).toEqual('SystemUser');
-      expect(orderedKinds[4]).toEqual('SystemGroup');
     });
 
     it('should put subjects under the appropriate kind', function() {
@@ -357,60 +348,46 @@ describe('MembershipService', function() {
                   "roles": {}
               }
           }
-      }, {
-          "kind": "SystemUser",
-          "sortOrder": 4,
-          "description": "System users are virtual users automatically provisioned by the system.",
-          "helpLinkKey": "users_and_groups",
-          "name": "SystemUser",
-          "subjects": {}
-      }, {
-          "kind": "SystemGroup",
-          "sortOrder": 5,
-          "description": "System groups are virtual groups automatically provisioned by the system.",
-          "helpLinkKey": "users_and_groups",
-          "name": "SystemGroup",
-          "subjects": {}
       }];
 
       _.each(mockRolebindingsByKindForUI, function(mockRBByKind, mappedIndex) {
 
-        it('should create a map of 5 tabs according to Kinds with a kind property', function() {
+        it('should create a map of 3 tabs according to Kinds with a kind property', function() {
           var mappedRoles = MembershipService.mapRolesForUI(roles, clusterRoles);
           var allMappedKinds = MembershipService.mapRolebindingsForUI(roleBindings, mappedRoles);
           var kind = allMappedKinds[mappedIndex];
           expect(kind.kind).toEqual(mockRBByKind.kind);
         });
 
-        it('should create a map of 5 tabs matching a predetermined sortOrder property', function() {
+        it('should create a map of 3 tabs matching a predetermined sortOrder property', function() {
           var mappedRoles = MembershipService.mapRolesForUI(roles, clusterRoles);
           var allMappedKinds = MembershipService.mapRolebindingsForUI(roleBindings, mappedRoles);
           var kind = allMappedKinds[mappedIndex];
           expect(kind.sortOrder).toEqual(mockRBByKind.sortOrder);
         });
 
-        it('should create a map of 5 tabs each with a description property', function() {
+        it('should create a map of 3 tabs each with a description property', function() {
           var mappedRoles = MembershipService.mapRolesForUI(roles, clusterRoles);
           var allMappedKinds = MembershipService.mapRolebindingsForUI(roleBindings, mappedRoles);
           var kind = allMappedKinds[mappedIndex];
           expect(kind.description).toEqual(mockRBByKind.description);
         });
 
-        it('should create a map of 5 tabs each with a helpLinkKey property', function() {
+        it('should create a map of 3 tabs each with a helpLinkKey property', function() {
           var mappedRoles = MembershipService.mapRolesForUI(roles, clusterRoles);
           var allMappedKinds = MembershipService.mapRolebindingsForUI(roleBindings, mappedRoles);
           var kind = allMappedKinds[mappedIndex];
           expect(kind.helpLinkKey).toEqual(mockRBByKind.helpLinkKey);
         });
 
-        it('should create a map of 5 tabs with a correct name property', function() {
+        it('should create a map of 3 tabs with a correct name property', function() {
           var mappedRoles = MembershipService.mapRolesForUI(roles, clusterRoles);
           var allMappedKinds = MembershipService.mapRolebindingsForUI(roleBindings, mappedRoles);
           var kind = allMappedKinds[mappedIndex];
           expect(kind.name).toEqual(mockRBByKind.name);
         });
 
-        it('should create a map of 5 tabs with the correct set of subjects', function() {
+        it('should create a map of 3 tabs with the correct set of subjects', function() {
           var mappedRoles = MembershipService.mapRolesForUI(roles, clusterRoles);
           var allMappedKinds = MembershipService.mapRolebindingsForUI(roleBindings, mappedRoles);
 
@@ -424,7 +401,7 @@ describe('MembershipService', function() {
 
         });
 
-        it('should create a map of 5 tabs that exactly match the expected output structure', function() {
+        it('should create a map of 3 tabs that exactly match the expected output structure', function() {
           var mappedRoles = MembershipService.mapRolesForUI(roles, clusterRoles);
           var allMappedKinds = MembershipService.mapRolebindingsForUI(roleBindings, mappedRoles);
           var kind = allMappedKinds[mappedIndex];

--- a/test/spec/services/membership/roleBindingsSpec.js
+++ b/test/spec/services/membership/roleBindingsSpec.js
@@ -48,17 +48,7 @@ describe('RoleBindingsService', function() {
           expect(_.keys(resp.roleRef)).toEqual(['name', 'namespace']);
         });
     });
-    it('should explicitly null userNames and groupNames', function() {
-      RoleBindingsService
-        .addSubject({
-          metadata: { name: 'admin'},
-          subjects: []
-        }, {name: 'jane', kind: 'user'})
-        .then(function(resp) {
-          expect(resp.userNames).toEqual(null);
-          expect(resp.groupNames).toEqual(null);
-        });
-    });
+
     it('should return the binding if no new subject provided', function() {
       // TODO: the early rejection should still be a thenable object!
       var binding = RoleBindingsService


### PR DESCRIPTION
This is a pretty simple change to remove the System User & System Group tabs.  I'll update the tests once I verify the other membership changes went it & won't conflict.  

![screen shot 2018-01-21 at 9 47 06 pm](https://user-images.githubusercontent.com/280512/35203136-b81739a6-fef4-11e7-8a94-c060e4191911.png)
