### PR TITLE
Bug 1549060 - Update OpenShift URL on about page

### DIFF
--- a/app/views/about.html
+++ b/app/views/about.html
@@ -12,7 +12,7 @@
                 <h1>Red Hat OpenShift <span class="about-reg">&reg;</span></h1>
                 <h2>About</h2>
                 <p>
-                  <a target="_blank" href="https://openshift.com">OpenShift</a> is Red Hat's container application platform
+                  <a target="_blank" href="https://www.openshift.com">OpenShift</a> is Red Hat's container application platform
                   that allows developers to quickly develop, host, and scale applications in a cloud environment.
                 </p>
 

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -715,7 +715,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<h1>Red Hat OpenShift <span class=\"about-reg\">&reg;</span></h1>\n" +
     "<h2>About</h2>\n" +
     "<p>\n" +
-    "<a target=\"_blank\" href=\"https://openshift.com\">OpenShift</a> is Red Hat's container application platform that allows developers to quickly develop, host, and scale applications in a cloud environment.\n" +
+    "<a target=\"_blank\" href=\"https://www.openshift.com\">OpenShift</a> is Red Hat's container application platform that allows developers to quickly develop, host, and scale applications in a cloud environment.\n" +
     "</p>\n" +
     "<h2 id=\"version\">Version</h2>\n" +
     "<dl class=\"dl-horizontal left\">\n" +


### PR DESCRIPTION
Use `https://www.openshift.com` instead of `https://openshift.com`.

https://bugzilla.redhat.com/show_bug.cgi?id=1549060

/assign @rhamilto 
cc @damemi 