### PR TITLE
Create ability to read annotation accessMode from StorageClasses

### DIFF
--- a/app/scripts/directives/oscPersistentVolumeClaim.js
+++ b/app/scripts/directives/oscPersistentVolumeClaim.js
@@ -24,12 +24,15 @@ angular.module("openshiftConsole")
       templateUrl: 'views/directives/osc-persistent-volume-claim.html',
       link: function(scope) {
         var amountAndUnit = $filter('amountAndUnit');
+        var storageClassAccessMode = $filter('storageClassAccessMode');
         var usageValue = $filter('usageValue');
 
         scope.nameValidation = DNS1123_SUBDOMAIN_VALIDATION;
 
         scope.storageClasses = [];
         scope.defaultStorageClass = "";
+        // Default to ReadWriteOnce access mode for new PVCs.
+        scope.claim.accessModes = 'ReadWriteOnce';
         scope.claim.unit = 'Gi';
         scope.units = [{
           value: "Mi",
@@ -84,6 +87,14 @@ angular.module("openshiftConsole")
 
         scope.showComputeUnitsHelp = function() {
           ModalsService.showComputeUnitsHelp();
+        };
+
+        scope.onStorageClassSelected = function(storageClass) {
+          // Update to use the access mode from the storage class if set.
+          var accessMode = storageClassAccessMode(storageClass);
+          if (accessMode) {
+            scope.claim.accessModes = accessMode;
+          }
         };
 
         var validateLimitRange = function() {

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -7,6 +7,11 @@ angular.module('openshiftConsole')
       return annotationFilter(pvc, 'volume.beta.kubernetes.io/storage-class');
     };
   })
+  .filter('storageClassAccessMode', function(annotationFilter) {
+    return function(storageClass) {
+      return annotationFilter(storageClass, 'storage.alpha.openshift.io/access-mode');
+    };
+  })
   .filter('tags', function(annotationFilter) {
     return function(resource, /* optional */ annotationKey) {
       annotationKey = annotationKey || "tags";

--- a/app/views/directives/osc-persistent-volume-claim.html
+++ b/app/views/directives/osc-persistent-volume-claim.html
@@ -8,11 +8,11 @@
       </div>
     </div>
     <div ng-if="storageClasses.length" class="form-group">
-      <!--storage class-->
       <label>Storage Class</label>
       <div>
         <ui-select
           ng-model="claim.storageClass"
+          on-select="onStorageClassSelected($item)"
           theme="bootstrap"
           search-enabled="true"
           title="Select a storage class"
@@ -26,8 +26,8 @@
             repeat="sclass as sclass in storageClasses | toArray | filter : { metadata: { name: $select.search } } ">
             <div>
               <span ng-bind-html="sclass.metadata.name  | highlight : $select.search"></span>
-              <span ng-if="sclass.parameters.type || sclass.parameters.zone || (sclass | description)" class="text-muted">
-                <small>&ndash;
+              <div ng-if="sclass.parameters.type || sclass.parameters.zone || (sclass | description) || (sclass | storageClassAccessMode)" class="text-muted">
+                <small>
                   <span ng-if="sclass.parameters.type">
                     Type: {{sclass.parameters.type}}
                   </span>
@@ -35,12 +35,16 @@
                     <span ng-if="sclass.parameters.type">|</span>
                     Zone: {{sclass.parameters.zone}}
                   </span>
-                  <span ng-if="sclass | description">
+                  <span ng-if="(sclass | storageClassAccessMode)">
                     <span ng-if="sclass.parameters.type || sclass.parameters.zone">|</span>
+                    Access: {{sclass | storageClassAccessMode}}
+                  </span>
+                  <span ng-if="sclass | description">
+                    <span ng-if="sclass.parameters.type || sclass.parameters.zone || (sclass | storageClassAccessMode)">|</span>
                     {{sclass | description}}
                   </span>
                 </small>
-              </span>
+              </div>
             </div>
           </ui-select-choices>
         </ui-select>
@@ -96,20 +100,31 @@
       </div>
     </div>
 
-    <div class="form-group" >
-      <label class="required">Access Mode</label><br/>
-      <label class="radio-inline">
-        <input type="radio" name="accessModes" ng-model="claim.accessModes" value="ReadWriteOnce" aria-describedby="access-modes-help" ng-checked="true" >
-        Single User (RWO)
-      </label>
-      <label class="radio-inline">
-        <input type="radio" id="accessModes" name="accessModes" ng-model="claim.accessModes" value="ReadWriteMany" aria-describedby="access-modes-help" >
-        Shared Access (RWX)
-      </label>
-      <label class="radio-inline">
-        <input type="radio" name="accessModes" ng-model="claim.accessModes" value="ReadOnlyMany" aria-describedby="access-modes-help">
-        Read Only (ROX)
-      </label>
+    <div class="form-group mar-bottom-xl" >
+      <label class="required">Access Mode</label>
+      <span ng-if="claim.storageClass && (claim.storageClass | storageClassAccessMode)" class="static-form-value-large">
+        <small>(cannot be changed)</small>
+      </span>
+      <div>
+        <label class="radio-inline">
+          <input type="radio" name="accessModes" ng-model="claim.accessModes" value="ReadWriteOnce"
+                 aria-describedby="access-modes-help" ng-true-value="’1’" ng-false-value="’0’"
+                 ng-disabled="(claim.storageClass | storageClassAccessMode)">
+          Single User (RWO)
+        </label>
+        <label class="radio-inline">
+          <input type="radio" id="accessModes" name="accessModes" ng-model="claim.accessModes" value="ReadWriteMany"
+                 aria-describedby="access-modes-help" ng-true-value="’1’" ng-false-value="’0’"
+                 ng-disabled="(claim.storageClass | storageClassAccessMode)">
+          Shared Access (RWX)
+        </label>
+        <label class="radio-inline">
+          <input type="radio" name="accessModes" ng-model="claim.accessModes" value="ReadOnlyMany"
+                 aria-describedby="access-modes-help" ng-true-value="’1’" ng-false-value="’0’"
+                 ng-disabled="(claim.storageClass | storageClassAccessMode)">
+          Read Only (ROX)
+        </label>
+      </div>
       <div>
         <span id="access-modes-help" class="help-block">Permissions to the mounted volume.</span>
       </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10180,8 +10180,8 @@ projectName: "="
 },
 templateUrl: "views/directives/osc-persistent-volume-claim.html",
 link: function(t) {
-var d = e("amountAndUnit"), m = e("usageValue");
-t.nameValidation = i, t.storageClasses = [], t.defaultStorageClass = "", t.claim.unit = "Gi", t.units = [ {
+var d = e("amountAndUnit"), m = e("storageClassAccessMode"), p = e("usageValue");
+t.nameValidation = i, t.storageClasses = [], t.defaultStorageClass = "", t.claim.accessModes = "ReadWriteOnce", t.claim.unit = "Gi", t.units = [ {
 value: "Mi",
 label: "MiB"
 }, {
@@ -10200,9 +10200,9 @@ label: "GB"
 value: "T",
 label: "TB"
 } ], t.claim.selectedLabels = [];
-var p = [];
+var f = [];
 t.$watch("useLabels", function(e, n) {
-e !== n && (e ? t.claim.selectedLabels = p : (p = t.claim.selectedLabels, t.claim.selectedLabels = []));
+e !== n && (e ? t.claim.selectedLabels = f : (f = t.claim.selectedLabels, t.claim.selectedLabels = []));
 }), t.groupUnits = function(e) {
 switch (e.value) {
 case "Mi":
@@ -10218,11 +10218,14 @@ return "Decimal Units";
 return "";
 }, t.showComputeUnitsHelp = function() {
 o.showComputeUnitsHelp();
+}, t.onStorageClassSelected = function(e) {
+var n = m(e);
+n && (t.claim.accessModes = n);
 };
-var f = function() {
-var e = t.claim.amount && m(t.claim.amount + t.claim.unit), n = _.has(t, "limits.min") && m(t.limits.min), r = _.has(t, "limits.max") && m(t.limits.max), a = !0, o = !0;
+var g = function() {
+var e = t.claim.amount && p(t.claim.amount + t.claim.unit), n = _.has(t, "limits.min") && p(t.limits.min), r = _.has(t, "limits.max") && p(t.limits.max), a = !0, o = !0;
 e && n && (a = e >= n), e && r && (o = e <= r), t.persistentVolumeClaimForm.capacity.$setValidity("limitRangeMin", a), t.persistentVolumeClaimForm.capacity.$setValidity("limitRangeMax", o);
-}, g = function() {
+}, v = function() {
 var e = a.isAnyStorageQuotaExceeded(t.quotas, t.clusterQuotas), n = a.willRequestExceedQuota(t.quotas, t.clusterQuotas, "requests.storage", t.claim.amount + t.claim.unit);
 t.persistentVolumeClaimForm.capacity.$setValidity("willExceedStorage", !n), t.persistentVolumeClaimForm.capacity.$setValidity("outOfClaims", !e);
 };
@@ -10255,12 +10258,12 @@ var n = e.by("metadata.name");
 if (!_.isEmpty(n)) {
 t.limits = r.getEffectiveLimitRange(n, "storage", "PersistentVolumeClaim");
 var a;
-t.limits.min && t.limits.max && m(t.limits.min) === m(t.limits.max) && (a = d(t.limits.max), t.claim.amount = Number(a[0]), t.claim.unit = a[1], t.capacityReadOnly = !0), t.$watchGroup([ "claim.amount", "claim.unit" ], f);
+t.limits.min && t.limits.max && p(t.limits.min) === p(t.limits.max) && (a = d(t.limits.max), t.claim.amount = Number(a[0]), t.claim.unit = a[1], t.capacityReadOnly = !0), t.$watchGroup([ "claim.amount", "claim.unit" ], g);
 }
 }), n.list(l, {
 namespace: t.projectName
 }, function(e) {
-t.quotas = e.by("metadata.name"), t.$watchGroup([ "claim.amount", "claim.unit" ], g);
+t.quotas = e.by("metadata.name"), t.$watchGroup([ "claim.amount", "claim.unit" ], v);
 }), n.list(u, {
 namespace: t.projectName
 }, function(e) {
@@ -15090,6 +15093,10 @@ return (r < 0 || a < 0 || o < 0) && (r = a = o = 0), r && t.push(r + "h"), a && 
 }), angular.module("openshiftConsole").filter("storageClass", [ "annotationFilter", function(e) {
 return function(t) {
 return e(t, "volume.beta.kubernetes.io/storage-class");
+};
+} ]).filter("storageClassAccessMode", [ "annotationFilter", function(e) {
+return function(t) {
+return e(t, "storage.alpha.openshift.io/access-mode");
 };
 } ]).filter("tags", [ "annotationFilter", function(e) {
 return function(t, n) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8192,10 +8192,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"storageClasses.length\" class=\"form-group\">\n" +
-    "\n" +
     "<label>Storage Class</label>\n" +
     "<div>\n" +
-    "<ui-select ng-model=\"claim.storageClass\" theme=\"bootstrap\" search-enabled=\"true\" title=\"Select a storage class\" class=\"select-role\">\n" +
+    "<ui-select ng-model=\"claim.storageClass\" on-select=\"onStorageClassSelected($item)\" theme=\"bootstrap\" search-enabled=\"true\" title=\"Select a storage class\" class=\"select-role\">\n" +
     "<ui-select-match placeholder=\"Select a storage class\">\n" +
     "<span>\n" +
     "{{$select.selected.metadata.name}}\n" +
@@ -8204,8 +8203,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<ui-select-choices repeat=\"sclass as sclass in storageClasses | toArray | filter : { metadata: { name: $select.search } } \">\n" +
     "<div>\n" +
     "<span ng-bind-html=\"sclass.metadata.name  | highlight : $select.search\"></span>\n" +
-    "<span ng-if=\"sclass.parameters.type || sclass.parameters.zone || (sclass | description)\" class=\"text-muted\">\n" +
-    "<small>&ndash;\n" +
+    "<div ng-if=\"sclass.parameters.type || sclass.parameters.zone || (sclass | description) || (sclass | storageClassAccessMode)\" class=\"text-muted\">\n" +
+    "<small>\n" +
     "<span ng-if=\"sclass.parameters.type\">\n" +
     "Type: {{sclass.parameters.type}}\n" +
     "</span>\n" +
@@ -8213,12 +8212,16 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"sclass.parameters.type\">|</span>\n" +
     "Zone: {{sclass.parameters.zone}}\n" +
     "</span>\n" +
-    "<span ng-if=\"sclass | description\">\n" +
+    "<span ng-if=\"(sclass | storageClassAccessMode)\">\n" +
     "<span ng-if=\"sclass.parameters.type || sclass.parameters.zone\">|</span>\n" +
+    "Access: {{sclass | storageClassAccessMode}}\n" +
+    "</span>\n" +
+    "<span ng-if=\"sclass | description\">\n" +
+    "<span ng-if=\"sclass.parameters.type || sclass.parameters.zone || (sclass | storageClassAccessMode)\">|</span>\n" +
     "{{sclass | description}}\n" +
     "</span>\n" +
     "</small>\n" +
-    "</span>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
@@ -8256,20 +8259,25 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</span>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div class=\"form-group\">\n" +
-    "<label class=\"required\">Access Mode</label><br/>\n" +
+    "<div class=\"form-group mar-bottom-xl\">\n" +
+    "<label class=\"required\">Access Mode</label>\n" +
+    "<span ng-if=\"claim.storageClass && (claim.storageClass | storageClassAccessMode)\" class=\"static-form-value-large\">\n" +
+    "<small>(cannot be changed)</small>\n" +
+    "</span>\n" +
+    "<div>\n" +
     "<label class=\"radio-inline\">\n" +
-    "<input type=\"radio\" name=\"accessModes\" ng-model=\"claim.accessModes\" value=\"ReadWriteOnce\" aria-describedby=\"access-modes-help\" ng-checked=\"true\">\n" +
+    "<input type=\"radio\" name=\"accessModes\" ng-model=\"claim.accessModes\" value=\"ReadWriteOnce\" aria-describedby=\"access-modes-help\" ng-true-value=\"’1’\" ng-false-value=\"’0’\" ng-disabled=\"(claim.storageClass | storageClassAccessMode)\">\n" +
     "Single User (RWO)\n" +
     "</label>\n" +
     "<label class=\"radio-inline\">\n" +
-    "<input type=\"radio\" id=\"accessModes\" name=\"accessModes\" ng-model=\"claim.accessModes\" value=\"ReadWriteMany\" aria-describedby=\"access-modes-help\">\n" +
+    "<input type=\"radio\" id=\"accessModes\" name=\"accessModes\" ng-model=\"claim.accessModes\" value=\"ReadWriteMany\" aria-describedby=\"access-modes-help\" ng-true-value=\"’1’\" ng-false-value=\"’0’\" ng-disabled=\"(claim.storageClass | storageClassAccessMode)\">\n" +
     "Shared Access (RWX)\n" +
     "</label>\n" +
     "<label class=\"radio-inline\">\n" +
-    "<input type=\"radio\" name=\"accessModes\" ng-model=\"claim.accessModes\" value=\"ReadOnlyMany\" aria-describedby=\"access-modes-help\">\n" +
+    "<input type=\"radio\" name=\"accessModes\" ng-model=\"claim.accessModes\" value=\"ReadOnlyMany\" aria-describedby=\"access-modes-help\" ng-true-value=\"’1’\" ng-false-value=\"’0’\" ng-disabled=\"(claim.storageClass | storageClassAccessMode)\">\n" +
     "Read Only (ROX)\n" +
     "</label>\n" +
+    "</div>\n" +
     "<div>\n" +
     "<span id=\"access-modes-help\" class=\"help-block\">Permissions to the mounted volume.</span>\n" +
     "</div>\n" +


### PR DESCRIPTION
Create ability to read annotation accessMode from StorageClasses so that users do not have the option to select an access mode that is different from how the storage class is defined. Annotation is in the metadata section under annotations:
kind: StorageClass
apiVersion: storage.k8s.io/v1beta1
metadata:
  name: gold
  annotations:
    description: Gold is a storage class for showing gold level
    storage.alpha.openshift.io/access-mode: ReadWriteMany
provisioner: kubernetes.io/aws-ebs
parameters:
  type: gp2
  zone: us-east-1d

Drop down now shows if accessMode is defined in storageClass annotation, also separated description to new line:
![annotations2-newstoragedropdown](https://user-images.githubusercontent.com/18728857/36394040-9ae0974c-156f-11e8-8916-9876d8259abd.png)


If annotation is defined, access mode pre selected and disabled:
![annotations4-storageclassselected](https://user-images.githubusercontent.com/18728857/36394054-ade971a6-156f-11e8-82d5-25090731439c.png)


If the storage class has no annotation for the access mode, the access mode will still be visible:
![annotations3-nostorageclassselected](https://user-images.githubusercontent.com/18728857/36394061-b6d0dd18-156f-11e8-974d-1b50f947d7e9.png)


@erinboyd @spadgett @jwforres @ncameronbritt 



