### PR TITLE
[WIP] feat(quotas): Add quota warnings to config maps and secrets pages.

### DIFF
--- a/app/scripts/controllers/configMaps.js
+++ b/app/scripts/controllers/configMaps.js
@@ -11,19 +11,47 @@ angular.module('openshiftConsole')
   .controller('ConfigMapsController',
               function ($scope,
                         $routeParams,
+                        AlertMessageService,
                         APIService,
                         DataService,
                         LabelFilter,
-                        ProjectsService) {
-    $scope.projectName = $routeParams.project;
-    $scope.loaded = false;
-    $scope.labelSuggestions = {};
-    $scope.configMapsVersion = APIService.getPreferredVersion('configmaps');
-    $scope.clearFilter = function () {
-      LabelFilter.clear();
-    };
-    var watches = [];
+                        ProjectsService,
+                        QuotaService) {
     var configMaps;
+    var quotaTypes = ['configmaps'];
+    var watches = [];
+
+    var setQuotaExceededWarning = function(exceeded) {
+      var isHidden = AlertMessageService.isAlertPermanentlyHidden("configmaps-quota-limit-reached", $scope.projectName);
+      $scope.quotaExceeded = exceeded;
+      if (!isHidden && $scope.quotaExceeded) {
+        if ($scope.alerts['quotaExceeded']) {
+          // Don't recreate the alert or it will reset the temporary hidden state
+          return;
+        }
+        $scope.alerts['quotaExceeded'] = {
+          type: 'warning',
+          message: 'Config Maps quota limit has been reached. You will not be able to create any new Config Maps.',
+          links: [{
+            href: "project/" + $scope.projectName + "/quota",
+            label: "View Quota"
+          },{
+            href: "",
+            label: "Don't Show Me Again",
+            onClick: function() {
+              // Hide the alert on future page loads.
+              AlertMessageService.permanentlyHideAlert("configmaps-quota-limit-reached", $scope.projectName);
+
+              // Return true close the existing alert.
+              return true;
+            }
+          }]
+        };
+      }
+      else {
+        delete $scope.alerts['quotaExceeded'];
+      }
+    };
 
     var updateFilterMessage = function() {
       $scope.filterWithZeroResults = !LabelFilter.getLabelSelector().isEmpty() && _.isEmpty($scope.configMaps) && !_.isEmpty(configMaps);
@@ -40,11 +68,21 @@ angular.module('openshiftConsole')
       updateFilterMessage();
     };
 
+    $scope.projectName = $routeParams.project;
+    $scope.loaded = false;
+    $scope.alerts = $scope.alerts || {};
+    $scope.quotaExceeded = false;
+    $scope.labelSuggestions = {};
+    $scope.configMapsVersion = APIService.getPreferredVersion('configmaps');
+    $scope.clearFilter = function () {
+      LabelFilter.clear();
+    };
+
     ProjectsService
       .get($routeParams.project)
       .then(_.spread(function(project, context) {
         $scope.project = project;
-
+        QuotaService.isAnyCurrentQuotaExceeded(context, quotaTypes).then(setQuotaExceededWarning);
         watches.push(DataService.watch($scope.configMapsVersion, context, function(configMapData) {
           configMaps = configMapData.by('metadata.name');
           updateLabelSuggestions();
@@ -59,5 +97,6 @@ angular.module('openshiftConsole')
         $scope.$on('$destroy', function(){
           DataService.unwatchAll(watches);
         });
+
       }));
   });

--- a/app/scripts/controllers/secrets.js
+++ b/app/scripts/controllers/secrets.js
@@ -8,28 +8,64 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('SecretsController', function (
-    $routeParams,
-    $scope,
-    APIService,
-    DataService,
-    LabelFilter,
-    ProjectsService) {
+  .controller('SecretsController',
+              function ($routeParams,
+                        $scope,
+                        AlertMessageService,
+                        APIService,
+                        DataService,
+                        LabelFilter,
+                        ProjectsService,
+                        QuotaService) {
+    var watches = [];
+    var quotaTypes = ['secrets'];
+    var setQuotaExceededWarning = function(exceeded){
+      var isHidden = AlertMessageService.isAlertPermanentlyHidden("secret-quota-limit-reached", $scope.projectName);
+      $scope.quotaExceeded = exceeded;
+      if (!isHidden && $scope.quotaExceeded) {
+        if ($scope.alerts['quotaExceeded']) {
+          // Don't recreate the alert or it will reset the temporary hidden state
+          return;
+        }
+        $scope.alerts['quotaExceeded'] = {
+          type: 'warning',
+          message: 'Secret quota limit has been reached. You will not be able to create any new secrets.',
+          links: [{
+            href: "project/" + $scope.projectName + "/quota",
+            label: "View Quota"
+          },{
+            href: "",
+            label: "Don't Show Me Again",
+            onClick: function() {
+              // Hide the alert on future page loads.
+              AlertMessageService.permanentlyHideAlert("secret-quota-limit-reached", $scope.projectName);
+
+              // Return true close the existing alert.
+              return true;
+            }
+          }]
+        };
+      }
+      else {
+        delete $scope.alerts['quotaExceeded'];
+      }
+    };
+
     $scope.projectName = $routeParams.project;
     $scope.labelSuggestions = {};
+    $scope.alerts = $scope.alerts || {};
+    $scope.quotaExceeded = false;
+    $scope.secretsVersion = APIService.getPreferredVersion('secrets');
     $scope.clearFilter = function() {
       LabelFilter.clear();
     };
-
-    $scope.secretsVersion = APIService.getPreferredVersion('secrets');
-
-    var watches = [];
 
     ProjectsService
       .get($routeParams.project)
       .then(_.spread(function(project, context) {
         $scope.project = project;
         $scope.context = context;
+        QuotaService.isAnyCurrentQuotaExceeded(context, quotaTypes).then(setQuotaExceededWarning);
         watches.push(DataService.watch($scope.secretsVersion, context, function(secrets) {
           $scope.unfilteredSecrets = _.sortBy(secrets.by("metadata.name"), ["type", "metadata.name"]);
           $scope.secretsLoaded = true;

--- a/app/views/browse/config-maps.html
+++ b/app/views/browse/config-maps.html
@@ -3,7 +3,8 @@
     <div class="container-fluid">
       <div class="page-header page-header-bleed-right page-header-bleed-left">
         <div class="pull-right" ng-if="project && (configMapsVersion | canI : 'create') && ((configMaps | hashSize) > 0 || filterWithZeroResults)">
-          <a ng-href="project/{{project.metadata.name}}/create-config-map" class="btn btn-default">Create Config Map</a>
+          <a ng-if="!quotaExceeded" ng-href="project/{{project.metadata.name}}/create-config-map" class="btn btn-default">Create Config Map</a>
+          <a ng-if="quotaExceeded" ng-href="" class="btn btn-default disabled">Create Config Map</a>
         </div>
         <h1>
           Config Maps
@@ -23,6 +24,7 @@
   </div><!-- /middle-header-->
   <div class="middle-content">
     <div class="container-fluid">
+      <alerts alerts="alerts"></alerts>
       <div class="row">
         <div class="col-md-12">
           <div ng-if="(configMaps | hashSize) == 0">

--- a/app/views/secrets.html
+++ b/app/views/secrets.html
@@ -3,7 +3,8 @@
     <div class="container-fluid">
       <div class="page-header page-header-bleed-right page-header-bleed-left">
         <div class="pull-right" ng-if="project && (secretsVersion | canI : 'create') && secrets.length">
-          <a ng-href="project/{{project.metadata.name}}/create-secret" class="btn btn-default">Create Secret</a>
+          <a ng-if="!quotaExceeded" ng-href="project/{{project.metadata.name}}/create-secret" class="btn btn-default">Create Secret</a>
+          <a ng-if="quotaExceeded" ng-href="" class="btn btn-default disabled">Create Secret</a>
         </div>
         <h1>
           Secrets
@@ -23,6 +24,7 @@
   </div><!-- /middle-header-->
   <div class="middle-content">
     <div class="container-fluid">
+      <alerts alerts="alerts"></alerts>
       <div class="row">
         <div class="col-md-12">
           <div ng-if="(secrets | size) === 0">

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2175,7 +2175,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-fluid\">\n" +
     "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
     "<div class=\"pull-right\" ng-if=\"project && (configMapsVersion | canI : 'create') && ((configMaps | hashSize) > 0 || filterWithZeroResults)\">\n" +
-    "<a ng-href=\"project/{{project.metadata.name}}/create-config-map\" class=\"btn btn-default\">Create Config Map</a>\n" +
+    "<a ng-if=\"!quotaExceeded\" ng-href=\"project/{{project.metadata.name}}/create-config-map\" class=\"btn btn-default\">Create Config Map</a>\n" +
+    "<a ng-if=\"quotaExceeded\" ng-href=\"\" class=\"btn btn-default disabled\">Create Config Map</a>\n" +
     "</div>\n" +
     "<h1>\n" +
     "Config Maps\n" +
@@ -2195,6 +2196,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<div ng-if=\"(configMaps | hashSize) == 0\">\n" +
@@ -13503,7 +13505,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"container-fluid\">\n" +
     "<div class=\"page-header page-header-bleed-right page-header-bleed-left\">\n" +
     "<div class=\"pull-right\" ng-if=\"project && (secretsVersion | canI : 'create') && secrets.length\">\n" +
-    "<a ng-href=\"project/{{project.metadata.name}}/create-secret\" class=\"btn btn-default\">Create Secret</a>\n" +
+    "<a ng-if=\"!quotaExceeded\" ng-href=\"project/{{project.metadata.name}}/create-secret\" class=\"btn btn-default\">Create Secret</a>\n" +
+    "<a ng-if=\"quotaExceeded\" ng-href=\"\" class=\"btn btn-default disabled\">Create Secret</a>\n" +
     "</div>\n" +
     "<h1>\n" +
     "Secrets\n" +
@@ -13523,6 +13526,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"middle-content\">\n" +
     "<div class=\"container-fluid\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
     "<div class=\"row\">\n" +
     "<div class=\"col-md-12\">\n" +
     "<div ng-if=\"(secrets | size) === 0\">\n" +


### PR DESCRIPTION
## Description
Add warning alert to config maps and secrets pages and disabled `create` button if quota is already met for those resources.

## Changes
- Add `QuotaService.getLatestQuotas(context)` function. Returns a promise which resolves to `[<array> quotas,  <array> clusterQuotas]`
- Add `QuotaService.isAnyCurrentQuotaExceeded(context, typesToCheck)` function which determines if current quotas are already exceeded. No quotas are passed to this function because it automatically retrieves the latest quotas for the given context and checks against those. Works exactly like `QuotaService.isAnyQuotaExceeded` except that the caller does not need to provide the quotas.
- Some style/structure updates in the files that were touched. Mainly moving variable declarations to the top.
- `QuotaService.getLatestQuotaAlerts` now uses `QuotaService.getLatestQuotas`.
- Update storage controller to use new `QuotaService.isAnyCurrentQuotaExceeded` function
- Add quota check to secrets and config maps controllers and update templates to include alerts and conditional disabled `create` button.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1504007
