### PR TITLE
Improve form markup in process or save template dialog

### DIFF
--- a/app/views/modals/process-or-save-template.html
+++ b/app/views/modals/process-or-save-template.html
@@ -7,21 +7,28 @@
   </div>
   <div class="modal-body">
     <p>What would you like to do?</p>
-
-    <p>
-      <label>
-        <input type="checkbox" ng-model="templateOptions.process"/>
-        <strong>Process the template</strong>
-      </label>
-      <span id="helpBlock" class="help-block">Create the objects defined in the template. You will have an opportunity to fill in template parameters.</span>
-    </p>
-    <p>
-      <label>
-        <input type="checkbox" ng-model="templateOptions.add"/>
-        <strong>{{updateTemplate ? "Update" : "Save"}} template</strong>
-      </label>
-      <span id="helpBlock" class="help-block">{{updateTemplate ? "This will overwrite the current version of the template." : "Save the template to the project. This will make the template available to anyone who can view the project."}}</span>
-    </p>
+    <div class="form-group">
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" ng-model="templateOptions.process" aria-descirbedby="process-template-help">
+          <strong>Process the template</strong>
+        </label>
+        <div id="process-template-help" class="help-block">
+          Create the objects defined in the template. You will have an opportunity to fill in template parameters.
+        </div>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" ng-model="templateOptions.add" aria-descirbedby="save-template-help">
+          <strong>{{updateTemplate ? "Update" : "Save"}} template</strong>
+        </label>
+        <div id="save-template-help" class="help-block">
+          {{updateTemplate ? "This will overwrite the current version of the template." : "Save the template to the project. This will make the template available to anyone who can view the project."}}
+        </div>
+      </div>
+    </div>
   </div>
   <div class="modal-footer">
     <button class="btn btn-default" type="button" ng-click="cancel();">Cancel</button>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -11179,20 +11179,28 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"modal-body\">\n" +
     "<p>What would you like to do?</p>\n" +
-    "<p>\n" +
+    "<div class=\"form-group\">\n" +
+    "<div class=\"checkbox\">\n" +
     "<label>\n" +
-    "<input type=\"checkbox\" ng-model=\"templateOptions.process\"/>\n" +
+    "<input type=\"checkbox\" ng-model=\"templateOptions.process\" aria-descirbedby=\"process-template-help\">\n" +
     "<strong>Process the template</strong>\n" +
     "</label>\n" +
-    "<span id=\"helpBlock\" class=\"help-block\">Create the objects defined in the template. You will have an opportunity to fill in template parameters.</span>\n" +
-    "</p>\n" +
-    "<p>\n" +
+    "<div id=\"process-template-help\" class=\"help-block\">\n" +
+    "Create the objects defined in the template. You will have an opportunity to fill in template parameters.\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"form-group\">\n" +
+    "<div class=\"checkbox\">\n" +
     "<label>\n" +
-    "<input type=\"checkbox\" ng-model=\"templateOptions.add\"/>\n" +
+    "<input type=\"checkbox\" ng-model=\"templateOptions.add\" aria-descirbedby=\"save-template-help\">\n" +
     "<strong>{{updateTemplate ? \"Update\" : \"Save\"}} template</strong>\n" +
     "</label>\n" +
-    "<span id=\"helpBlock\" class=\"help-block\">{{updateTemplate ? \"This will overwrite the current version of the template.\" : \"Save the template to the project. This will make the template available to anyone who can view the project.\"}}</span>\n" +
-    "</p>\n" +
+    "<div id=\"save-template-help\" class=\"help-block\">\n" +
+    "{{updateTemplate ? \"This will overwrite the current version of the template.\" : \"Save the template to the project. This will make the template available to anyone who can view the project.\"}}\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
     "</div>\n" +
     "<div class=\"modal-footer\">\n" +
     "<button class=\"btn btn-default\" type=\"button\" ng-click=\"cancel();\">Cancel</button>\n" +


### PR DESCRIPTION
Use Patternfly `form-group` and `checkbox` styles in the dialog for
better spacing. Also use correct `aria-descirbedby` and `id` attributes
for help text.

Before:

![openshift web console 2018-02-03 08-13-47](https://user-images.githubusercontent.com/1167259/35767434-386197f4-08ba-11e8-8708-b15f1fe6bd16.png)

After:

![openshift web console 2018-02-03 08-16-15](https://user-images.githubusercontent.com/1167259/35767452-89dca506-08ba-11e8-9a19-4b84f976e22c.png)

