### PR TITLE
Change routes help link on browse page

### DIFF
--- a/app/views/browse/service.html
+++ b/app/views/browse/service.html
@@ -91,7 +91,7 @@
                   <traffic-table ports-by-route="portsByRoute" routes="routesForService" services="services" show-node-ports="showNodePorts" custom-name-header="'Route'"></traffic-table>
                 </div>
                 <p>
-                  Learn more about <a ng-href="{{'route-types' | helpLink}}" target="_blank">routes</a> and <a ng-href="{{'services' | helpLink}}" target="_blank">services</a>.
+                  Learn more about <a ng-href="{{'routes' | helpLink}}" target="_blank">routes</a> and <a ng-href="{{'services' | helpLink}}" target="_blank">services</a>.
                 </p>
                 <h3>Pods</h3>
                 <div>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -3859,7 +3859,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<traffic-table ports-by-route=\"portsByRoute\" routes=\"routesForService\" services=\"services\" show-node-ports=\"showNodePorts\" custom-name-header=\"'Route'\"></traffic-table>\n" +
     "</div>\n" +
     "<p>\n" +
-    "Learn more about <a ng-href=\"{{'route-types' | helpLink}}\" target=\"_blank\">routes</a> and <a ng-href=\"{{'services' | helpLink}}\" target=\"_blank\">services</a>.\n" +
+    "Learn more about <a ng-href=\"{{'routes' | helpLink}}\" target=\"_blank\">routes</a> and <a ng-href=\"{{'services' | helpLink}}\" target=\"_blank\">services</a>.\n" +
     "</p>\n" +
     "<h3>Pods</h3>\n" +
     "<div>\n" +


### PR DESCRIPTION
Relevant BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1502540#c3

This just changes the Routes page to link to the main [routes](https://github.com/openshift/origin-web-console/blob/d7ca56bbd4561bfc9b1fe26ac26b7913d5e87ecc/app/scripts/constants.js#L56) doc page instead of the [route-types](https://github.com/openshift/origin-web-console/blob/d7ca56bbd4561bfc9b1fe26ac26b7913d5e87ecc/app/scripts/constants.js#L25) sub-header, at the recommendation of QE based on the context of the link.