### PR TITLE
[WIP] show v2beta1 autoscaler metrics details message

### DIFF
--- a/app/scripts/controllers/deployment.js
+++ b/app/scripts/controllers/deployment.js
@@ -66,7 +66,7 @@ angular.module('openshiftConsole')
         var limitRanges = {};
 
         var updateHPAWarnings = function() {
-            HPAService.getHPAWarnings($scope.deployment, $scope.autoscalers, limitRanges, project)
+            HPAService.getHPAWarningsForResource($scope.deployment, $scope.autoscalers, limitRanges, project)
                       .then(function(warnings) {
               $scope.hpaWarnings = warnings;
             });

--- a/app/scripts/controllers/deploymentConfig.js
+++ b/app/scripts/controllers/deploymentConfig.js
@@ -72,7 +72,7 @@ angular.module('openshiftConsole')
         var limitRanges = {};
 
         var updateHPAWarnings = function() {
-            HPAService.getHPAWarnings($scope.deploymentConfig, $scope.autoscalers, limitRanges, project)
+            HPAService.getHPAWarningsForResource($scope.deploymentConfig, $scope.autoscalers, limitRanges, project)
                       .then(function(warnings) {
               $scope.hpaWarnings = warnings;
             });

--- a/app/scripts/controllers/edit/autoscaler.js
+++ b/app/scripts/controllers/edit/autoscaler.js
@@ -189,7 +189,7 @@ angular.module('openshiftConsole')
 
 
           $scope.showV2Beta1Warning = HPAService.isUnsupportedAPI(resource);
-
+          $scope.v2Beta1Metrics = $filter('hpaMetrics')(resource);
           // Are we editing an existing HPA?
           if ($routeParams.kind === "HorizontalPodAutoscaler") {
             $scope.targetKind = _.get(resource, 'spec.scaleTargetRef.kind');

--- a/app/scripts/controllers/edit/autoscaler.js
+++ b/app/scripts/controllers/edit/autoscaler.js
@@ -186,6 +186,10 @@ angular.module('openshiftConsole')
                               };
                             });
 
+
+
+          $scope.showV2Beta1Warning = HPAService.isUnsupportedAPI(resource);
+
           // Are we editing an existing HPA?
           if ($routeParams.kind === "HorizontalPodAutoscaler") {
             $scope.targetKind = _.get(resource, 'spec.scaleTargetRef.kind');

--- a/app/scripts/controllers/replicaSet.js
+++ b/app/scripts/controllers/replicaSet.js
@@ -142,7 +142,7 @@ angular.module('openshiftConsole')
         };
 
         var updateHPAWarnings = function() {
-            HPAService.getHPAWarnings($scope.replicaSet, $scope.autoscalers, $scope.limitRanges, project)
+            HPAService.getHPAWarningsForResource($scope.replicaSet, $scope.autoscalers, $scope.limitRanges, project)
                       .then(function(warnings) {
               $scope.hpaWarnings = warnings;
             });

--- a/app/scripts/directives/oscAutoscaling.js
+++ b/app/scripts/directives/oscAutoscaling.js
@@ -13,7 +13,8 @@ angular.module("openshiftConsole")
       scope: {
         autoscaling: "=model",
         showNameInput: "=?",
-        nameReadOnly: "=?"
+        nameReadOnly: "=?",
+        showCPURequestInput: "=?"
       },
       templateUrl: 'views/directives/osc-autoscaling.html',
       link: function(scope) {

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -1355,4 +1355,9 @@ angular.module('openshiftConsole')
   })
   .filter('humanizePodStatus', function(humanizeReasonFilter) {
     return humanizeReasonFilter;
+  })
+  .filter('hpaWarningsForResource', function() {
+    return function(warnings) {
+      return _.reject(warnings, ['reason', 'V2Beta1HPA']);
+    };
   });

--- a/app/views/directives/osc-autoscaling.html
+++ b/app/views/directives/osc-autoscaling.html
@@ -99,7 +99,7 @@
       </span>
     </div>
   </div>
-  <div class="form-group">
+  <div ng-show="showCPURequestInput"  class="form-group">
     <label>
       CPU Request Target
     </label>

--- a/app/views/edit/autoscaler.html
+++ b/app/views/edit/autoscaler.html
@@ -38,11 +38,21 @@
               <span ng-if="!('cpu' | isRequestCalculated : project)">request.</span>
             </div>
 
+            <!-- Warning: V2Beta1 HPA -->
+            <div ng-if="showV2Beta1Warning" class="alert alert-warning">
+              <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
+              <span class="sr-only">Warning:</span>
+              This autoscaler uses a newer API, consider editing it with the
+              <a href="command-line" target="_blank">command line tools</a>.
+            </div>
+
+
             <fieldset ng-disabled="disableInputs" class="gutter-top">
               <osc-autoscaling
                   model="autoscaling"
                   show-name-input="true"
-                  name-read-only="kind === 'HorizontalPodAutoscaler'">
+                  name-read-only="kind === 'HorizontalPodAutoscaler'"
+                  show-cpu-request-input="showV2Beta1Warning">
               </osc-autoscaling>
 
               <label-editor

--- a/app/views/edit/autoscaler.html
+++ b/app/views/edit/autoscaler.html
@@ -40,10 +40,35 @@
 
             <!-- Warning: V2Beta1 HPA -->
             <div ng-if="showV2Beta1Warning" class="alert alert-warning">
-              <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
-              <span class="sr-only">Warning:</span>
-              This autoscaler uses a newer API, consider editing it with the
-              <a href="command-line" target="_blank">command line tools</a>.
+              <div class="pficon pficon-warning-triangle-o" aria-hidden="true"></div>
+              <div class="sr-only">Warning:</div>
+              <div>
+                <div>
+                  This autoscaler uses a newer API, consider editing it with the
+                  <a href="command-line" target="_blank">command line tools</a>.
+                </div>
+              </div>
+            </div>
+            <div ng-if="showV2Beta1Warning" class="alert alert-info">
+              <div>This autoscaler is configured to work on the following metrics:</div>
+              <div ng-repeat="metric in v2Beta1Metrics">
+                <div>type: <strong>{{metric.type}}</strong></div>
+                <div ng-if="metric.resource">
+                  <div ng-repeat="(key, value) in metric.resource">
+                    <span>{{key}} : {{value}}</span>
+                  </div>
+                </div>
+                <div ng-if="metric.pods">
+                  <div ng-repeat="(key, value) in metric.pods">
+                    <span>{{key}} : {{value}}</span>
+                  </div>
+                </div>
+                <div ng-if="metric.object">
+                  <div ng-repeat="(key, value) in metric.object">
+                    <span>{{key}} : {{value}}</span>
+                  </div>
+                </div>
+              </div>
             </div>
 
 

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8068,7 +8068,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"form-group\">\n" +
+    "<div ng-show=\"showCPURequestInput\" class=\"form-group\">\n" +
     "<label>\n" +
     "CPU Request Target\n" +
     "</label>\n" +
@@ -9476,8 +9476,15 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"'cpu' | isRequestCalculated : project\">limit.</span>\n" +
     "<span ng-if=\"!('cpu' | isRequestCalculated : project)\">request.</span>\n" +
     "</div>\n" +
+    "\n" +
+    "<div ng-if=\"showV2Beta1Warning\" class=\"alert alert-warning\">\n" +
+    "<span class=\"pficon pficon-warning-triangle-o\" aria-hidden=\"true\"></span>\n" +
+    "<span class=\"sr-only\">Warning:</span>\n" +
+    "This autoscaler uses a newer API, consider editing it with the\n" +
+    "<a href=\"command-line\" target=\"_blank\">command line tools</a>.\n" +
+    "</div>\n" +
     "<fieldset ng-disabled=\"disableInputs\" class=\"gutter-top\">\n" +
-    "<osc-autoscaling model=\"autoscaling\" show-name-input=\"true\" name-read-only=\"kind === 'HorizontalPodAutoscaler'\">\n" +
+    "<osc-autoscaling model=\"autoscaling\" show-name-input=\"true\" name-read-only=\"kind === 'HorizontalPodAutoscaler'\" show-cpu-request-input=\"showV2Beta1Warning\">\n" +
     "</osc-autoscaling>\n" +
     "<label-editor labels=\"labels\" expand=\"true\" can-toggle=\"false\"></label-editor>\n" +
     "<div class=\"buttons gutter-top gutter-bottom\">\n" +


### PR DESCRIPTION
WIP, and currently branched off of #2708.

Tinkering with the best way to message this, apart from the main alert:

![screen shot 2018-01-30 at 5 43 46 pm 1](https://user-images.githubusercontent.com/280512/35596017-921b4938-05e6-11e8-9a24-e22746c74476.png)

@spadgett @jwforres, we made listing out this information optional on [the trello](https://trello.com/c/EuQHe0LT/1113-handle-hpa-objects-persisted-with-v2beta1), but I think the `metrics` data structure is fairly stable. 
