### PR TITLE
Bug 1540916: Set correct group and version in HPA scale target

### DIFF
--- a/app/scripts/controllers/edit/autoscaler.js
+++ b/app/scripts/controllers/edit/autoscaler.js
@@ -90,48 +90,6 @@ angular.module('openshiftConsole')
           return;
         }
 
-        var createHPA = function() {
-          $scope.disableInputs = true;
-          hideErrorNotifications();
-          var hpa = {
-            apiVersion: "autoscaling/v1",
-            kind: "HorizontalPodAutoscaler",
-            metadata: {
-              name: $scope.autoscaling.name,
-              labels: keyValueEditorUtils.mapEntries(keyValueEditorUtils.compactEntries($scope.labels))
-            },
-            spec: {
-              scaleTargetRef: {
-                kind: $routeParams.kind,
-                name: $routeParams.name,
-                apiVersion: "extensions/v1beta1",
-                subresource: "scale"
-              },
-              minReplicas: $scope.autoscaling.minReplicas,
-              maxReplicas: $scope.autoscaling.maxReplicas,
-              targetCPUUtilizationPercentage: $scope.autoscaling.targetCPU
-            }
-          };
-
-          DataService.create(horizontalPodAutoscalerVersion, null, hpa, context)
-            .then(function(hpa) { // Success
-              NotificationsService.addNotification({
-                type: 'success',
-                message: 'Horizontal pod autoscaler ' + hpa.metadata.name + ' successfully created.'
-              });
-
-              navigateBack();
-            }, function(result) { // Failure
-              $scope.disableInputs = false;
-              NotificationsService.addNotification({
-                id: 'edit-hpa-error',
-                type: 'error',
-                message: 'An error occurred creating the horizontal pod autoscaler.',
-                details: getErrorDetails(result)
-              });
-            });
-        };
-
         var updateHPA = function(hpa) {
           $scope.disableInputs = true;
 
@@ -177,6 +135,47 @@ angular.module('openshiftConsole')
         }
 
         DataService.get(resourceGroup, $routeParams.name, context).then(function(resource) {
+          var createHPA = function() {
+            $scope.disableInputs = true;
+            hideErrorNotifications();
+            var hpa = {
+              apiVersion: "autoscaling/v1",
+              kind: "HorizontalPodAutoscaler",
+              metadata: {
+                name: $scope.autoscaling.name,
+                labels: keyValueEditorUtils.mapEntries(keyValueEditorUtils.compactEntries($scope.labels))
+              },
+              spec: {
+                scaleTargetRef: {
+                  kind: resource.kind,
+                  name: resource.metadata.name,
+                  apiVersion: resource.apiVersion
+                },
+                minReplicas: $scope.autoscaling.minReplicas,
+                maxReplicas: $scope.autoscaling.maxReplicas,
+                targetCPUUtilizationPercentage: $scope.autoscaling.targetCPU
+              }
+            };
+
+            DataService.create(horizontalPodAutoscalerVersion, null, hpa, context)
+              .then(function(hpa) { // Success
+                NotificationsService.addNotification({
+                  type: 'success',
+                  message: 'Horizontal pod autoscaler ' + hpa.metadata.name + ' successfully created.'
+                });
+
+                navigateBack();
+              }, function(result) { // Failure
+                $scope.disableInputs = false;
+                NotificationsService.addNotification({
+                  id: 'edit-hpa-error',
+                  type: 'error',
+                  message: 'An error occurred creating the horizontal pod autoscaler.',
+                  details: getErrorDetails(result)
+                });
+              });
+          };
+
           $scope.labels = _.map(
                             _.get(resource, 'metadata.labels', {}),
                             function(val, key) {

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7637,7 +7637,52 @@ if (o.canI({
 resource: "horizontalpodautoscalers",
 group: "autoscaling"
 }, l, n.project)) {
-var m = function() {
+var m = function(t) {
+e.disableInputs = !0, (t = angular.copy(t)).metadata.labels = p.mapEntries(p.compactEntries(e.labels)), t.spec.minReplicas = e.autoscaling.minReplicas, t.spec.maxReplicas = e.autoscaling.maxReplicas, t.spec.targetCPUUtilizationPercentage = e.autoscaling.targetCPU, s.update(y, t.metadata.name, t, r).then(function(e) {
+d.addNotification({
+type: "success",
+message: "Horizontal pod autoscaler " + e.metadata.name + " successfully updated."
+}), v();
+}, function(t) {
+e.disableInputs = !1, d.addNotification({
+id: "edit-hpa-error",
+type: "error",
+message: "An error occurred creating the horizontal pod autoscaler.",
+details: g(t)
+});
+});
+}, f = {};
+f = "HorizontalPodAutoscaler" === n.kind ? {
+resource: "horizontalpodautoscalers",
+group: "autoscaling",
+version: "v1"
+} : {
+resource: a.kindToResource(n.kind),
+group: n.group
+}, s.get(f, n.name, r).then(function(a) {
+if (e.labels = _.map(_.get(a, "metadata.labels", {}), function(e, t) {
+return {
+name: t,
+value: e
+};
+}), "HorizontalPodAutoscaler" === n.kind) e.targetKind = _.get(a, "spec.scaleTargetRef.kind"), e.targetName = _.get(a, "spec.scaleTargetRef.name"), _.assign(e.autoscaling, {
+minReplicas: _.get(a, "spec.minReplicas"),
+maxReplicas: _.get(a, "spec.maxReplicas"),
+targetCPU: _.get(a, "spec.targetCPUUtilizationPercentage")
+}), e.disableInputs = !1, e.save = function() {
+m(a);
+}, e.breadcrumbs = i.getBreadcrumbs({
+name: e.targetName,
+kind: e.targetKind,
+namespace: n.project,
+project: t,
+subpage: "Autoscale"
+}); else {
+e.breadcrumbs = i.getBreadcrumbs({
+object: a,
+project: t,
+subpage: "Autoscale"
+}), e.save = function() {
 e.disableInputs = !0, h();
 var t = {
 apiVersion: "autoscaling/v1",
@@ -7648,10 +7693,9 @@ labels: p.mapEntries(p.compactEntries(e.labels))
 },
 spec: {
 scaleTargetRef: {
-kind: n.kind,
-name: n.name,
-apiVersion: "extensions/v1beta1",
-subresource: "scale"
+kind: a.kind,
+name: a.metadata.name,
+apiVersion: a.apiVersion
 },
 minReplicas: e.autoscaling.minReplicas,
 maxReplicas: e.autoscaling.maxReplicas,
@@ -7671,52 +7715,7 @@ message: "An error occurred creating the horizontal pod autoscaler.",
 details: g(t)
 });
 });
-}, f = function(t) {
-e.disableInputs = !0, (t = angular.copy(t)).metadata.labels = p.mapEntries(p.compactEntries(e.labels)), t.spec.minReplicas = e.autoscaling.minReplicas, t.spec.maxReplicas = e.autoscaling.maxReplicas, t.spec.targetCPUUtilizationPercentage = e.autoscaling.targetCPU, s.update(y, t.metadata.name, t, r).then(function(e) {
-d.addNotification({
-type: "success",
-message: "Horizontal pod autoscaler " + e.metadata.name + " successfully updated."
-}), v();
-}, function(t) {
-e.disableInputs = !1, d.addNotification({
-id: "edit-hpa-error",
-type: "error",
-message: "An error occurred creating the horizontal pod autoscaler.",
-details: g(t)
-});
-});
-}, S = {};
-S = "HorizontalPodAutoscaler" === n.kind ? {
-resource: "horizontalpodautoscalers",
-group: "autoscaling",
-version: "v1"
-} : {
-resource: a.kindToResource(n.kind),
-group: n.group
-}, s.get(S, n.name, r).then(function(a) {
-if (e.labels = _.map(_.get(a, "metadata.labels", {}), function(e, t) {
-return {
-name: t,
-value: e
 };
-}), "HorizontalPodAutoscaler" === n.kind) e.targetKind = _.get(a, "spec.scaleTargetRef.kind"), e.targetName = _.get(a, "spec.scaleTargetRef.name"), _.assign(e.autoscaling, {
-minReplicas: _.get(a, "spec.minReplicas"),
-maxReplicas: _.get(a, "spec.maxReplicas"),
-targetCPU: _.get(a, "spec.targetCPUUtilizationPercentage")
-}), e.disableInputs = !1, e.save = function() {
-f(a);
-}, e.breadcrumbs = i.getBreadcrumbs({
-name: e.targetName,
-kind: e.targetKind,
-namespace: n.project,
-project: t,
-subpage: "Autoscale"
-}); else {
-e.breadcrumbs = i.getBreadcrumbs({
-object: a,
-project: t,
-subpage: "Autoscale"
-}), e.save = m;
 var o = {}, l = function() {
 var n = _.get(a, "spec.template.spec.containers", []);
 e.showCPURequestWarning = !c.hasCPURequest(n, o, t);


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1540916

I had to move the function inside the data service callback, so the diff is larger than it looks. This changes the HPA scale target to use the correct group/version for the resource being scaled.

/assign @jwforres 
/cc @DirectXMan12 