### PR TITLE
Fix bug "Open link in new tab" in right click menu jumps to home page

### DIFF
--- a/app/scripts/controllers/monitoring.js
+++ b/app/scripts/controllers/monitoring.js
@@ -272,15 +272,6 @@ angular.module('openshiftConsole')
       }
     };
 
-    $scope.viewPodsForSet = function(set) {
-      var pods = _.get($scope, ['podsByOwnerUID', set.metadata.uid], []);
-      if (_.isEmpty(pods)) {
-        return;
-      }
-
-      Navigate.toPodsForDeployment(set, pods);
-    };
-
     ProjectsService
       .get($routeParams.project)
       .then(_.spread(function(project, context) {

--- a/app/scripts/directives/overview/listRow.js
+++ b/app/scripts/directives/overview/listRow.js
@@ -352,14 +352,6 @@
       return Navigate.resourceURL(imageStreamName, 'ImageStream', imageStreamNamespace);
     };
 
-    row.navigateToPods = function() {
-      var pods = row.getPods(row.current);
-      if (_.isEmpty(pods)) {
-        return;
-      }
-      Navigate.toPodsForDeployment(row.current, pods);
-    };
-
     row.closeOverlayPanel = function() {
       _.set(row, 'overlay.panelVisible', false);
     };

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -1377,4 +1377,14 @@ angular.module('openshiftConsole')
   })
   .filter('humanizePodStatus', function(humanizeReasonFilter) {
     return humanizeReasonFilter;
+  })
+  .filter('donutURL', function(navigateResourceURLFilter) {
+    return function(set, pods) {
+      if (_.size(pods) === 1) {
+        return navigateResourceURLFilter(_.sample(pods));
+      }
+      if (_.size(pods) > 1) {
+        return navigateResourceURLFilter(set);
+      }
+    };
   });

--- a/app/scripts/services/navigate.js
+++ b/app/scripts/services/navigate.js
@@ -162,11 +162,7 @@ angular.module("openshiftConsole")
           this.toResourceURL(_.sample(pods));
           return;
         }
-
-        $location.url("/project/" + deployment.metadata.namespace + "/browse/pods");
-        $timeout(function() {
-          LabelFilter.setLabelSelector(new LabelSelector(deployment.spec.selector, true));
-        }, 1);
+        this.toResourceURL(deployment);
       },
 
       // Resource is either a resource object, or a name.  If resource is a name, kind and namespace must be specified

--- a/app/views/monitoring.html
+++ b/app/views/monitoring.html
@@ -190,8 +190,7 @@
                     <div class="list-pf-additional-content">
                       <div class="list-pf-additional-content-item">
                         <div class="pods">
-                          <a href=""
-                            ng-click="viewPodsForSet(replicationController)"
+                          <a ng-href="{{replicationController | donutURL : podsByOwnerUID[replicationController.metadata.uid]}}"
                             class="mini-donut-link"
                             ng-class="{ 'disabled-link': !(podsByOwnerUID[replicationController.metadata.uid] | size) }">
                             <pod-donut pods="podsByOwnerUID[replicationController.metadata.uid]" mini="true"></pod-donut>
@@ -261,8 +260,7 @@
                     <div class="list-pf-additional-content">
                       <div class="list-pf-additional-content-item">
                         <div class="pods">
-                          <a href=""
-                            ng-click="viewPodsForSet(replicaSet)"
+                          <a ng-href="{{replicaSet | donutURL : podsByOwnerUID[replicaSet.metadata.uid]}}"
                             class="mini-donut-link"
                             ng-class="{ 'disabled-link': !(podsByOwnerUID[replicaSet.metadata.uid] | size) }">
                             <pod-donut pods="podsByOwnerUID[replicaSet.metadata.uid]" mini="true"></pod-donut>
@@ -308,7 +306,7 @@
                   Logs are not available for replica sets.
                   <span ng-if="podsByOwnerUID[replicaSet.metadata.uid] | size">
                     To see application logs, view the logs for one of the replica set's
-                    <a href="" ng-click="viewPodsForSet(replicaSet)">pods</a>.
+                    <a ng-href="{{replicaSet | donutURL : podsByOwnerUID[replicaSet.metadata.uid]}}">pods</a>.
                   </span>
                   <div class="mar-top-lg" ng-if="metricsAvailable">
                     <deployment-metrics
@@ -365,8 +363,7 @@
                     <div class="list-pf-additional-content">
                       <div class="list-pf-additional-content-item">
                         <div class="pods">
-                          <a href=""
-                            ng-click="viewPodsForSet(set)"
+                          <a ng-href="{{set | donutURL : podsByOwnerUID[set.metadata.uid]}}"
                             class="mini-donut-link"
                             ng-class="{ 'disabled-link': !(podsByOwnerUID[set.metadata.uid] | size) }">
                             <pod-donut pods="podsByOwnerUID[set.metadata.uid]" mini="true"></pod-donut>
@@ -386,7 +383,7 @@
                   Logs are not available for stateful sets.
                   <span ng-if="podsByOwnerUID[set.metadata.uid] | size">
                     To see application logs, view the logs for one of the stateful sets's
-                    <a href="" ng-click="viewPodsForSet(set)">pods</a>.
+                    <a ng-href="{{set | donutURL : podsByOwnerUID[set.metadata.uid]}}">pods</a>.
                   </span>
                   <div class="mar-top-lg" ng-if="metricsAvailable">
                     <deployment-metrics

--- a/app/views/overview/_list-row-content.html
+++ b/app/views/overview/_list-row-content.html
@@ -79,7 +79,7 @@
       </a>
     </div>
     <div ng-if="row.apiObject.kind !== 'Pod'">
-      <a href="" ng-click="row.navigateToPods()" class="mini-donut-link" ng-class="{ 'disabled-link': !(row.getPods(row.current) | size) }">
+      <a ng-href="{{row.current | donutURL : row.getPods(row.current)}}" class="mini-donut-link" ng-class="{ 'disabled-link': !(row.getPods(row.current) | size) }">
         <pod-donut
           pods="row.getPods(row.current)"
           idled="!(row.getPods(row.current) | size) && (row.apiObject | annotation : 'idledAt')"

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1824,10 +1824,8 @@ name: t
 };
 _.isObject(r) && _.extend(a, r), e.path("project/" + encodeURIComponent(n) + "/create/next").search(a);
 },
-toPodsForDeployment: function(t, r) {
-1 !== _.size(r) ? (e.url("/project/" + t.metadata.namespace + "/browse/pods"), n(function() {
-a.setLabelSelector(new LabelSelector(t.spec.selector, !0));
-}, 1)) : this.toResourceURL(_.sample(r));
+toPodsForDeployment: function(e, t) {
+1 !== _.size(t) ? this.toResourceURL(e) : this.toResourceURL(_.sample(t));
 },
 resourceURL: function(e, t, n, r, a) {
 if (r = r || "browse", !(e && (e.metadata || t && n))) return null;
@@ -5186,9 +5184,6 @@ case "StatefulSet":
 s = !n.expanded.statefulSets[a.metadata.name], n.expanded.statefulSets[a.metadata.name] = s, c = s ? "event.resource.highlight" : "event.resource.clear-highlight", f.$emit(c, a);
 }
 }
-}, n.viewPodsForSet = function(e) {
-var t = _.get(n, [ "podsByOwnerUID", e.metadata.uid ], []);
-_.isEmpty(t) || d.toPodsForDeployment(e, t);
 }, p.get(e.project).then(_.spread(function(e, r) {
 n.project = e, n.projectContext = r, v.push(i.watch("pods", r, function(e) {
 n.podsByName = e.by("metadata.name"), n.pods = w(n.podsByName, !0), n.podsByOwnerUID = m.groupByOwnerUID(n.pods), n.podsLoaded = !0, _.each(n.pods, I), N(), l.log("pods", n.pods);
@@ -14230,9 +14225,6 @@ message: "Deployment #" + a + " is no longer the latest."
 }, l.urlForImageChangeTrigger = function(t) {
 var n = e("stripTag")(_.get(t, "imageChangeParams.from.name")), r = _.get(l, "apiObject.metadata.namespace"), a = _.get(t, "imageChangeParams.from.namespace", r);
 return s.resourceURL(n, "ImageStream", a);
-}, l.navigateToPods = function() {
-var e = l.getPods(l.current);
-_.isEmpty(e) || s.toPodsForDeployment(l.current, e);
 }, l.closeOverlayPanel = function() {
 _.set(l, "overlay.panelVisible", !1);
 }, l.showOverlayPanel = function(e, t) {
@@ -15926,6 +15918,10 @@ return _.startCase(e).replace("Back Off", "Back-off").replace("O Auth", "OAuth")
 };
 }).filter("humanizePodStatus", [ "humanizeReasonFilter", function(e) {
 return e;
+} ]).filter("donutURL", [ "navigateResourceURLFilter", function(e) {
+return function(t, n) {
+return 1 === _.size(n) ? e(_.sample(n)) : _.size(n) > 1 ? e(t) : void 0;
+};
 } ]), angular.module("openshiftConsole").filter("canIDoAny", [ "APIService", "canIFilter", function(e, t) {
 var n = {
 buildConfigs: [ {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -11430,7 +11430,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"list-pf-additional-content\">\n" +
     "<div class=\"list-pf-additional-content-item\">\n" +
     "<div class=\"pods\">\n" +
-    "<a href=\"\" ng-click=\"viewPodsForSet(replicationController)\" class=\"mini-donut-link\" ng-class=\"{ 'disabled-link': !(podsByOwnerUID[replicationController.metadata.uid] | size) }\">\n" +
+    "<a ng-href=\"{{replicationController | donutURL : podsByOwnerUID[replicationController.metadata.uid]}}\" class=\"mini-donut-link\" ng-class=\"{ 'disabled-link': !(podsByOwnerUID[replicationController.metadata.uid] | size) }\">\n" +
     "<pod-donut pods=\"podsByOwnerUID[replicationController.metadata.uid]\" mini=\"true\"></pod-donut>\n" +
     "</a>\n" +
     "</div>\n" +
@@ -11482,7 +11482,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"list-pf-additional-content\">\n" +
     "<div class=\"list-pf-additional-content-item\">\n" +
     "<div class=\"pods\">\n" +
-    "<a href=\"\" ng-click=\"viewPodsForSet(replicaSet)\" class=\"mini-donut-link\" ng-class=\"{ 'disabled-link': !(podsByOwnerUID[replicaSet.metadata.uid] | size) }\">\n" +
+    "<a ng-href=\"{{replicaSet | donutURL : podsByOwnerUID[replicaSet.metadata.uid]}}\" class=\"mini-donut-link\" ng-class=\"{ 'disabled-link': !(podsByOwnerUID[replicaSet.metadata.uid] | size) }\">\n" +
     "<pod-donut pods=\"podsByOwnerUID[replicaSet.metadata.uid]\" mini=\"true\"></pod-donut>\n" +
     "</a>\n" +
     "</div>\n" +
@@ -11511,7 +11511,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Logs are not available for replica sets.\n" +
     "<span ng-if=\"podsByOwnerUID[replicaSet.metadata.uid] | size\">\n" +
     "To see application logs, view the logs for one of the replica set's\n" +
-    "<a href=\"\" ng-click=\"viewPodsForSet(replicaSet)\">pods</a>.\n" +
+    "<a ng-href=\"{{replicaSet | donutURL : podsByOwnerUID[replicaSet.metadata.uid]}}\">pods</a>.\n" +
     "</span>\n" +
     "<div class=\"mar-top-lg\" ng-if=\"metricsAvailable\">\n" +
     "<deployment-metrics pods=\"podsByOwnerUID[replicaSet.metadata.uid]\" containers=\"replicaSet.spec.template.spec.containers\" alerts=\"alerts\">\n" +
@@ -11561,7 +11561,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"list-pf-additional-content\">\n" +
     "<div class=\"list-pf-additional-content-item\">\n" +
     "<div class=\"pods\">\n" +
-    "<a href=\"\" ng-click=\"viewPodsForSet(set)\" class=\"mini-donut-link\" ng-class=\"{ 'disabled-link': !(podsByOwnerUID[set.metadata.uid] | size) }\">\n" +
+    "<a ng-href=\"{{set | donutURL : podsByOwnerUID[set.metadata.uid]}}\" class=\"mini-donut-link\" ng-class=\"{ 'disabled-link': !(podsByOwnerUID[set.metadata.uid] | size) }\">\n" +
     "<pod-donut pods=\"podsByOwnerUID[set.metadata.uid]\" mini=\"true\"></pod-donut>\n" +
     "</a>\n" +
     "</div>\n" +
@@ -11578,7 +11578,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Logs are not available for stateful sets.\n" +
     "<span ng-if=\"podsByOwnerUID[set.metadata.uid] | size\">\n" +
     "To see application logs, view the logs for one of the stateful sets's\n" +
-    "<a href=\"\" ng-click=\"viewPodsForSet(set)\">pods</a>.\n" +
+    "<a ng-href=\"{{set | donutURL : podsByOwnerUID[set.metadata.uid]}}\">pods</a>.\n" +
     "</span>\n" +
     "<div class=\"mar-top-lg\" ng-if=\"metricsAvailable\">\n" +
     "<deployment-metrics pods=\"podsByOwnerUID[set.metadata.uid]\" containers=\"set.spec.template.spec.containers\" alerts=\"alerts\">\n" +
@@ -12364,7 +12364,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</a>\n" +
     "</div>\n" +
     "<div ng-if=\"row.apiObject.kind !== 'Pod'\">\n" +
-    "<a href=\"\" ng-click=\"row.navigateToPods()\" class=\"mini-donut-link\" ng-class=\"{ 'disabled-link': !(row.getPods(row.current) | size) }\">\n" +
+    "<a ng-href=\"{{row.current | donutURL : row.getPods(row.current)}}\" class=\"mini-donut-link\" ng-class=\"{ 'disabled-link': !(row.getPods(row.current) | size) }\">\n" +
     "<pod-donut pods=\"row.getPods(row.current)\" idled=\"!(row.getPods(row.current) | size) && (row.apiObject | annotation : 'idledAt')\" mini=\"true\">\n" +
     "</pod-donut>\n" +
     "</a>\n" +


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1470998

And also changes Navigate.toPodsForDeployment to go to the replication
controller page rather than the filtered pods page.