### PR TITLE
Open Remote Desktop for a windows VM (kubevirt)

### DIFF
--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -933,6 +933,24 @@ function OverviewController($scope,
     });
   };
 
+  var updateServicesForOvms = function () {
+    if (!overview.offlineVirtualMachines || !state.allServices) {
+      return;
+    }
+    _.each(overview.offlineVirtualMachines, function(ovm) {
+      var ovmDomain = _.get(ovm, 'metadata.labels["kubevirt.io/domain"]');
+      if (!ovmDomain) {
+        return false;
+      }
+
+      var services = _.filter(state.allServices, function (service) {
+          var domain = _.get(service, 'spec.selector["kubevirt.io/domain"]');
+          return domain === ovmDomain;
+      });
+      ovm.services = services;
+    });
+  };
+
   // Update the list of services for all API objects.
   //
   // Updates `state.servicesByObjectUID`
@@ -959,6 +977,7 @@ function OverviewController($scope,
     _.each(toUpdate, updateServicesForObjects);
 
     updateRoutesByApp();
+    updateServicesForOvms();
   };
 
   // Group routes by the services they route to (either as a primary service or
@@ -1508,6 +1527,7 @@ function OverviewController($scope,
       var ovmCallback = function (ovms) {
         overview.offlineVirtualMachines = ovms.by('metadata.name');
         updateVirtualMachineMapping();
+        updateServicesForOvms(); // https://github.com/kubevirt/user-guide/blob/master/service.md
         updateFilter();
       };
       watches.push(DataService.watch(

--- a/app/styles/_virtual-machine.less
+++ b/app/styles/_virtual-machine.less
@@ -1,0 +1,3 @@
+.virtual-machine-detail-col {
+  width: 50%;
+}

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -68,3 +68,4 @@
 @import "_add-config-to-application.less";
 @import "_instances.less";
 @import "_set-home-page.less";
+@import "_virtual-machine.less";

--- a/app/views/overview/_virtual-machine-row.html
+++ b/app/views/overview/_virtual-machine-row.html
@@ -41,17 +41,29 @@
   </div>
   <div class="list-pf-expansion collapse" ng-if="row.expanded" ng-class="{ in: row.expanded }">
     <div class="list-pf-container">
-      <div class="expanded-section resource-details">
+      <div class="expanded-section resource-details row-expanded-top">
         <h3>Details</h3>
-        <dl class="dl-horizontal">
-          <dt>State:</dt>
-          <dd>
-            <div vm-state ovm="row.apiObject"></div>
-          </dd>
+        <div class="virtual-machine-detail-col">
+          <dl class="dl-horizontal">
+            <dt>State:</dt>
+            <dd>
+              <div vm-state ovm="row.apiObject"></div>
+            </dd>
 
-          <dt>Operating System:</dt>
-          <dd>{{row.apiObject.metadata.labels['kubevirt.io/os'] || '-'}}</dd>
-        </dl>
+            <dt>Operating System:</dt>
+            <dd>{{row.apiObject.metadata.labels['kubevirt.io/os'] || '-'}}</dd>
+          </dl>
+        </div>
+
+        <div class="virtual-machine-detail-col" ng-if="row.isWindowsVM() && row.isOvmRunning()">
+          <dl class="dl-horizontal">
+            <dt>Remote Desktop:</dt>
+            <dd>
+              <a href="" ng-if="row.isRdpService()" ng-click="row.onOpenRemoteDesktop()">Open Console</a>
+              <div ng-if="!row.isRdpService()">No RDP service defined</div>
+            </dd>
+          </dl>
+        </div>
       </div>
     </div>
   </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -285,19 +285,28 @@ e.matches(r) && t.push(be.allServices[n]);
 }), be.servicesByObjectUID[n] = _.sortBy(t, "metadata.name");
 });
 }, dt = function() {
+B.offlineVirtualMachines && be.allServices && _.each(B.offlineVirtualMachines, function(e) {
+var t = _.get(e, 'metadata.labels["kubevirt.io/domain"]');
+if (!t) return !1;
+var n = _.filter(be.allServices, function(e) {
+return _.get(e, 'spec.selector["kubevirt.io/domain"]') === t;
+});
+e.services = n;
+});
+}, mt = function() {
 if (be.allServices) {
 lt = _.mapValues(be.allServices, function(e) {
 return new LabelSelector(e.spec.selector);
 });
 var e = [ B.deploymentConfigs, B.vanillaReplicationControllers, B.deployments, B.vanillaReplicaSets, B.statefulSets, B.daemonSets, B.monopods ];
-_.each(e, ut), Re();
+_.each(e, ut), Re(), dt();
 }
-}, mt = function() {
+}, pt = function() {
 var e = E.groupByService(B.routes, !0);
 be.routesByService = _.mapValues(e, E.sortRoutesByScore), Re();
-}, pt = function() {
+}, ft = function() {
 be.hpaByResource = g.groupHPAs(B.horizontalPodAutoscalers);
-}, ft = function(e) {
+}, gt = function(e) {
 var t = F(e), n = B.buildConfigs[t];
 if (n) {
 B.recentPipelinesByBuildConfig[t] = B.recentPipelinesByBuildConfig[t] || [], B.recentPipelinesByBuildConfig[t].push(e);
@@ -306,23 +315,23 @@ _.each(r, function(t) {
 be.recentPipelinesByDeploymentConfig[t] = be.recentPipelinesByDeploymentConfig[t] || [], be.recentPipelinesByDeploymentConfig[t].push(e);
 }), Te();
 }
-}, gt = {}, vt = function() {
-gt = l.groupBuildConfigsByOutputImage(B.buildConfigs);
-}, ht = function(e) {
+}, vt = {}, ht = function() {
+vt = l.groupBuildConfigsByOutputImage(B.buildConfigs);
+}, yt = function(e) {
 var t = _e(e);
 if (t) return _.get(be, [ "buildConfigsByObjectUID", t ], []);
-}, yt = function(e) {
-var t = [], n = ht(e);
+}, bt = function(e) {
+var t = [], n = yt(e);
 _.each(n, function(e) {
 var n = _.get(be, [ "recentBuildsByBuildConfig", e.metadata.name ], []);
 t = t.concat(n);
 });
 var r = Ce(e);
 _.set(be, [ "recentBuildsByDeploymentConfig", r ], t);
-}, bt = function(e, t) {
+}, St = function(e, t) {
 var n = _e(t);
 n && _.set(be, [ "buildConfigsByObjectUID", n ], e);
-}, St = function() {
+}, Ct = function() {
 var e = [];
 B.deploymentConfigsByPipeline = {}, be.pipelinesByDeploymentConfig = {}, _.each(B.buildConfigs, function(t) {
 if (q(t)) {
@@ -333,37 +342,37 @@ be.pipelinesByDeploymentConfig[e] = be.pipelinesByDeploymentConfig[e] || [], be.
 });
 }
 }), B.pipelineBuildConfigs = _.sortBy(e, "metadata.name"), Te(), tt(B.pipelineBuildConfigs), Ne();
-}, Ct = function() {
+}, _t = function() {
 be.buildConfigsByObjectUID = {}, _.each(B.deploymentConfigs, function(e) {
 var t = [], n = _.get(e, "spec.triggers");
 _.each(n, function(n) {
 var r = _.get(n, "imageChangeParams.from");
 if (r) {
-var a = M(r, e.metadata.namespace), o = gt[a];
+var a = M(r, e.metadata.namespace), o = vt[a];
 _.isEmpty(o) || (t = t.concat(o));
 }
-}), t = _.sortBy(t, "metadata.name"), bt(t, e), yt(e);
+}), t = _.sortBy(t, "metadata.name"), St(t, e), bt(e);
 });
-}, _t = function() {
-St(), Ct();
 }, wt = function() {
-_.each(B.deploymentConfigs, yt);
+Ct(), _t();
 }, Pt = function() {
+_.each(B.deploymentConfigs, bt);
+}, jt = function() {
 if (be.builds && B.buildConfigs) {
 B.recentPipelinesByBuildConfig = {}, be.recentBuildsByBuildConfig = {}, be.recentPipelinesByDeploymentConfig = {};
 var e = {};
 _.each(l.interestingBuilds(be.builds), function(t) {
 var n = F(t);
-q(t) ? ft(t) : (e[n] = e[n] || [], e[n].push(t));
+q(t) ? gt(t) : (e[n] = e[n] || [], e[n].push(t));
 }), B.recentPipelinesByBuildConfig = _.mapValues(B.recentPipelinesByBuildConfig, function(e) {
 return l.sortBuilds(e, !0);
 }), be.recentPipelinesByDeploymentConfig = _.mapValues(be.recentPipelinesByDeploymentConfig, function(e) {
 return l.sortBuilds(e, !0);
 }), be.recentBuildsByBuildConfig = _.mapValues(e, function(e) {
 return l.sortBuilds(e, !0);
-}), wt();
+}), Pt();
 }
-}, jt = function() {
+}, kt = function() {
 R.setQuotaNotifications(be.quotas, be.clusterQuotas, a.project);
 };
 B.clearFilter = function() {
@@ -383,7 +392,7 @@ w.toProjectCatalog(e.projectName);
 }, b.onActiveFiltersChanged(function() {
 e.$evalAsync(Le);
 }), B.startBuild = l.startBuild;
-var kt = function() {
+var It = function() {
 if (be.bindingsByApplicationUID = {}, be.applicationsByBinding = {}, be.deleteableBindingsByApplicationUID = {}, !_.isEmpty(be.bindings)) {
 var e = [ B.deployments, B.deploymentConfigs, B.vanillaReplicationControllers, B.vanillaReplicaSets, B.statefulSets, B.daemonSets ];
 if (!_.some(e, function(e) {
@@ -405,19 +414,19 @@ return _.get(_.head(t), [ "metadata", "name" ]) || e.metadata.name;
 }, {});
 }
 }
-}, It = function() {
+}, Rt = function() {
 be.bindableServiceInstances = c.filterBindableServiceInstances(be.serviceInstances, be.serviceClasses, be.servicePlans), be.orderedServiceInstances = c.sortServiceInstances(be.serviceInstances, be.serviceClasses);
-}, Rt = [], Et = L ? {
+}, Et = [], Tt = L ? {
 skipErrorNotFound: !0
 } : {};
-k.get(a.project, Et).then(_.spread(function(t, r) {
+k.get(a.project, Tt).then(_.spread(function(t, r) {
 be.project = e.project = t, be.context = e.context = r;
 var a = function() {
 B.pods && h.fetchReferencedImageStreamImages(B.pods, be.imagesByDockerReference, be.imageStreamImageRefByDockerReference, r);
 }, o = function(e) {
-B.daemonSets = e.by("metadata.name"), ut(B.daemonSetData), ut(B.monopods), ze(B.daemonSets), et(B.daemonSets), kt(), Le(), S.log("daemonsets", B.daemonSets);
+B.daemonSets = e.by("metadata.name"), ut(B.daemonSetData), ut(B.monopods), ze(B.daemonSets), et(B.daemonSets), It(), Le(), S.log("daemonsets", B.daemonSets);
 }, i = !1, s = function() {
-i || (Rt.push(m.watch(J, r, o, {
+i || (Et.push(m.watch(J, r, o, {
 poll: V,
 pollInterval: 6e4
 })), i = !0);
@@ -430,61 +439,61 @@ kind: "DaemonSet"
 }, l = function() {
 i || _.some(B.pods, c) && s();
 };
-if (Rt.push(m.watch(ne, r, function(e, t) {
+if (Et.push(m.watch(ne, r, function(e, t) {
 B.pods = e.by("metadata.name"), rt(), a(), Xe(), ut(B.monopods), ze(B.monopods), et(B.monopods), Le(), t && "ADDED" !== t || l(), S.log("pods (subscribe)", B.pods);
-})), Rt.push(m.watch(ae, r, function(e) {
-B.replicationControllers = e.by("metadata.name"), it(), ut(B.vanillaReplicationControllers), ut(B.monopods), ze(B.vanillaReplicationControllers), et(B.vanillaReplicationControllers), kt(), Le(), S.log("replicationcontrollers (subscribe)", B.replicationControllers);
-})), Rt.push(m.watch(Y, r, function(e) {
-B.deploymentConfigs = e.by("metadata.name"), it(), ut(B.deploymentConfigs), ut(B.vanillaReplicationControllers), et(B.deploymentConfigs), Ye(), _t(), wt(), kt(), Le(), S.log("deploymentconfigs (subscribe)", B.deploymentConfigs);
-})), Rt.push(m.watch(re, r, function(e) {
-B.replicaSets = e.by("metadata.name"), ct(), ut(B.vanillaReplicaSets), ut(B.monopods), ze(B.vanillaReplicaSets), et(B.vanillaReplicaSets), kt(), Le(), S.log("replicasets (subscribe)", B.replicaSets);
-})), Rt.push(m.watch(Z, r, function(e) {
-fe = e.by("metadata.uid"), B.deployments = _.sortBy(fe, "metadata.name"), ct(), ut(B.deployments), ut(B.vanillaReplicaSets), et(B.deployments), kt(), Le(), S.log("deployments (subscribe)", B.deploymentsByUID);
-})), Rt.push(m.watch(W, r, function(e) {
-be.builds = e.by("metadata.name"), Pt(), S.log("builds (subscribe)", be.builds);
-})), Rt.push(m.watch(me, r, function(e) {
-B.statefulSets = e.by("metadata.name"), ut(B.statefulSets), ut(B.monopods), ze(B.statefulSets), et(B.statefulSets), kt(), Le(), S.log("statefulsets (subscribe)", B.statefulSets);
+})), Et.push(m.watch(ae, r, function(e) {
+B.replicationControllers = e.by("metadata.name"), it(), ut(B.vanillaReplicationControllers), ut(B.monopods), ze(B.vanillaReplicationControllers), et(B.vanillaReplicationControllers), It(), Le(), S.log("replicationcontrollers (subscribe)", B.replicationControllers);
+})), Et.push(m.watch(Y, r, function(e) {
+B.deploymentConfigs = e.by("metadata.name"), it(), ut(B.deploymentConfigs), ut(B.vanillaReplicationControllers), et(B.deploymentConfigs), Ye(), wt(), Pt(), It(), Le(), S.log("deploymentconfigs (subscribe)", B.deploymentConfigs);
+})), Et.push(m.watch(re, r, function(e) {
+B.replicaSets = e.by("metadata.name"), ct(), ut(B.vanillaReplicaSets), ut(B.monopods), ze(B.vanillaReplicaSets), et(B.vanillaReplicaSets), It(), Le(), S.log("replicasets (subscribe)", B.replicaSets);
+})), Et.push(m.watch(Z, r, function(e) {
+fe = e.by("metadata.uid"), B.deployments = _.sortBy(fe, "metadata.name"), ct(), ut(B.deployments), ut(B.vanillaReplicaSets), et(B.deployments), It(), Le(), S.log("deployments (subscribe)", B.deploymentsByUID);
+})), Et.push(m.watch(W, r, function(e) {
+be.builds = e.by("metadata.name"), jt(), S.log("builds (subscribe)", be.builds);
+})), Et.push(m.watch(me, r, function(e) {
+B.statefulSets = e.by("metadata.name"), ut(B.statefulSets), ut(B.monopods), ze(B.statefulSets), et(B.statefulSets), It(), Le(), S.log("statefulsets (subscribe)", B.statefulSets);
 }, {
 poll: V,
 pollInterval: 6e4
 })), m.list(J, r, function(e) {
 o(e), _.isEmpty(B.daemonSets) || s();
-}), Rt.push(m.watch(de, r, function(e) {
-be.allServices = e.by("metadata.name"), dt(), S.log("services (subscribe)", be.allServices);
+}), Et.push(m.watch(de, r, function(e) {
+be.allServices = e.by("metadata.name"), mt(), S.log("services (subscribe)", be.allServices);
 }, {
 poll: V,
 pollInterval: 6e4
-})), Rt.push(m.watch(ie, r, function(e) {
-B.routes = e.by("metadata.name"), mt(), S.log("routes (subscribe)", B.routes);
+})), Et.push(m.watch(ie, r, function(e) {
+B.routes = e.by("metadata.name"), pt(), S.log("routes (subscribe)", B.routes);
 }, {
 poll: V,
 pollInterval: 6e4
-})), Rt.push(m.watch(K, r, function(e) {
-B.buildConfigs = e.by("metadata.name"), vt(), _t(), Pt(), Le(), S.log("buildconfigs (subscribe)", B.buildConfigs);
+})), Et.push(m.watch(K, r, function(e) {
+B.buildConfigs = e.by("metadata.name"), ht(), wt(), jt(), Le(), S.log("buildconfigs (subscribe)", B.buildConfigs);
 }, {
 poll: V,
 pollInterval: 6e4
-})), Rt.push(m.watch(X, r, function(e) {
-B.horizontalPodAutoscalers = e.by("metadata.name"), pt(), S.log("autoscalers (subscribe)", B.horizontalPodAutoscalers);
+})), Et.push(m.watch(X, r, function(e) {
+B.horizontalPodAutoscalers = e.by("metadata.name"), ft(), S.log("autoscalers (subscribe)", B.horizontalPodAutoscalers);
 }, {
 poll: V,
 pollInterval: 6e4
-})), Rt.push(m.watch(ee, r, function(e) {
+})), Et.push(m.watch(ee, r, function(e) {
 ge = e.by("metadata.name"), h.buildDockerRefMapForImageStreams(ge, be.imageStreamImageRefByDockerReference), a(), S.log("imagestreams (subscribe)", ge);
 }, {
 poll: V,
 pollInterval: 6e4
-})), Rt.push(m.watch(oe, r, function(e) {
-be.quotas = e.by("metadata.name"), jt();
+})), Et.push(m.watch(oe, r, function(e) {
+be.quotas = e.by("metadata.name"), kt();
 }, {
 poll: !0,
 pollInterval: 6e4
-})), Rt.push(m.watch(Q, r, function(e) {
-be.clusterQuotas = e.by("metadata.name"), jt();
+})), Et.push(m.watch(Q, r, function(e) {
+be.clusterQuotas = e.by("metadata.name"), kt();
 }, {
 poll: !0,
 pollInterval: 6e4
-})), e.AEROGEAR_MOBILE_ENABLED && Rt.push(m.watch({
+})), e.AEROGEAR_MOBILE_ENABLED && Et.push(m.watch({
 group: "mobile.k8s.io",
 version: "v1alpha1",
 resource: "mobileclients"
@@ -494,13 +503,13 @@ B.mobileClients = e.by("metadata.name"), Le(), S.log("mobileclients (subscribe)"
 poll: V,
 pollInterval: 6e4
 })), e.KUBEVIRT_ENABLED) {
-Rt.push(m.watch(N.offlineVirtualMachine, r, function(e) {
-B.offlineVirtualMachines = e.by("metadata.name"), A(), Le();
+Et.push(m.watch(N.offlineVirtualMachine, r, function(e) {
+B.offlineVirtualMachines = e.by("metadata.name"), A(), dt(), Le();
 }, {
 poll: V,
 pollInterval: 6e4
 }));
-Rt.push(m.watch(N.virtualMachine, r, function(e) {
+Et.push(m.watch(N.virtualMachine, r, function(e) {
 B.virtualMachines = e.by("metadata.name"), A(), Le();
 }, {
 poll: V,
@@ -526,20 +535,20 @@ return be.servicePlans[t] = e, e;
 }).finally(function() {
 delete v[t];
 })), v[t]);
-}, Rt.push(m.watch(le, r, function(e) {
+}, Et.push(m.watch(le, r, function(e) {
 be.serviceInstances = e.by("metadata.name");
 var t = [];
 _.each(be.serviceInstances, function(e) {
 var n = R.getServiceInstanceAlerts(e);
 xe(e, n), t.push(p(e)), t.push(f(e));
 }), I.waitForAll(t).finally(function() {
-It(), Le();
+Rt(), Le();
 }), et(be.serviceInstances);
 }, {
 poll: V,
 pollInterval: 6e4
-}))), u.SERVICE_CATALOG_ENABLED && U(se, "watch") && Rt.push(m.watch(se, r, function(e) {
-be.bindings = e.by("metadata.name"), B.bindingsByInstanceRef = _.groupBy(be.bindings, "spec.instanceRef.name"), kt();
+}))), u.SERVICE_CATALOG_ENABLED && U(se, "watch") && Et.push(m.watch(se, r, function(e) {
+be.bindings = e.by("metadata.name"), B.bindingsByInstanceRef = _.groupBy(be.bindings, "spec.instanceRef.name"), It();
 }, {
 poll: V,
 pollInterval: 6e4
@@ -554,7 +563,7 @@ errorNotification: !1
 }).then(function(t) {
 B.samplePipelineURL = w.createFromTemplateURL(t, e.projectName);
 }), e.$on("$destroy", function() {
-m.unwatchAll(Rt), $(window).off(".overview");
+m.unwatchAll(Et), $(window).off(".overview");
 });
 }), function(t) {
 L && _.get(t, "notFound") && (f.notifyInvalidProjectHomePage(e.projectName), w.toProjectList());
@@ -13992,34 +14001,67 @@ state: "<"
 templateUrl: "views/overview/_mobile-client-row.html"
 });
 }(), function() {
-angular.module("openshiftConsole").component("virtualMachineRow", {
-controller: [ "$scope", "$filter", "$routeParams", "APIService", "AuthorizationService", "DataService", "ListRowUtils", "Navigate", "ProjectsService", "KubevirtVersions", function(e, t, n, r, a, o, i, s, c, l) {
-function u() {
-return p.apiObject.spec.running;
+function e(e, t, n) {
+t = t || "vm.rdp", n = n || "application/rdp";
+var r = document.createElement("a");
+if (navigator.msSaveBlob) return navigator.msSaveBlob(new Blob([ e ], {
+type: n
+}), t);
+if ("download" in r) return r.href = "data:" + n + "," + encodeURIComponent(e), r.setAttribute("download", t), document.body.appendChild(r), r.click(), document.body.removeChild(r), !0;
+var a = document.createElement("iframe");
+return document.body.appendChild(a), a.src = "data:" + n + "," + encodeURIComponent(e), setTimeout(function() {
+document.body.removeChild(a);
+}, 333), !0;
 }
-function d() {
-var e = angular.copy(p.apiObject);
+function t(e, t) {
+return "full address:s:" + e + "\nserver port:i: " + t + "\ndesktopwidth:i:1024\ndesktopheight:i:768\nscreen mode id:i:1\nauthentication level:i:2\nredirectclipboard:i:1\nsession bpp:i:32\ncompression:i:1\nkeyboardhook:i:2\naudiocapturemode:i:0\nvideoplaybackmode:i:1\nconnection type:i:2\ndisplayconnectionbar:i:1\ndisable wallpaper:i:1\nallow font smoothing:i:0\nallow desktop composition:i:0\ndisable full window drag:i:1\ndisable menu anims:i:1\ndisable themes:i:0\ndisable cursor setting:i:0\nbitmapcachepersistenable:i:1\naudiomode:i:0\nredirectcomports:i:0\nredirectposdevices:i:0\nredirectdirectx:i:1\nautoreconnection enabled:i:1\nprompt for credentials:i:1\nnegotiate security layer:i:1\nremoteapplicationmode:i:0\nalternate shell:s:\nshell working directory:s:\ngatewayhostname:s:\ngatewayusagemethod:i:4\ngatewaycredentialssource:i:4\ngatewayprofileusagemethod:i:0\npromptcredentialonce:i:1\nuse redirection server name:i:0\n";
+}
+angular.module("openshiftConsole").component("virtualMachineRow", {
+controller: [ "$scope", "$filter", "$routeParams", "APIService", "AuthorizationService", "DataService", "ListRowUtils", "Navigate", "ProjectsService", "KubevirtVersions", function(r, a, o, i, s, c, l, u, d, m) {
+function p() {
+var e = angular.copy(g.apiObject);
 return delete e._pod, delete e._vm, e;
 }
-function m(t) {
-var n = d();
-return n.spec.running = t, o.update(l.offlineVirtualMachine.resource, n.metadata.name, n, e.$parent.context);
+function f(e) {
+var t = p();
+return t.spec.running = e, c.update(m.offlineVirtualMachine.resource, t.metadata.name, t, r.$parent.context);
 }
-var p = this;
-p.OfflineVirtualMachineVersion = l.offlineVirtualMachine, _.extend(p, i.ui), p.actionsDropdownVisible = function() {
-return !_.get(p.apiObject, "metadata.deletionTimestamp") && a.canI(l.offlineVirtualMachine, "delete");
-}, p.projectName = n.project, p.startOvm = function() {
-m(!0);
-}, p.stopOvm = function() {
-m(!1);
-}, p.restartOvm = function() {
-return o.delete(l.virtualMachine, p.apiObject._vm.metadata.name, e.$parent.context);
-}, p.canStartOvm = function() {
-return !u();
-}, p.canStopOvm = function() {
-return u();
-}, p.canRestartOvm = function() {
-return u() && p.apiObject._vm && "Running" === _.get(p.apiObject, "_pod.status.phase");
+var g = this;
+g.OfflineVirtualMachineVersion = m.offlineVirtualMachine, _.extend(g, l.ui), g.actionsDropdownVisible = function() {
+return !_.get(g.apiObject, "metadata.deletionTimestamp") && s.canI(m.offlineVirtualMachine, "delete");
+}, g.projectName = o.project, g.isOvmRunning = function() {
+return g.apiObject.spec.running;
+}, g.startOvm = function() {
+f(!0);
+}, g.stopOvm = function() {
+f(!1);
+}, g.restartOvm = function() {
+return c.delete(m.virtualMachine, g.apiObject._vm.metadata.name, r.$parent.context);
+}, g.canStartOvm = function() {
+return !g.isOvmRunning();
+}, g.canStopOvm = function() {
+return g.isOvmRunning();
+}, g.canRestartOvm = function() {
+return g.isOvmRunning() && g.apiObject._vm && "Running" === _.get(g.apiObject, "_pod.status.phase");
+}, g.isWindowsVM = function() {
+var e = g.apiObject, t = _.get(e, 'metadata.labels["kubevirt.io/os"]');
+return t && _.startsWith(t, "win");
+}, g.isRdpService = function() {
+var e = g.apiObject;
+return !_.isEmpty(e.services);
+}, g.onOpenRemoteDesktop = function() {
+var r = g.apiObject;
+if (!_.isEmpty(r.services)) {
+var a = function(e) {
+return _.find(_.get(e, "spec.ports"), function(e) {
+return e.targetPort === n;
+});
+}, o = _.find(r.services, a), i = a(o), s = _.get(i, "port");
+if (s) {
+var c = _.get(o, "spec.externalIPs");
+_.isEmpty(c) ? console.warn("externalIP is not defined for the RDP Service: ", o, r) : e(t(c[0], s));
+} else console.warn("Port is not defined: ", i, r);
+}
 };
 } ],
 controllerAs: "row",
@@ -14028,7 +14070,9 @@ apiObject: "<",
 state: "<"
 },
 templateUrl: "views/overview/_virtual-machine-row.html"
-}), angular.module("openshiftConsole").directive("vmState", function() {
+});
+var n = 3389;
+angular.module("openshiftConsole").directive("vmState", function() {
 function e(e) {
 var t = _.get(e, "_vm.status.phase");
 return void 0 !== t ? t : _.get(e, ".spec.running") ? "Unknown" : "Off";

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -13070,8 +13070,9 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "<div class=\"list-pf-expansion collapse\" ng-if=\"row.expanded\" ng-class=\"{ in: row.expanded }\">\n" +
     "<div class=\"list-pf-container\">\n" +
-    "<div class=\"expanded-section resource-details\">\n" +
+    "<div class=\"expanded-section resource-details row-expanded-top\">\n" +
     "<h3>Details</h3>\n" +
+    "<div class=\"virtual-machine-detail-col\">\n" +
     "<dl class=\"dl-horizontal\">\n" +
     "<dt>State:</dt>\n" +
     "<dd>\n" +
@@ -13080,6 +13081,16 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt>Operating System:</dt>\n" +
     "<dd>{{row.apiObject.metadata.labels['kubevirt.io/os'] || '-'}}</dd>\n" +
     "</dl>\n" +
+    "</div>\n" +
+    "<div class=\"virtual-machine-detail-col\" ng-if=\"row.isWindowsVM() && row.isOvmRunning()\">\n" +
+    "<dl class=\"dl-horizontal\">\n" +
+    "<dt>Remote Desktop:</dt>\n" +
+    "<dd>\n" +
+    "<a href=\"\" ng-if=\"row.isRdpService()\" ng-click=\"row.onOpenRemoteDesktop()\">Open Console</a>\n" +
+    "<div ng-if=\"!row.isRdpService()\">No RDP service defined</div>\n" +
+    "</dd>\n" +
+    "</dl>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/scripts/vendor.js
+++ b/dist/scripts/vendor.js
@@ -76178,13 +76178,13 @@ f.prototype._uniqueKey = function(e, t, n, i) {
 var r, o = n && n.namespace || _.get(n, "project.metadata.name") || n.projectName, a = _.get(i, "http.params"), s = this._urlForResource(e, t, n, null, angular.extend({}, {}, {
 namespace: o
 }));
-return r = s ? s.toString() : e || "<unknown>", r += x(a || {}), _.get(i, "partialObjectMetadataList") ? r + "#application/json;as=PartialObjectMetadataList;v=v1beta1;g=meta.k8s.io,application/json" : r;
+return r = s ? s.toString() : e || "<unknown>", r += x(a || {}), _.get(i, "partialObjectMetadataList") ? r + "#application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io" : r;
 }, f.prototype._startListOp = function(e, n, i) {
 i = i || {};
 var r = _.get(i, "http.params") || {}, o = this._uniqueKey(e, null, n, i);
 this._listInFlight(o, !0);
 var a = {};
-i.partialObjectMetadataList && (a.Accept = "application/json;as=PartialObjectMetadataList;v=v1beta1;g=meta.k8s.io,application/json");
+i.partialObjectMetadataList && (a.Accept = "application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io");
 var s, l = this;
 if (n.projectPromise && !e.equals("projects")) n.projectPromise.done(function(c) {
 if (!(s = l._urlForResource(e, null, n, !1, _.assign({}, r, {

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -6275,3 +6275,4 @@ notification-drawer-wrapper .expanded-notification.unread .drawer-pf-notificatio
 .add-config-to-application .updating{background-color:#fff;bottom:55px;left:0;padding-top:60px;position:absolute;right:0;top:55px;z-index:1000}
 .service-instance-details .instance-status-message{white-space:pre-line}
 .set-home-page .select-project-container{max-width:360px;padding-left:20px}
+.virtual-machine-detail-col{width:50%}


### PR DESCRIPTION
Link to download an RDP file to access Windows VM is added.
Mime-type of downloaded content is "application/rdp".

Requires LoadBalancer Service object exposing VM ports [1].
The Service.spec.selector["kubevirt.io/domain"] is expected
to match OVM.metadata.labels["kubevirt.io/domain"].

The RDP link is rendered if:
- matching Service is defined
- VM is running
- VM is Windows (OVM.metadata.labels["kubevirt.io/domain"] starts at "win")

If Service object can not be found, but the VM is Windows and running,
informative text about missing Service is rendered instead of the link.

VM operating system is determined from "kubevirt.io/os" label of
the running OfflineVirtualMachine object.

[1] https://github.com/kubevirt/user-guide/blob/master/service.md
