### PR TITLE
Bug 1577359 - Don't show Create Project button if you cannot create a…

### DIFF
--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -13411,7 +13411,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "OpenShift helps you quickly develop, host, and scale applications.<br>\n" +
     "<span ng-if=\"canCreate\">Create a project for your application.</span>\n" +
     "</p>\n" +
-    "<div>\n" +
+    "<div ng-if=\"canCreate\">\n" +
     "<button ng-click=\"createProject($event)\" class=\"btn btn-lg btn-primary\">\n" +
     "<span class=\"fa fa-plus\" aria-hidden=\"true\"></span>\n" +
     "<span class=\"icon-button-text\">Create Project</span>\n" +


### PR DESCRIPTION
Bug 1577359 - Don't show Create Project button if you cannot create a project

Add the correct ng-if=\"canCreate\" to the <div> that surrounds the Create Project button in the template.