### PR TITLE
Create Opaque Secrets from File

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -312,7 +312,7 @@
         <script src="scripts/directives/createSecret.js"></script>
         <script src="scripts/directives/date.js"></script>
         <script src="scripts/directives/deleteLink.js"></script>
-        <script src="scripts/directives/editConfigMap.js"></script>
+        <script src="scripts/directives/editConfigMapOrSecret.js"></script>
         <script src="scripts/directives/editEnvironmentFrom.js"></script>
         <script src="scripts/directives/events.js"></script>
         <script src="scripts/directives/eventsSidebar.js"></script>

--- a/app/scripts/directives/createSecret.js
+++ b/app/scripts/directives/createSecret.js
@@ -70,6 +70,15 @@ angular.module("openshiftConsole")
                 label: "Webhook Secret"
               }
             ]
+          },
+          generic: {
+            label: "Generic Secret",
+            authTypes: [
+              {
+                id: "Opaque",
+                label: "Generic Secret"
+              }
+            ]
           }
         };
 
@@ -95,7 +104,11 @@ angular.module("openshiftConsole")
           $scope.newSecret = {
             type: "source",
             authType: "kubernetes.io/basic-auth",
-            data: {},
+            data: {
+              genericKeyValues: {
+                data: {}
+              }
+            },
             linkSecret: false,
             pickedServiceAccountToLink: "",
           };
@@ -172,6 +185,9 @@ angular.module("openshiftConsole")
             case "Opaque":
               if (data.webhookSecretKey) {
                 secret.stringData.WebHookSecretKey = data.webhookSecretKey;
+              }
+              if (data.genericKeyValues.data) {
+                secret.stringData = data.genericKeyValues.data;
               }
               break;
           }

--- a/app/scripts/directives/editConfigMapOrSecret.js
+++ b/app/scripts/directives/editConfigMapOrSecret.js
@@ -1,16 +1,17 @@
 "use strict";
 
 angular.module("openshiftConsole")
-  .directive("editConfigMap",
+  .directive("editConfigMapOrSecret",
              function(DNS1123_SUBDOMAIN_VALIDATION) {
     return {
       require: '^form',
       restrict: 'E',
       scope: {
-        configMap: "=model",
-        showNameInput: "="
+        map: "=model",
+        showNameInput: "=",
+        type: "@"
       },
-      templateUrl: 'views/directives/edit-config-map.html',
+      templateUrl: 'views/directives/edit-config-map-or-secret.html',
       link: function($scope, element, attrs, formCtl) {
         $scope.form = formCtl;
 
@@ -32,7 +33,7 @@ angular.module("openshiftConsole")
         };
 
         // Load the data once when it is first set.
-        var clearWatch = $scope.$watch('configMap.data', function(data) {
+        var clearWatch = $scope.$watch('map.data', function(data) {
           if (!data) {
             return;
           }
@@ -53,14 +54,14 @@ angular.module("openshiftConsole")
 
           clearWatch();
 
-          // Update `$scope.configMap` as the form data changes.
+          // Update `$scope.map` as the form data changes.
           $scope.$watch('data', function(data) {
             var map = {};
             _.each(data, function(keyValuePair) {
               map[keyValuePair.key] = keyValuePair.value;
             });
 
-            _.set($scope, 'configMap.data', map);
+            _.set($scope, 'map.data', map);
           }, true);
         });
       }

--- a/app/views/create-config-map.html
+++ b/app/views/create-config-map.html
@@ -12,7 +12,7 @@
             </div>
             <form name="createConfigMapForm" class="mar-top-xl">
               <fieldset ng-disabled="disableInputs">
-                <edit-config-map model="configMap" show-name-input="true"></edit-config-map>
+                <edit-config-map-or-secret model="configMap" type="config-map" show-name-input="true"></edit-config-map-or-secret>
                 <div class="button-group gutter-top gutter-bottom">
                   <button type="submit"
                       class="btn btn-primary btn-lg"

--- a/app/views/directives/create-secret.html
+++ b/app/views/directives/create-secret.html
@@ -85,7 +85,7 @@
       </div>
     </div>
 
-    <div ng-if="newSecret.type != 'webhook'">
+    <div ng-if="newSecret.type === 'source' || newSecret.type === 'image'">
       <div class="form-group">
         <label for="authentification-type">Authentication Type</label>
         <ui-select required input-id="authentification-type" ng-model="newSecret.authType" search-enabled="false">
@@ -349,6 +349,9 @@
           </div>
         </div>
       </div>
+    </div>
+    <div ng-if="newSecret.type === 'generic'">
+      <edit-config-map-or-secret model="newSecret.data.genericKeyValues" type="secret"></edit-config-map-or-secret>
     </div>
   </div>
   <div class="buttons gutter-top-bottom">

--- a/app/views/directives/edit-config-map-or-secret.html
+++ b/app/views/directives/edit-config-map-or-secret.html
@@ -1,40 +1,40 @@
-<ng-form name="configMapForm">
+<ng-form name="keyValueMapForm">
   <fieldset>
     <!-- Name -->
     <div ng-show="showNameInput" class="form-group">
-      <label for="config-map-name" class="required">Name</label>
+      <label for="key-value-map-name" class="required">Name</label>
       <!-- regex, maxlength from k8s.io/kubernetes/pkg/util/validation/validation.go -->
-      <div ng-class="{ 'has-error': configMapForm.name.$invalid && configMapForm.name.$touched }">
+      <div ng-class="{ 'has-error': keyValueMapForm.name.$invalid && keyValueMapForm.name.$touched }">
         <input
-            id="config-map-name"
+            id="key-value-map-name"
             class="form-control"
             type="text"
             name="name"
-            ng-model="configMap.metadata.name"
+            ng-model="map.metadata.name"
             ng-required="showNameInput"
             ng-pattern="nameValidation.pattern"
             ng-maxlength="nameValidation.maxlength"
-            placeholder="my-config-map"
+            placeholder="my-{{type}}"
             select-on-focus
             autocorrect="off"
             autocapitalize="none"
             spellcheck="false"
-            aria-describedby="config-map-name-help">
+            aria-describedby="key-value-map-name-help">
       </div>
       <div>
-        <span id="config-map-name-help" class="help-block">A unique name for the config map within the project.</span>
+        <span id="key-value-map-name-help" class="help-block">A unique name for the {{type}} within the project.</span>
       </div>
-      <div class="has-error" ng-show="configMapForm.name.$error.pattern && configMapForm.name.$touched">
+      <div class="has-error" ng-show="keyValueMapForm.name.$error.pattern && keyValueMapForm.name.$touched">
         <span class="help-block">
           {{nameValidation.description}}
         </span>
       </div>
-      <div class="has-error" ng-show="configMapForm.name.$error.required && configMapForm.name.$touched">
+      <div class="has-error" ng-show="keyValueMapForm.name.$error.required && keyValueMapForm.name.$touched">
         <span class="help-block">
           Name is required.
         </span>
       </div>
-      <div class="has-error" ng-show="configMapForm.name.$error.maxlength">
+      <div class="has-error" ng-show="keyValueMapForm.name.$error.maxlength">
         <span class="help-block">
           Can't be longer than {{nameValidation.maxlength}} characters.
         </span>
@@ -42,7 +42,7 @@
     </div>
 
     <div ng-if="!data.length">
-      <p><em>The config map has no items.</em></p>
+      <p><em>The {{type}} has no items.</em></p>
       <a href="" ng-click="addItem()">Add Item</a>
     </div>
 
@@ -53,7 +53,7 @@
           Config map validation:
           https://github.com/openshift/origin/blob/32708e768d77db08b118d084955a7ccf2aebbf1c/vendor/k8s.io/client-go/1.4/pkg/util/validation/validation.go#L271-L273
         -->
-        <div ng-class="{ 'has-error': configMapForm['key-' + $id].$invalid && configMapForm['key-' + $id].$touched }">
+        <div ng-class="{ 'has-error': keyValueMapForm['key-' + $id].$invalid && keyValueMapForm['key-' + $id].$touched }">
           <input
               class="form-control"
               name="key-{{$id}}"
@@ -72,26 +72,26 @@
               aria-describedby="key-{{$id}}-help">
         </div>
         <div class="help-block">
-          A unique key for this config map entry.
+          A unique key for this {{type}} entry.
         </div>
-        <div class="has-error" ng-show="configMapForm['key-' + $id].$error.required && configMapForm['key-' + $id].$touched">
+        <div class="has-error" ng-show="keyValueMapForm['key-' + $id].$error.required && keyValueMapForm['key-' + $id].$touched">
           <span class="help-block">
             Key is required.
           </span>
         </div>
-        <div class="has-error" ng-show="configMapForm['key-' + $id].$error.oscUnique && configMapForm['key-' + $id].$touched">
+        <div class="has-error" ng-show="keyValueMapForm['key-' + $id].$error.oscUnique && keyValueMapForm['key-' + $id].$touched">
           <span class="help-block">
-            Duplicate key "{{item.key}}". Keys must be unique within the config map.
+            Duplicate key "{{item.key}}". Keys must be unique within the {{type}}.
           </span>
         </div>
-        <div class="has-error" ng-show="configMapForm['key-' + $id].$error.pattern && configMapForm['key-' + $id].$touched">
+        <div class="has-error" ng-show="keyValueMapForm['key-' + $id].$error.pattern && keyValueMapForm['key-' + $id].$touched">
           <span class="help-block">
-            Config map keys may only consist of letters, numbers, periods, hyphens, and underscores.
+            Keys may only consist of letters, numbers, periods, hyphens, and underscores.
           </span>
         </div>
-        <div class="has-error" ng-show="configMapForm['key-' + $id].$error.maxlength">
+        <div class="has-error" ng-show="keyValueMapForm['key-' + $id].$error.maxlength">
           <span class="help-block">
-            Config map keys may not be longer than 253 characters.
+            Keys may not be longer than 253 characters.
           </span>
         </div>
       </div>
@@ -100,7 +100,7 @@
         <osc-file-input
           model="item.value"
           drop-zone-id="drop-zone-{{$id}}"
-          help-text="Enter a value for the config map entry or use the contents of a file."></osc-file-input>
+          help-text="Enter a value for the {{type}} entry or use the contents of a file."></osc-file-input>
         <div ui-ace="{
           theme: 'eclipse',
           rendererOptions: {

--- a/app/views/edit/config-map.html
+++ b/app/views/edit/config-map.html
@@ -25,7 +25,7 @@
                   Config map {[configMap.metadata.name}} has been deleted since you started editing it.
                 </div>
                 <fieldset ng-disabled="disableInputs">
-                  <edit-config-map model="configMap"></edit-config-map>
+                  <edit-config-map-or-secret model="configMap" type="config map"></edit-config-map-or-secret>
                   <div class="button-group gutter-top gutter-bottom">
                     <button type="submit"
                         class="btn btn-primary btn-lg"

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -9152,6 +9152,13 @@ authTypes: [ {
 id: "Opaque",
 label: "Webhook Secret"
 } ]
+},
+generic: {
+label: "Generic Secret",
+authTypes: [ {
+id: "Opaque",
+label: "Generic Secret"
+} ]
 }
 }, l.secretTypes = _.keys(l.secretAuthTypeMap), l.type ? l.newSecret = {
 type: l.type,
@@ -9162,7 +9169,11 @@ pickedServiceAccountToLink: l.serviceAccountToLink || ""
 } : l.newSecret = {
 type: "source",
 authType: "kubernetes.io/basic-auth",
-data: {},
+data: {
+genericKeyValues: {
+data: {}
+}
+},
 linkSecret: !1,
 pickedServiceAccountToLink: ""
 }, l.add = {
@@ -9206,7 +9217,7 @@ auth: o
 break;
 
 case "Opaque":
-e.webhookSecretKey && (r.stringData.WebHookSecretKey = e.webhookSecretKey);
+e.webhookSecretKey && (r.stringData.WebHookSecretKey = e.webhookSecretKey), e.genericKeyValues.data && (r.stringData = e.genericKeyValues.data);
 }
 return r;
 }, d = function() {
@@ -9395,15 +9406,16 @@ details: n("getErrorDetails")(e)
 };
 }
 };
-} ]), angular.module("openshiftConsole").directive("editConfigMap", [ "DNS1123_SUBDOMAIN_VALIDATION", function(e) {
+} ]), angular.module("openshiftConsole").directive("editConfigMapOrSecret", [ "DNS1123_SUBDOMAIN_VALIDATION", function(e) {
 return {
 require: "^form",
 restrict: "E",
 scope: {
-configMap: "=model",
-showNameInput: "="
+map: "=model",
+showNameInput: "=",
+type: "@"
 },
-templateUrl: "views/directives/edit-config-map.html",
+templateUrl: "views/directives/edit-config-map-or-secret.html",
 link: function(t, n, r, a) {
 t.form = a, t.nameValidation = e, t.addItem = function() {
 t.data.push({
@@ -9415,7 +9427,7 @@ t.data.splice(e, 1), t.form.$setDirty();
 }, t.getKeys = function() {
 return _.map(t.data, "key");
 };
-var o = t.$watch("configMap.data", function(e) {
+var o = t.$watch("map.data", function(e) {
 e && (t.data = _.map(e, function(e, t) {
 return {
 key: t,
@@ -9425,7 +9437,7 @@ value: e
 var n = {};
 _.each(e, function(e) {
 n[e.key] = e.value;
-}), _.set(t, "configMap.data", n);
+}), _.set(t, "map.data", n);
 }, !0));
 });
 }

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -4538,7 +4538,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<form name=\"createConfigMapForm\" class=\"mar-top-xl\">\n" +
     "<fieldset ng-disabled=\"disableInputs\">\n" +
-    "<edit-config-map model=\"configMap\" show-name-input=\"true\"></edit-config-map>\n" +
+    "<edit-config-map-or-secret model=\"configMap\" type=\"config-map\" show-name-input=\"true\"></edit-config-map-or-secret>\n" +
     "<div class=\"button-group gutter-top gutter-bottom\">\n" +
     "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-click=\"createConfigMap()\" ng-disabled=\"createConfigMapForm.$invalid || disableInputs\" value=\"\">Create</button>\n" +
     "<a class=\"btn btn-default btn-lg\" href=\"\" ng-click=\"cancel()\" role=\"button\">Cancel</a>\n" +
@@ -6143,7 +6143,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-if=\"newSecret.type != 'webhook'\">\n" +
+    "<div ng-if=\"newSecret.type === 'source' || newSecret.type === 'image'\">\n" +
     "<div class=\"form-group\">\n" +
     "<label for=\"authentification-type\">Authentication Type</label>\n" +
     "<ui-select required input-id=\"authentification-type\" ng-model=\"newSecret.authType\" search-enabled=\"false\">\n" +
@@ -6326,6 +6326,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
+    "</div>\n" +
+    "<div ng-if=\"newSecret.type === 'generic'\">\n" +
+    "<edit-config-map-or-secret model=\"newSecret.data.genericKeyValues\" type=\"secret\"></edit-config-map-or-secret>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"buttons gutter-top-bottom\">\n" +
@@ -6653,73 +6656,73 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
-  $templateCache.put('views/directives/edit-config-map.html',
-    "<ng-form name=\"configMapForm\">\n" +
+  $templateCache.put('views/directives/edit-config-map-or-secret.html',
+    "<ng-form name=\"keyValueMapForm\">\n" +
     "<fieldset>\n" +
     "\n" +
     "<div ng-show=\"showNameInput\" class=\"form-group\">\n" +
-    "<label for=\"config-map-name\" class=\"required\">Name</label>\n" +
+    "<label for=\"key-value-map-name\" class=\"required\">Name</label>\n" +
     "\n" +
-    "<div ng-class=\"{ 'has-error': configMapForm.name.$invalid && configMapForm.name.$touched }\">\n" +
-    "<input id=\"config-map-name\" class=\"form-control\" type=\"text\" name=\"name\" ng-model=\"configMap.metadata.name\" ng-required=\"showNameInput\" ng-pattern=\"nameValidation.pattern\" ng-maxlength=\"nameValidation.maxlength\" placeholder=\"my-config-map\" select-on-focus autocorrect=\"off\" autocapitalize=\"none\" spellcheck=\"false\" aria-describedby=\"config-map-name-help\">\n" +
+    "<div ng-class=\"{ 'has-error': keyValueMapForm.name.$invalid && keyValueMapForm.name.$touched }\">\n" +
+    "<input id=\"key-value-map-name\" class=\"form-control\" type=\"text\" name=\"name\" ng-model=\"map.metadata.name\" ng-required=\"showNameInput\" ng-pattern=\"nameValidation.pattern\" ng-maxlength=\"nameValidation.maxlength\" placeholder=\"my-{{type}}\" select-on-focus autocorrect=\"off\" autocapitalize=\"none\" spellcheck=\"false\" aria-describedby=\"key-value-map-name-help\">\n" +
     "</div>\n" +
     "<div>\n" +
-    "<span id=\"config-map-name-help\" class=\"help-block\">A unique name for the config map within the project.</span>\n" +
+    "<span id=\"key-value-map-name-help\" class=\"help-block\">A unique name for the {{type}} within the project.</span>\n" +
     "</div>\n" +
-    "<div class=\"has-error\" ng-show=\"configMapForm.name.$error.pattern && configMapForm.name.$touched\">\n" +
+    "<div class=\"has-error\" ng-show=\"keyValueMapForm.name.$error.pattern && keyValueMapForm.name.$touched\">\n" +
     "<span class=\"help-block\">\n" +
     "{{nameValidation.description}}\n" +
     "</span>\n" +
     "</div>\n" +
-    "<div class=\"has-error\" ng-show=\"configMapForm.name.$error.required && configMapForm.name.$touched\">\n" +
+    "<div class=\"has-error\" ng-show=\"keyValueMapForm.name.$error.required && keyValueMapForm.name.$touched\">\n" +
     "<span class=\"help-block\">\n" +
     "Name is required.\n" +
     "</span>\n" +
     "</div>\n" +
-    "<div class=\"has-error\" ng-show=\"configMapForm.name.$error.maxlength\">\n" +
+    "<div class=\"has-error\" ng-show=\"keyValueMapForm.name.$error.maxlength\">\n" +
     "<span class=\"help-block\">\n" +
     "Can't be longer than {{nameValidation.maxlength}} characters.\n" +
     "</span>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"!data.length\">\n" +
-    "<p><em>The config map has no items.</em></p>\n" +
+    "<p><em>The {{type}} has no items.</em></p>\n" +
     "<a href=\"\" ng-click=\"addItem()\">Add Item</a>\n" +
     "</div>\n" +
     "<div ng-repeat=\"item in data\" ng-init=\"keys = getKeys()\">\n" +
     "<div class=\"form-group\">\n" +
     "<label ng-attr-for=\"key-{{$id}}\" class=\"required\">Key</label>\n" +
     "\n" +
-    "<div ng-class=\"{ 'has-error': configMapForm['key-' + $id].$invalid && configMapForm['key-' + $id].$touched }\">\n" +
+    "<div ng-class=\"{ 'has-error': keyValueMapForm['key-' + $id].$invalid && keyValueMapForm['key-' + $id].$touched }\">\n" +
     "<input class=\"form-control\" name=\"key-{{$id}}\" ng-attr-id=\"key-{{$id}}\" type=\"text\" ng-model=\"item.key\" required ng-pattern=\"/^[-._a-zA-Z0-9]+$/\" ng-maxlength=\"253\" osc-unique=\"keys\" placeholder=\"my.key\" select-on-focus autocorrect=\"off\" autocapitalize=\"none\" spellcheck=\"false\" aria-describedby=\"key-{{$id}}-help\">\n" +
     "</div>\n" +
     "<div class=\"help-block\">\n" +
-    "A unique key for this config map entry.\n" +
+    "A unique key for this {{type}} entry.\n" +
     "</div>\n" +
-    "<div class=\"has-error\" ng-show=\"configMapForm['key-' + $id].$error.required && configMapForm['key-' + $id].$touched\">\n" +
+    "<div class=\"has-error\" ng-show=\"keyValueMapForm['key-' + $id].$error.required && keyValueMapForm['key-' + $id].$touched\">\n" +
     "<span class=\"help-block\">\n" +
     "Key is required.\n" +
     "</span>\n" +
     "</div>\n" +
-    "<div class=\"has-error\" ng-show=\"configMapForm['key-' + $id].$error.oscUnique && configMapForm['key-' + $id].$touched\">\n" +
+    "<div class=\"has-error\" ng-show=\"keyValueMapForm['key-' + $id].$error.oscUnique && keyValueMapForm['key-' + $id].$touched\">\n" +
     "<span class=\"help-block\">\n" +
-    "Duplicate key \"{{item.key}}\". Keys must be unique within the config map.\n" +
+    "Duplicate key \"{{item.key}}\". Keys must be unique within the {{type}}.\n" +
     "</span>\n" +
     "</div>\n" +
-    "<div class=\"has-error\" ng-show=\"configMapForm['key-' + $id].$error.pattern && configMapForm['key-' + $id].$touched\">\n" +
+    "<div class=\"has-error\" ng-show=\"keyValueMapForm['key-' + $id].$error.pattern && keyValueMapForm['key-' + $id].$touched\">\n" +
     "<span class=\"help-block\">\n" +
-    "Config map keys may only consist of letters, numbers, periods, hyphens, and underscores.\n" +
+    "Keys may only consist of letters, numbers, periods, hyphens, and underscores.\n" +
     "</span>\n" +
     "</div>\n" +
-    "<div class=\"has-error\" ng-show=\"configMapForm['key-' + $id].$error.maxlength\">\n" +
+    "<div class=\"has-error\" ng-show=\"keyValueMapForm['key-' + $id].$error.maxlength\">\n" +
     "<span class=\"help-block\">\n" +
-    "Config map keys may not be longer than 253 characters.\n" +
+    "Keys may not be longer than 253 characters.\n" +
     "</span>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div class=\"form-group\" ng-attr-id=\"drop-zone-{{$id}}\">\n" +
     "<label ng-attr-for=\"name-{{$id}}\">Value</label>\n" +
-    "<osc-file-input model=\"item.value\" drop-zone-id=\"drop-zone-{{$id}}\" help-text=\"Enter a value for the config map entry or use the contents of a file.\"></osc-file-input>\n" +
+    "<osc-file-input model=\"item.value\" drop-zone-id=\"drop-zone-{{$id}}\" help-text=\"Enter a value for the {{type}} entry or use the contents of a file.\"></osc-file-input>\n" +
     "<div ui-ace=\"{\n" +
     "          theme: 'eclipse',\n" +
     "          rendererOptions: {\n" +
@@ -9988,7 +9991,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Config map {[configMap.metadata.name}} has been deleted since you started editing it.\n" +
     "</div>\n" +
     "<fieldset ng-disabled=\"disableInputs\">\n" +
-    "<edit-config-map model=\"configMap\"></edit-config-map>\n" +
+    "<edit-config-map-or-secret model=\"configMap\" type=\"config map\"></edit-config-map-or-secret>\n" +
     "<div class=\"button-group gutter-top gutter-bottom\">\n" +
     "<button type=\"submit\" class=\"btn btn-primary btn-lg\" ng-click=\"updateConfigMap()\" ng-disabled=\"forms.editConfigMapForm.$invalid || forms.editConfigMapForm.$pristine || disableInputs || resourceChanged || resourceDeleted\" value=\"\">Save</button>\n" +
     "<a class=\"btn btn-default btn-lg\" href=\"\" ng-click=\"cancel()\" role=\"button\">Cancel</a>\n" +


### PR DESCRIPTION
https://trello.com/c/SANVwQnv

- Created a new Secret Type 'Opaque Secret'.  Not sure if this should be 'Input' or 'Builder' secret?
- 'Opaque Secret' form is same key-value map used in Create Config Map.
![image](https://user-images.githubusercontent.com/12733153/37102182-45abf7a2-21f5-11e8-9110-36fe4f2fe2d8.png)

Not sure what code to use to Create this type of secret.  Creating a Secret is:
```
DataService.create(secretsVersion, null, newSecret, $scope).then(function(secret) { // Success
            // In order to link:
            // - the SA has to be defined
            // - defined SA has to be present in the obtained SA list
            // - user can update SA
            // Else the linking will be skipped
            if ($scope.newSecret.linkSecret && $scope.serviceAccountsNames.contains($scope.newSecret.pickedServiceAccountToLink) && AuthorizationService.canI('serviceaccounts', 'update')) {
              linkSecretToServiceAccount(secret);
```
- Do I need to show the 'Link secret to a service account.' checkbox for 'Opaque Secrets' ?

Creating a Config Map is:
```
DataService.create(createConfigMapVersion, null, $scope.configMap, context)
```
- where `$scope.configMap.data` is the key-value pairs map.

Looking into `DataService.create(secretsVersion...` to see if it supports `data.keyvaluepairs`


