### PR TITLE
BC's build secret destination dir label and help-text are not align properly

### DIFF
--- a/app/styles/_secrets.less
+++ b/app/styles/_secrets.less
@@ -47,9 +47,9 @@
         width: 50%;
         display: inline-block;
       }
-      .destination-dir {
-        padding-left: 5px;
-      }
+    }
+    .destination-dir-padding {
+      padding-left: 5px;
     }
   }
 }

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -288,7 +288,7 @@
                               <div class="is-item-description">
                                 <dt>Paths:</dt>
                                 <div ng-repeat="(source, destination) in imageSourcesPaths[$index]" class="image-source-paths">
-                                  <dd><span class="source-path">{{source}}</span><i class="fa fa-long-arrow-right"></i><span class="destination-dir">{{destination}}</span></dd>
+                                  <dd><span class="source-path">{{source}}</span><i class="fa fa-long-arrow-right" aria-hidden="true"></i><span class="destination-dir">{{destination}}</span></dd>
                                 </div>
                               </div>
                             </dl>

--- a/app/views/directives/osc-source-secrets.html
+++ b/app/views/directives/osc-source-secrets.html
@@ -7,7 +7,7 @@
           <label class="input-label">
             Build Secret
           </label>
-          <label class="input-label">
+          <label class="input-label destination-dir-padding">
             Destination Directory
           </label>
         </div>
@@ -21,7 +21,7 @@
                 </ui-select-choices>
               </ui-select>
             </div>
-            <div class="destination-dir">
+            <div class="destination-dir destination-dir-padding">
               <input class="form-control"
                 id="destinationDir"
                 name="destinationDir"
@@ -42,7 +42,7 @@
         </div>
         <div class="help-blocks">
             <div class="help-block">Source secret to copy into the builder pod at build time.</div>
-            <div class="help-block">Directory where the files will be available at build time.</div>
+            <div class="help-block destination-dir-padding">Directory where the files will be available at build time.</div>
         </div>
       </div>
     </div>
@@ -55,7 +55,7 @@
           <label class="input-label">
             Build Secret
           </label>
-          <label class="input-label">
+          <label class="input-label destination-dir-padding">
             Mount path
           </label>
         </div>
@@ -69,7 +69,7 @@
                 </ui-select-choices>
               </ui-select>
             </div>
-            <div class="destination-dir">
+            <div class="destination-dir destination-dir-padding">
               <input class="form-control"
                 id="mountPath"
                 name="mountPath"
@@ -89,8 +89,8 @@
           </div>
         </div>
         <div class="help-blocks">
-            <div class="help-block">Source secret to mount into the builder pod at build time.</div>
-            <div class="help-block">Path at which to mount the secret.</div>
+          <div class="help-block">Source secret to mount into the builder pod at build time.</div>
+          <div class="help-block destination-dir-padding">Path at which to mount the secret.</div>
         </div>
       </div>
     </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1801,7 +1801,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"is-item-description\">\n" +
     "<dt>Paths:</dt>\n" +
     "<div ng-repeat=\"(source, destination) in imageSourcesPaths[$index]\" class=\"image-source-paths\">\n" +
-    "<dd><span class=\"source-path\">{{source}}</span><i class=\"fa fa-long-arrow-right\"></i><span class=\"destination-dir\">{{destination}}</span></dd>\n" +
+    "<dd><span class=\"source-path\">{{source}}</span><i class=\"fa fa-long-arrow-right\" aria-hidden=\"true\"></i><span class=\"destination-dir\">{{destination}}</span></dd>\n" +
     "</div>\n" +
     "</div>\n" +
     "</dl>\n" +
@@ -8750,7 +8750,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<label class=\"input-label\">\n" +
     "Build Secret\n" +
     "</label>\n" +
-    "<label class=\"input-label\">\n" +
+    "<label class=\"input-label destination-dir-padding\">\n" +
     "Destination Directory\n" +
     "</label>\n" +
     "</div>\n" +
@@ -8764,7 +8764,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
     "</div>\n" +
-    "<div class=\"destination-dir\">\n" +
+    "<div class=\"destination-dir destination-dir-padding\">\n" +
     "<input class=\"form-control\" id=\"destinationDir\" name=\"destinationDir\" ng-model=\"pickedSecret.destinationDir\" type=\"text\" placeholder=\"/\" autocorrect=\"off\" autocapitalize=\"none\" spellcheck=\"false\">\n" +
     "</div>\n" +
     "<div class=\"remove-secret\">\n" +
@@ -8777,7 +8777,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"help-blocks\">\n" +
     "<div class=\"help-block\">Source secret to copy into the builder pod at build time.</div>\n" +
-    "<div class=\"help-block\">Directory where the files will be available at build time.</div>\n" +
+    "<div class=\"help-block destination-dir-padding\">Directory where the files will be available at build time.</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -8789,7 +8789,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<label class=\"input-label\">\n" +
     "Build Secret\n" +
     "</label>\n" +
-    "<label class=\"input-label\">\n" +
+    "<label class=\"input-label destination-dir-padding\">\n" +
     "Mount path\n" +
     "</label>\n" +
     "</div>\n" +
@@ -8803,7 +8803,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</ui-select-choices>\n" +
     "</ui-select>\n" +
     "</div>\n" +
-    "<div class=\"destination-dir\">\n" +
+    "<div class=\"destination-dir destination-dir-padding\">\n" +
     "<input class=\"form-control\" id=\"mountPath\" name=\"mountPath\" ng-model=\"pickedSecret.mountPath\" type=\"text\" placeholder=\"/\" autocorrect=\"off\" autocapitalize=\"none\" spellcheck=\"false\">\n" +
     "</div>\n" +
     "<div class=\"remove-secret\">\n" +
@@ -8816,7 +8816,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"help-blocks\">\n" +
     "<div class=\"help-block\">Source secret to mount into the builder pod at build time.</div>\n" +
-    "<div class=\"help-block\">Path at which to mount the secret.</div>\n" +
+    "<div class=\"help-block destination-dir-padding\">Path at which to mount the secret.</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5668,7 +5668,7 @@ td.visible-print,th.visible-print{display:table-cell!important}
 .osc-secrets-form .advanced-secrets .secret-row .remove-secret,.osc-secrets-form .basic-secrets .secret-row .remove-secret{position:absolute;right:0;top:0}
 .osc-secrets-form .advanced-secrets .help-blocks .help-block,.osc-secrets-form .advanced-secrets .help-blocks .input-label,.osc-secrets-form .advanced-secrets .input-labels .help-block,.osc-secrets-form .advanced-secrets .input-labels .input-label{width:50%}
 .osc-secrets-form .advanced-secrets .secret-row .destination-dir,.osc-secrets-form .advanced-secrets .secret-row .secret-name{width:50%;display:inline-block}
-.osc-secrets-form .advanced-secrets .secret-row .destination-dir{padding-left:5px}
+.osc-secrets-form .advanced-secrets .destination-dir-padding{padding-left:5px}
 dl.secret-data dd{margin-bottom:10px}
 dl.secret-data dt{margin-bottom:5px}
 @media (min-width:992px){dl.secret-data dd{margin-left:180px}


### PR DESCRIPTION
Replacing `destination-dir` class with `secrets-location` that should be added on both `label` and `div.help-block` elements that are surrounding the *Destination Directory* and *Mount path* input fields.
Screen for both Source and Custom build configs:
![download 2](https://user-images.githubusercontent.com/1668218/36097598-d9931e34-0ffb-11e8-942b-598461b0d76c.png)

![download](https://user-images.githubusercontent.com/1668218/36097515-96495508-0ffb-11e8-9f08-45a405264de3.png)

Fixes https://github.com/openshift/origin-web-console/issues/2775