### PR TITLE
Catalog dependency version bump to fix 'set home page to view only proj.' and

### DIFF
--- a/app/views/modals/set-home-page-modal.html
+++ b/app/views/modals/set-home-page-modal.html
@@ -30,6 +30,7 @@
           </label>
           <div class="select-project-container" ng-if="availableProjects.length > 1">
             <select-project is-required="homePagePreference === 'project-overview'"
+                            skip-can-add-validation="true"
                             on-project-selected="onProjectSelected"
                             on-open="onOpen"
                             available-projects="availableProjects"

--- a/bower.json
+++ b/bower.json
@@ -47,7 +47,7 @@
     "angular-utf8-base64": "0.0.5",
     "file-saver": "1.3.3",
     "origin-web-common": "3.9.0-alpha.10",
-    "origin-web-catalog": "3.9.0-alpha.8"
+    "origin-web-catalog": "3.9.0-alpha.10"
   },
   "devDependencies": {
     "angular-mocks": "1.5.11",

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -11235,7 +11235,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Overview Page for{{availableProjects.length === 1 ? ' ' + (selectedProject | displayName) : ':'}}\n" +
     "</label>\n" +
     "<div class=\"select-project-container\" ng-if=\"availableProjects.length > 1\">\n" +
-    "<select-project is-required=\"homePagePreference === 'project-overview'\" on-project-selected=\"onProjectSelected\" on-open=\"onOpen\" available-projects=\"availableProjects\" selected-project=\"selectedProject\" hide-create-project=\"true\" hide-label=\"true\">\n" +
+    "<select-project is-required=\"homePagePreference === 'project-overview'\" skip-can-add-validation=\"true\" on-project-selected=\"onProjectSelected\" on-open=\"onOpen\" available-projects=\"availableProjects\" selected-project=\"selectedProject\" hide-create-project=\"true\" hide-label=\"true\">\n" +
     "</select-project>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/scripts/vendor.js
+++ b/dist/scripts/vendor.js
@@ -78574,6 +78574,7 @@ onProjectSelected: "<?",
 onOpen: "<?",
 availableProjects: "<?",
 showDivider: "<?",
+skipCanAddValidation: "<?",
 hideCreateProject: "<?",
 hideLabel: "<?",
 isRequired: "<?"
@@ -79377,15 +79378,31 @@ e.exports = '<div class="order-service">\n  <pf-wizard wizard-title="{{$ctrl.dis
 "use strict";
 t.__esModule = !0;
 var i = n(1), r = n(0), o = function() {
-function e(e, t) {
-var n = this;
+function e(e, t, n) {
+var o = this;
 this.ctrl = this, this.onKeywordKeyPress = function(e) {
-13 === e.which && n.ctrl.keywordFilter.value.length > 0 && (n.ctrl.keywordFilter.values.push(n.ctrl.keywordFilter.value), delete n.ctrl.keywordFilter.value, n.constructFiltersFromModel());
+if (13 === e.which && o.ctrl.keywordFilter.value.length > 0) {
+var t = o.ctrl.keywordFilter.value;
+o.keywordFilterExists(t) ? o.highlightKeywordFilter(t) : (o.ctrl.keywordFilter.values.push(t), o.constructFiltersFromModel()), delete o.ctrl.keywordFilter.value;
+}
 }, this.filterChanged = function() {
-n.constructFiltersFromModel();
-}, this.onFilterChange = function(e, t, r) {
-i.isDefined(t) && i.isDefined(r) ? n.updateFilterPanelModel(t, r) : n.resetFilterPanelModel(), n.constructFiltersFromModel();
-}, this.$scope = e, this.Catalog = t, this.ctrl.filterPanelModel = [], this.ctrl.keywordFilter = {
+o.constructFiltersFromModel();
+}, this.keywordFilterExists = function(e) {
+return r.some(o.ctrl.keywordFilter.values, function(t) {
+return e.toLowerCase() === t.toLowerCase();
+});
+}, this.highlightKeywordFilter = function(e) {
+var t = document.querySelectorAll("pf-filter-panel-results .label-info"), n = r.find(t, function(t) {
+return t.innerText.trim() === "Keyword:" + e.toLowerCase();
+});
+n && (o.$timeout(function() {
+n.classList.add("flash-filter-tag");
+}, 100), o.$timeout(function() {
+n.classList.remove("flash-filter-tag");
+}, 300));
+}, this.onFilterChange = function(e, t, n) {
+i.isDefined(t) && i.isDefined(n) ? o.updateFilterPanelModel(t, n) : o.resetFilterPanelModel(), o.constructFiltersFromModel();
+}, this.$scope = e, this.$timeout = t, this.Catalog = n, this.ctrl.filterPanelModel = [], this.ctrl.keywordFilter = {
 id: "keyword",
 title: "Keyword",
 placeholder: "Filter by Keyword",
@@ -79470,7 +79487,7 @@ e.selected = !1;
 });
 }, e;
 }();
-o.$inject = [ "$scope", "Catalog" ], t.CatalogFilterController = o;
+o.$inject = [ "$scope", "$timeout", "Catalog" ], t.CatalogFilterController = o;
 }, function(e, t, n) {
 "use strict";
 t.__esModule = !0;
@@ -80226,7 +80243,7 @@ var e = this;
 this.ctrl.noProjectsCantCreate = !1, this.ctrl.noProjectsConfig = {
 title: "No Projects Found",
 info: "Services cannot be provisioned without a project."
-}, void 0 === this.ctrl.showDivider && (this.ctrl.showDivider = !0), void 0 === this.ctrl.isRequired && (this.ctrl.isRequired = !0), this.ProjectsService.canCreate().then(function() {
+}, void 0 === this.ctrl.showDivider && (this.ctrl.showDivider = !0), void 0 === this.ctrl.skipCanAddValidation && (this.ctrl.skipCanAddValidation = !1), void 0 === this.ctrl.isRequired && (this.ctrl.isRequired = !0), this.ProjectsService.canCreate().then(function() {
 e.ctrl.canCreate = !0;
 }, function(t) {
 if (e.ctrl.canCreate = !1, 403 !== t.status) {
@@ -80246,7 +80263,7 @@ e.listProjects();
 }, e.prototype.$onChanges = function(e) {
 e.nameTaken && !e.nameTaken.isFirstChange() && this.ctrl.forms.createProjectForm.name.$setValidity("nameTaken", !this.ctrl.nameTaken), e.availableProjects && !e.availableProjects.isFirstChange() && this.updateProjects(this.ctrl.availableProjects);
 }, e.prototype.onSelectProjectChange = function() {
-this.canIAddToProject(), i.isFunction(this.ctrl.onProjectSelected) && this.ctrl.onProjectSelected(this.ctrl.selectedProject);
+this.ctrl.skipCanAddValidation || this.canIAddToProject(), i.isFunction(this.ctrl.onProjectSelected) && this.ctrl.onProjectSelected(this.ctrl.selectedProject);
 }, e.prototype.onOpenClose = function(e) {
 e && r.isFunction(this.ctrl.onOpen) && this.ctrl.onOpen();
 }, e.prototype.onNewProjectNameChange = function() {

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4235,6 +4235,9 @@ body>.ui-select-bootstrap.open{z-index:1050}
 .ui-select-bootstrap .ui-select-placeholder{display:block;overflow:hidden;text-overflow:ellipsis;width:100%}
 .ui-select-bootstrap .ui-select-toggle>.caret{font-style:normal;right:6px;top:10px;pointer-events:none}
 .ui-select-bootstrap .ui-select-search{width:100%!important}
+@keyframes flash{0%{opacity:0}
+100%{opacity:1}
+}
 @keyframes modalBackdropIn{0%{opacity:0}
 100%{opacity:.5}
 }
@@ -4499,6 +4502,7 @@ body.overlay-open,body.overlay-open .landing,body.overlay-open .landing-side-bar
 .services-view .vendor-info-icon,services-view .vendor-info-icon{font-size:10px;padding-left:2px;vertical-align:middle}
 .services-view .blank-slate-pf{background-color:transparent;border:none}
 .services-view .filter-panel-container ul{margin-bottom:10px}
+.services-view .flash-filter-tag{animation:flash linear 1s 1}
 .services-view .pf-empty-state{margin:0 20px;width:100%}
 .services-view .services-item{color:#363636;min-height:140px;overflow:hidden;padding:0 10px 20px;position:relative;text-align:center;width:50%;word-break:break-word;z-index:99}
 @media (min-width:480px){.services-view .services-item{width:33.3333%}


### PR DESCRIPTION
...'flash catalog filter dups' issues

Fixes "Set Home Page to View Only Project"
https://bugzilla.redhat.com/show_bug.cgi?id=1540490

Final update to resolve: https://github.com/openshift/origin-web-catalog/issues/617  and https://patternfly.atlassian.net/browse/OSUX-457
"Upon entering a duplicate keyword, the existing filter tag flashes."
