### PR TITLE
Update homePagePreferenceSpec test describe() and it() statements

### DIFF
--- a/test/spec/services/homePagePreferenceSpec.js
+++ b/test/spec/services/homePagePreferenceSpec.js
@@ -29,39 +29,59 @@ describe("HomePagePreferenceService", function(){
 
    });
 
-  describe("#getHomePagePath", function(){
-    it("default set to catalog-home",function(){
-      var homePagePref = {};
-      HomePagePreferenceService.setHomePagePreference(homePagePref);
-      var homePagePreference = HomePagePreferenceService.getHomePagePath();
-      expect(homePagePreference).toEqual("/catalog");
-    });
+   describe("#getHomePagePath", function(){
+     describe('when given an empty config object', function() {
+       it("should set the default home page to /catalog",function(){
+         var homePagePref = {};
+         HomePagePreferenceService.setHomePagePreference(homePagePref);
+         var homePagePreference = HomePagePreferenceService.getHomePagePath();
 
-    it("set project list", function(){
-      var homePagePref = {"type":"project-list"};
-      HomePagePreferenceService.setHomePagePreference(homePagePref);
-      var homePagePreference = HomePagePreferenceService.getHomePagePath();
-      expect(homePagePreference).toEqual("/projects");
-    });
+         expect(homePagePreference).toEqual("/catalog");
+       });
+     });
 
-    it("set to project overview",function(){
-      var homePagePref = {
-          "type":"project-overview",
-          "project":"test-pro"
-      };
-      HomePagePreferenceService.setHomePagePreference(homePagePref);
-      var homePagePreference = HomePagePreferenceService.getHomePagePath();
-      expect(homePagePreference).toEqual("/project/test-pro/overview?isHomePage=true");
-    });
+     describe('when given a config object with `type` set to `project-list`', function() {
+       it("should set the home page to /projects", function(){
+         var homePagePref = {"type":"project-list"};
+         HomePagePreferenceService.setHomePagePreference(homePagePref);
+         var homePagePreference = HomePagePreferenceService.getHomePagePath();
 
-    it("should notify invalid project", function(){
-      var homePagePref = {
-          "type":"project-overview",
-          "project":"test-project"
-      };
-      HomePagePreferenceService.setHomePagePreference(homePagePref);
-      HomePagePreferenceService.notifyInvalidProjectHomePage(homePagePref.project);
-      expect(localStorage.getItem("openshift/home-page-pref/")).toBeFalsy();
+         expect(homePagePreference).toEqual("/projects");
+       });
+     });
+
+     describe('when given a config object with `type` set to `project-overview`', function() {
+       it("should set the home page to the overview of the provided project at /project/test-pro/overview",function(){
+         var homePagePref = {
+             "type":"project-overview",
+             "project":"test-pro"
+         };
+         HomePagePreferenceService.setHomePagePreference(homePagePref);
+         var homePagePreference = HomePagePreferenceService.getHomePagePath();
+
+         expect(homePagePreference).toEqual("/project/test-pro/overview?isHomePage=true");
+       });
+     });
+  });
+
+  describe('#notifyInvalidProjectHomePage', function() {
+    describe('when given a config object with an invalid `type` option', function() {
+      // in the UI, this will also trigger a notification that the project is
+      // invalid.  This additional functionality should be verified either with
+      // a unit test or an e2e test against the appropriate controller.
+      it("should clear the configuration object from localStorage", function() {
+        var homePagePref = {
+            "type":"project-overview",
+            "project":"test-project"
+        };
+        HomePagePreferenceService.setHomePagePreference(homePagePref);
+        HomePagePreferenceService.notifyInvalidProjectHomePage(homePagePref.project);
+
+        var setting = localStorage.getItem("openshift/home-page-pref/");
+
+        expect(setting).toBeFalsy();
+      });
     });
   });
+
 });


### PR DESCRIPTION
Had this as part of some local changes I was going to push to #2736 in an attempt to figure out the `localStorage` `spyOn` quirks in Firefox.  I'm good to punt on that, seems a big hassle, but prob the updated test language is worth salvaging.

