### PR TITLE
Bug 1537438: Import YAML/JSON lost Browse button when file folder does not have executive right in sandbox

### DIFF
--- a/app/scripts/directives/oscFileInput.js
+++ b/app/scripts/directives/oscFileInput.js
@@ -184,10 +184,12 @@ angular.module('openshiftConsole')
               if (_.isFunction(cb)) {
                 cb(reader.result);
               }
+              if (!reader.error) {
+                scope.uploadError = false;
+              }
             });
           };
           reader.onerror = function(e){
-            scope.supportsFileUpload = false;
             scope.uploadError = true;
             Logger.error("Could not read file", e);
           };

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -9919,10 +9919,10 @@ r.onloadend = function() {
 t.$apply(function() {
 t.fileName = n.name, t.model = r.result;
 var e = t.onFileAdded;
-_.isFunction(e) && e(r.result);
+_.isFunction(e) && e(r.result), r.error || (t.uploadError = !1);
 });
 }, r.onerror = function(n) {
-t.supportsFileUpload = !1, t.uploadError = !0, e.error("Could not read file", n);
+t.uploadError = !0, e.error("Could not read file", n);
 }, r.readAsText(n);
 }
 function a() {


### PR DESCRIPTION
Fixed the issue with hidding the input-group of `input` with 'Browse' button and showing `textarea`.
Problem was that we have been setting the `supportsFileUpload` scope variable on error to `false` even though testing the support on the line ~24. Also if the `onloadend` ends without error we should set reset the `uploadError` scope variable back to `true`

@spadgett PTAL