### PR TITLE
adding service integrations to service overview row

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -370,6 +370,8 @@
         <script src="scripts/directives/imageNames.js"></script>
         <script src="scripts/directives/serviceBinding.js"></script>
         <script src="scripts/directives/overview/mobileClientRow.js"></script>
+        <script src="scripts/directives/serviceInstanceIntegrations.js"></script>
+        <script src="scripts/directives/serviceIntegration.js"></script>
 
         <!-- New Overview -->
         <script src="scripts/directives/buildCounts.js"></script>
@@ -401,6 +403,7 @@
         <script src="scripts/filters/resources.js"></script>
         <script src="scripts/filters/canI.js"></script>
         <script src="scripts/filters/util.js"></script>
+        <script src="scripts/filters/mobile.js"></script>
         <script src="scripts/services/logLinks.js"></script>
 
         <!-- add bundled extensions here -->

--- a/app/scripts/directives/bindService.js
+++ b/app/scripts/directives/bindService.js
@@ -17,7 +17,9 @@
     bindings: {
       target: '<',
       project: '<',
-      onClose: '<'
+      onClose: '<',
+      onFinish: '<',
+      parameterData: '<'
     },
     templateUrl: 'views/directives/bind-service.html'
   });
@@ -193,7 +195,7 @@
       ctrl.serviceSelection = {};
       ctrl.projectDisplayName = $filter('displayName')(ctrl.project);
       ctrl.podPresets = enableTechPreviewFeature('pod_presets');
-      ctrl.parameterData = {};
+      ctrl.parameterData = ctrl.parameterData || {};
 
       ctrl.steps = [ bindFormStep, bindParametersStep, resultsStep ];
       ctrl.hideBack = bindParametersStep.hidden;
@@ -249,9 +251,16 @@
         bindingWatch = DataService.watchObject(BindingService.bindingResource, _.get(ctrl.binding, 'metadata.name'), context, function(binding) {
           ctrl.binding = binding;
         });
+        ctrl.wizardFinished(binding);
       }, function(e) {
         ctrl.error = e;
       });
+    };
+
+    ctrl.wizardFinished = function(binding) {
+      if (_.isFunction(ctrl.onFinish)) {
+        ctrl.onFinish(binding);
+      }
     };
 
     ctrl.closeWizard = function() {

--- a/app/scripts/directives/overview/serviceInstanceRow.js
+++ b/app/scripts/directives/overview/serviceInstanceRow.js
@@ -4,6 +4,7 @@
   angular.module('openshiftConsole').component('serviceInstanceRow', {
     controller: [
       '$filter',
+      '$rootScope',
       'APIService',
       'AuthorizationService',
       'BindingService',
@@ -21,12 +22,14 @@
   });
 
   function ServiceInstanceRow($filter,
+                              $rootScope,
                               APIService,
                               AuthorizationService,
                               BindingService,
                               ListRowUtils,
                               ServiceInstancesService) {
     var row = this;
+
     var isBindingFailed = $filter('isBindingFailed');
     var isBindingReady = $filter('isBindingReady');
     var serviceInstanceFailedMessage = $filter('serviceInstanceFailedMessage');
@@ -38,6 +41,7 @@
 
     row.serviceBindingsVersion = APIService.getPreferredVersion('servicebindings');
     row.serviceInstancesVersion = APIService.getPreferredVersion('serviceinstances');
+    row.isMobileService = $filter('isMobileService');
 
     var getServiceClass = function() {
       var serviceClassName = ServiceInstancesService.getServiceClassNameForInstance(row.apiObject);
@@ -74,6 +78,13 @@
     row.$onChanges = function(changes) {
       if (changes.bindings) {
         row.deleteableBindings = _.reject(row.bindings, 'metadata.deletionTimestamp');
+      }
+      if (row.isMobileService(row.apiObject) && $rootScope.AEROGEAR_MOBILE_ENABLED) {
+        var serviceClass = getServiceClass();
+        var integrations = _.get(serviceClass, "spec.externalMetadata.integrations");
+        if (integrations) {
+          row.integrations = integrations.split(",");
+        }
       }
     };
 

--- a/app/scripts/directives/serviceInstanceIntegrations.js
+++ b/app/scripts/directives/serviceInstanceIntegrations.js
@@ -1,0 +1,29 @@
+'use strict';
+
+angular.module('openshiftConsole').component('serviceInstanceIntegrations', {
+  controller: [
+    'APIService',
+    'DataService',
+    ServiceInstanceIntegrations
+  ],
+  controllerAs: '$ctrl',
+  bindings: {
+    integrations: '<',
+    consumerService: '<'
+  },
+  templateUrl: 'views/directives/service-instance-integrations.html'
+});
+
+function ServiceInstanceIntegrations(APIService, DataService) {
+  var ctrl = this;
+
+  var serviceClassesPreferredVersion = APIService.getPreferredVersion('clusterserviceclasses');
+
+  DataService.list(serviceClassesPreferredVersion, {})
+  .then(function(serviceClasses) {
+    ctrl.integrationsData = _.filter(serviceClasses.by('metadata.name'), function(serviceClass) {
+      var serviceClassName = _.get(serviceClass, 'spec.externalMetadata.serviceName');
+      return ctrl.integrations.contains(serviceClassName);
+    });
+  });
+}

--- a/app/scripts/directives/serviceIntegration.js
+++ b/app/scripts/directives/serviceIntegration.js
@@ -1,0 +1,272 @@
+'use strict';
+
+(function() {
+  angular.module('openshiftConsole').component('serviceIntegration', {
+    controller: [
+      '$filter',
+      '$scope',
+      'APIService',
+      'AuthorizationService',
+      'BindingService',
+      'Catalog',
+      'DataService',
+      'NotificationsService',
+      ServiceIntegration
+    ],
+    bindings: {
+      integration: '<',
+      consumerService: '<?'
+    },
+    templateUrl: 'views/directives/_service-integration.html'
+  });
+
+  function ServiceIntegration(
+                          $filter,
+                          $scope,
+                          APIService,
+                          AuthorizationService,
+                          BindingService,
+                          Catalog,
+                          DataService,
+                          NotificationsService) {
+    var ctrl = this;
+
+    var deploymentPreferredVersion = APIService.getPreferredVersion('deployments');
+    var bindingPreferredVersion = APIService.getPreferredVersion('servicebindings');
+    var instancePreferredVersion = APIService.getPreferredVersion('serviceinstances');
+    var podPresetPreferredVersion = APIService.kindToResourceGroupVersion({group: "settings.k8s.io", kind: "podpreset"});
+    
+    var isServiceInstanceReady = $filter('isServiceInstanceReady');
+    var isBindingReady = $filter("isBindingReady");
+    var getErrorDetails = $filter('getErrorDetails');
+
+    var integrationName = ctrl.integration.spec.externalMetadata.serviceName;
+
+    var watches = [];
+    var ppwatch = false;
+
+    $scope.$on('$destroy', function() {
+      DataService.unwatchAll(watches);
+      if(ppwatch) {
+        DataService.unwatch(ppwatch);
+      }
+    });
+
+    ctrl.$onInit = function() {
+      var context = {namespace: ctrl.consumerService.metadata.namespace};
+
+      //setup watch on service instances, looking for an instance which provides this integration
+      watches.push(DataService.watch(instancePreferredVersion, context, function(serviceInstancesData) {
+        var data = serviceInstancesData.by('metadata.name');
+        $scope.serviceInstance = _.find(data, function(serviceInstance) {
+          var clusterServiceClassExternalName = _.get(serviceInstance, "spec.clusterServiceClassExternalName");
+          return (clusterServiceClassExternalName === ctrl.integration.spec.externalName);
+        });
+      }));
+
+      //pod preset watch should only exist when we have a handle to the service instance
+      $scope.$watch('serviceInstance', function(serviceInstance){
+        if(!serviceInstance && ppwatch !== false){
+          DataService.unwatch(ppwatch);
+          ppwatch = false;
+          return;
+        }
+        //dont recreate the pod preset watch
+        if(ppwatch !== false) {
+          return;
+        }
+        // watch for the pod preset for this integration
+        ppwatch = DataService.watch(podPresetPreferredVersion, context, function(podPresets) {
+          var data = podPresets.by("metadata.name");
+          ctrl.podPreset = _.find(data, function(podPreset) {
+            return podPreset.metadata.name === _.get(ctrl.consumerService, 'metadata.name') + "-" + _.get($scope.serviceInstance, 'metadata.name');
+          });
+        });
+      });
+      
+      //setup watch on servincebindings, watch for bindings consumed by this service
+      watches.push(DataService.watch(bindingPreferredVersion, context, function(bindingData) {
+        var data = bindingData.by("metadata.name");
+        ctrl.binding = _.find(data, function(binding) {
+          var bindingProviderName = _.get(binding, ["metadata", "annotations", "integrations.aerogear.org/provider"]);
+          var bindingConsumerName = _.get(binding, ["metadata", "annotations", "integrations.aerogear.org/consumer"]);
+          var consumerName = _.get(ctrl, "consumerService.metadata.labels.serviceName");
+          return (bindingProviderName && bindingConsumerName && consumerName && bindingProviderName === integrationName && bindingConsumerName === consumerName);
+        });
+      }));
+    };
+
+    var generatePodPresetTemplate = function(consumerService, providerService, binding) {
+      var consumerSvcName = _.get(consumerService, 'metadata.name');
+      var providerSvcName = _.get(providerService, 'metadata.name');
+      var podPreset = {
+        apiVersion: "settings.k8s.io/v1alpha1",
+        kind: "PodPreset",
+        metadata: {
+          name: consumerSvcName + '-' + providerSvcName,
+          labels: {
+            group: "mobile",
+            service: providerSvcName
+          }
+        },
+        spec: {
+          selector: {
+            matchLabels: {
+              run: consumerSvcName
+            }
+          },
+          volumeMounts: [
+            {
+              mountPath: "/etc/secrets/" + providerSvcName,
+              readOnly: true,
+              name: providerSvcName
+            }
+          ],
+          volumes: [
+            {
+              name: providerSvcName,
+              secret: {
+                secretName: _.get(binding, 'spec.secretName')
+              }
+            }
+          ]
+        }
+      };
+
+      podPreset.spec.selector.matchLabels[providerSvcName] = "enabled";
+      return podPreset;
+    };
+
+    ctrl.integrationPanelVisible = false;
+
+    ctrl.closeIntegrationPanel = function() {
+      ctrl.integrationPanelVisible = false;
+    };
+
+    ctrl.openIntegrationPanel = function() {
+      ctrl.parameterData = {
+        service: _.get(ctrl.consumerService, 'metadata.labels.serviceName')
+      };
+      ctrl.integrationPanelVisible = true;
+    };
+
+    ctrl.provision = function() {
+      $scope.$emit("open-overlay-panel", Catalog.getServiceItem(ctrl.integration));
+    };
+
+    ctrl.onBind = function(binding) {
+      var context = {namespace: _.get(ctrl.consumerService, 'metadata.namespace')};
+      var podPreset = generatePodPresetTemplate(ctrl.consumerService, $scope.serviceInstance, binding);
+      
+      //binding might not be ready currently, so
+      //watch binding to wait for it to be ready
+      var bindingReadyWatch = DataService.watchObject(bindingPreferredVersion, _.get(binding, 'metadata.name'), context, function(watchBinding) {
+        if (isBindingReady(watchBinding)) {
+          DataService.unwatch(bindingReadyWatch);
+          var copiedBinding = angular.copy(watchBinding);
+          NotificationsService.addNotification({
+            type: "success",
+            message: "A binding has been created for " + _.get(ctrl, 'consumerService.metadata.labels.serviceName') + " and it has been redeployed."
+          });
+          _.setWith(copiedBinding, ["metadata", "annotations", "integrations.aerogear.org/consumer"], ctrl.consumerService.metadata.labels.serviceName);
+          _.setWith(copiedBinding, ["metadata", "annotations", "integrations.aerogear.org/provider"], integrationName);
+          // update the binding with consumer and provider metadata annotations
+          DataService.update(bindingPreferredVersion, copiedBinding.metadata.name, copiedBinding, context)
+          // then retrieve the deployment
+          .then(function() {
+            return DataService.get(
+              deploymentPreferredVersion, 
+              _.get(ctrl, 'consumerService.metadata.labels.serviceName'), 
+              context, {errorNotification: false}
+            );
+          })
+          // then add the enabled service metadata label
+          .then(function(deployment) {
+            deployment.spec.template.metadata.labels[_.get($scope.serviceInstance, 'metadata.labels.serviceName')] = "enabled";
+            // and update the deployment and trigger a redeploy
+            return DataService.update(
+              deploymentPreferredVersion, 
+              _.get(ctrl, 'consumerService.metadata.labels.serviceName'), 
+              deployment, 
+              context
+            );
+          })
+          .catch(function(err) {
+            NotificationsService.addNotification({
+              type: "error",
+              message: "Failed to integrate service binding.",
+              details: err.data.message
+            });
+          });
+        }
+      });
+      
+      //create the pod preset asynchronously to the binding
+      DataService.create(podPresetPreferredVersion, null, podPreset, context)
+      .catch(function(err) {
+        NotificationsService.addNotification({
+          type: "error",
+          message: "Failed to create pod preset.",
+          details: getErrorDetails(err)
+        });
+      });
+      
+    };
+
+    ctrl.getState = function() {
+      if (ctrl.podPreset && !ctrl.binding) {
+        // pending create
+        return "pending";
+      }
+      if (ctrl.podPreset && ctrl.binding) {
+        //pod preset and binding exist, state 1
+        return "active";
+      }
+      if (ctrl.binding && !ctrl.podPreset) {
+        //pending delete
+        return "pending";
+      }
+      if ($scope.serviceInstance && isServiceInstanceReady($scope.serviceInstance)) {
+        return "no-binding";
+      } 
+      if ($scope.serviceInstance && !isServiceInstanceReady($scope.serviceInstance) && _.get($scope, 'serviceInstance.status.currentOperation') === 'Provision') {
+        return "service-provision-pending";
+      }
+      if ($scope.serviceInstance && !isServiceInstanceReady($scope.serviceInstance) && _.get($scope, 'serviceInstance.status.currentOperation') === 'Deprovision') {
+        return "service-deprovision-pending";
+      }
+      return "no-service";
+    };
+
+    //called in callback from succesful delete-link for binding
+    ctrl.deletePodPreset = function() {
+      var context = {namespace: ctrl.consumerService.metadata.namespace};
+      var deleteOptions = {propagationPolicy: null};
+      DataService.delete(podPresetPreferredVersion, ctrl.podPreset.metadata.name, context, deleteOptions)
+      .then(function() {
+        return DataService.get(
+          deploymentPreferredVersion, 
+          _.get(ctrl, 'consumerService.metadata.labels.serviceName'), 
+          context
+        );
+      })
+      .then(function(deployment) {
+        var copyDeployment = angular.copy(deployment);
+        delete copyDeployment.spec.template.metadata.labels[integrationName];
+        return DataService.update(
+          deploymentPreferredVersion, 
+          _.get(ctrl, 'consumerService.metadata.labels.serviceName'), 
+          copyDeployment, 
+          context
+        );
+      })
+      .catch(function(error) {
+        NotificationsService.addNotification({
+          type: "error",
+          message: "There was an error deleting the integration.",
+          details: getErrorDetails(error)
+        });
+      });
+    };
+  }
+})();

--- a/app/scripts/filters/mobile.js
+++ b/app/scripts/filters/mobile.js
@@ -1,0 +1,8 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .filter('isMobileService', function() {
+    return function(serviceInstance) {
+      return _.get(serviceInstance, 'metadata.labels.mobile', {}) === 'enabled';
+    };
+  });

--- a/app/styles/_integrations.less
+++ b/app/styles/_integrations.less
@@ -1,0 +1,74 @@
+.service-integrations {
+  .component-label.section-label {
+    margin: 0 20px;
+  }
+
+  .integrate-link{
+    color: #0088ce;
+    cursor: pointer;
+  }
+
+  .service-integration {
+    height: 40px;
+    margin: 10px 20px 0 0;
+    .image-icon {
+      padding-top: 5px;
+      margin: 0 15px;
+      width: 30px;
+    }
+    .id {
+      .text-muted();
+    }
+
+    .inline-delete{
+      display: inline-block;
+    }
+
+    .integration {
+      color: @link-color;
+
+      .integration-name {
+        display: inline;
+      }
+
+      &.active {
+        .pficon-error-circle-o {
+          &:before {
+            color: @link-color;
+          }
+          cursor: pointer;
+        }
+      }
+
+      //override delete-link default icon with the patternfly icon
+      .description {
+        .inline-delete {
+          .fa-trash-o {
+            font-family: "PatternFlyIcons-webfont";
+            color: @text-color;
+            background-color: @body-bg;
+            &:before {
+              content: "\e611";
+            }
+          }
+        }
+      }
+
+      &.inactive {
+        .pficon-add-circle-o {
+          cursor: pointer;
+        }
+      }
+
+      &.unknown {
+        .description h4 {
+          .text-muted();
+        }
+        .id {
+          color: @link-color;
+          cursor: pointer;
+        }
+      }
+    }
+  }
+}

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -30,6 +30,7 @@
 @import "_core.less";
 @import "_data-toolbar.less";
 @import "_ellipsis.less";
+@import "_integrations.less";
 @import "_layouts.less";
 @import "_list-pf.less";
 @import "_list-view.less";

--- a/app/views/directives/_service-integration.html
+++ b/app/views/directives/_service-integration.html
@@ -1,0 +1,40 @@
+<div class="service-integration pull-left" ng-if="$ctrl.integration">
+  <div ng-class="{active: $ctrl.getState() == 'active',
+                  inactive: $ctrl.getState() == 'no-binding',
+                  unknown: $ctrl.getState() == 'no-service'}" class="integration">
+    <img class="image-icon pull-left" ng-src="{{ $ctrl.integration.spec.externalMetadata.imageUrl }}">
+    <div class="description pull-left" ng-switch="$ctrl.getState()">
+      <h4 class="integration-name">{{$ctrl.integration.spec.externalMetadata.displayName || "Service Integration"}}</h4>
+      <span class="integration-error" ng-if="$ctrl.getState() == 'pending' || $ctrl.getState() == 'service-provision-pending' || $ctrl.getState() == 'service-deprovision-pending'"><span class="spinner spinner-xs spinner-inline" aria-hidden="true"></span></span>
+      <delete-link
+        class="inline-delete"
+        ng-if="$ctrl.getState() == 'active'"
+        kind="servicebinding"
+        group="servicecatalog.k8s.io"
+        button-only="true"
+        stay-on-current-page="true"
+        resource-name="{{$ctrl.binding.metadata.name}}"
+        project-name="{{$ctrl.binding.metadata.namespace}}"
+        success="$ctrl.deletePodPreset">
+      </delete-link>
+      <div class="id" ng-switch-when="pending">Status: Pending</div>
+      <div class="id" ng-switch-when="active">ID: {{ $ctrl.binding.metadata.name }}</div>
+      <div class="id" ng-switch-when="no-binding">No {{$ctrl.integration.spec.externalMetadata.displayName}} integration found. 
+        <span ng-click="$ctrl.openIntegrationPanel()" class="integrate-link">Integrate {{$ctrl.integration.spec.externalMetadata.displayName}}</span>
+      </div>
+      <div class="id" ng-switch-when="service-provision-pending">Waiting for {{$ctrl.integration.spec.externalMetadata.displayName}} provision to complete.</div>
+      <div class="id" ng-switch-when="service-deprovision-pending">Waiting for {{$ctrl.integration.spec.externalMetadata.displayName}} deprovision to complete.</div>
+      <div class="id" ng-switch-when="no-service">
+        <span ng-click="$ctrl.provision()">Provision {{$ctrl.integration.spec.externalMetadata.displayName}} to enable integration.</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<overlay-panel show-panel="$ctrl.integrationPanelVisible" handle-close="$ctrl.closeIntegrationPanel">
+  <bind-service target="serviceInstance"
+                project="$ctrl.project"
+                on-close="$ctrl.closeIntegrationPanel"
+                on-finish="$ctrl.onBind"
+                parameter-data="$ctrl.parameterData"></bind-service>
+</overlay-panel>

--- a/app/views/directives/service-instance-integrations.html
+++ b/app/views/directives/service-instance-integrations.html
@@ -1,0 +1,9 @@
+<div ng-if="($ctrl.integrationsData | size)" class="row service-integrations">
+  <div class="component-label section-label">Integrations</div>
+  <service-integration
+    ng-repeat="integration in $ctrl.integrationsData"
+    integration="integration"
+    consumer-service="$ctrl.consumerService">
+  </service-integration>
+</div>
+  

--- a/app/views/overview/_service-instance-row.html
+++ b/app/views/overview/_service-instance-row.html
@@ -160,7 +160,7 @@
         </div>
       </div>
       <div class="expanded-section">
-        <div ng-if="row.isBindable || (row.bindings | size)">
+        <div ng-if="(row.isBindable || (row.bindings | size))">
           <div class="component-label section-label">Bindings</div>
           <service-instance-bindings
             is-overview="true"
@@ -170,6 +170,13 @@
             service-class="row.serviceClass"
             service-plan="row.servicePlan">
           </service-instance-bindings>
+        </div>
+        <div ng-if="row.integrations | size">
+          <service-instance-integrations ng-if="row.instanceStatus === 'ready'"
+            is-overview="true"
+            integrations="row.integrations"
+            consumer-service="row.apiObject">
+          </service-instance-integrations>
         </div>
       </div>
     </div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5698,6 +5698,36 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/directives/_service-integration.html',
+    "<div class=\"service-integration pull-left\" ng-if=\"$ctrl.integration\">\n" +
+    "<div ng-class=\"{active: $ctrl.getState() == 'active',\n" +
+    "                  inactive: $ctrl.getState() == 'no-binding',\n" +
+    "                  unknown: $ctrl.getState() == 'no-service'}\" class=\"integration\">\n" +
+    "<img class=\"image-icon pull-left\" ng-src=\"{{ $ctrl.integration.spec.externalMetadata.imageUrl }}\">\n" +
+    "<div class=\"description pull-left\" ng-switch=\"$ctrl.getState()\">\n" +
+    "<h4 class=\"integration-name\">{{$ctrl.integration.spec.externalMetadata.displayName || \"Service Integration\"}}</h4>\n" +
+    "<span class=\"integration-error\" ng-if=\"$ctrl.getState() == 'pending' || $ctrl.getState() == 'service-provision-pending' || $ctrl.getState() == 'service-deprovision-pending'\"><span class=\"spinner spinner-xs spinner-inline\" aria-hidden=\"true\"></span></span>\n" +
+    "<delete-link class=\"inline-delete\" ng-if=\"$ctrl.getState() == 'active'\" kind=\"servicebinding\" group=\"servicecatalog.k8s.io\" button-only=\"true\" stay-on-current-page=\"true\" resource-name=\"{{$ctrl.binding.metadata.name}}\" project-name=\"{{$ctrl.binding.metadata.namespace}}\" success=\"$ctrl.deletePodPreset\">\n" +
+    "</delete-link>\n" +
+    "<div class=\"id\" ng-switch-when=\"pending\">Status: Pending</div>\n" +
+    "<div class=\"id\" ng-switch-when=\"active\">ID: {{ $ctrl.binding.metadata.name }}</div>\n" +
+    "<div class=\"id\" ng-switch-when=\"no-binding\">No {{$ctrl.integration.spec.externalMetadata.displayName}} integration found.\n" +
+    "<span ng-click=\"$ctrl.openIntegrationPanel()\" class=\"integrate-link\">Integrate {{$ctrl.integration.spec.externalMetadata.displayName}}</span>\n" +
+    "</div>\n" +
+    "<div class=\"id\" ng-switch-when=\"service-provision-pending\">Waiting for {{$ctrl.integration.spec.externalMetadata.displayName}} provision to complete.</div>\n" +
+    "<div class=\"id\" ng-switch-when=\"service-deprovision-pending\">Waiting for {{$ctrl.integration.spec.externalMetadata.displayName}} deprovision to complete.</div>\n" +
+    "<div class=\"id\" ng-switch-when=\"no-service\">\n" +
+    "<span ng-click=\"$ctrl.provision()\">Provision {{$ctrl.integration.spec.externalMetadata.displayName}} to enable integration.</span>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<overlay-panel show-panel=\"$ctrl.integrationPanelVisible\" handle-close=\"$ctrl.closeIntegrationPanel\">\n" +
+    "<bind-service target=\"serviceInstance\" project=\"$ctrl.project\" on-close=\"$ctrl.closeIntegrationPanel\" on-finish=\"$ctrl.onBind\" parameter-data=\"$ctrl.parameterData\"></bind-service>\n" +
+    "</overlay-panel>"
+  );
+
+
   $templateCache.put('views/directives/_status-icon.html',
     "<span ng-switch=\"status\" class=\"hide-ng-leave status-icon\">\n" +
     "<span ng-switch-when=\"Cancelled\" class=\"fa fa-ban text-muted\" aria-hidden=\"true\"></span>\n" +
@@ -9383,6 +9413,15 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/directives/service-instance-integrations.html',
+    "<div ng-if=\"($ctrl.integrationsData | size)\" class=\"row service-integrations\">\n" +
+    "<div class=\"component-label section-label\">Integrations</div>\n" +
+    "<service-integration ng-repeat=\"integration in $ctrl.integrationsData\" integration=\"integration\" consumer-service=\"$ctrl.consumerService\">\n" +
+    "</service-integration>\n" +
+    "</div>"
+  );
+
+
   $templateCache.put('views/directives/traffic-table.html',
     " <table class=\"table table-bordered table-mobile\">\n" +
     "<thead>\n" +
@@ -12973,10 +13012,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "<div class=\"expanded-section\">\n" +
-    "<div ng-if=\"row.isBindable || (row.bindings | size)\">\n" +
+    "<div ng-if=\"(row.isBindable || (row.bindings | size))\">\n" +
     "<div class=\"component-label section-label\">Bindings</div>\n" +
     "<service-instance-bindings is-overview=\"true\" project=\"row.state.project\" bindings=\"row.bindings\" service-instance=\"row.apiObject\" service-class=\"row.serviceClass\" service-plan=\"row.servicePlan\">\n" +
     "</service-instance-bindings>\n" +
+    "</div>\n" +
+    "<div ng-if=\"row.integrations | size\">\n" +
+    "<service-instance-integrations ng-if=\"row.instanceStatus === 'ready'\" is-overview=\"true\" integrations=\"row.integrations\" consumer-service=\"row.apiObject\">\n" +
+    "</service-instance-integrations>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5109,6 +5109,9 @@ pre.clipped.scroll{max-height:150px;overflow:auto;width:100%}
 .data-toolbar .data-toolbar-filter .form-group{margin-bottom:0}
 .header-toolbar .data-toolbar{background-color:#fff;border-bottom:1px solid #e4e4e4;margin:0 -20px;padding-left:20px;padding-right:20px}
 .data-toolbar .vertical-divider+.data-toolbar-filter{margin-top:10px}
+@media (min-width:768px){.data-toolbar .data-toolbar-filter{flex:1 1 0%}
+.data-toolbar .vertical-divider+.data-toolbar-filter{margin-top:0}
+}
 .selectize-dropdown{font-size:12px}
 .ellipsis-pulser{padding:10px;text-align:center}
 .ellipsis-pulser .dot{display:inline-block;height:4px;position:relative;width:4px}
@@ -5121,7 +5124,6 @@ pre.clipped.scroll{max-height:150px;overflow:auto;width:100%}
 .ellipsis-pulser.ellipsis-md .dot{height:8px;margin-bottom:-2px;width:8px}
 .ellipsis-pulser.ellipsis-md .ellipsis-msg{font-size:17px;font-weight:300;margin-right:3px}
 .ellipsis-pulser.ellipsis-lg .dot{height:12px;margin-bottom:-2px;width:12px}
-.layout-pf.layout-pf-fixed .container-pf-nav-pf-vertical .middle-header,.list-pf-content .alert-wrapper:last-child{margin-bottom:20px}
 .ellipsis-pulser.ellipsis-lg .ellipsis-msg{font-size:25px;font-weight:300;margin-right:6px}
 .ellipsis-pulser.ellipsis-dark .dot.pulse:after,.ellipsis-pulser.ellipsis-dark .dot.pulse:before{background:#333}
 .ellipsis-pulser.ellipsis-dark .ellipsis-msg{color:#333}
@@ -5133,12 +5135,25 @@ pre.clipped.scroll{max-height:150px;overflow:auto;width:100%}
 70%{transform:scale(.66)}
 100%{opacity:.33;z-index:1}
 }
+.service-integrations .component-label.section-label{margin:0 20px}
+.service-integrations .integrate-link{color:#0088ce;cursor:pointer}
+.service-integrations .service-integration{height:40px;margin:10px 20px 0 0}
+.service-integrations .service-integration .image-icon{padding-top:5px;margin:0 15px;width:30px}
+.layout-pf.layout-pf-fixed .container-pf-nav-pf-vertical .middle-header,.list-pf-content .alert-wrapper:last-child{margin-bottom:20px}
+.service-integrations .service-integration .id{color:#757575}
+.service-integrations .service-integration .integration,.service-integrations .service-integration .integration.active .pficon-error-circle-o:before{color:#0088ce}
+.service-integrations .service-integration .inline-delete{display:inline-block}
+.service-integrations .service-integration .integration .integration-name{display:inline}
+.service-integrations .service-integration .integration.active .pficon-error-circle-o{cursor:pointer}
+.service-integrations .service-integration .integration .description .inline-delete .fa-trash-o{font-family:PatternFlyIcons-webfont;color:#363636;background-color:#fff}
+.service-integrations .service-integration .integration .description .inline-delete .fa-trash-o:before{content:"\e611"}
+.service-integrations .service-integration .integration.inactive .pficon-add-circle-o{cursor:pointer}
+.service-integrations .service-integration .integration.unknown .description h4{color:#757575}
+.service-integrations .service-integration .integration.unknown .id{color:#0088ce;cursor:pointer}
 .layout-pf.layout-pf-fixed{height:1px}
 .layout-pf.layout-pf-fixed body{height:1px;padding-top:41px}
 .layout-pf.layout-pf-fixed .container-pf-nav-pf-vertical,.layout-pf.layout-pf-fixed .container-pf-nav-pf-vertical .view{height:100%}
-@media (min-width:768px){.data-toolbar .data-toolbar-filter{flex:1 1 0%}
-.data-toolbar .vertical-divider+.data-toolbar-filter{margin-top:0}
-.layout-pf.layout-pf-fixed body{padding-top:61px}
+@media (min-width:768px){.layout-pf.layout-pf-fixed body{padding-top:61px}
 }
 .layout-pf.layout-pf-fixed body.has-project-bar{padding-top:69px}
 .layout-pf.layout-pf-fixed body.has-project-bar.has-project-search{padding-top:116px}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/openshift/origin.git"
   },
   "devDependencies": {
-    "bower": "1.8.2",
+    "bower": "^1.8.2",
     "clean-css": "3.4.12",
     "connect-modrewrite": "0.7.9",
     "geckodriver": "1.3.0",


### PR DESCRIPTION
It is possible for various mobile services to be bound to each other, these changes to the UI will make it easier for a mobile developer using OpenShift to host the services for their mobile client to connect these services to each other.

Creating an integration between services will create a binding between the two services and also create a pod preset for the binding values to be connected to the correct pods. The deployment of the consuming service will then be updated to trigger a fresh deployment with the new config values present.

There are various states possible:
1. A service is running which can integrate with a service that is not running:
![integrations-provision](https://user-images.githubusercontent.com/1033452/38039083-6399a588-32a4-11e8-96c8-1577a3c85f39.png)

1.1 A service is being provisioned, which can be integrated with:
![integrations-provisioning](https://user-images.githubusercontent.com/1033452/38039106-7183fc20-32a4-11e8-8e19-44189dfff658.png)

2. A service is running which can integrate with a service that is also running:
![integrations-no-binding](https://user-images.githubusercontent.com/1033452/38039119-78d71200-32a4-11e8-8744-8ba02286529f.png)

3. A service is in the process of being integrated or de-integrated with another service:
![integrations-pending-binding](https://user-images.githubusercontent.com/1033452/38039128-7e22ff3a-32a4-11e8-826a-1c6305d87f34.png)

4. A service is currently integrated with another service:
![integrations-binding-active](https://user-images.githubusercontent.com/1033452/38039149-84d2178a-32a4-11e8-97a0-a37aecd065cd.png)

4. A service which could be integrated with, is being deprovisioned:
![integrations-service-deprovisioning](https://user-images.githubusercontent.com/1033452/38039175-93b2cb78-32a4-11e8-8db6-93908b110440.png)
