### PR TITLE
Added PVC Expand functionality in Storage tab

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -296,6 +296,7 @@
         <script src="scripts/controllers/modals/confirmScale.js"></script>
         <script src="scripts/controllers/modals/confirmSaveLog.js"></script>
         <script src="scripts/controllers/modals/deleteModal.js"></script>
+        <script src="scripts/controllers/modals/editPvcModal.js"></script>
         <script src="scripts/controllers/modals/debugTerminal.js"></script>
         <script src="scripts/controllers/modals/confirmReplaceModal.js"></script>
         <script src="scripts/controllers/modals/processOrSaveTemplateModal.js"></script>
@@ -312,6 +313,7 @@
         <script src="scripts/directives/date.js"></script>
         <script src="scripts/directives/deleteLink.js"></script>
         <script src="scripts/directives/editConfigMapOrSecret.js"></script>
+        <script src="scripts/directives/editPvc.js"></script>
         <script src="scripts/directives/editEnvironmentFrom.js"></script>
         <script src="scripts/directives/events.js"></script>
         <script src="scripts/directives/eventsSidebar.js"></script>

--- a/app/scripts/controllers/modals/editPvcModal.js
+++ b/app/scripts/controllers/modals/editPvcModal.js
@@ -1,0 +1,129 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .controller('EditPvcModalController', function(APIService, DataService, $filter, LimitRangesService, QuotaService, $scope, $uibModalInstance) {
+
+    var limitRangesVersion = APIService.getPreferredVersion('limitranges');
+    var resourceQuotasVersion = APIService.getPreferredVersion('resourcequotas');
+    var appliedClusterResourceQuotasVersion = APIService.getPreferredVersion('appliedclusterresourcequotas');
+
+    var amountAndUnit = $filter('amountAndUnit');
+    var usageWithUnits = $filter('usageWithUnits');
+    var usageValue = $filter('usageValue');
+
+    var allocatedAmountAndUnit = amountAndUnit($scope.pvc.spec.resources.requests['storage']);
+
+    $scope.projectName = $scope.pvc.metadata.namespace;
+    $scope.typeDisplayName = $filter('humanizeKind')($scope.pvc.metadata.name);
+    $scope.claim = {}
+    $scope.claim.capacity = Number(allocatedAmountAndUnit[0]);
+    $scope.claim.unit = allocatedAmountAndUnit[1];
+    $scope.disableButton = true;
+
+    $scope.currentCapacityUnits = angular.copy($scope.claim);
+
+    $scope.units = [{
+      value: "Mi",
+      label: "MiB"
+    }, {
+      value: "Gi",
+      label: "GiB"
+    }, {
+      value: "Ti",
+      label: "TiB"
+    }, {
+      value: "M",
+      label: "MB"
+    }, {
+      value: "G",
+      label: "GB"
+    }, {
+      value: "T",
+      label: "TB"
+    }];
+
+    $scope.groupUnits = function(unit) {
+      switch (unit.value) {
+      case 'Mi':
+      case 'Gi':
+      case 'Ti':
+        return 'Binary Units';
+      case 'M':
+      case 'G':
+      case 'T':
+        return 'Decimal Units';
+      }
+
+      return '';
+    };
+
+    $scope.expand = function() {
+      $scope.updatedCapacity = $scope.claim.capacity + $scope.claim.unit;
+      $uibModalInstance.close($scope.updatedCapacity);
+    };
+
+    $scope.cancel = function() {
+      $uibModalInstance.dismiss('cancel');
+    };
+
+    var validateLimitRange = function() {
+      // Use usageValue filter to normalize units for comparison.
+      var value = $scope.claim.capacity && usageValue($scope.claim.capacity + $scope.claim.unit);
+      var currentValue = $scope.currentCapacityUnits.capacity && usageValue($scope.currentCapacityUnits.capacity + $scope.currentCapacityUnits.unit);
+      var min = _.has($scope, 'limits.min') && usageValue($scope.limits.min);
+      var max = _.has($scope, 'limits.max') && usageValue($scope.limits.max);
+      var minValid = true;
+      var maxValid = true;
+      var requestValid = true;
+
+      minValid = value >= min;
+      maxValid = value <= max;
+      requestValid = value > currentValue;
+
+      $scope.expandPersistentVolumeClaimForm.capacity.$setValidity('limitRangeMin', minValid);
+      $scope.expandPersistentVolumeClaimForm.capacity.$setValidity('limitRangeMax', maxValid);
+      $scope.expandPersistentVolumeClaimForm.capacity.$setValidity('checkCurrentCapacity', requestValid);
+      $scope.expandPersistentVolumeClaimForm.capacity.$touched =  true;
+    };
+
+    var validateQuota = function() {
+      var newValue = $scope.claim.capacity && usageValue($scope.claim.capacity + $scope.claim.unit);
+      var oldValue = $scope.currentCapacityUnits.capacity && usageValue($scope.currentCapacityUnits.capacity + $scope.currentCapacityUnits.unit);
+      var outOfClaims = QuotaService.isAnyStorageQuotaExceeded($scope.quotas, $scope.clusterQuotas);
+      var willExceedStorage = QuotaService.willRequestExceedQuota($scope.quotas, $scope.clusterQuotas, 'requests.storage', (newValue - oldValue));
+      $scope.expandPersistentVolumeClaimForm.capacity.$setValidity('willExceedStorage', !willExceedStorage);
+      $scope.expandPersistentVolumeClaimForm.capacity.$setValidity('outOfClaims', !outOfClaims);
+    };
+
+    DataService.list(limitRangesVersion, { namespace: $scope.projectName }, function(limitRangeData) {
+      var limitRanges = limitRangeData.by('metadata.name');
+      $scope.disableButton = false;
+      if (_.isEmpty(limitRanges)) {
+        return;
+      }
+
+      $scope.limits = LimitRangesService.getEffectiveLimitRange(limitRanges, 'storage', 'PersistentVolumeClaim');
+      if ($scope.limits.min && $scope.limits.max) {
+        var minUsage = usageValue($scope.limits.min);
+        var maxUsage = usageValue($scope.limits.max);
+        if (minUsage === maxUsage) {
+          var requiredAmountAndUnit = amountAndUnit($scope.limits.max);
+          $scope.claim.capacity = Number(requiredAmountAndUnit[0]);
+          $scope.claim.unit = requiredAmountAndUnit[1];
+          $scope.capacityReadOnly = true;
+        }
+      }
+
+      $scope.$watchGroup(['claim.capacity', 'claim.unit'], validateLimitRange);
+    });
+
+    DataService.list(resourceQuotasVersion, { namespace: $scope.projectName }, function(quotaData) {
+      $scope.quotas = quotaData.by('metadata.name');
+      $scope.$watchGroup(['claim.capacity', 'claim.unit'], validateQuota);
+    });
+
+    DataService.list(appliedClusterResourceQuotasVersion, { namespace: $scope.projectName }, function(quotaData) {
+      $scope.clusterQuotas = quotaData.by('metadata.name');
+    });
+
+  });

--- a/app/scripts/directives/editPvc.js
+++ b/app/scripts/directives/editPvc.js
@@ -1,0 +1,72 @@
+'use strict';
+
+angular.module("openshiftConsole")
+  .directive("editPvc",
+             function($uibModal,
+                      $filter,
+                      $routeParams,
+                      APIService,
+                      DataService,
+                      ProjectsService,
+                      NotificationsService,
+                      Logger) {
+
+    return {
+      restrict: "E",
+      scope: {
+        // pvc object
+        pvc: "<",
+      },
+      template: '<a href="" ng-click="openEditModal()" role="button">Expand PVC</a>',
+      replace: true,
+      link: function(scope) {
+
+        scope.openEditModal = function() {
+          // opening the modal with settings scope as parent
+          var modalInstance = $uibModal.open({
+            templateUrl: 'views/modals/edit-pvc-resource.html',
+            controller: 'EditPvcModalController',
+            scope: scope
+          });
+
+          var hideErrorNotifications = function() {
+            NotificationsService.hideNotification("expand-pvc-error");
+          };
+
+          scope.$on('$destroy', hideErrorNotifications);
+
+          modalInstance.result.then(function(updatedSize) {
+            hideErrorNotifications();
+            var updatedPvc = angular.copy(scope.pvc);
+            _.set(updatedPvc, 'spec.resources.requests.storage', updatedSize);
+            var kind = scope.pvc.kind;
+            var resourceName = scope.pvc.metadata.name;
+            var typeDisplayName = $filter('humanizeKind')(kind);
+            var formattedResource = typeDisplayName + ' ' + "\'"  + resourceName + "\'";
+
+            DataService.update({
+              resource: APIService.kindToResource(kind)
+            }, resourceName,
+               updatedPvc,
+               {namespace: scope.pvc.metadata.namespace })
+            .then(function() {
+              NotificationsService.addNotification({
+                type: "success",
+                message: formattedResource + " expand request has been submitted."
+              });
+            })
+            .catch(function(err) {
+             // called if failure to edit
+              NotificationsService.addNotification({
+                id: "expand-pvc-error",
+                type: "error",
+                message: "Could not save " + formattedResource,
+                details: $filter('getErrorDetails')(err)
+              });
+              Logger.error(formattedResource + " could not be expanded.", err);
+            });
+          });
+        };
+      }
+    };
+  });

--- a/app/views/browse/persistent-volume-claim.html
+++ b/app/views/browse/persistent-volume-claim.html
@@ -19,6 +19,12 @@
                 <a ng-href="{{pvc | editYamlURL}}" role="button">Edit YAML</a>
               </li>
               <li>
+                <edit-pvc
+                  ng-if="isExpansionAllowed && (pvcVersion | canI : 'update')"
+                  pvc="pvc">
+                </edit-pvc>
+              </li>
+              <li>
                 <delete-link
                   ng-if="pvcVersion | canI : 'delete'"
                   kind="PersistentVolumeClaim"

--- a/app/views/modals/edit-pvc-resource.html
+++ b/app/views/modals/edit-pvc-resource.html
@@ -1,0 +1,110 @@
+<div class="modal-resource-action">
+  <div class="modal-header">
+    <button type="button" class="close" data-dismiss="modal" aria-hidden="true" aria-label="Close" ng-click="cancel()">
+      <span class="pficon pficon-close" aria-hidden="true"></span>
+    </button>
+    <h1 class="modal-title">Expand Persistent Volume Claim</h1>
+  </div>
+
+  <div class="modal-body">
+    <h3>Increase the capacity of claim
+      <strong>{{typeDisplayName}}</strong>.
+      <a ng-href="{{'persistent_volumes' | helpLink}}" target="_blank">
+        <span class="learn-more-inline">Learn More
+          <i class="fa fa-external-link" aria-hidden="true"></i>
+        </span>
+      </a>
+    </h3>
+
+    <p>This can be a time-consuming process.</p>
+
+    <ng-form name="expandPersistentVolumeClaimForm">
+      <div ng-if="capacityReadOnly" class="form-group mar-bottom-xl">
+        <label>Size</label>
+        <div class="static-form-value-large">
+          {{claim.capacity}} {{claim.unit | humanizeUnit : 'storage'}}
+          <small>(cannot be changed)</small>
+        </div>
+      </div>
+      <div ng-if="!capacityReadOnly" class="form-group">
+        <fieldset class="form-inline compute-resource">
+          <label>
+            Capacity
+            <small ng-if="limits.min && limits.max">
+              {{limits.min | usageWithUnits : 'storage'}} min to {{limits.max | usageWithUnits : 'storage'}} max
+            </small>
+            <small ng-if="limits.min && !limits.max">
+              Min: {{limits.min | usageWithUnits : 'storage'}}
+            </small>
+            <small ng-if="limits.max && !limits.min">
+              Max: {{limits.max | usageWithUnits : 'storage'}}
+            </small>
+          </label>
+          <div class="resource-size" ng-class="{ 'has-error': expandPersistentVolumeClaimForm.capacity.$invalid && expandPersistentVolumeClaimForm.capacity.$touched}">
+            <div class="resource-amount">
+              <label for="claim-amount" class="sr-only">Amount</label>
+              <input type="number"
+                     name="capacity"
+                     id="claim-amount"
+                     ng-model="claim.capacity"
+                     required min="0"
+                     pattern="\d+(\.\d+)?"
+                     select-on-focus class="form-control"
+                     aria-describedby="claim-capacity-help">
+            </div>
+            <div class="resource-unit">
+                <label class="sr-only">Unit</label>
+                <ui-select search-enabled="false"
+                           ng-model="claim.unit"
+                           input-id="claim-capacity-unit">
+                    <ui-select-match>{{$select.selected.label}}</ui-select-match>
+                    <ui-select-choices repeat="option.value as option in units" group-by="groupUnits">
+                        {{option.label}}
+                    </ui-select-choices>
+                </ui-select>
+            </div>
+          </div>
+          <div id="claim-capacity-help" class="help-block">
+            Desired storage capacity.
+          </div>
+          <div ng-if="expandPersistentVolumeClaimForm.capacity.$invalid">
+            <div class="has-error" ng-show="expandPersistentVolumeClaimForm.capacity.$error.required">
+              <span class="help-block">Size is required.</span>
+            </div>
+            <div class="has-error" ng-show="expandPersistentVolumeClaimForm.capacity.$error.number">
+              <span class="help-block">Must be a number.</span>
+            </div>
+            <div class="has-error" ng-show="expandPersistentVolumeClaimForm .capacity.$error.min">
+              <span class="help-block">Must be a positive number.</span>
+            </div>
+            <div class="has-error" ng-show="expandPersistentVolumeClaimForm.capacity.$error.checkCurrentCapacity">
+              <span class="help-block">The requested capacity may not be less than the current capacity.</span>
+            </div>
+            <div ng-if="expandPersistentVolumeClaimForm.capacity.$error.limitRangeMin" class="has-error">
+              <span class="help-block">
+                Can't be less than {{limits.min | usageWithUnits : 'storage'}}.
+              </span>
+            </div>
+            <div ng-if="expandPersistentVolumeClaimForm.capacity.$error.limitRangeMax" class="has-error">
+              <span class="help-block">
+                Can't be greater than {{limits.max | usageWithUnits : 'storage'}}.
+              </span>
+            </div>
+            <div ng-if="expandPersistentVolumeClaimForm.capacity.$error.willExceedStorage" class="has-error">
+              <span class="help-block">
+                Storage quota will be exceeded. <a ng-href="project/{{projectName}}/quota" target="_blank">View Quota&nbsp;</a>
+              </span>
+            </div>
+          </div>
+
+        </fieldset>
+      </div>
+
+      <div class="modal-footer" style="padding-right: 0;">
+        <button class="btn btn-default" type="button" ng-click="cancel()">Cancel</button>
+        <button class="btn btn-primary" type="submit" ng-disabled="expandPersistentVolumeClaimForm.$invalid || disableButton" ng-click="expand()"> Expand
+        </button>
+      </div>
+    </ng-form>
+  </div>
+</div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -7042,9 +7042,14 @@ title: "Storage",
 link: "project/" + n.project + "/browse/storage"
 }, {
 title: n.pvc
-} ], t.pvcVersion = r.getPreferredVersion("persistentvolumeclaims"), t.eventsVersion = r.getPreferredVersion("events");
-var i = [], s = function(e, n) {
-t.pvc = e, t.loaded = !0, "DELETED" === n && (t.alerts.deleted = {
+} ], t.storageClassesVersion = r.getPreferredVersion("storageclasses"), t.pvcVersion = r.getPreferredVersion("persistentvolumeclaims"), t.eventsVersion = r.getPreferredVersion("events"), t.isExpansionAllowed = !1;
+var i = e("storageClass"), s = [], c = function(e) {
+var n = i(t.pvc);
+n !== _.get(i, "metadata.name") && a.get(t.storageClassesVersion, n, {}).then(function(n) {
+t.isExpansionAllowed = (!n || n.allowVolumeExpansion) && "Bound" === e.status.phase;
+});
+}, l = function(e, n) {
+t.pvc = e, t.loaded = !0, c(e), "DELETED" === n && (t.alerts.deleted = {
 type: "warning",
 message: "This persistent volume claim has been deleted."
 });
@@ -7053,7 +7058,7 @@ o.get(n.project).then(_.spread(function(r, o) {
 t.project = r, t.projectContext = o, a.get(t.pvcVersion, n.pvc, o, {
 errorNotification: !1
 }).then(function(e) {
-s(e), i.push(a.watchObject(t.pvcVersion, n.pvc, o, s));
+l(e), s.push(a.watchObject(t.pvcVersion, n.pvc, o, l));
 }, function(n) {
 t.loaded = !0, t.alerts.load = {
 type: "error",
@@ -7061,7 +7066,7 @@ message: "The persistent volume claim details could not be loaded.",
 details: e("getErrorDetails")(n)
 };
 }), t.$on("$destroy", function() {
-a.unwatchAll(i);
+a.unwatchAll(s);
 });
 }));
 } ]), angular.module("openshiftConsole").controller("SetLimitsController", [ "$filter", "$location", "$parse", "$routeParams", "$scope", "APIService", "AuthorizationService", "BreadcrumbsService", "DataService", "LimitRangesService", "Navigate", "NotificationsService", "ProjectsService", function(e, t, n, r, a, o, i, s, c, l, u, d, m) {
@@ -8998,6 +9003,71 @@ t.close("delete");
 }, e.cancel = function() {
 t.dismiss("cancel");
 };
+} ]), angular.module("openshiftConsole").controller("EditPvcModalController", [ "APIService", "DataService", "$filter", "LimitRangesService", "QuotaService", "$scope", "$uibModalInstance", function(e, t, n, r, a, o, i) {
+var s = e.getPreferredVersion("limitranges"), c = e.getPreferredVersion("resourcequotas"), l = e.getPreferredVersion("appliedclusterresourcequotas"), u = n("amountAndUnit"), d = (n("usageWithUnits"), n("usageValue")), m = u(o.pvc.spec.resources.requests.storage);
+o.projectName = o.pvc.metadata.namespace, o.typeDisplayName = n("humanizeKind")(o.pvc.metadata.name), o.claim = {}, o.claim.capacity = Number(m[0]), o.claim.unit = m[1], o.disableButton = !0, o.currentCapacityUnits = angular.copy(o.claim), o.units = [ {
+value: "Mi",
+label: "MiB"
+}, {
+value: "Gi",
+label: "GiB"
+}, {
+value: "Ti",
+label: "TiB"
+}, {
+value: "M",
+label: "MB"
+}, {
+value: "G",
+label: "GB"
+}, {
+value: "T",
+label: "TB"
+} ], o.groupUnits = function(e) {
+switch (e.value) {
+case "Mi":
+case "Gi":
+case "Ti":
+return "Binary Units";
+
+case "M":
+case "G":
+case "T":
+return "Decimal Units";
+}
+return "";
+}, o.expand = function() {
+o.updatedCapacity = o.claim.capacity + o.claim.unit, i.close(o.updatedCapacity);
+}, o.cancel = function() {
+i.dismiss("cancel");
+};
+var p = function() {
+var e = o.claim.capacity && d(o.claim.capacity + o.claim.unit), t = o.currentCapacityUnits.capacity && d(o.currentCapacityUnits.capacity + o.currentCapacityUnits.unit), n = !0, r = !0, a = !0;
+n = e >= (_.has(o, "limits.min") && d(o.limits.min)), r = e <= (_.has(o, "limits.max") && d(o.limits.max)), a = e > t, o.expandPersistentVolumeClaimForm.capacity.$setValidity("limitRangeMin", n), o.expandPersistentVolumeClaimForm.capacity.$setValidity("limitRangeMax", r), o.expandPersistentVolumeClaimForm.capacity.$setValidity("checkCurrentCapacity", a), o.expandPersistentVolumeClaimForm.capacity.$touched = !0;
+}, f = function() {
+var e = o.claim.capacity && d(o.claim.capacity + o.claim.unit), t = o.currentCapacityUnits.capacity && d(o.currentCapacityUnits.capacity + o.currentCapacityUnits.unit), n = a.isAnyStorageQuotaExceeded(o.quotas, o.clusterQuotas), r = a.willRequestExceedQuota(o.quotas, o.clusterQuotas, "requests.storage", e - t);
+o.expandPersistentVolumeClaimForm.capacity.$setValidity("willExceedStorage", !r), o.expandPersistentVolumeClaimForm.capacity.$setValidity("outOfClaims", !n);
+};
+t.list(s, {
+namespace: o.projectName
+}, function(e) {
+var t = e.by("metadata.name");
+if (o.disableButton = !1, !_.isEmpty(t)) {
+if (o.limits = r.getEffectiveLimitRange(t, "storage", "PersistentVolumeClaim"), o.limits.min && o.limits.max && d(o.limits.min) === d(o.limits.max)) {
+var n = u(o.limits.max);
+o.claim.capacity = Number(n[0]), o.claim.unit = n[1], o.capacityReadOnly = !0;
+}
+o.$watchGroup([ "claim.capacity", "claim.unit" ], p);
+}
+}), t.list(c, {
+namespace: o.projectName
+}, function(e) {
+o.quotas = e.by("metadata.name"), o.$watchGroup([ "claim.capacity", "claim.unit" ], f);
+}), t.list(l, {
+namespace: o.projectName
+}, function(e) {
+o.clusterQuotas = e.by("metadata.name");
+});
 } ]), angular.module("openshiftConsole").controller("DebugTerminalModalController", [ "$scope", "$filter", "$uibModalInstance", "container", "image", function(e, t, n, r, a) {
 e.container = r, e.image = a, e.$watch("debugPod.status.containerStatuses", function() {
 e.containerState = _.get(e, "debugPod.status.containerStatuses[0].state");
@@ -9500,6 +9570,49 @@ n[e.key] = e.value;
 }), _.set(t, "map.data", n);
 }, !0));
 });
+}
+};
+} ]), angular.module("openshiftConsole").directive("editPvc", [ "$uibModal", "$filter", "$routeParams", "APIService", "DataService", "ProjectsService", "NotificationsService", "Logger", function(e, t, n, r, a, o, i, s) {
+return {
+restrict: "E",
+scope: {
+pvc: "<"
+},
+template: '<a href="" ng-click="openEditModal()" role="button">Expand PVC</a>',
+replace: !0,
+link: function(n) {
+n.openEditModal = function() {
+var o = e.open({
+templateUrl: "views/modals/edit-pvc-resource.html",
+controller: "EditPvcModalController",
+scope: n
+}), c = function() {
+i.hideNotification("expand-pvc-error");
+};
+n.$on("$destroy", c), o.result.then(function(e) {
+c();
+var o = angular.copy(n.pvc);
+_.set(o, "spec.resources.requests.storage", e);
+var l = n.pvc.kind, u = n.pvc.metadata.name, d = t("humanizeKind")(l) + " '" + u + "'";
+a.update({
+resource: r.kindToResource(l)
+}, u, o, {
+namespace: n.pvc.metadata.namespace
+}).then(function() {
+i.addNotification({
+type: "success",
+message: d + " expand request has been submitted."
+});
+}).catch(function(e) {
+i.addNotification({
+id: "expand-pvc-error",
+type: "error",
+message: "Could not save " + d,
+details: t("getErrorDetails")(e)
+}), s.error(d + " could not be expanded.", e);
+});
+});
+};
 }
 };
 } ]), function() {


### PR DESCRIPTION
[trello Increase size of pv storage](https://trello.com/c/WhnpxDH8/1138-increase-size-of-pv-storage)

This patch will add another button "Expand PVC” which should appear in the Actions menu of the details page for PVCs that support expansion.

1. If the allowVolumeExpension is set to true then on the "Expand PVC" will appear.
2. Set default number greater one(+1) than the previously allocated capacity. (if the allocated capacity is 6GB currently and when you open the expand modal it will show you to expand to 7GB).
3. The dropdown  has these values(GB, Gib, TB, Tib)

**Validation on textbox**
1. The text entered should be a positive number.
2. It should be greater than the allocated capacity.
3. The textbox should not be empty.

Once then the number in the textbox is valid then you can click on expand and the toast notification will say that the Persistent volume claim 'demo' expand request has been submitted and the user can wait for an expansion to happen.
If the requested capacity is greater than the bricks available capacity it will generate an event in the events tab then we "Failed to allocate volume expansion: Minimum brick size limit reached. Out of space".
