### PR TITLE
Fixes incorrect focus on first "add from secret or config map" click

### DIFF
--- a/app/scripts/directives/keyValueEditor.js
+++ b/app/scripts/directives/keyValueEditor.js
@@ -234,8 +234,10 @@
                   utils.setFocusOn('.'+ $scope.setFocusKeyClass);
                 },
                 onAddRowWithSelectors: function() {
+                  var entriesCount = $scope.entries.length;
+                  var extraFocusDelay = (entriesCount === 1) ? 125 : null;
                   utils.addEntryWithSelectors($scope.entries);
-                  utils.setFocusOn('.'+ $scope.setFocusKeyClass);
+                  utils.setFocusOn('.'+ $scope.setFocusKeyClass, null, extraFocusDelay);
                 },
                 isValueFromReadonly: function(entry) {
                   return $scope.isReadonlyAny ||

--- a/app/scripts/services/keyValueEditorUtils.js
+++ b/app/scripts/services/keyValueEditorUtils.js
@@ -161,7 +161,7 @@
                   }, {});
         };
 
-        var setFocusOn = function(selector, value) {
+        var setFocusOn = function(selector, value, delay) {
           // $timeout just delays enough to ensure event/$digest resolution
           $timeout(function() {
             var element = _.head($window.document.querySelectorAll(selector));
@@ -173,7 +173,7 @@
                 element.value = value;
               }
             }
-          }, 25);
+          }, delay || 25);
         };
 
         var uniqueForKey = function(unique, $index) {

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -4227,11 +4227,11 @@ return Logger.log("DEPRECATED: mapEntries() drops valueFrom from the entry."), _
 return e[t.name] = t.value, e;
 }, {});
 },
-setFocusOn: function(n, r) {
+setFocusOn: function(n, r, a) {
 e(function() {
 var e = _.head(t.document.querySelectorAll(n));
 e && (e.focus(), r && (e.value = "", e.value = r));
-}, 25);
+}, a || 25);
 },
 uniqueForKey: function(e, t) {
 return "key-value-editor-key-" + e + "-" + t;
@@ -14656,7 +14656,8 @@ onAddRow: function() {
 a.addEntry(t.entries), a.setFocusOn("." + t.setFocusKeyClass);
 },
 onAddRowWithSelectors: function() {
-a.addEntryWithSelectors(t.entries), a.setFocusOn("." + t.setFocusKeyClass);
+var e = 1 === t.entries.length ? 125 : null;
+a.addEntryWithSelectors(t.entries), a.setFocusOn("." + t.setFocusKeyClass, null, e);
 },
 isValueFromReadonly: function(e) {
 return t.isReadonlyAny || e.isReadonlyValue || e.refType && !e.selectedValueFrom || _.isEmpty(t.valueFromSelectorOptions);


### PR DESCRIPTION
Re [bugzilla 1369315](https://bugzilla.redhat.com/show_bug.cgi?id=1369315)

Adds a slightly longer delay to the first "add from secret or config map".  Guessing it is a timing issue with instantiating the ui-select boxes & angular's $digest.  Oddly only happens the first time.  

