### PR TITLE
Disable autoprefixer's removal of outdated prefixes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -236,7 +236,10 @@ module.exports = function (grunt) {
     postcss: {
       options: {
         processors: [
-          require('autoprefixer')({browsers: ['last 1 version']})
+          require('autoprefixer')({
+            browsers: ['last 1 version'],
+            remove: false
+          })
         ]
       },
       dist: {


### PR DESCRIPTION
in order to fix bug where autoprefixer is removing -webkit-box-orient
declarations needed for line truncation.  See https://github.com/postcss/autoprefixer#outdated-prefixes for details.