### PR TITLE
Prevent pod-template and section-label from abutting next to metrics …

### DIFF
--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -631,13 +631,13 @@
     }
     .overview-pod-template {
       flex: 1 1 auto;
-      .pod-template-block {
-        // add space so text can't touch metrics or doughnut
-        padding-right: 10px;
-        &.ng-leave-prepare {
-          // prevent previous-donut initial "flash" before animation
-          display: none;
-        }
+      // preview .section-label underline and pod-template text from touching metrics when they are next to each other >1200px
+      @media(min-width: @screen-lg-min) {
+        padding-right: (@grid-gutter-width / 2);
+      }
+      .pod-template-block.ng-leave-prepare {
+        // prevent previous-donut initial "flash" before animation
+        display: none;
       }
     }
   }

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5372,8 +5372,6 @@ h2+.list-view-pf{margin-top:20px}
 100%{transform:translateX(0)}
 }
 .overview .row-expanded-top{display:flex;flex-wrap:wrap;justify-content:space-between}
-@media (min-width:1200px){.overview .row-expanded-top .overview-animation-block,.overview .row-expanded-top .overview-pod-template{width:50%}
-}
 .overview .row-expanded-top .overview-animation-block{display:flex;flex:1 1 auto;justify-content:center}
 @media (min-width:768px){.overview .row-expanded-top .overview-animation-block.animation-in-progress .overview-deployment-donut .latest-donut{justify-content:flex-end}
 }
@@ -5407,7 +5405,9 @@ h2+.list-view-pf{margin-top:20px}
 }
 .overview .row-expanded-top.metrics-not-active .overview-pod-template{width:50%}
 .overview .row-expanded-top .overview-pod-template{flex:1 1 auto}
-.overview .row-expanded-top .overview-pod-template .pod-template-block{padding-right:10px}
+@media (min-width:1200px){.overview .row-expanded-top .overview-animation-block,.overview .row-expanded-top .overview-pod-template{width:50%}
+.overview .row-expanded-top .overview-pod-template{padding-right:20px}
+}
 .overview .row-expanded-top .overview-pod-template .pod-template-block.ng-leave-prepare{display:none}
 @keyframes flexGrow{to{flex-basis:auto;flex-grow:1;flex-shrink:1}
 }


### PR DESCRIPTION
…when they are next one another

Fixes https://github.com/openshift/origin-web-console/issues/2851

<img width="865" alt="screen shot 2018-02-23 at 4 01 29 pm" src="https://user-images.githubusercontent.com/1874151/36616788-0c3aa6a8-18b3-11e8-8c5d-3a1a80d05aca.png">
