### PR TITLE
Update ::selection styles for log text & link highlighting to be consistent across browsers

### DIFF
--- a/app/styles/_log.less
+++ b/app/styles/_log.less
@@ -232,12 +232,22 @@
   white-space: pre-wrap;
   width: 100%;
   .word-break();
-  // Invert colors on selection in Firefox. Change the background style for
-  // Firefox only since it's illegible with its defaults and our log colors.
-  // https://developer.mozilla.org/en-US/docs/Web/CSS/::selection
-  &::-moz-selection {
+  // Invert colors on selection
+  &::-moz-selection, *:not(a)::-moz-selection {
+    background: #a0a1a1;
     color: @log-bg-color;
-    background: lighten(#d1d1d1, 8%);
+  }
+  a::-moz-selection {
+    background: #a0a1a1;
+    color: darken(@link-color, 8%);
+  }
+  &::selection, *::selection {
+    background: lighten(#d1d1d1, 15%);
+    color: @log-bg-color;
+  }
+  a::selection {
+    background: lighten(#d1d1d1, 15%);
+    color: darken(@link-color, 8%);
   }
 }
 .table-log-pods {

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5993,7 +5993,10 @@ alerts+.chromeless .log-loading-msg{margin-top:130px}
 .log-line-number{-ms-user-select:none;border-right:1px #272b30 solid;padding-right:10px;vertical-align:top;white-space:nowrap;width:60px;color:#72767b}
 .log-line-text{padding:0 10px;white-space:pre-wrap;width:100%}
 .appended-icon,.project-date [am-time-ago],.projects-list [am-time-ago]{white-space:nowrap}
-.log-line-text::-moz-selection{color:#101214;background:#e5e5e5}
+.log-line-text :not(a)::-moz-selection,.log-line-text::-moz-selection{background:#a0a1a1;color:#101214}
+.log-line-text a::-moz-selection{background:#a0a1a1;color:#006da5}
+.log-line-text ::selection,.log-line-text::selection{background:#f7f7f7;color:#101214}
+.log-line-text a::selection{background:#f7f7f7;color:#006da5}
 .table-log-pods{background-color:#fff;border:1px solid #D1D1D1}
 .table-log-pods>tbody+tbody{border-top-width:1px}
 .log-fixed-height.empty-state-message{margin-top:0}


### PR DESCRIPTION
…
Fixes https://github.com/openshift/origin-web-console/issues/2724

<img width="615" alt="screen shot 2018-01-30 at 4 42 44 pm" src="https://user-images.githubusercontent.com/1874151/35593455-f10410fa-05dd-11e8-9775-e73f43c9860f.png">
<img width="685" alt="screen shot 2018-01-30 at 4 37 18 pm" src="https://user-images.githubusercontent.com/1874151/35592729-eb2fe58e-05db-11e8-9f5f-1a284b37b7de.png">
<img width="653" alt="screen shot 2018-01-30 at 4 40 43 pm" src="https://user-images.githubusercontent.com/1874151/35593497-08851ed6-05de-11e8-8daa-f52a6f4619c5.png">
<img width="594" alt="screen shot 2018-01-30 at 4 48 19 pm" src="https://user-images.githubusercontent.com/1874151/35593453-f0e29b8c-05dd-11e8-99d3-a195fb8d27b8.png">


