### PR TITLE
[enterprise-3.9] Fall back to JSON when PartialObjectMetadataList not available

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -46,8 +46,8 @@
     "angular-moment": "1.0.0",
     "angular-utf8-base64": "0.0.5",
     "file-saver": "1.3.3",
-    "origin-web-common": "3.9.1",
-    "origin-web-catalog": "3.9.0-rc.0"
+    "origin-web-common": "3.9.2",
+    "origin-web-catalog": "3.9.0"
   },
   "devDependencies": {
     "angular-mocks": "1.5.11",

--- a/dist/scripts/vendor.js
+++ b/dist/scripts/vendor.js
@@ -31121,10 +31121,6 @@ updateNavArrows: function() {
 if (this._allow_update) {
 var e, t, n = new Date(this.viewDate), i = n.getUTCFullYear(), r = n.getUTCMonth(), o = this.o.startDate !== -1 / 0 ? this.o.startDate.getUTCFullYear() : -1 / 0, a = this.o.startDate !== -1 / 0 ? this.o.startDate.getUTCMonth() : -1 / 0, s = this.o.endDate !== 1 / 0 ? this.o.endDate.getUTCFullYear() : 1 / 0, l = this.o.endDate !== 1 / 0 ? this.o.endDate.getUTCMonth() : 1 / 0, c = 1;
 switch (this.viewMode) {
-case 0:
-e = i <= o && r <= a, t = i >= s && r >= l;
-break;
-
 case 4:
 c *= 10;
 
@@ -31135,7 +31131,11 @@ case 2:
 c *= 10;
 
 case 1:
-e = Math.floor(i / c) * c <= o, t = Math.floor(i / c) * c + c >= s;
+e = Math.floor(i / c) * c < o, t = Math.floor(i / c) * c + c > s;
+break;
+
+case 0:
+e = i <= o && r < a, t = i >= s && r > l;
 }
 this.picker.find(".prev").toggleClass("disabled", e), this.picker.find(".next").toggleClass("disabled", t);
 }
@@ -31255,6 +31255,11 @@ return e.valueOf();
 });
 e.each(this.pickers, function(e, n) {
 n.setRange(t);
+});
+},
+clearDates: function() {
+e.each(this.pickers, function(e, t) {
+t.clearDates();
 });
 },
 dateUpdated: function(n) {
@@ -31476,7 +31481,7 @@ footTemplate: '<tfoot><tr><th colspan="7" class="today"></th></tr><tr><th colspa
 };
 v.template = '<div class="datepicker"><div class="datepicker-days"><table class="table-condensed">' + v.headTemplate + "<tbody></tbody>" + v.footTemplate + '</table></div><div class="datepicker-months"><table class="table-condensed">' + v.headTemplate + v.contTemplate + v.footTemplate + '</table></div><div class="datepicker-years"><table class="table-condensed">' + v.headTemplate + v.contTemplate + v.footTemplate + '</table></div><div class="datepicker-decades"><table class="table-condensed">' + v.headTemplate + v.contTemplate + v.footTemplate + '</table></div><div class="datepicker-centuries"><table class="table-condensed">' + v.headTemplate + v.contTemplate + v.footTemplate + "</table></div></div>", e.fn.datepicker.DPGlobal = v, e.fn.datepicker.noConflict = function() {
 return e.fn.datepicker = h, this;
-}, e.fn.datepicker.version = "1.7.1", e.fn.datepicker.deprecated = function(e) {
+}, e.fn.datepicker.version = "1.8.0", e.fn.datepicker.deprecated = function(e) {
 var t = window.console;
 t && t.warn && t.warn("DEPRECATED: " + e);
 }, e(document).on("focus.datepicker.data-api click.datepicker.data-api", '[data-provide="datepicker"]', function(t) {
@@ -75673,13 +75678,13 @@ f.prototype._uniqueKey = function(e, t, n, i) {
 var r, o = n && n.namespace || _.get(n, "project.metadata.name") || n.projectName, a = _.get(i, "http.params"), s = this._urlForResource(e, t, n, null, angular.extend({}, {}, {
 namespace: o
 }));
-return r = s ? s.toString() : e || "<unknown>", r += x(a || {}), _.get(i, "partialObjectMetadataList") ? r + "#application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io" : r;
+return r = s ? s.toString() : e || "<unknown>", r += x(a || {}), _.get(i, "partialObjectMetadataList") ? r + "#application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io,application/json" : r;
 }, f.prototype._startListOp = function(e, n, i) {
 i = i || {};
 var r = _.get(i, "http.params") || {}, o = this._uniqueKey(e, null, n, i);
 this._listInFlight(o, !0);
 var a = {};
-i.partialObjectMetadataList && (a.Accept = "application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io");
+i.partialObjectMetadataList && (a.Accept = "application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io,application/json");
 var s, l = this;
 if (n.projectPromise && !e.equals("projects")) n.projectPromise.done(function(c) {
 if (!(s = l._urlForResource(e, null, n, !1, _.assign({}, r, {

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -2498,7 +2498,7 @@ td>.progress:first-child:last-child{margin-bottom:0;margin-top:3px}
 .datepicker .cw{font-size:10px;width:12px;padding:0 2px 0 5px;vertical-align:middle}
 .input-daterange{width:100%}
 .input-daterange input{text-align:center}
-.input-daterange .input-group-addon{width:auto;min-width:16px;text-shadow:0 1px 0 #fff;border-width:1px 0;margin-left:-5px;margin-right:-5px}
+.input-daterange .input-group-addon{width:auto;min-width:16px;border-width:1px 0;margin-left:-5px;margin-right:-5px}
 select.bs-select-hidden,select.selectpicker{display:none!important}
 .bootstrap-select{width:220px\9}
 .bootstrap-select>.dropdown-toggle{width:100%;padding-right:25px;z-index:1}


### PR DESCRIPTION
Avoids an error when the 3.9 console is talking to a 3.10 master.

Bumps origin-web-common to 3.9.2.

/assign @jwforres 