### PR TITLE
Bug 1551991 - Correctly clear key when another valueFrom resource selected

### DIFF
--- a/app/scripts/directives/keyValueEditor.js
+++ b/app/scripts/directives/keyValueEditor.js
@@ -160,7 +160,7 @@
                 };
                 delete entry.valueFrom.configMapKeyRef;
               }
-              delete entry.valueFrom.key;
+              delete entry.selectedValueFromKey;
             };
 
             $scope.valueFromKeySelected = function(entry, selected) {

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -14690,7 +14690,7 @@ return i(e.kind);
 name: t.metadata.name
 }, delete e.valueFrom.secretKeyRef) : "Secret" === t.kind && (e.valueFrom.secretKeyRef = {
 name: t.metadata.name
-}, delete e.valueFrom.configMapKeyRef), delete e.valueFrom.key;
+}, delete e.valueFrom.configMapKeyRef), delete e.selectedValueFromKey;
 }, e.valueFromKeySelected = function(e, t) {
 e.valueFrom.configMapKeyRef ? e.valueFrom.configMapKeyRef.key = t : e.valueFrom.secretKeyRef && (e.valueFrom.secretKeyRef.key = t);
 }, angular.extend(e, {


### PR DESCRIPTION
In our key/value editor, correctly clear the valueFrom key when a different
resource reference is selected.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1551991
/assign @benjaminapetersen 