### PR TITLE
Provide link to create pull secret to private repo image on the deploy image.

### DIFF
--- a/app/scripts/directives/deployImage.js
+++ b/app/scripts/directives/deployImage.js
@@ -404,6 +404,17 @@ angular.module("openshiftConsole")
             });
           };
 
+          $scope.openCreateWebhookSecretModal = function() {
+            var dialogScope = $scope.$new();
+            dialogScope.type = "image";
+            dialogScope.namespace = $scope.input.selectedProject.metadata.name;
+            $uibModal.open({
+              templateUrl: 'views/modals/create-secret.html',
+              controller: 'CreateSecretModalController',
+              scope: dialogScope
+            });
+          };
+
           // When the deploy-image component is displayed in a dialog, the create
           // button is outside the component since it is in the wizard footer. Listen
           // for an event for when the button is clicked.

--- a/app/styles/_overlay-forms.less
+++ b/app/styles/_overlay-forms.less
@@ -7,10 +7,13 @@
   }
 
   .deploy-image .empty-state-message {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     margin-bottom: 0;
-    margin-top: 35px;
+    margin-top: 0;
+    min-height: 130px;
     @media(min-width: @screen-sm-min) {
-      margin-top: 90px;
       .landing-page & {
         margin-top: 40px;
       }

--- a/app/views/directives/deploy-image.html
+++ b/app/views/directives/deploy-image.html
@@ -2,7 +2,7 @@
   <select-project ng-if="!project" selected-project="input.selectedProject" name-taken="projectNameTaken"></select-project>
   <span ng-show="!noProjectsCantCreate">
     <p>
-      Deploy an existing image from an image stream tag or docker pull spec.
+      Deploy an existing image from an image stream tag or image registry.
     </p>
     <ng-form name="forms.imageSelection">
       <fieldset ng-disabled="loading">
@@ -60,6 +60,10 @@
                 </button>
               </span>
             </div>
+            <div class="help-block">To deploy an image from a private repository, you must
+              <a href=""
+                ng-click="openCreateWebhookSecretModal()">create an image pull secret</a>
+               with your image registry credentials.<a href="https://docs.openshift.org/latest/dev_guide/managing_images.html#using-image-pull-secrets" target="_blank"><span class="learn-more-inline">Learn More&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></span></a></div>
           </div>
         </fieldset>
       </fieldset>
@@ -196,6 +200,7 @@
         Could not load image metadata.
       </h2>
       <p>{{import.error | upperFirst}}</p>
+      <p>The image may not exist or it may be in a secure registry. Check that you have entered the image name correctly or <a href="" ng-click="openCreateWebhookSecretModal()">create an image pull secret</a> with your image registry credentials and try again.</p>
     </div>
 
     <div ng-if="!loading && import && !import.error && !import.image" class="empty-state-message text-center">

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -14581,6 +14581,13 @@ message: "An error occurred creating project.",
 details: y(e)
 });
 });
+}, n.openCreateWebhookSecretModal = function() {
+var e = n.$new();
+e.type = "image", e.namespace = n.input.selectedProject.metadata.name, r.open({
+templateUrl: "views/modals/create-secret.html",
+controller: "CreateSecretModalController",
+scope: e
+});
 }, n.$on("newAppFromDeployImage", n.create), n.$on("$destroy", S);
 }
 };

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -6396,7 +6396,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<select-project ng-if=\"!project\" selected-project=\"input.selectedProject\" name-taken=\"projectNameTaken\"></select-project>\n" +
     "<span ng-show=\"!noProjectsCantCreate\">\n" +
     "<p>\n" +
-    "Deploy an existing image from an image stream tag or docker pull spec.\n" +
+    "Deploy an existing image from an image stream tag or image registry.\n" +
     "</p>\n" +
     "<ng-form name=\"forms.imageSelection\">\n" +
     "<fieldset ng-disabled=\"loading\">\n" +
@@ -6438,6 +6438,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</button>\n" +
     "</span>\n" +
     "</div>\n" +
+    "<div class=\"help-block\">To deploy an image from a private repository, you must\n" +
+    "<a href=\"\" ng-click=\"openCreateWebhookSecretModal()\">create an image pull secret</a>\n" +
+    "with your image registry credentials.<a href=\"https://docs.openshift.org/latest/dev_guide/managing_images.html#using-image-pull-secrets\" target=\"_blank\"><span class=\"learn-more-inline\">Learn More&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></span></a></div>\n" +
     "</div>\n" +
     "</fieldset>\n" +
     "</fieldset>\n" +
@@ -6532,6 +6535,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "Could not load image metadata.\n" +
     "</h2>\n" +
     "<p>{{import.error | upperFirst}}</p>\n" +
+    "<p>The image may not exist or it may be in a secure registry. Check that you have entered the image name correctly or <a href=\"\" ng-click=\"openCreateWebhookSecretModal()\">create an image pull secret</a> with your image registry credentials and try again.</p>\n" +
     "</div>\n" +
     "<div ng-if=\"!loading && import && !import.error && !import.image\" class=\"empty-state-message text-center\">\n" +
     "<h2>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5241,9 +5241,8 @@ h2+.list-view-pf{margin-top:20px}
 .navbar-toggle:focus{color:#fff;outline:dotted thin!important;outline:-webkit-focus-ring-color auto 5px!important;outline-offset:-2px!important}
 .wizard-pf-main .ace_editor.editor{height:265px}
 .landing-page .wizard-pf-main .ace_editor.editor{height:175px}
-.wizard-pf-main .deploy-image .empty-state-message{margin-bottom:0;margin-top:35px}
-@media (min-width:768px){.wizard-pf-main .deploy-image .empty-state-message{margin-top:90px}
-.landing-page .wizard-pf-main .deploy-image .empty-state-message{margin-top:40px}
+.wizard-pf-main .deploy-image .empty-state-message{display:flex;flex-direction:column;justify-content:center;margin-bottom:0;margin-top:0;min-height:130px}
+@media (min-width:768px){.landing-page .wizard-pf-main .deploy-image .empty-state-message{margin-top:40px}
 }
 .build-count .builds,.build-count .pipelines{display:block}
 .build-count .icon-count,.builds-label{display:inline-block}


### PR DESCRIPTION
 Also, provide additional help text to help the user understand that a image pull secret must exist to deploy an image from a private repository.
- If no project exists then do not show create pull secret link option
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1489374

![deploy-image-create-pull-secret-first-then-deploy2](https://user-images.githubusercontent.com/1874151/37676919-af3645f6-2c4f-11e8-9a51-99d32376b294.gif)


[Updated] Help text slightly altered to the following.
<img width="671" alt="screen shot 2018-03-21 at 1 56 18 pm" src="https://user-images.githubusercontent.com/1874151/37728110-ccfda866-2d0f-11e8-8b72-a084038a7b3e.png">
<img width="847" alt="screen shot 2018-03-21 at 1 56 13 pm" src="https://user-images.githubusercontent.com/1874151/37728112-cd1362aa-2d0f-11e8-8b35-e86c78c4fcbe.png">

