### PR TITLE
Add HawtioExtension shim

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -182,6 +182,7 @@
 
         <script src="scripts/constants.js"></script>
         <script src="scripts/app.js"></script>
+        <script src="scripts/services/shims/hawtioExtension.js"></script>
         <script src="scripts/services/browserStore.js"></script>
         <script src="scripts/services/discovery.js"></script>
         <script src="scripts/services/applicationGenerator.js"></script>

--- a/app/scripts/services/shims/hawtioExtension.js
+++ b/app/scripts/services/shims/hawtioExtension.js
@@ -1,0 +1,19 @@
+'use strict';
+angular
+ .module('openshiftConsole')
+ .factory('HawtioExtension', [
+   'extensionRegistry',
+   function(extensionRegistry) {
+     console.warn('HawtioExtension.add() has been deprecated.  Please migrate to angular-extension-registry https://github.com/openshift/angular-extension-registry');
+     return {
+       add: function(endpointName, domNodeGenerator) {
+         extensionRegistry.add(endpointName, function(args) {
+           return {
+             type: 'dom',
+             node: domNodeGenerator(args)
+           };
+         });
+       }
+     };
+   }
+ ]);

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1520,7 +1520,18 @@ icon: "fa fa-database"
 }), Logger.info("AEROGEAR_MOBILE_ENABLED: " + e.AEROGEAR_MOBILE_ENABLED);
 } ]).run([ "$rootScope", "APIService", "KubevirtVersions", function(e, t, n) {
 e.KUBEVIRT_ENABLED = !!t.apiInfo(n.offlineVirtualMachine);
-} ]), pluginLoader.addModule("openshiftConsole"), angular.module("openshiftConsole").factory("BrowserStore", [ function() {
+} ]), pluginLoader.addModule("openshiftConsole"), angular.module("openshiftConsole").factory("HawtioExtension", [ "extensionRegistry", function(e) {
+return console.warn("HawtioExtension.add() has been deprecated.  Please migrate to angular-extension-registry https://github.com/openshift/angular-extension-registry"), {
+add: function(t, n) {
+e.add(t, function(e) {
+return {
+type: "dom",
+node: n(e)
+};
+});
+}
+};
+} ]), angular.module("openshiftConsole").factory("BrowserStore", [ function() {
 var e = {
 local: window.localStorage,
 session: window.sessionStorage

--- a/dist/scripts/vendor.js
+++ b/dist/scripts/vendor.js
@@ -74391,34 +74391,38 @@ return e.Logger = t._prevLogger, t;
 }(this), function(e, t) {
 "function" == typeof define && define.amd ? define([], t) : "object" == typeof exports ? module.exports = t() : e.compareVersions = t();
 }(this, function() {
-function e(e) {
-var t = e.replace(/^v/, "").split("."), n = t.splice(0, 2);
-return n.push(t.join(".")), n;
+function e(e, t) {
+return -1 === e.indexOf(t) ? e.length : e.indexOf(t);
 }
-function t(e) {
-return isNaN(Number(e)) ? e : Number(e);
+function t(t) {
+var n = t.replace(/^v/, "").replace(/\+.*$/, ""), i = e(n, "-"), r = n.substring(0, i).split(".");
+return r.push(n.substring(i + 1)), r;
 }
 function n(e) {
+return isNaN(Number(e)) ? e : Number(e);
+}
+function i(e) {
 if ("string" != typeof e) throw new TypeError("Invalid argument expected string");
-if (!i.test(e)) throw new Error("Invalid argument not valid semver");
+if (!r.test(e)) throw new Error("Invalid argument not valid semver");
 }
-var i = /^v?(?:\d+)(\.(?:[x*]|\d+)(\.(?:[x*]|\d+)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?)?)?$/i, r = /-([0-9A-Za-z-.]+)/;
-return function(i, o) {
-[ i, o ].forEach(n);
-for (var a = e(i), s = e(o), l = 0; l < 3; l++) {
-var c = parseInt(a[l] || 0, 10), u = parseInt(s[l] || 0, 10);
-if (c > u) return 1;
-if (u > c) return -1;
+var r = /^v?(?:\d+)(\.(?:[x*]|\d+)(\.(?:[x*]|\d+)(\.(?:[x*]|\d+))?(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?)?)?$/i;
+return function(e, r) {
+[ e, r ].forEach(i);
+for (var o = t(e), a = t(r), s = 0; s < Math.max(o.length - 1, a.length - 1); s++) {
+var l = parseInt(o[s] || 0, 10), c = parseInt(a[s] || 0, 10);
+if (l > c) return 1;
+if (c > l) return -1;
 }
-if ([ a[2], s[2] ].every(r.test.bind(r))) {
-var d = r.exec(a[2])[1].split(".").map(t), h = r.exec(s[2])[1].split(".").map(t);
-for (l = 0; l < Math.max(d.length, h.length); l++) {
-if (void 0 === d[l] || "string" == typeof h[l] && "number" == typeof d[l]) return -1;
-if (void 0 === h[l] || "string" == typeof d[l] && "number" == typeof h[l]) return 1;
-if (d[l] > h[l]) return 1;
-if (h[l] > d[l]) return -1;
+var u = o[o.length - 1], d = a[a.length - 1];
+if (u && d) {
+var h = u.split(".").map(n), f = d.split(".").map(n);
+for (s = 0; s < Math.max(h.length, f.length); s++) {
+if (void 0 === h[s] || "string" == typeof f[s] && "number" == typeof h[s]) return -1;
+if (void 0 === f[s] || "string" == typeof h[s] && "number" == typeof f[s]) return 1;
+if (h[s] > f[s]) return 1;
+if (f[s] > h[s]) return -1;
 }
-} else if ([ a[2], s[2] ].some(r.test.bind(r))) return r.test(a[2]) ? -1 : 1;
+} else if (u || d) return u ? -1 : 1;
 return 0;
 };
 }), function() {


### PR DESCRIPTION
Fixes [Trello issue](https://trello.com/c/lDwZBWL4/251-free-int-error-loading-web-console-after-upgrade-to-310)

Adds a shim for `HawtioExtension.add()` to map to `extensionRegistry.add()`.  API is fairly similar, however `extensionRegistry` provides `args` to the callback function rather than reference to raw `$scope`.  

The shim will also log a deprecation notice:

![screen shot 2018-05-14 at 12 20 50 pm](https://user-images.githubusercontent.com/280512/40010019-980e5a1a-5771-11e8-9839-b9c4e47714c3.png)

@spadgett @TheRealJon @jupierce 



