### PR TITLE
Make the mini <pod-donut> positioned absolute, taking it out of flow,…

### DIFF
--- a/app/styles/_components.less
+++ b/app/styles/_components.less
@@ -84,25 +84,30 @@ code.command {
   cursor: pointer;
 }
 .pods {
-  display: inline-block;
+  display: block;
+  // mini donut circle diameter
+  height: @pod-mini-donut-diameter;
+  width: @pod-mini-donut-diameter;
   // align pod text with right outer edge of .list-pf-details text
-  margin-right: 25px;
+  @media(min-width: @screen-sm-min) {
+    margin-right: 32px;
+  }
 }
 pod-donut[mini] {
   display:inline-block;
-  // match size setting in podDonut.js
-  min-height: 45px;
-  min-width: 45px;
+  height: @pod-mini-donut-diameter;
   position: relative;
+  width: @pod-mini-donut-diameter;
 }
 .pod-donut {
   &.mini {
     display: inline-block;
-    // match size setting in podDonut.js
-    min-height: 45px;
-		min-width: 45px;
+    // Take mini donut out of flow; positioning is controlled by .pods parent element
+    height: @pod-mini-donut-diameter;
     position: absolute !important;
-		top: 2px;
+    // center donut within .pods element
+    transform: translate(-8px, -5px);
+    width: @pod-mini-donut-diameter;
   }
   .c3-defocused {
     // Adjusting the default hover "opacity: .3" to be slightly darker
@@ -130,20 +135,23 @@ pod-donut[mini] {
   }
 }
 
+// center # within mini-donut
 .donut-mini-text {
   left: 51%;
+  line-height: 1;
   position: absolute;
-	top: 49%;
-  transform: translate(-49%, -51%);
+  text-align: center;
+  top: 50%;
+  transform: translate(-51%,-50%);
 }
+// vertically position "pod" text with the # inside mini-donut
 .donut-mini-text-name {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  line-height: 1;
   position: absolute;
-	transform: translate(45px,-51%);
-	top: 49%;
-	line-height: 1;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
+  transform: translate(40px, 9px);
 }
 
 .deployment-donut {

--- a/app/styles/_list-pf.less
+++ b/app/styles/_list-pf.less
@@ -55,10 +55,17 @@
     .list-pf-details {
       align-items: center;
       display: flex;
-      width: 55%;
+      @media (min-width: @screen-sm-min) {
+        width: auto;
+      }
+      @media (min-width: @screen-md-min) {
+        width: 50%;
+      }
     }
     .list-pf-name {
-      width: 45%;
+      @media (min-width: @screen-sm-min) {
+        width: 50%;
+      }
     }
   }
   .list-pf-content-right {

--- a/app/styles/_monitoring.less
+++ b/app/styles/_monitoring.less
@@ -69,8 +69,10 @@
       }
     }
   }
-  pod-donut {
-    margin-left: -8px; // left align with text
+  @media(max-width: @screen-sm-max) {
+    .pods {
+      margin: 5px 0;
+    }
   }
   .text-prepended-icon {
     .fa,

--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -222,7 +222,13 @@
   .list-pf-actions {
     // if no actions-dropdown-kebab is present, still take up space
     justify-content: flex-end;
-    min-width: 35px;
+    // Allow more space for mini-pod-donut and metrics at narrower widths
+    @media(min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+      margin-left: 25px;
+    }
+    @media(min-width: @screen-md-min) and (max-width: @screen-md-max) {
+      margin-left: 35px;
+    }
   }
   .list-pf-details {
     .fade-in();
@@ -230,9 +236,9 @@
       justify-content: flex-end;
     }
     @media(max-width: @screen-xs-max) {
+      width: 100% !important; // stacked name and details so set to full width
       &.deployment-in-progress-msg {
         margin-top: 5px;
-        width: 100%;
       }
     }
   }
@@ -306,8 +312,6 @@
           .word-break();
         }
         @media (min-width: @screen-sm-min) {
-          // Prevent the row from shrinking slightly on expand.
-          min-height: 45px;
           padding-right: 15px;
         }
       }
@@ -356,7 +360,16 @@
   }
   .metrics-collapsed {
     flex-grow: 1;
-    .text-center();
+    padding-top: 10px;
+    text-align: left;
+    @media(min-width:@screen-md-min) {
+      padding-right: 60px;
+      padding-top: 20px;
+      text-align: right;
+    }
+    @media(min-width:@screen-lg-min) {
+      padding-right: 90px;
+    }
   }
   .metrics-summary {
     display: inline-block;

--- a/app/styles/_variables.less
+++ b/app/styles/_variables.less
@@ -66,6 +66,7 @@
 @navbar-os-project-menu-hover-bg: lighten(@project-bar-bg, 8%);
 @panel-light: @body-bg;
 @panel-shaded: #ededed;
+@pod-mini-donut-diameter: 30px;
 @project-bar-bg: @color-pf-black-900; // #292e34 project bar
 @project-bar-border-color: #050505;
 @project-bar-border-inset-color: rgba(255,255,255,.04);

--- a/app/views/directives/pod-donut.html
+++ b/app/views/directives/pod-donut.html
@@ -4,9 +4,6 @@
   <span ng-if="!idled && total <= 99">
     {{total}}
   </span>
-  <span ng-if="idled">
-    Idle
-  </span>
 </div>
 <span ng-if="mini && total === 1 && !idled" class="donut-mini-text-name">pod</span>
 <span ng-if="mini && total !== 1 && !idled" class="donut-mini-text-name">
@@ -14,6 +11,7 @@
     {{total}}
   </span> pods
 </span>
+<span ng-if="mini && idled" class="donut-mini-text-name">Idle</span>
 
 <!-- Include text values for screen readers -->
 <div class="sr-only">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8871,9 +8871,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"!idled && total <= 99\">\n" +
     "{{total}}\n" +
     "</span>\n" +
-    "<span ng-if=\"idled\">\n" +
-    "Idle\n" +
-    "</span>\n" +
     "</div>\n" +
     "<span ng-if=\"mini && total === 1 && !idled\" class=\"donut-mini-text-name\">pod</span>\n" +
     "<span ng-if=\"mini && total !== 1 && !idled\" class=\"donut-mini-text-name\">\n" +
@@ -8881,6 +8878,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "{{total}}\n" +
     "</span> pods\n" +
     "</span>\n" +
+    "<span ng-if=\"mini && idled\" class=\"donut-mini-text-name\">Idle</span>\n" +
     "\n" +
     "<div class=\"sr-only\">\n" +
     "<div ng-if=\"(pods | hashSize) === 0\">No pods.</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4628,7 +4628,7 @@ body.overlay-open,body.overlay-open .landing,body.overlay-open .landing-side-bar
 }
 .btn-file{position:relative;overflow:hidden}
 .btn-file input[type=file]{position:absolute;top:0;right:0;min-width:100%;min-height:100%;font-size:100px;text-align:right;filter:alpha(opacity=0);opacity:0;cursor:inherit;display:block}
-.osc-form .icon,.service-table,.service-table thead tr th,.show-drag-and-drop-zone{text-align:center}
+.donut-mini-text,.osc-form .icon,.service-table,.service-table thead tr th,.show-drag-and-drop-zone{text-align:center}
 .btn-flat-default{border:1px solid transparent}
 .btn-flat-default:focus,.btn-flat-default:hover{background-color:#f7f7f7;border-color:#e7e7e7}
 .btn-remove{color:#333;display:inline-block;font-size:15px;line-height:1;opacity:.65;padding:5px 7px;vertical-align:middle}
@@ -4718,20 +4718,22 @@ h3 .component-label{padding-bottom:4px}
 .pod-template-block .pod-template .icon-row{border-left:3px solid #f1f1f1;padding:2px 0 0 2px}
 .pod-template-block .pod-template .fa,.pod-template-block .pod-template .pficon,.pod-template-block .pod-template span[data-icon]{color:#888}
 .pod-template-block .pod-template .pod-template-build{word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
-.pod-donut.mini,pod-donut[mini]{display:inline-block;min-height:45px;min-width:45px}
 .pod-template-container{margin:0 0 20px}
 .pod-template-container h3{margin-top:0;padding-bottom:0}
 code.command{display:inline-block;line-height:1.3;margin-right:2px}
 .hash{font-size:12px}
 .clickable{cursor:pointer}
-.pods{display:inline-block;margin-right:25px}
-.pod-donut.mini{position:absolute!important;top:2px}
+.pods{display:block;height:30px;width:30px}
+.pod-donut.mini,pod-donut[mini]{display:inline-block;height:30px;width:30px}
+@media (min-width:768px){.pods{margin-right:32px}
+}
+.pod-donut.mini{position:absolute!important;transform:translate(-8px,-5px)}
 .pod-donut .c3-defocused{opacity:.5!important}
 .pod-donut .c3-tooltip-container{top:-27px!important;left:50%!important;transform:translateX(-50%);white-space:nowrap}
 .pod-donut path.c3-arc-Empty{stroke:#d1d1d1;cursor:inherit!important}
 .pod-donut .c3-tooltip-name--Empty .name{display:none}
-.donut-mini-text{left:51%;position:absolute;top:49%;transform:translate(-49%,-51%)}
-.donut-mini-text-name{position:absolute;transform:translate(45px,-51%);top:49%;line-height:1;display:flex;flex-direction:column;align-items:center}
+.donut-mini-text{left:51%;line-height:1;position:absolute;top:50%;transform:translate(-51%,-50%)}
+.donut-mini-text-name{align-items:center;display:flex;flex-direction:column;line-height:1;position:absolute;transform:translate(40px,9px)}
 .deployment-donut{justify-content:center}
 .browse-deployment-donut .deployment-donut{align-items:center}
 .deployment-donut .scaling-controls{justify-content:center;font-size:24px}
@@ -5123,6 +5125,7 @@ pre.clipped.scroll{max-height:150px;overflow:auto;width:100%}
 @media (min-width:768px){.layout-pf.layout-pf-fixed body.has-project-bar,.layout-pf.layout-pf-fixed body.has-project-bar.has-project-search{padding-top:101px}
 .layout-pf.layout-pf-fixed body.has-project-bar .container-pf-nav-pf-vertical{margin-left:220px}
 .layout-pf.layout-pf-fixed body.has-project-bar .container-pf-nav-pf-vertical.collapsed-nav{margin-left:75px}
+.list-pf-chevron+.list-pf-content .list-pf-details{width:auto}
 }
 .layout-pf.layout-pf-fixed .container-pf-nav-pf-vertical,.layout-pf.layout-pf-fixed .container-pf-nav-pf-vertical.collapsed-nav{margin-left:0}
 .layout-pf.layout-pf-fixed .has-project-bar .container-pf-nav-pf-vertical{transition:margin-left .1s ease-in-out}
@@ -5137,8 +5140,12 @@ pre.clipped.scroll{max-height:150px;overflow:auto;width:100%}
 .list-pf-content .alert:first-child{margin-top:0}
 .list-pf-chevron+.list-pf-content{align-items:center;display:flex;flex-grow:1}
 .list-pf-chevron+.list-pf-content .list-pf-details,.list-pf-chevron+.list-pf-content .list-pf-name{flex-grow:1}
-.list-pf-chevron+.list-pf-content .list-pf-details{align-items:center;display:flex;width:55%}
-.list-pf-chevron+.list-pf-content .list-pf-name{width:45%}
+.list-pf-chevron+.list-pf-content .list-pf-details{align-items:center;display:flex}
+@media (min-width:992px){.data-toolbar .data-toolbar-filter{max-width:787px}
+.list-pf-chevron+.list-pf-content .list-pf-details{width:50%}
+}
+@media (min-width:768px){.list-pf-chevron+.list-pf-content .list-pf-name{width:50%}
+}
 .list-pf-content .list-pf-content-right{min-width:300px}
 .list-pf-item:not(.active) .list-pf-chevron+.list-pf-content{border-left-color:#dcdcdc}
 .list-pf-name{margin:0}
@@ -5169,8 +5176,7 @@ h2+.list-view-pf{margin-top:20px}
 .list-view-pf-main-info{padding-bottom:10px;padding-top:10px}
 @media (max-width:991px){.list-view-pf-main-info .list-view-pf-body{display:block}
 }
-@media (min-width:992px){.data-toolbar .data-toolbar-filter{max-width:787px}
-.list-view-pf .list-group-item-heading,.list-view-pf .list-group-item-text{flex:1 0 auto;margin:0;padding:0 20px 0 0;width:50%}
+@media (min-width:992px){.list-view-pf .list-group-item-heading,.list-view-pf .list-group-item-text{flex:1 0 auto;margin:0;padding:0 20px 0 0;width:50%}
 .list-view-pf-additional-info{width:40%}
 .list-view-pf-description{width:60%}
 .monitoring-page .list-pf-main-content{flex-basis:30%}
@@ -5189,7 +5195,8 @@ h2+.list-view-pf{margin-top:20px}
 .monitoring-page .list-pf-additional-content .list-pf-additional-content-item{width:40%}
 .monitoring-page .list-pf-additional-content .list-pf-additional-content-item+.list-pf-additional-content-item{width:50%}
 }
-.monitoring-page pod-donut{margin-left:-8px}
+@media (max-width:991px){.monitoring-page .pods{margin:5px 0}
+}
 .monitoring-page .text-prepended-icon .fa,.monitoring-page .text-prepended-icon .pficon{margin-right:7px}
 #header-logo{background-image:url(../images/logo-origin-thin.svg);background-position:left center;background-repeat:no-repeat;height:40px;width:196px}
 @media (min-width:768px){#header-logo{width:230px}
@@ -5271,19 +5278,22 @@ h2+.list-view-pf{margin-top:20px}
 .overview .expanded-section{margin-top:20px}
 .overview .expanded-section.no-margin{margin:0}
 .overview .expanded-section .row>[class^=col-]{margin-bottom:10px}
-@media (min-width:1200px){.overview .expanded-section .row>[class^=col-].overview-builds-msg,.overview .expanded-section .row>[class^=col-].overview-routes{padding-left:0}
-}
 .overview .expanded-section h3{line-height:1.4;margin-bottom:5px;margin-top:0;width:100%;word-wrap:break-word;word-break:break-word;overflow-wrap:break-word;min-width:0}
 .overview .filter-status{margin-bottom:5px}
 .overview h1,.overview h2{line-height:normal;min-width:130px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .overview h2{margin-top:0}
 .overview h2>.component-label{font-weight:500;padding-bottom:0}
 .overview .list-pf{border-bottom-color:#dcdcdc;margin-bottom:50px}
-.overview .list-pf-actions{justify-content:flex-end;min-width:35px}
+.overview .list-pf-actions{justify-content:flex-end}
+@media (min-width:768px) and (max-width:991px){.overview .list-pf-actions{margin-left:25px}
+}
+@media (min-width:992px) and (max-width:1199px){.overview .list-pf-actions{margin-left:35px}
+}
 .overview .list-pf-details.ng-enter,.overview .list-pf-details.ng-hide-remove{animation:.3s appear cubic-bezier(.55,.055,.675,.19)}
 @media (min-width:768px){.overview .list-pf-details{justify-content:flex-end}
 }
-@media (max-width:767px){.overview .list-pf-details.deployment-in-progress-msg{margin-top:5px;width:100%}
+@media (max-width:767px){.overview .list-pf-details{width:100%!important}
+.overview .list-pf-details.deployment-in-progress-msg{margin-top:5px}
 }
 .overview .list-pf-expansion.in .deployment-donut>div[row]{justify-content:center}
 .overview .list-pf-expansion.in .empty-state-message{margin-bottom:30px;margin-top:20px;max-width:none;padding:0;text-align:center}
@@ -5311,12 +5321,17 @@ h2+.list-view-pf{margin-top:20px}
 }
 .overview .list-row-longname{color:#757575;font-size:11px;margin-top:3px}
 .overview .list-row-tabset{margin-top:20px}
-@media (min-width:768px){.overview .list-pf-item>.list-pf-container>.list-pf-content{min-height:45px;padding-right:15px}
+@media (min-width:768px){.overview .list-pf-item>.list-pf-container>.list-pf-content{padding-right:15px}
 .overview .list-row-tabset{margin-top:0}
 }
 .overview .list-row-tabset .nav-tabs>li.active>a .build-count{color:#4d5258}
 .overview .loading-message{padding-top:20px}
-.overview .metrics-collapsed{flex-grow:1;text-align:center}
+.overview .metrics-collapsed{flex-grow:1;padding-top:10px;text-align:left}
+@media (min-width:992px){.overview .metrics-collapsed{padding-right:60px;padding-top:20px;text-align:right}
+}
+@media (min-width:1200px){.overview .expanded-section .row>[class^=col-].overview-builds-msg,.overview .expanded-section .row>[class^=col-].overview-routes{padding-left:0}
+.overview .metrics-collapsed{padding-right:90px}
+}
 .overview .metrics-summary{display:inline-block;text-align:center}
 .overview .metrics-summary+.metrics-summary{margin-left:20px}
 .overview .metrics-compact{white-space:nowrap}


### PR DESCRIPTION
… so that it doesn't alter the height of the pf-list-container row based on if it's displayed or not.
Note:
- expand and collapsed heights are now the same height.
- row height is slightly shorter since donut height no longer has an effect.

Fixes https://github.com/openshift/origin-web-console/issues/2696
Fixes #2744

Cross browser and Android, iOS tested.

![mini-new-animated](https://user-images.githubusercontent.com/1874151/35360260-259fe26a-012b-11e8-9f38-2c64dacdaa32.gif)

**NEW**
<img width="971" alt="new" src="https://user-images.githubusercontent.com/1874151/35360248-1d72b392-012b-11e8-96c0-056397d81c97.png">

**OLD**
<img width="974" alt="old" src="https://user-images.githubusercontent.com/1874151/35360276-315dd35a-012b-11e8-8789-15259cbc268d.png">

