### PR TITLE
Fix loading of local-extensions(.css, .js)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ openshift-jvm
 /app/config.local.js
 .DS_Store
 test/junit/
+/extensions/local-extensions.css
+/extensions/local-extensions.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,6 +73,10 @@ module.exports = function (grunt) {
           }
         }
       },
+      extensions: {
+        files: ['extensions/local-extensions.js', 'extensions/local-extensions.css'],
+        tasks: ['copy:extensions']
+      },
       index: {
         files: ['<%= yeoman.app %>/index.html'],
         tasks: ['replace:index']


### PR DESCRIPTION
Follow to #2677, realized that while we have this:

```html 
    <!-- build:remove -->
    <!-- Local / test stylesheets only. These files will not be included in the built dist. -->
    <link rel="stylesheet" type="text/css" href="extensions/local-extensions.css">
    <!-- endbuild -->

    <!-- build:remove -->
    <!-- Local / test scripts only. These files will not be included in the built dist. -->
    <script src="extensions/local-extensions.js"></script>
    <!-- endbuild -->
```
But these files aren't actually loading (I have a few things in `extensions.js` that didn't run).  Adding the extensions block back to `Gruntfile.js` fixes. 

I don't think the `.gitignore` works for the two extension files since they have already been committed. 
