### PR TITLE
hpa v2beta1 api warning on DC & edit autoscaler pages

### DIFF
--- a/app/scripts/controllers/edit/autoscaler.js
+++ b/app/scripts/controllers/edit/autoscaler.js
@@ -78,6 +78,7 @@ angular.module('openshiftConsole')
     var horizontalPodAutoscalerVersion = APIService.getPreferredVersion('horizontalpodautoscalers');
     var limitRangesVersion = APIService.getPreferredVersion('limitranges');
 
+
     ProjectsService
       .get($routeParams.project)
       .then(_.spread(function(project, context) {
@@ -185,6 +186,8 @@ angular.module('openshiftConsole')
                                 value: val
                               };
                             });
+
+          $scope.usesV2Metrics = HPAService.usesV2Metrics(resource);
 
           // Are we editing an existing HPA?
           if ($routeParams.kind === "HorizontalPodAutoscaler") {

--- a/app/scripts/directives/oscAutoscaling.js
+++ b/app/scripts/directives/oscAutoscaling.js
@@ -13,10 +13,11 @@ angular.module("openshiftConsole")
       scope: {
         autoscaling: "=model",
         showNameInput: "=?",
-        nameReadOnly: "=?"
+        nameReadOnly: "=?",
+        showRequestInput: "=?"
       },
       templateUrl: 'views/directives/osc-autoscaling.html',
-      link: function(scope) {
+      link: function(scope, elem, attrs) {
         scope.nameValidation = DNS1123_SUBDOMAIN_VALIDATION;
 
         // Prefill a default value if DEFAULT_HPA_CPU_TARGET_PERCENT is set and
@@ -25,6 +26,10 @@ angular.module("openshiftConsole")
         var targetCPU = _.get(scope, 'autoscaling.targetCPU');
         if (_.isNil(targetCPU) && defaultTargetCPU) {
           _.set(scope, 'autoscaling.targetCPU', defaultTargetCPU);
+        }
+        // true if not present
+        if( !('showRequestInput' in attrs) ) {
+          scope.showRequestInput = true;
         }
       }
     };

--- a/app/views/directives/osc-autoscaling.html
+++ b/app/views/directives/osc-autoscaling.html
@@ -99,7 +99,7 @@
       </span>
     </div>
   </div>
-  <div class="form-group">
+  <div ng-show="showRequestInput" class="form-group">
     <label>
       CPU Request Target
     </label>

--- a/app/views/edit/autoscaler.html
+++ b/app/views/edit/autoscaler.html
@@ -38,11 +38,21 @@
               <span ng-if="!('cpu' | isRequestCalculated : project)">request.</span>
             </div>
 
+            <!-- Warning: V2Beta1 HPA -->
+            <div ng-if="usesV2Metrics" class="alert alert-warning">
+              <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
+              <span class="sr-only">Warning:</span>
+              This autoscaler uses a newer API, consider editing it with the
+              <a href="command-line" target="_blank">command line tools</a>.
+            </div>
+
+
             <fieldset ng-disabled="disableInputs" class="gutter-top">
               <osc-autoscaling
                   model="autoscaling"
                   show-name-input="true"
-                  name-read-only="kind === 'HorizontalPodAutoscaler'">
+                  name-read-only="kind === 'HorizontalPodAutoscaler'"
+                  show-request-input="autoscaling.targetCPU">
               </osc-autoscaling>
 
               <label-editor

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3109,40 +3109,44 @@ controller: "SetHomePageModalController"
 }
 };
 } ]), angular.module("openshiftConsole").factory("HPAService", [ "$filter", "$q", "LimitRangesService", "MetricsService", function(e, t, n, r) {
-var a = function(e, t, n) {
+var a = e("annotation"), o = function(e, t, n) {
 return _.every(n, function(n) {
 return _.get(n, [ "resources", t, e ]);
 });
-}, o = function(e, t) {
-return a(e, "requests", t);
 }, i = function(e, t) {
-return a(e, "limits", t);
-}, s = function(e, t, r) {
+return o(e, "requests", t);
+}, s = function(e, t) {
+return o(e, "limits", t);
+}, c = function(e, t, r) {
 return !!n.getEffectiveLimitRange(r, e, "Container")[t];
-}, c = function(e, t) {
-return s(e, "defaultRequest", t);
 }, l = function(e, t) {
-return s(e, "defaultLimit", t);
-}, u = function(e, t, r) {
-return !!n.hasClusterResourceOverrides(r) || (!(!o("cpu", e) && !c("cpu", t)) || !(!i("cpu", e) && !l("cpu", t)));
-}, d = e("humanizeKind"), m = e("hasDeploymentConfig"), p = function(e) {
+return c(e, "defaultRequest", t);
+}, u = function(e, t) {
+return c(e, "defaultLimit", t);
+}, d = function(e, t, r) {
+return !!n.hasClusterResourceOverrides(r) || (!(!i("cpu", e) && !l("cpu", t)) || !(!s("cpu", e) && !u("cpu", t)));
+}, m = e("humanizeKind"), p = e("hasDeploymentConfig"), f = function(e) {
 if (!e) return {
 message: "Metrics might not be configured by your cluster administrator. Metrics are required for autoscaling.",
 reason: "MetricsNotAvailable"
 };
-}, f = function(e, t, n) {
+}, g = function(e, t, n) {
 var r, a = _.get(e, "spec.template.spec.containers", []);
-if (!u(a, t, n)) return r = d(e.kind), {
+if (!d(a, t, n)) return r = m(e.kind), {
 message: "This " + r + " does not have any containers with a CPU request set. Autoscaling will not work without a CPU request.",
 reason: "NoCPURequest"
 };
-}, g = function(e) {
+}, v = function(e) {
+return _.some(e, function(e) {
+return a(e, "autoscaling.alpha.kubernetes.io/metrics");
+});
+}, h = function(e) {
 if (_.size(e) > 1) return {
 message: "More than one autoscaler is scaling this resource. This is not recommended because they might compete with each other. Consider removing all but one autoscaler.",
 reason: "MultipleHPA"
 };
-}, v = function(e, t) {
-if ("ReplicationController" === e.kind && m(e) && _.some(t, function() {
+}, y = function(e, t) {
+if ("ReplicationController" === e.kind && p(e) && _.some(t, function() {
 return _.some(t, function(e) {
 return "ReplicationController" === _.get(e, "spec.scaleTargetRef.kind");
 });
@@ -3152,7 +3156,10 @@ reason: "DeploymentHasHPA"
 };
 };
 return {
-hasCPURequest: u,
+usesV2Metrics: function(e) {
+return v([ e ]);
+},
+hasCPURequest: d,
 filterHPA: function(e, t, n) {
 return _.filter(e, function(e) {
 return e.spec.scaleTargetRef.kind === t && e.spec.scaleTargetRef.name === n;
@@ -3160,7 +3167,8 @@ return e.spec.scaleTargetRef.kind === t && e.spec.scaleTargetRef.name === n;
 },
 getHPAWarnings: function(e, n, a, o) {
 return !e || _.isEmpty(n) ? t.when([]) : r.isAvailable().then(function(t) {
-return _.compact([ p(t), f(e, a, o), g(n), v(e, n) ]);
+var r = v(n);
+return _.compact([ f(t), !r && g(e, a, o), h(n), y(e, n) ]);
 });
 },
 groupHPAs: function(e) {
@@ -7699,7 +7707,7 @@ return {
 name: t,
 value: e
 };
-}), "HorizontalPodAutoscaler" === n.kind) e.targetKind = _.get(a, "spec.scaleTargetRef.kind"), e.targetName = _.get(a, "spec.scaleTargetRef.name"), _.assign(e.autoscaling, {
+}), e.usesV2Metrics = c.usesV2Metrics(a), "HorizontalPodAutoscaler" === n.kind) e.targetKind = _.get(a, "spec.scaleTargetRef.kind"), e.targetName = _.get(a, "spec.scaleTargetRef.name"), _.assign(e.autoscaling, {
 minReplicas: _.get(a, "spec.minReplicas"),
 maxReplicas: _.get(a, "spec.maxReplicas"),
 targetCPU: _.get(a, "spec.targetCPUUtilizationPercentage")
@@ -10259,13 +10267,14 @@ restrict: "E",
 scope: {
 autoscaling: "=model",
 showNameInput: "=?",
-nameReadOnly: "=?"
+nameReadOnly: "=?",
+showRequestInput: "=?"
 },
 templateUrl: "views/directives/osc-autoscaling.html",
-link: function(t) {
+link: function(t, r, a) {
 t.nameValidation = n;
-var r = e.DEFAULT_HPA_CPU_TARGET_PERCENT, a = _.get(t, "autoscaling.targetCPU");
-_.isNil(a) && r && _.set(t, "autoscaling.targetCPU", r);
+var o = e.DEFAULT_HPA_CPU_TARGET_PERCENT, i = _.get(t, "autoscaling.targetCPU");
+_.isNil(i) && o && _.set(t, "autoscaling.targetCPU", o), "showRequestInput" in a || (t.showRequestInput = !0);
 }
 };
 } ]), angular.module("openshiftConsole").directive("oscSecrets", [ "$uibModal", "$filter", "APIService", "DataService", "SecretsService", function(e, t, n, r, a) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8086,7 +8086,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"form-group\">\n" +
+    "<div ng-show=\"showRequestInput\" class=\"form-group\">\n" +
     "<label>\n" +
     "CPU Request Target\n" +
     "</label>\n" +
@@ -9492,8 +9492,15 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"'cpu' | isRequestCalculated : project\">limit.</span>\n" +
     "<span ng-if=\"!('cpu' | isRequestCalculated : project)\">request.</span>\n" +
     "</div>\n" +
+    "\n" +
+    "<div ng-if=\"usesV2Metrics\" class=\"alert alert-warning\">\n" +
+    "<span class=\"pficon pficon-warning-triangle-o\" aria-hidden=\"true\"></span>\n" +
+    "<span class=\"sr-only\">Warning:</span>\n" +
+    "This autoscaler uses a newer API, consider editing it with the\n" +
+    "<a href=\"command-line\" target=\"_blank\">command line tools</a>.\n" +
+    "</div>\n" +
     "<fieldset ng-disabled=\"disableInputs\" class=\"gutter-top\">\n" +
-    "<osc-autoscaling model=\"autoscaling\" show-name-input=\"true\" name-read-only=\"kind === 'HorizontalPodAutoscaler'\">\n" +
+    "<osc-autoscaling model=\"autoscaling\" show-name-input=\"true\" name-read-only=\"kind === 'HorizontalPodAutoscaler'\" show-request-input=\"autoscaling.targetCPU\">\n" +
     "</osc-autoscaling>\n" +
     "<label-editor labels=\"labels\" expand=\"true\" can-toggle=\"false\"></label-editor>\n" +
     "<div class=\"buttons gutter-top gutter-bottom\">\n" +


### PR DESCRIPTION
This PR depends on [common 285](https://github.com/openshift/origin-web-common/pull/285).

[WIP] notes:

`bower link origin-web-common` with the above PR or the tests will fail. 

On the DC page:

![screen shot 2018-01-23 at 6 21 58 pm](https://user-images.githubusercontent.com/280512/35306332-132de372-006b-11e8-8552-ee94bd4673a2.png)

- probably only want to show the v2beta1 message, will hide the other

On the edit autoscaler page:

![screen shot 2018-01-23 at 6 25 12 pm](https://user-images.githubusercontent.com/280512/35306333-1337b924-006b-11e8-9cc7-3abacf3a6e91.png)

- shows a message w/a link to CLI
- hides the CPU request input as editing this is probably not what the user wants to do

TODO (perhaps follow-on PR):

- Update the warning message to show the user the data from the `metrics` annotation so they can easily see what the autoscaler is using to scale the resource.


