### PR TITLE
Bug 1563595 - Update wording when deploying image from private registry with incorrect image pull credentials

### DIFF
--- a/app/views/directives/deploy-image.html
+++ b/app/views/directives/deploy-image.html
@@ -203,7 +203,7 @@
         Could not load image metadata.
       </h2>
       <p>{{import.error | upperFirst}}</p>
-      <p>The image may not exist or it may be in a secure registry. Check that you have entered the image name correctly or <a href="" ng-click="openCreateWebhookSecretModal()">create an image pull secret</a> with your image registry credentials and try again.</p>
+      <p>The image may not exist or it may be in a secure registry. Check that you have entered the image name correctly. In case of private image repository, check that your image pull secret credentials are correct or <a href="" ng-click="openCreateWebhookSecretModal()">create an image pull secret</a> with your image registry credentials and try again.</p>
     </div>
 
     <div ng-if="!loading && import && !import.error && !import.image" class="empty-state-message text-center">


### PR DESCRIPTION
As we shortly discussed, Im updating the working in the deploy-image modal, since we ruled out deleting of any secrets from the modal or any similar logic.

Screen:
![download](https://user-images.githubusercontent.com/1668218/38801084-276679d2-4169-11e8-94e4-1b86392c59a8.png)


@spadgett  PTAL