### PR TITLE
Don't force users to tap tabs twice on iPad

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -7,8 +7,18 @@
   display: none !important;
 }
 
-@media only screen and (max-device-width: 736px) {
-  body.ios {
+body.ios {
+  // Prevent having to tap tabs twice on iOS.
+  .nav-tabs > {
+    li > a:hover:before {
+      content: none;
+    }
+    li.active > a:before {
+      content: '';
+    }
+  }
+
+  @media only screen and (max-device-width: 736px) {
     // Fix Bootstrap modal dialog zoom on the iPhone
     // See http://stackoverflow.com/questions/32675849/screen-zooms-in-when-a-bootstrap-modal-is-opened-on-ios-9-safari
     padding-right: 0px !important;
@@ -31,16 +41,6 @@
     textarea.form-control,
     .console-os .ace_editor {
       font-size: 16px;
-    }
-
-    // Prevent having to tap tabs twice on iOS.
-    .nav-tabs > {
-      li > a:hover:before {
-        content: none;
-      }
-      li.active > a:before {
-        content: '';
-      }
     }
   }
 }

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4763,11 +4763,11 @@ code.command{display:inline-block;line-height:1.3;margin-right:2px}
 .service-binding-actions>a:first-of-type{border-left:0;padding-left:0;padding-right:5px}
 .service-description .truncated-content{white-space:pre-wrap}
 .ng-cloak,.x-ng-cloak,[data-ng-cloak],[ng-cloak],[ng\:cloak],[x-ng-cloak]{display:none!important}
+body.ios .nav-tabs li>a:hover:before{content:none}
+body.ios .nav-tabs li.active>a:before{content:''}
 @media only screen and (max-device-width:736px){body.ios{padding-right:0px!important}
 body.ios.modal-open,body.ios.overlay-open{overflow-y:auto;position:fixed}
 body.ios .console-os .ace_editor,body.ios input[type=text],body.ios input[type=url],body.ios input[type=number],body.ios input[type=search],body.ios select,body.ios select.form-control,body.ios textarea,body.ios textarea.form-control{font-size:16px}
-body.ios .nav-tabs li>a:hover:before{content:none}
-body.ios .nav-tabs li.active>a:before{content:''}
 }
 @-moz-document url-prefix(){.console-os fieldset{display:table-cell}
 }


### PR DESCRIPTION
Move iOS tab styles outside max-device-width media query so they apply to iPads, too.

Fixes #2762