### PR TITLE
Fix bugzilla 1545011: cpu input disappears in edit autoscaler if value set to 0

### DIFF
--- a/app/scripts/directives/oscAutoscaling.js
+++ b/app/scripts/directives/oscAutoscaling.js
@@ -14,7 +14,10 @@ angular.module("openshiftConsole")
         autoscaling: "=model",
         showNameInput: "=?",
         nameReadOnly: "=?",
-        showRequestInput: "=?"
+        // one way binding allows this field to be hidden if the
+        // autoscaler is not using cpuRequest, but the field should
+        // not disappear if a user edits it
+        showRequestInput: "&"
       },
       templateUrl: 'views/directives/osc-autoscaling.html',
       link: function(scope, elem, attrs) {
@@ -31,6 +34,7 @@ angular.module("openshiftConsole")
         if( !('showRequestInput' in attrs) ) {
           scope.showRequestInput = true;
         }
+
       }
     };
   });

--- a/app/views/edit/autoscaler.html
+++ b/app/views/edit/autoscaler.html
@@ -52,7 +52,7 @@
                   model="autoscaling"
                   show-name-input="true"
                   name-read-only="kind === 'HorizontalPodAutoscaler'"
-                  show-request-input="autoscaling.targetCPU">
+                  show-request-input="autoscaling.targetCPU && !(usesV2Metrics)">
               </osc-autoscaling>
 
               <label-editor

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10269,7 +10269,7 @@ scope: {
 autoscaling: "=model",
 showNameInput: "=?",
 nameReadOnly: "=?",
-showRequestInput: "=?"
+showRequestInput: "&"
 },
 templateUrl: "views/directives/osc-autoscaling.html",
 link: function(t, r, a) {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -9500,7 +9500,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<a href=\"command-line\" target=\"_blank\">command line tools</a>.\n" +
     "</div>\n" +
     "<fieldset ng-disabled=\"disableInputs\" class=\"gutter-top\">\n" +
-    "<osc-autoscaling model=\"autoscaling\" show-name-input=\"true\" name-read-only=\"kind === 'HorizontalPodAutoscaler'\" show-request-input=\"autoscaling.targetCPU\">\n" +
+    "<osc-autoscaling model=\"autoscaling\" show-name-input=\"true\" name-read-only=\"kind === 'HorizontalPodAutoscaler'\" show-request-input=\"autoscaling.targetCPU && !(usesV2Metrics)\">\n" +
     "</osc-autoscaling>\n" +
     "<label-editor labels=\"labels\" expand=\"true\" can-toggle=\"false\"></label-editor>\n" +
     "<div class=\"buttons gutter-top gutter-bottom\">\n" +


### PR DESCRIPTION
Part of the work to tolerate v2beta1 autoscalers.

- if the user sets the cpu input to `0`, the input would disappear
- this change makes the attribute bound one-way, which ensures we can hide it on load (if the appropriate conditions are met) but that the user input doesn't flip the `ng-show` to a falsy value while editing.  It should be set to false by the controller only if it is already falsy && metrics are in use.