### PR TITLE
Fix for DISABLE_SERVICE_CATALOG_LANDING_PAGE = true when Set Home page is set to Project List

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -43,18 +43,14 @@ angular
     };
     if (_.get(window, 'OPENSHIFT_CONSTANTS.DISABLE_SERVICE_CATALOG_LANDING_PAGE')) {
       landingPageRoute = projectsPageRoute;
-      $routeProvider.when('/projects', {
-        redirectTo: '/'
-      });
     } else {
       landingPageRoute = {
         templateUrl: 'views/landing-page.html',
         controller: 'LandingPageController',
         reloadOnSearch: false
       };
-      $routeProvider.when('/projects', projectsPageRoute);
     }
-
+    $routeProvider.when('/projects', projectsPageRoute);
     $routeProvider
       .when('/', {
         redirectTo: function() {

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1078,13 +1078,11 @@ var r, a = {
 templateUrl: "views/projects.html",
 controller: "ProjectsController"
 };
-_.get(window, "OPENSHIFT_CONSTANTS.DISABLE_SERVICE_CATALOG_LANDING_PAGE") ? (r = a, e.when("/projects", {
-redirectTo: "/"
-})) : (r = {
+r = _.get(window, "OPENSHIFT_CONSTANTS.DISABLE_SERVICE_CATALOG_LANDING_PAGE") ? a : {
 templateUrl: "views/landing-page.html",
 controller: "LandingPageController",
 reloadOnSearch: !1
-}, e.when("/projects", a)), e.when("/", {
+}, e.when("/projects", a), e.when("/", {
 redirectTo: function() {
 return n.$get().getHomePagePath();
 }


### PR DESCRIPTION
Fixes #2892

No longer infinite loops when DISABLE_SERVICE_CATALOG_LANDING_PAGE=true and Set Home page is set to Project List.  Tested various other combinations of Setting Home page to Catalog, Project List, and Project Overview along with setting DISABLE_SERVICE_CATALOG_LANDING_PAGE to true and false.



