### PR TITLE
Fix bug #1538431, pod table triggers $digest() loop 

### DIFF
--- a/app/scripts/directives/resources.js
+++ b/app/scripts/directives/resources.js
@@ -169,7 +169,7 @@ angular.module('openshiftConsole')
       templateUrl: 'views/directives/_probe.html'
     };
   })
-  .directive('podsTable', function() {
+  .directive('podsTable', function($filter) {
     return {
       restrict: 'E',
       scope: {
@@ -183,7 +183,17 @@ angular.module('openshiftConsole')
         // Optional map of explanations or warnings for each phase of a pod
         podFailureReasons: '=?'
       },
-      templateUrl: 'views/directives/pods-table.html'
+      templateUrl: 'views/directives/pods-table.html',
+      link: function($scope) {
+        var orderObjectsByDate = $filter('orderObjectsByDate');
+        var sortPods = _.debounce(function(pods) {
+          $scope.$evalAsync(function() {
+            $scope.sortedPods = orderObjectsByDate(pods, true);
+          });
+        }, 150, { maxWait: 500 });
+
+        $scope.$watch('pods', sortPods);
+      }
     };
   })
   .directive('trafficTable', function() {

--- a/app/views/directives/pods-table.html
+++ b/app/views/directives/pods-table.html
@@ -16,7 +16,7 @@
     <tr><td colspan="{{activePods ? 6 : 5}}"><em>{{emptyMessage || 'No pods to show'}}</em></td></tr>
   </tbody>
   <tbody ng-if="(pods | hashSize) > 0">
-    <tr ng-repeat="pod in pods | orderObjectsByDate : true">
+    <tr ng-repeat="pod in sortedPods track by (pod | uid)">
       <td data-title="{{customNameHeader || 'Name'}}">
         <a href="{{pod | navigateResourceURL}}">{{pod.metadata.name}}</a>
         <span ng-if="pod | isDebugPod">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10746,7 +10746,7 @@ probe:"="
 },
 templateUrl:"views/directives/_probe.html"
 };
-}).directive("podsTable", function() {
+}).directive("podsTable", [ "$filter", function(a) {
 return {
 restrict:"E",
 scope:{
@@ -10756,9 +10756,19 @@ emptyMessage:"=?",
 customNameHeader:"=?",
 podFailureReasons:"=?"
 },
-templateUrl:"views/directives/pods-table.html"
+templateUrl:"views/directives/pods-table.html",
+link:function(b) {
+var c = a("orderObjectsByDate"), d = _.debounce(function(a) {
+b.$evalAsync(function() {
+b.sortedPods = c(a, !0);
+});
+}, 150, {
+maxWait:500
+});
+b.$watch("pods", d);
+}
 };
-}).directive("trafficTable", function() {
+} ]).directive("trafficTable", function() {
 return {
 restrict:"E",
 scope:{

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8721,7 +8721,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tr><td colspan=\"{{activePods ? 6 : 5}}\"><em>{{emptyMessage || 'No pods to show'}}</em></td></tr>\n" +
     "</tbody>\n" +
     "<tbody ng-if=\"(pods | hashSize) > 0\">\n" +
-    "<tr ng-repeat=\"pod in pods | orderObjectsByDate : true\">\n" +
+    "<tr ng-repeat=\"pod in sortedPods track by (pod | uid)\">\n" +
     "<td data-title=\"{{customNameHeader || 'Name'}}\">\n" +
     "<a href=\"{{pod | navigateResourceURL}}\">{{pod.metadata.name}}</a>\n" +
     "<span ng-if=\"pod | isDebugPod\">\n" +


### PR DESCRIPTION
Fix [bug #1538431](https://bugzilla.redhat.com/show_bug.cgi?id=1538431), pod table triggers $digest() loop that surpasses the limit set by Angular.  This change is a backport of current code in the pod table.

