### PR TITLE
Handle UTF-8 BOM when decoding secrets for display

### DIFF
--- a/app/scripts/services/secrets.js
+++ b/app/scripts/services/secrets.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module("openshiftConsole")
-  .factory("SecretsService", function($filter, Logger, NotificationsService){
+  .factory("SecretsService", function($filter, base64, Logger, NotificationsService){
     var isNonPrintable = $filter('isNonPrintable');
 
     var groupSecretsByType = function(secrets) {
@@ -52,7 +52,7 @@ angular.module("openshiftConsole")
             params.username = username;
             params.password = password;
           });
-          setParams(_.split(window.atob(serverData.auth), ':', 2));
+          setParams(_.split(base64.decode(serverData.auth), ':', 2));
         } catch(e) {
           handleDecodeException(e, 'username:password');
           return;
@@ -89,7 +89,7 @@ angular.module("openshiftConsole")
       };
 
       try {
-        decodedData = JSON.parse(window.atob(encodedData));
+        decodedData = JSON.parse(base64.decode(encodedData));
       } catch(e) {
         handleDecodeException(e, configType);
       }
@@ -125,7 +125,7 @@ angular.module("openshiftConsole")
         if (configType === ".dockercfg" || configType === ".dockerconfigjson") {
           return decodeDockerConfig(data, configType);
         } else {
-          decoded = window.atob(data);
+          decoded = base64.decode(data);
           // Allow whitespace like newlines and tabs, but detect other
           // non-printable characters in the unencoded data.
           if (isNonPrintable(decoded)) {

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3300,44 +3300,44 @@ message: null
 };
 }
 };
-}), angular.module("openshiftConsole").factory("SecretsService", [ "$filter", "Logger", "NotificationsService", function(e, t, n) {
-var r = e("isNonPrintable"), a = function(r, a) {
-n.addNotification({
+}), angular.module("openshiftConsole").factory("SecretsService", [ "$filter", "base64", "Logger", "NotificationsService", function(e, t, n, r) {
+var a = e("isNonPrintable"), o = function(t, a) {
+r.addNotification({
 type: "error",
 message: "Base64-encoded " + a + " string could not be decoded.",
-details: e("getErrorDetails")(r)
-}), t.error("Base64-encoded " + a + " string could not be decoded.", r);
-}, o = function(e) {
-var t = _.pick(e, [ "email", "username", "password" ]);
+details: e("getErrorDetails")(t)
+}), n.error("Base64-encoded " + a + " string could not be decoded.", t);
+}, i = function(e) {
+var n = _.pick(e, [ "email", "username", "password" ]);
 if (e.auth) try {
-_.spread(function(e, n) {
-t.username = e, t.password = n;
-})(_.split(window.atob(e.auth), ":", 2));
+_.spread(function(e, t) {
+n.username = e, n.password = t;
+})(_.split(t.decode(e.auth), ":", 2));
 } catch (e) {
-return void a(e, "username:password");
+return void o(e, "username:password");
 }
-return t;
-}, i = function(e, t) {
-var n, r = {
+return n;
+}, s = function(e, n) {
+var r, a = {
 auths: {}
 };
 try {
-n = JSON.parse(window.atob(e));
+r = JSON.parse(t.decode(e));
 } catch (e) {
-a(e, t);
+o(e, n);
 }
-return n.auths ? (_.each(n.auths, function(e, t) {
-e.auth ? r.auths[t] = o(e) : r.auths[t] = e;
-}), n.credsStore && (r.credsStore = n.credsStore)) : _.each(n, function(e, t) {
-r.auths[t] = o(e);
-}), r;
-}, s = function(e) {
-var t = {}, n = _.mapValues(e, function(e, n) {
+return r.auths ? (_.each(r.auths, function(e, t) {
+e.auth ? a.auths[t] = i(e) : a.auths[t] = e;
+}), r.credsStore && (a.credsStore = r.credsStore)) : _.each(r, function(e, t) {
+a.auths[t] = i(e);
+}), a;
+}, c = function(e) {
+var n = {}, r = _.mapValues(e, function(e, r) {
 if (!e) return "";
-var a;
-return ".dockercfg" === n || ".dockerconfigjson" === n ? i(e, n) : (a = window.atob(e), r(a) ? (t[n] = !0, e) : a);
+var o;
+return ".dockercfg" === r || ".dockerconfigjson" === r ? s(e, r) : (o = t.decode(e), a(o) ? (n[r] = !0, e) : o);
 });
-return n.$$nonprintable = t, n;
+return r.$$nonprintable = n, r;
 };
 return {
 groupSecretsByType: function(e) {
@@ -3365,7 +3365,7 @@ t.other.push(e);
 }
 }), t;
 },
-decodeSecretData: s,
+decodeSecretData: c,
 getWebhookSecretValue: function(e, t) {
 if (_.get(e, "secretReference.name") && t) {
 var n = _.find(t, {
@@ -3373,7 +3373,7 @@ metadata: {
 name: e.secretReference.name
 }
 });
-return s(n.data).WebHookSecretKey;
+return c(n.data).WebHookSecretKey;
 }
 return _.get(e, "secret");
 }


### PR DESCRIPTION
UTF-8 BOM can show up when decoding secret data using `window.atob()`.
Prevent this by use `base64.decode()` when decoding for display, which
handles the BOM.

Note: We should not use `base64.encode()` to encode the secret because
it will not correctly handle binary data. Since we're only decoding the
secret to display it and we don't display data with non-printable
characters, there's no danger of losing data using `base64.decode()`.

Before:

![openshift web console 2018-03-23 12-06-58](https://user-images.githubusercontent.com/1167259/37840165-b77892c4-2e92-11e8-8c2a-f26b81dcbba4.png)

After:

![openshift web console 2018-03-23 12-07-36](https://user-images.githubusercontent.com/1167259/37840198-c91f0c7e-2e92-11e8-8168-6c297b5e28f1.png)

/assign @benjaminapetersen 

