### PR TITLE
Remove duplicate DaemonSet from Other Resources

### DIFF
--- a/app/scripts/controllers/otherResources.js
+++ b/app/scripts/controllers/otherResources.js
@@ -41,6 +41,8 @@ angular.module('openshiftConsole')
         case "ServiceInstance":
         case "StatefulSet":
           return false;
+        case "DaemonSet":
+          return kind.group === "apps";
         default:
           return true;
       }

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -6865,6 +6865,9 @@ case "ServiceInstance":
 case "StatefulSet":
 return !1;
 
+case "DaemonSet":
+return "apps" === e.group;
+
 default:
 return !0;
 }


### PR DESCRIPTION
Fixes #2751 

I think we used to have some of this driven by `constants.js`, but looks like the bit `switch` is the only filtering mechanism now. 