### PR TITLE
Fixes null != undefined error in homePagePreferenceSpec.js

### DIFF
--- a/test/spec/services/homePagePreferenceSpec.js
+++ b/test/spec/services/homePagePreferenceSpec.js
@@ -8,12 +8,12 @@ describe("HomePagePreferenceService", function(){
     inject(function(_HomePagePreferenceService_){
       HomePagePreferenceService = _HomePagePreferenceService_;
     });
-    
+
     // LocalStorage mock
     spyOn(localStorage, 'getItem').and.callFake(function(key) {
       return store[key];
     });
-    
+
     spyOn(localStorage, 'setItem').and.callFake(function (key, value) {
       /* jshint boss:true */
       return store[key] = value + '';
@@ -21,7 +21,7 @@ describe("HomePagePreferenceService", function(){
 
     spyOn(localStorage, 'removeItem').and.callFake(function (key) {
       delete store[key];
-    }); 
+    });
 
     spyOn(localStorage, 'clear').and.callFake(function () {
       store = {};
@@ -36,14 +36,14 @@ describe("HomePagePreferenceService", function(){
       var homePagePreference = HomePagePreferenceService.getHomePagePath();
       expect(homePagePreference).toEqual("/catalog");
     });
-        
+
     it("set project list", function(){
       var homePagePref = {"type":"project-list"};
       HomePagePreferenceService.setHomePagePreference(homePagePref);
       var homePagePreference = HomePagePreferenceService.getHomePagePath();
       expect(homePagePreference).toEqual("/projects");
     });
-   
+
     it("set to project overview",function(){
       var homePagePref = {
           "type":"project-overview",
@@ -61,7 +61,7 @@ describe("HomePagePreferenceService", function(){
       };
       HomePagePreferenceService.setHomePagePreference(homePagePref);
       HomePagePreferenceService.notifyInvalidProjectHomePage(homePagePref.project);
-      expect(localStorage.getItem("openshift/home-page-pref/")).not.toBeDefined();
+      expect(localStorage.getItem("openshift/home-page-pref/")).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
I tried this with a few versions of node & npm:

```
# first
node -v 6.10.2; npm -v 3.10.10
# then
node -v 9.4.0; npm -v 5.6.0
```

But either way the test failed due to `null != undefined`.  This tiny change gets the test passing again, though I'm not sure it actually fixes the test.  `getHomePagePath - should notify invalid project` is confusing to me in light of the `expect` statement.

Thoughts @dtaylor113 ?

