### PR TITLE
Remove redundant "Container" heading at mobile on overview

### DIFF
--- a/app/scripts/directives/resources.js
+++ b/app/scripts/directives/resources.js
@@ -81,8 +81,7 @@ angular.module('openshiftConsole')
         container: '=podTemplateContainer',
         imagesByDockerReference: '=',
         builds: '=',
-        detailed: '=?',
-        labelPrefix: '@?'
+        detailed: '=?'
       },
       templateUrl: 'views/_pod-template-container.html'
     };

--- a/app/views/_container-statuses.html
+++ b/app/views/_container-statuses.html
@@ -26,7 +26,7 @@
   <div class="animate-if"
        ng-if="expandInitContainers"
        ng-repeat="containerStatus in pod.status.initContainerStatuses track by containerStatus.name" >
-    <h4 class="component-label">Init container {{containerStatus.name}}</h4>
+    <h4>Init container {{containerStatus.name}}</h4>
 
     <dl class="dl-horizontal left">
       <dt>State:</dt>

--- a/app/views/_pod-template-container.html
+++ b/app/views/_pod-template-container.html
@@ -4,11 +4,9 @@
   imagesByDockerReference (optional)
   builds (optional)
   detailed (optional)
-  labelPrefix (optional)
  -->
 
 <div class="pod-template">
-  <div class="component-label section-label" ng-if="!detailed" ng-bind-template="{{labelPrefix||'Container'}}"></div>
   <div class="pod-container-name">{{container.name}}</div>
   <div row ng-if="container.image" class="pod-template-image icon-row">
     <div class="icon-wrap">

--- a/app/views/_pod-template.html
+++ b/app/views/_pod-template.html
@@ -26,8 +26,7 @@
         pod-template-container="container"
         images-by-docker-reference="imagesByDockerReference"
         builds="builds"
-        detailed="detailed"
-        label-prefix="Init Container"></pod-template-container>
+        detailed="detailed"></pod-template-container>
 
     </div>
   </div>

--- a/app/views/overview/_list-row-expanded.html
+++ b/app/views/overview/_list-row-expanded.html
@@ -10,7 +10,7 @@
           'ng-enter': row.previous,
           'hidden-sm hidden-md': row.previous
         }">
-          <!-- TODO: markup semantics suggest div.component-label in <pod-template> should be an h4, but only here on the overview -->
+          <h4 class="component-label section-label">Containers</h4>
           <pod-template
             pod-template="row.current | podTemplate"
             images-by-docker-reference="row.state.imagesByDockerReference"
@@ -115,8 +115,6 @@
           </uib-tab>
           <uib-tab ng-if="row.current" active="row.selectedTab.containers">
             <uib-tab-heading>Containers</uib-tab-heading>
-            <!-- TODO: markup semantics suggest div.component-label in <pod-template> should be an h4,
-                       but only here on the overview -->
             <pod-template
               pod-template="row.current | podTemplate"
               images-by-docker-reference="row.state.imagesByDockerReference"

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10480,8 +10480,7 @@ scope: {
 container: "=podTemplateContainer",
 imagesByDockerReference: "=",
 builds: "=",
-detailed: "=?",
-labelPrefix: "@?"
+detailed: "=?"
 },
 templateUrl: "views/_pod-template-container.html"
 };

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -134,7 +134,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</h4>\n" +
     "<div class=\"animate-if\" ng-if=\"expandInitContainers\" ng-repeat=\"containerStatus in pod.status.initContainerStatuses track by containerStatus.name\">\n" +
-    "<h4 class=\"component-label\">Init container {{containerStatus.name}}</h4>\n" +
+    "<h4>Init container {{containerStatus.name}}</h4>\n" +
     "<dl class=\"dl-horizontal left\">\n" +
     "<dt>State:</dt>\n" +
     "<dd>\n" +
@@ -238,7 +238,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
 
   $templateCache.put('views/_pod-template-container.html',
     " <div class=\"pod-template\">\n" +
-    "<div class=\"component-label section-label\" ng-if=\"!detailed\" ng-bind-template=\"{{labelPrefix||'Container'}}\"></div>\n" +
     "<div class=\"pod-container-name\">{{container.name}}</div>\n" +
     "<div row ng-if=\"container.image\" class=\"pod-template-image icon-row\">\n" +
     "<div class=\"icon-wrap\">\n" +
@@ -410,7 +409,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<h4>Init Containers</h4>\n" +
     "<div class=\"pod-template-container\">\n" +
     "<div class=\"pod-template-block\" ng-repeat=\"container in podTemplate.spec.initContainers\">\n" +
-    "<pod-template-container pod-template-container=\"container\" images-by-docker-reference=\"imagesByDockerReference\" builds=\"builds\" detailed=\"detailed\" label-prefix=\"Init Container\"></pod-template-container>\n" +
+    "<pod-template-container pod-template-container=\"container\" images-by-docker-reference=\"imagesByDockerReference\" builds=\"builds\" detailed=\"detailed\"></pod-template-container>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -12387,7 +12386,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "          'ng-enter': row.previous,\n" +
     "          'hidden-sm hidden-md': row.previous\n" +
     "        }\">\n" +
-    "\n" +
+    "<h4 class=\"component-label section-label\">Containers</h4>\n" +
     "<pod-template pod-template=\"row.current | podTemplate\" images-by-docker-reference=\"row.state.imagesByDockerReference\" builds=\"row.state.builds\" class=\"hide-ng-leave\">\n" +
     "</pod-template>\n" +
     "<init-containers-summary api-object=\"row.apiObject\"></init-containers-summary>\n" +
@@ -12451,7 +12450,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</uib-tab>\n" +
     "<uib-tab ng-if=\"row.current\" active=\"row.selectedTab.containers\">\n" +
     "<uib-tab-heading>Containers</uib-tab-heading>\n" +
-    "\n" +
     "<pod-template pod-template=\"row.current | podTemplate\" images-by-docker-reference=\"row.state.imagesByDockerReference\" builds=\"row.state.builds\"></pod-template>\n" +
     "<init-containers-summary api-object=\"row.apiObject\"></init-containers-summary>\n" +
     "</uib-tab>\n" +


### PR DESCRIPTION
Fixes #2753

![screen shot 2018-02-02 at 11 27 05 am](https://user-images.githubusercontent.com/895728/35743986-250ee196-080d-11e8-8f92-89724a7ef6c4.PNG)

![screen shot 2018-02-02 at 11 27 18 am](https://user-images.githubusercontent.com/895728/35743990-281c7240-080d-11e8-9f75-8c24c29de99f.PNG)

Also
* removes orphaned labelPrefix attribute in pod-template-container
directive
* corrects styling on init container headings
BEFORE:
![screen shot 2018-02-02 at 11 28 24 am](https://user-images.githubusercontent.com/895728/35744020-3789239a-080d-11e8-9a39-b43a94b470f7.PNG)
AFTER:
![screen shot 2018-02-02 at 11 27 51 am](https://user-images.githubusercontent.com/895728/35744026-3c5ed964-080d-11e8-9df5-019b55728e12.PNG)

