### PR TITLE
Remove rolBindingsService.list

### DIFF
--- a/app/scripts/services/membership/roleBindings.js
+++ b/app/scripts/services/membership/roleBindings.js
@@ -9,26 +9,12 @@ angular
 
     var roleBindingsVersion = APIService.getPreferredVersion('rolebindings');
 
-    var cache = {};
-
-    // recurse until we get a unique binding name compared to what is cached
-    var qualifyBindingName = function(name, suffix) {
-      var search = suffix ?
-                name + suffix :
-                name;
-      return _.some(cache, _.matchesProperty('metadata.name', search)) ?
-              qualifyBindingName(name, _.uniqueId()) :
-              search;
-    };
-
     var bindingTPL = function(role, projectNamespace) {
-      var roleName = _.get(role, 'metadata.name');
-      var bindingName = roleName ? qualifyBindingName(roleName) : null;
       return {
         kind: 'RoleBinding',
         apiVersion: 'v1',
         metadata: {
-          name: bindingName,
+          generateName: _.get(role, 'metadata.name') + '-',
           namespace: projectNamespace,
         },
         roleRef: {
@@ -103,16 +89,7 @@ angular
         }));
     };
 
-    var list = function(context, fn, opts) {
-      return DataService
-              .list(roleBindingsVersion, context, function(resp) {
-                cache = resp.by('metadata.name');
-                fn(resp);
-              }, opts);
-    };
-
     return {
-      list: list,
       create: create,
       addSubject: addSubject,
       removeSubject: removeSubject

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -2518,16 +2518,12 @@ return e.all([ n.list(r, t, null), n.list(a, {}, null) ]);
 }
 };
 } ]), angular.module("openshiftConsole").factory("RoleBindingsService", [ "$q", "APIService", "DataService", function(e, t, n) {
-var r = t.getPreferredVersion("rolebindings"), a = {}, o = function(e, t) {
-var n = t ? e + t : e;
-return _.some(a, _.matchesProperty("metadata.name", n)) ? o(e, _.uniqueId()) : n;
-}, i = function(e, t) {
-var n = _.get(e, "metadata.name");
+var r = t.getPreferredVersion("rolebindings"), a = function(e, t) {
 return {
 kind: "RoleBinding",
 apiVersion: "v1",
 metadata: {
-name: n ? o(n) : null,
+generateName: _.get(e, "metadata.name") + "-",
 namespace: t
 },
 roleRef: {
@@ -2536,41 +2532,36 @@ namespace: _.get(e, "metadata.namespace")
 },
 subjects: []
 };
-}, s = function(e, t) {
+}, o = function(e, t) {
 return _.isEqual(e.kind, "ServiceAccount") && (e.namespace = e.namespace || t), e;
 };
 return {
-list: function(e, t, o) {
-return n.list(r, e, function(e) {
-a = e.by("metadata.name"), t(e);
-}, o);
+create: function(e, r, i, s) {
+var c = a(e, i), l = t.objectToResourceGroupVersion(c);
+return r = o(r, i), c.subjects.push(angular.copy(r)), n.create(l, null, c, s);
 },
-create: function(e, r, a, o) {
-var c = i(e, a), l = t.objectToResourceGroupVersion(c);
-return r = s(r, a), c.subjects.push(angular.copy(r)), n.create(l, null, c, o);
-},
-addSubject: function(e, r, a, o) {
-var c = i(), l = _.extend(c, e), u = t.objectToResourceGroupVersion(l);
+addSubject: function(e, r, i, s) {
+var c = a(), l = _.extend(c, e), u = t.objectToResourceGroupVersion(l);
 if (!r) return l;
-if (r = s(r, a), _.isArray(l.subjects)) {
+if (r = o(r, i), _.isArray(l.subjects)) {
 if (_.includes(l.subjects, r)) return;
 l.subjects.push(r);
 } else l.subjects = [ r ];
-return n.update(u, l.metadata.name, l, o);
+return n.update(u, l.metadata.name, l, s);
 },
-removeSubject: function(t, a, o, s, c) {
+removeSubject: function(t, o, i, s, c) {
 var l = _.filter(s, {
 roleRef: {
-name: a
+name: o
 }
 });
 return e.all(_.map(l, function(e) {
-var a = i();
-e = _.extend(a, e);
+var o = a();
+e = _.extend(o, e);
 var s = {
 name: t
 };
-return o && (s.namespace = o), e.subjects = _.reject(e.subjects, s), e.subjects.length ? n.update(r, e.metadata.name, e, c) : n.delete(r, e.metadata.name, c).then(function() {
+return i && (s.namespace = i), e.subjects = _.reject(e.subjects, s), e.subjects.length ? n.update(r, e.metadata.name, e, c) : n.delete(r, e.metadata.name, c).then(function() {
 return e;
 });
 }));


### PR DESCRIPTION
At one point `watch` was added & we stopped using `list`.  This PR removes the list function from the RoleBindings Service. We can eliminate the `qualifyBindingName` function by using the `generateName` prop.

@spadgett @jwforres 