### PR TITLE
Bug 1577359 - Check canCreate in projects empty state message

### DIFF
--- a/app/views/projects.html
+++ b/app/views/projects.html
@@ -175,7 +175,7 @@
                 OpenShift helps you quickly develop, host, and scale applications.<br>
                 <span ng-if="canCreate">Create a project for your application.</span>
               </p>
-              <div>
+              <div ng-if="canCreate">
                 <button ng-click="createProject($event)" class="btn btn-lg btn-primary">
                   <span class="fa fa-plus" aria-hidden="true"></span>
                   <span class="icon-button-text">Create Project</span>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -13411,7 +13411,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "OpenShift helps you quickly develop, host, and scale applications.<br>\n" +
     "<span ng-if=\"canCreate\">Create a project for your application.</span>\n" +
     "</p>\n" +
-    "<div>\n" +
+    "<div ng-if=\"canCreate\">\n" +
     "<button ng-click=\"createProject($event)\" class=\"btn btn-lg btn-primary\">\n" +
     "<span class=\"fa fa-plus\" aria-hidden=\"true\"></span>\n" +
     "<span class=\"icon-button-text\">Create Project</span>\n" +


### PR DESCRIPTION
Don't show the Create Project button in the empty state message if the
user doesn't have authority.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1577359

/assign @rhamilto 