### PR TITLE
Bug 1527689 - Let users add the same PVC multiple times

### DIFF
--- a/app/views/attach-pvc.html
+++ b/app/views/attach-pvc.html
@@ -44,9 +44,10 @@
                             name="persistentVolumeClaim"
                             ng-model="attach.persistentVolumeClaim"
                             ng-value="pvc"
+                            ng-change="onPVCSelected()"
                             aria-describedby="pvc-help">
                         </td>
-                        <td><a ng-href="{{pvc | navigateResourceURL}}">{{pvc.metadata.name}}</a></td>
+                        <td><a ng-href="{{pvc | navigateResourceURL}}" target="_blank">{{pvc.metadata.name}}</a></td>
                         <td ng-if="pvc.spec.volumeName">{{pvc.status.capacity['storage'] | usageWithUnits: 'storage'}}</td>
                         <td ng-if="!pvc.spec.volumeName">{{pvc.spec.resources.requests['storage'] | usageWithUnits: 'storage'}}</td>
                         <td>({{pvc.spec.accessModes | accessModes | join}})</td>
@@ -135,6 +136,7 @@
                     Volume name must conform to a DNS label
                     https://github.com/kubernetes/kubernetes/blob/master/docs/design/identifiers.md
                     https://github.com/kubernetes/kubernetes/blob/d7a87c228506ed11240049ae95cbb4efb07fd178/pkg/util/validation/validation.go#L61-L70
+                    Reuse the volume name and disable uniqueness validation if it's already mounted under another mount path / subpath.
                   -->
                   <input
                       id="volume-path"
@@ -142,8 +144,10 @@
                       type="text"
                       name="volumeName"
                       ng-model="attach.volumeName"
-                      osc-unique="existingVolumeNames"
                       ng-pattern="/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/"
+                      ng-readonly="volumeAlreadyMounted"
+                      osc-unique="existingVolumeNames"
+                      osc-unique-disabled="volumeAlreadyMounted"
                       maxlength="63"
                       placeholder="(generated if empty)"
                       autocorrect="off"

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -8684,6 +8684,18 @@ var e = _.get(n, "attach.resource.spec.template");
 n.existingMountPaths = m.getMountPaths(e, P);
 };
 n.$watchGroup([ "attach.resource", "attach.allContainers" ], j), n.$watch("attach.containers", j, !0);
+var k = function() {
+var e = _.get(n, "attach.persistentVolumeClaim");
+if (e) {
+var t = _.get(n, "attach.resource.spec.template.spec.volumes"), r = _.find(t, {
+persistentVolumeClaim: {
+claimName: e.metadata.name
+}
+});
+r ? (n.attach.volumeName = r.name, n.volumeAlreadyMounted = !0) : n.volumeAlreadyMounted && (n.attach.volumeName = "", n.volumeAlreadyMounted = !1);
+}
+};
+n.onPVCSelected = k;
 s.get(v, t.name, d).then(function(e) {
 n.attach.resource = e, n.breadcrumbs = i.getBreadcrumbs({
 object: e,
@@ -8691,11 +8703,11 @@ project: a,
 subpage: "Add Storage"
 });
 var t = _.get(e, "spec.template");
-n.existingVolumeNames = m.getVolumeNames(t);
+n.existingVolumeNames = m.getVolumeNames(t), k();
 }, function(e) {
 S(t.name + " could not be loaded.", f(e));
 }), s.list(n.pvcVersion, d).then(function(e) {
-n.pvcs = p(e.by("metadata.name")), _.isEmpty(n.pvcs) || n.attach.persistentVolumeClaim || (n.attach.persistentVolumeClaim = _.head(n.pvcs));
+n.pvcs = p(e.by("metadata.name")), _.isEmpty(n.pvcs) || n.attach.persistentVolumeClaim || (n.attach.persistentVolumeClaim = _.head(n.pvcs), k());
 }), s.list(h, {
 namespace: n.projectName
 }, function(e) {
@@ -8713,9 +8725,7 @@ if (P(e)) {
 var t = m.createVolumeMount(o, i, c, l);
 e.volumeMounts || (e.volumeMounts = []), e.volumeMounts.push(t);
 }
-});
-var p = m.createVolume(o, a);
-r.spec.volumes || (r.spec.volumes = []), r.spec.volumes.push(p), s.update(v, e.metadata.name, n.attach.resource, d).then(function() {
+}), n.volumeAlreadyMounted || (r.spec.volumes = r.spec.volumes || [], r.spec.volumes.push(m.createVolume(o, a))), s.update(v, e.metadata.name, n.attach.resource, d).then(function() {
 var e;
 i || (e = "No mount path was provided. The volume reference was added to the configuration, but it will not be mounted into running pods."), u.addNotification({
 type: "success",

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -943,9 +943,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tbody>\n" +
     "<tr ng-repeat=\"pvc in pvcs track by (pvc | uid)\">\n" +
     "<td style=\"padding-left:0\">\n" +
-    "<input type=\"radio\" name=\"persistentVolumeClaim\" ng-model=\"attach.persistentVolumeClaim\" ng-value=\"pvc\" aria-describedby=\"pvc-help\">\n" +
+    "<input type=\"radio\" name=\"persistentVolumeClaim\" ng-model=\"attach.persistentVolumeClaim\" ng-value=\"pvc\" ng-change=\"onPVCSelected()\" aria-describedby=\"pvc-help\">\n" +
     "</td>\n" +
-    "<td><a ng-href=\"{{pvc | navigateResourceURL}}\">{{pvc.metadata.name}}</a></td>\n" +
+    "<td><a ng-href=\"{{pvc | navigateResourceURL}}\" target=\"_blank\">{{pvc.metadata.name}}</a></td>\n" +
     "<td ng-if=\"pvc.spec.volumeName\">{{pvc.status.capacity['storage'] | usageWithUnits: 'storage'}}</td>\n" +
     "<td ng-if=\"!pvc.spec.volumeName\">{{pvc.spec.resources.requests['storage'] | usageWithUnits: 'storage'}}</td>\n" +
     "<td>({{pvc.spec.accessModes | accessModes | join}})</td>\n" +
@@ -1002,7 +1002,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"form-group\">\n" +
     "<label for=\"volume-name\">Volume Name</label>\n" +
     "\n" +
-    "<input id=\"volume-path\" class=\"form-control\" type=\"text\" name=\"volumeName\" ng-model=\"attach.volumeName\" osc-unique=\"existingVolumeNames\" ng-pattern=\"/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/\" maxlength=\"63\" placeholder=\"(generated if empty)\" autocorrect=\"off\" autocapitalize=\"none\" spellcheck=\"false\" aria-describedby=\"volume-name-help\">\n" +
+    "<input id=\"volume-path\" class=\"form-control\" type=\"text\" name=\"volumeName\" ng-model=\"attach.volumeName\" ng-pattern=\"/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/\" ng-readonly=\"volumeAlreadyMounted\" osc-unique=\"existingVolumeNames\" osc-unique-disabled=\"volumeAlreadyMounted\" maxlength=\"63\" placeholder=\"(generated if empty)\" autocorrect=\"off\" autocapitalize=\"none\" spellcheck=\"false\" aria-describedby=\"volume-name-help\">\n" +
     "<div>\n" +
     "<span id=\"volume-name-help\" class=\"help-block\">Unique name used to identify this volume. If not specified, a volume name is generated.</span>\n" +
     "</div>\n" +


### PR DESCRIPTION
Reuse the same volume name if the PVC has already been added as a volume
to a pod template. This lets users add the same volume more than once
using different mount paths / subpaths.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1527689
Closes #1665

/assign @jwforres 
/cc @erinboyd @zherman0 