### PR TITLE
Bug 1549450 - Better to use the same name for Clear filters, Clear Filter, Clear All Filters

### DIFF
--- a/app/styles/_core.less
+++ b/app/styles/_core.less
@@ -126,6 +126,13 @@ body.ios {
   display: none;
 }
 
+.btn-link.inline-btn-link {
+  font-size: inherit;
+  font-weight: inherit;
+  vertical-align: initial;
+  padding: 0;
+}
+
 .empty-state-message {
   margin: 40px auto 60px;
   max-width: 600px;

--- a/app/views/browse/config-maps.html
+++ b/app/views/browse/config-maps.html
@@ -38,7 +38,7 @@
                 </p>
               </div>
               <div ng-if="filterWithZeroResults">
-                <h2>The filter is hiding all config maps. <a href="" ng-click="clearFilter()" role="button" class="nowrap">Clear Filter</a></h2>
+                <h2>The filter is hiding all config maps. <button type="button" class="btn btn-link inline-btn-link" ng-click="clearFilter()">Clear All Filters</button></h2>
               </div>
             </div>
           </div>

--- a/app/views/browse/routes.html
+++ b/app/views/browse/routes.html
@@ -38,7 +38,7 @@
                 </p>
               </div>
               <div ng-if="filterWithZeroResults">
-                <h2>The filter is hiding all routes. <a href="" ng-click="clearFilter()" role="button" class="nowrap">Clear Filter</a></h2>
+                <h2>The filter is hiding all routes. <button type="button" class="btn btn-link inline-btn-link" ng-click="clearFilter()">Clear All Filters</button></h2>
               </div>
             </div>
           </div>

--- a/app/views/browse/stateful-sets.html
+++ b/app/views/browse/stateful-sets.html
@@ -35,7 +35,7 @@
                 <p>No stateful sets have been added to project {{projectName}}.</p>
               </div>
               <div ng-if="filterWithZeroResults">
-                <h2>The filter is hiding all stateful sets. <a href="" ng-click="clearFilter()" role="button" class="nowrap">Clear Filter</a></h2>
+                <h2>The filter is hiding all stateful sets. <button type="button" class="btn btn-link inline-btn-link" ng-click="clearFilter()">Clear All Filters</button></h2>
               </div>
             </div>
           </div>

--- a/app/views/builds.html
+++ b/app/views/builds.html
@@ -32,7 +32,7 @@
                 <p>No builds have been added to project {{projectName}}.</p>
               </div>
               <div ng-if="filterWithZeroResults">
-                <h2>The filter is hiding all builds. <a href="" ng-click="clearFilter()" role="button" class="nowrap">Clear Filter</a></h2>
+                <h2>The filter is hiding all builds. <button type="button" class="btn btn-link inline-btn-link" ng-click="clearFilter()">Clear All Filters</button></h2>
               </div>
             </div>
           </div>

--- a/app/views/catalog/catalog.html
+++ b/app/views/catalog/catalog.html
@@ -50,7 +50,7 @@
 
   <div ng-if="allContentHidden" class="empty-state-message text-center h2">
     All content is hidden by the current filter.
-    <a href="" ng-click="filter.keyword = ''" role="button" class="nowrap">Clear Filter</a>
+    <button type="button" class="btn btn-link inline-btn-link" ng-click="filter.keyword = ''">Clear All Filters</button>
   </div>
 
   <div ng-if="!filterActive">

--- a/app/views/catalog/category-content.html
+++ b/app/views/catalog/category-content.html
@@ -45,7 +45,7 @@
 
   <div ng-if="!filteredBuilderImages.length && !filteredTemplates.length && loaded" class="empty-state-message text-center h2">
     All content is hidden by the current filter.
-    <a href="" ng-click="filter.keyword = ''" role="button" class="nowrap">Clear Filter</a>
+    <button type="button" class="btn btn-link inline-btn-link" ng-click="filter.keyword = ''">Clear All Filters</button>
   </div>
 
   <div class="row row-cards-pf row-cards-pf-flex mar-top-xl">

--- a/app/views/deployments.html
+++ b/app/views/deployments.html
@@ -32,7 +32,7 @@
                 <p>No deployments have been added to project {{projectName}}.</p>
               </div>
               <div ng-if="filterWithZeroResults">
-                <h2>The filter is hiding all deployments. <a href="" ng-click="clearFilter()" role="button" class="nowrap">Clear Filter</a></h2>
+                <h2>The filter is hiding all deployments. <button type="button" class="btn btn-link inline-btn-link" ng-click="clearFilter()">Clear All Filters</button></h2>
               </div>
             </div>
           </div>

--- a/app/views/directives/events.html
+++ b/app/views/directives/events.html
@@ -57,14 +57,14 @@
           <span ng-if="(events | hashSize) === 0"><em>No events to show.</em></span>
           <span ng-if="(events | hashSize) > 0">
             All events hidden by filter.
-            <a href="" ng-click="filter.text = ''" role="button" class="nowrap">Clear Filter</a>
+            <button type="button" class="btn btn-link inline-btn-link" ng-click="filter.text = ''">Clear All Filters</button>
           </span>
         </td>
           <td class="hidden-xs hidden-sm hidden-md" colspan="{{showKindAndName ? 6 : 4}}">
           <span ng-if="(events | hashSize) === 0"><em>No events to show.</em></span>
           <span ng-if="(events | hashSize) > 0">
             All events hidden by filter.
-            <a href="" ng-click="filter.text = ''" role="button" class="nowrap">Clear Filter</a>
+            <button type="button" class="btn btn-link inline-btn-link" ng-click="filter.text = ''">Clear All Filters</button>
           </span>
         </td>
       </tr>

--- a/app/views/images.html
+++ b/app/views/images.html
@@ -32,7 +32,7 @@
                 <p>No image streams have been added to project {{projectName}}.</p>
               </div>
               <div ng-if="filterWithZeroResults">
-                <h2>The filter is hiding all image streams. <a href="" ng-click="clearFilter()" role="button" class="nowrap">Clear Filter</a></h2>
+                <h2>The filter is hiding all image streams. <button type="button" class="btn btn-link inline-btn-link" ng-click="clearFilter()">Clear All Filters</button></h2>
               </div>
             </div>
           </div>

--- a/app/views/other-resources.html
+++ b/app/views/other-resources.html
@@ -35,7 +35,7 @@
                 </p>
               </div>
               <div ng-if="filterWithZeroResults">
-                <h2>The filter is hiding all {{resourceName}}. <a href="" ng-click="clearFilter()" role="button" class="nowrap">Clear Filter</a></h2>
+                <h2>The filter is hiding all {{resourceName}}. <button type="button" class="btn btn-link inline-btn-link" ng-click="clearFilter()">Clear All Filters</button></h2>
               </div>
             </div>
           </div>

--- a/app/views/overview.html
+++ b/app/views/overview.html
@@ -112,7 +112,7 @@
           <div ng-if="overview.everythingFiltered && overview.viewBy !== 'pipeline'">
             <div class="empty-state-message text-center h2">
               The filter is hiding all resources.
-              <a href="" ng-click="overview.clearFilter()" role="button" class="nowrap">Clear Filter</a>
+              <button type="button" class="btn btn-link inline-btn-link" ng-click="overview.clearFilter()">Clear All Filters</button>
             </div>
           </div>
           <div ng-if="!overview.everythingFiltered || overview.viewBy === 'pipeline'">
@@ -276,7 +276,7 @@
               <div ng-if="(overview.pipelineBuildConfigs | hashSize) && !(overview.filteredPipelineBuildConfigs | hashSize)">
                 <div class="empty-state-message text-center h2">
                   All pipelines are filtered.
-                  <a href="" ng-click="overview.clearFilter()" role="button" class="nowrap">Clear Filter</a>
+                  <button type="button" class="btn btn-link inline-btn-link" ng-click="overview.clearFilter()">Clear All Filters</button>
                 </div>
               </div>
               <div ng-repeat="pipeline in overview.filteredPipelineBuildConfigs track by (pipeline | uid)">

--- a/app/views/pods.html
+++ b/app/views/pods.html
@@ -32,7 +32,7 @@
                 <p>No pods have been added to project {{projectName}}.</p>
               </div>
               <div ng-if="filterWithZeroResults">
-                <h2>The filter is hiding all pods. <a href="" ng-click="clearFilter()" role="button" class="nowrap">Clear Filter</a></h2>
+                <h2>The filter is hiding all pods. <button type="button" class="btn btn-link inline-btn-link" ng-click="clearFilter()">Clear All Filters</button></h2>
               </div>
             </div>
           </div>

--- a/app/views/projects.html
+++ b/app/views/projects.html
@@ -90,9 +90,9 @@
                   </div>
                 </form>
               </div>
-              <div ng-if="!projects.length && !isProjectListIncomplete" class="h3">
+              <div ng-if="!projects.length && !isProjectListIncomplete" class="h3 empty-state-message">
                 The current filter is hiding all projects.
-                <a href="" ng-click="search.text = ''" role="button" class="nowrap">Clear Filter</a>
+                <button type="button" class="btn btn-link inline-btn-link" ng-click="search.text = ''">Clear All Filters</button>
               </div>
               <div ng-if="projects.length" class="list-pf list-group projects-list">
                 <div ng-repeat="project in projects | limitTo: limitListTo track by (project | uid)" class="list-pf-item list-group-item project-info tile-click">

--- a/app/views/secrets.html
+++ b/app/views/secrets.html
@@ -38,7 +38,7 @@
                 </p>
               </div>
               <div ng-if="filterWithZeroResults">
-                <h2>The filter is hiding all secrets. <a href="" ng-click="clearFilter()" role="button" class="nowrap">Clear Filter</a></h2>
+                <h2>The filter is hiding all secrets. <button type="button" class="btn btn-link inline-btn-link" ng-click="clearFilter()">Clear All Filters</button></h2>
               </div>
             </div>
           </div>

--- a/app/views/service-instances.html
+++ b/app/views/service-instances.html
@@ -32,7 +32,7 @@
                     <p>No provisioned services have been added to project {{projectName}}.</p>
                   </div>
                   <div ng-if="filterWithZeroResults">
-                    <h2>The filter is hiding all provisioned services. <a href="" ng-click="clearFilter()" role="button" class="nowrap">Clear Filter</a></h2>
+                    <h2>The filter is hiding all provisioned services. <button type="button" class="btn btn-link inline-btn-link" ng-click="clearFilter()">Clear All Filters</button></h2>
                   </div>
                 </div>
               </div>

--- a/app/views/services.html
+++ b/app/views/services.html
@@ -32,7 +32,7 @@
                 <p>No services have been added to project {{projectName}}.</p>
               </div>
               <div ng-if="filterWithZeroResults">
-                <h2>The filter is hiding all services. <a href="" ng-click="clearFilter()" role="button" class="nowrap">Clear Filter</a></h2>
+                <h2>The filter is hiding all services. <button type="button" class="btn btn-link inline-btn-link" ng-click="clearFilter()">Clear All Filters</button></h2>
               </div>
             </div>
           </div>

--- a/app/views/storage.html
+++ b/app/views/storage.html
@@ -43,7 +43,7 @@
                 </p>
               </div>
               <div ng-if="filterWithZeroResults">
-                <h2>The filter is hiding all persistent volume claims. <a href="" ng-click="clearFilter()" role="button" class="nowrap">Clear Filter</a></h2>
+                <h2>The filter is hiding all persistent volume claims. <button type="button" class="btn btn-link inline-btn-link" ng-click="clearFilter()">Clear All Filters</button></h2>
               </div>
             </div>
           </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2212,7 +2212,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "</div>\n" +
     "<div ng-if=\"filterWithZeroResults\">\n" +
-    "<h2>The filter is hiding all config maps. <a href=\"\" ng-click=\"clearFilter()\" role=\"button\" class=\"nowrap\">Clear Filter</a></h2>\n" +
+    "<h2>The filter is hiding all config maps. <button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"clearFilter()\">Clear All Filters</button></h2>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -3468,7 +3468,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "</div>\n" +
     "<div ng-if=\"filterWithZeroResults\">\n" +
-    "<h2>The filter is hiding all routes. <a href=\"\" ng-click=\"clearFilter()\" role=\"button\" class=\"nowrap\">Clear Filter</a></h2>\n" +
+    "<h2>The filter is hiding all routes. <button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"clearFilter()\">Clear All Filters</button></h2>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -4013,7 +4013,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p>No stateful sets have been added to project {{projectName}}.</p>\n" +
     "</div>\n" +
     "<div ng-if=\"filterWithZeroResults\">\n" +
-    "<h2>The filter is hiding all stateful sets. <a href=\"\" ng-click=\"clearFilter()\" role=\"button\" class=\"nowrap\">Clear Filter</a></h2>\n" +
+    "<h2>The filter is hiding all stateful sets. <button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"clearFilter()\">Clear All Filters</button></h2>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -4086,7 +4086,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p>No builds have been added to project {{projectName}}.</p>\n" +
     "</div>\n" +
     "<div ng-if=\"filterWithZeroResults\">\n" +
-    "<h2>The filter is hiding all builds. <a href=\"\" ng-click=\"clearFilter()\" role=\"button\" class=\"nowrap\">Clear Filter</a></h2>\n" +
+    "<h2>The filter is hiding all builds. <button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"clearFilter()\">Clear All Filters</button></h2>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -4352,7 +4352,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</form>\n" +
     "<div ng-if=\"allContentHidden\" class=\"empty-state-message text-center h2\">\n" +
     "All content is hidden by the current filter.\n" +
-    "<a href=\"\" ng-click=\"filter.keyword = ''\" role=\"button\" class=\"nowrap\">Clear Filter</a>\n" +
+    "<button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"filter.keyword = ''\">Clear All Filters</button>\n" +
     "</div>\n" +
     "<div ng-if=\"!filterActive\">\n" +
     "<div ng-repeat=\"category in categories\" ng-if=\"hasContent[category.id]\">\n" +
@@ -4456,7 +4456,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</form>\n" +
     "<div ng-if=\"!filteredBuilderImages.length && !filteredTemplates.length && loaded\" class=\"empty-state-message text-center h2\">\n" +
     "All content is hidden by the current filter.\n" +
-    "<a href=\"\" ng-click=\"filter.keyword = ''\" role=\"button\" class=\"nowrap\">Clear Filter</a>\n" +
+    "<button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"filter.keyword = ''\">Clear All Filters</button>\n" +
     "</div>\n" +
     "<div class=\"row row-cards-pf row-cards-pf-flex mar-top-xl\">\n" +
     "<catalog-image image-stream=\"builder\" project=\"{{projectName}}\" is-builder=\"true\" keywords=\"keywords\" ng-repeat=\"builder in filteredBuilderImages track by (builder | uid)\">\n" +
@@ -5119,7 +5119,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p>No deployments have been added to project {{projectName}}.</p>\n" +
     "</div>\n" +
     "<div ng-if=\"filterWithZeroResults\">\n" +
-    "<h2>The filter is hiding all deployments. <a href=\"\" ng-click=\"clearFilter()\" role=\"button\" class=\"nowrap\">Clear Filter</a></h2>\n" +
+    "<h2>The filter is hiding all deployments. <button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"clearFilter()\">Clear All Filters</button></h2>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -7130,14 +7130,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span ng-if=\"(events | hashSize) === 0\"><em>No events to show.</em></span>\n" +
     "<span ng-if=\"(events | hashSize) > 0\">\n" +
     "All events hidden by filter.\n" +
-    "<a href=\"\" ng-click=\"filter.text = ''\" role=\"button\" class=\"nowrap\">Clear Filter</a>\n" +
+    "<button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"filter.text = ''\">Clear All Filters</button>\n" +
     "</span>\n" +
     "</td>\n" +
     "<td class=\"hidden-xs hidden-sm hidden-md\" colspan=\"{{showKindAndName ? 6 : 4}}\">\n" +
     "<span ng-if=\"(events | hashSize) === 0\"><em>No events to show.</em></span>\n" +
     "<span ng-if=\"(events | hashSize) > 0\">\n" +
     "All events hidden by filter.\n" +
-    "<a href=\"\" ng-click=\"filter.text = ''\" role=\"button\" class=\"nowrap\">Clear Filter</a>\n" +
+    "<button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"filter.text = ''\">Clear All Filters</button>\n" +
     "</span>\n" +
     "</td>\n" +
     "</tr>\n" +
@@ -10538,7 +10538,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p>No image streams have been added to project {{projectName}}.</p>\n" +
     "</div>\n" +
     "<div ng-if=\"filterWithZeroResults\">\n" +
-    "<h2>The filter is hiding all image streams. <a href=\"\" ng-click=\"clearFilter()\" role=\"button\" class=\"nowrap\">Clear Filter</a></h2>\n" +
+    "<h2>The filter is hiding all image streams. <button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"clearFilter()\">Clear All Filters</button></h2>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -11757,7 +11757,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "</div>\n" +
     "<div ng-if=\"filterWithZeroResults\">\n" +
-    "<h2>The filter is hiding all {{resourceName}}. <a href=\"\" ng-click=\"clearFilter()\" role=\"button\" class=\"nowrap\">Clear Filter</a></h2>\n" +
+    "<h2>The filter is hiding all {{resourceName}}. <button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"clearFilter()\">Clear All Filters</button></h2>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -11908,7 +11908,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"overview.everythingFiltered && overview.viewBy !== 'pipeline'\">\n" +
     "<div class=\"empty-state-message text-center h2\">\n" +
     "The filter is hiding all resources.\n" +
-    "<a href=\"\" ng-click=\"overview.clearFilter()\" role=\"button\" class=\"nowrap\">Clear Filter</a>\n" +
+    "<button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"overview.clearFilter()\">Clear All Filters</button>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"!overview.everythingFiltered || overview.viewBy === 'pipeline'\">\n" +
@@ -12025,7 +12025,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div ng-if=\"(overview.pipelineBuildConfigs | hashSize) && !(overview.filteredPipelineBuildConfigs | hashSize)\">\n" +
     "<div class=\"empty-state-message text-center h2\">\n" +
     "All pipelines are filtered.\n" +
-    "<a href=\"\" ng-click=\"overview.clearFilter()\" role=\"button\" class=\"nowrap\">Clear Filter</a>\n" +
+    "<button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"overview.clearFilter()\">Clear All Filters</button>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div ng-repeat=\"pipeline in overview.filteredPipelineBuildConfigs track by (pipeline | uid)\">\n" +
@@ -13058,7 +13058,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p>No pods have been added to project {{projectName}}.</p>\n" +
     "</div>\n" +
     "<div ng-if=\"filterWithZeroResults\">\n" +
-    "<h2>The filter is hiding all pods. <a href=\"\" ng-click=\"clearFilter()\" role=\"button\" class=\"nowrap\">Clear Filter</a></h2>\n" +
+    "<h2>The filter is hiding all pods. <button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"clearFilter()\">Clear All Filters</button></h2>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -13150,9 +13150,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</form>\n" +
     "</div>\n" +
-    "<div ng-if=\"!projects.length && !isProjectListIncomplete\" class=\"h3\">\n" +
+    "<div ng-if=\"!projects.length && !isProjectListIncomplete\" class=\"h3 empty-state-message\">\n" +
     "The current filter is hiding all projects.\n" +
-    "<a href=\"\" ng-click=\"search.text = ''\" role=\"button\" class=\"nowrap\">Clear Filter</a>\n" +
+    "<button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"search.text = ''\">Clear All Filters</button>\n" +
     "</div>\n" +
     "<div ng-if=\"projects.length\" class=\"list-pf list-group projects-list\">\n" +
     "<div ng-repeat=\"project in projects | limitTo: limitListTo track by (project | uid)\" class=\"list-pf-item list-group-item project-info tile-click\">\n" +
@@ -13524,7 +13524,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "</div>\n" +
     "<div ng-if=\"filterWithZeroResults\">\n" +
-    "<h2>The filter is hiding all secrets. <a href=\"\" ng-click=\"clearFilter()\" role=\"button\" class=\"nowrap\">Clear Filter</a></h2>\n" +
+    "<h2>The filter is hiding all secrets. <button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"clearFilter()\">Clear All Filters</button></h2>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -13597,7 +13597,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p>No provisioned services have been added to project {{projectName}}.</p>\n" +
     "</div>\n" +
     "<div ng-if=\"filterWithZeroResults\">\n" +
-    "<h2>The filter is hiding all provisioned services. <a href=\"\" ng-click=\"clearFilter()\" role=\"button\" class=\"nowrap\">Clear Filter</a></h2>\n" +
+    "<h2>The filter is hiding all provisioned services. <button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"clearFilter()\">Clear All Filters</button></h2>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -13694,7 +13694,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<p>No services have been added to project {{projectName}}.</p>\n" +
     "</div>\n" +
     "<div ng-if=\"filterWithZeroResults\">\n" +
-    "<h2>The filter is hiding all services. <a href=\"\" ng-click=\"clearFilter()\" role=\"button\" class=\"nowrap\">Clear Filter</a></h2>\n" +
+    "<h2>The filter is hiding all services. <button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"clearFilter()\">Clear All Filters</button></h2>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -13838,7 +13838,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "</div>\n" +
     "<div ng-if=\"filterWithZeroResults\">\n" +
-    "<h2>The filter is hiding all persistent volume claims. <a href=\"\" ng-click=\"clearFilter()\" role=\"button\" class=\"nowrap\">Clear Filter</a></h2>\n" +
+    "<h2>The filter is hiding all persistent volume claims. <button type=\"button\" class=\"btn btn-link inline-btn-link\" ng-click=\"clearFilter()\">Clear All Filters</button></h2>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -4805,6 +4805,7 @@ body.ios .console-os .ace_editor,body.ios input[type=text],body.ios input[type=u
 .resource-details h3{border-bottom:1px solid #eee;padding-bottom:10px}
 .resource-details overlay-panel h3{border-bottom:0;padding-bottom:0}
 .hide-tabs .nav-tabs{display:none}
+.btn-link.inline-btn-link{font-size:inherit;font-weight:inherit;vertical-align:initial;padding:0}
 .empty-state-message{margin:40px auto 60px;max-width:600px;padding:0}
 .empty-state-message.loading{margin:0 auto;padding:40px 0 60px}
 .empty-state-message.loading h2{margin-top:0}


### PR DESCRIPTION
Reword all the `Clear Filter` into `Clear All Filters` since this wording is from patternfly.
As part of the work, it would be good also to align on the wording for case when the filters all hidding all the options, since we are using different working for the same case, eg:
1. The filter is hiding all persistent volume claims
2. The current filter is hiding all projects.
3. All pipelines are filtered.

I suggest to use the first one and modify it into "The filters are hiding all persistent volume claims", since the first one is used on most places and with this change we are moving from singular `Clear Filter` to plural  `Clear All Filters`.

@spadgett @beanh66 @cshinn PTAL