### PR TITLE
Bug 1539840: Drag and Drop zone area should use absolute positioning

### DIFF
--- a/app/scripts/directives/oscFileInput.js
+++ b/app/scripts/directives/oscFileInput.js
@@ -135,16 +135,15 @@ angular.module('openshiftConsole')
           });
 
           var positionOver = function(element, target) {
-            var offset = target.offset();
+            // If there is a label element for the osc-file-input directive get its height the subtract it from the dropzone.
+            var labelElementHeight = target.find('label').outerHeight();
+            var outerHeight = labelElementHeight ? target.outerHeight() - labelElementHeight : target.outerHeight();
             var outerWidth = target.outerWidth();
-            var outerHeight = target.outerHeight();
             element.css({
-              // Account for -3px margin by adding 6 to width and height.
-              height: outerHeight + 6,
+              // Account for -3px margin by adding 6 to width.
               width: outerWidth + 6,
-              top: offset.top,
-              left: offset.left,
-              position: 'fixed',
+              height: outerHeight,
+              position: 'absolute',
               'z-index': 100
             });
           };

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -9945,13 +9945,11 @@ return n.length > 0 && (t.file = _.head(n), r(t.file)), a(), $(".drag-and-drop-z
 }
 });
 var o = function(e, t) {
-var n = t.offset(), r = t.outerWidth(), a = t.outerHeight();
+var n = t.find("label").outerHeight(), r = n ? t.outerHeight() - n : t.outerHeight(), a = t.outerWidth();
 e.css({
-height: a + 6,
-width: r + 6,
-top: n.top,
-left: n.left,
-position: "fixed",
+width: a + 6,
+height: r,
+position: "absolute",
 "z-index": 100
 });
 };


### PR DESCRIPTION
Also adjust the size of the drop and drop zone area to not include the label height.
With the label height:
![incorrect](https://user-images.githubusercontent.com/1668218/35576654-d38878fc-05df-11e8-9483-33e048b47acd.png)

Without it:
![correct](https://user-images.githubusercontent.com/1668218/35576662-d84a3fba-05df-11e8-9218-833450db0e85.png)

Tested the change on osc-file-input used in modal and non-modal html and both Chrome and FF 

@jwforres PTAL