### PR TITLE
Remove extra 'reason' in membership prompt

### DIFF
--- a/app/scripts/controllers/membership.js
+++ b/app/scripts/controllers/membership.js
@@ -55,7 +55,7 @@ angular
             exists: _.template('The role "<%= roleName %>" has already been granted to "<%= subjectName %>".')
           }
         },
-        errorReason: _.template('Reason: "<%= httpErr %>"')
+        errorReason: _.template('"<%= httpErr %>"')
       };
 
       var showToast = function(type, message, details) {
@@ -102,7 +102,7 @@ angular
               roleBindings: resp.by('metadata.name'),
               subjectKindsForUI: MembershipService.mapRolebindingsForUI(resp.by('metadata.name'), allRoles)
             });
-			      resetForm();
+            resetForm();
           }, function() {
             // if the request errors but we have an object, we can at least update in place
             if(toUpdateOnError) {

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -5235,7 +5235,7 @@ error: _.template('The role "<%= roleName %>" could not be granted to "<%= subje
 exists: _.template('The role "<%= roleName %>" has already been granted to "<%= subjectName %>".')
 }
 },
-errorReason: _.template('Reason: "<%= httpErr %>"')
+errorReason: _.template('"<%= httpErr %>"')
 }, P = function(e, t, n) {
 m.addNotification({
 type: e,


### PR DESCRIPTION
Re [bugzilla 1535787](https://bugzilla.redhat.com/show_bug.cgi?id=1535787)

Initially just removing the extra `Reason:` in the string.  

Looking into @jwforres comment about:

     @ben looks like in one place you are not using errorDetailsFilter, not sure if this was an oversight or if there was a reason for it:

     https://github.com/openshift/origin-web-console/blob/master/app/scripts/controllers/membership.js#L58


