### PR TITLE
Virtual Machines UI turned off

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -655,7 +655,8 @@ angular
   })
   .run(['$rootScope', 'APIService', 'KubevirtVersions',
     function ($rootScope, APIService, KubevirtVersions) {
-    $rootScope.KUBEVIRT_ENABLED = !!APIService.apiInfo(KubevirtVersions.offlineVirtualMachine);
+    // Entities needs to be renamed in 3.11, https://groups.google.com/forum/#!topic/kubevirt-dev/CU_VskPIisg
+    // $rootScope.KUBEVIRT_ENABLED = !!APIService.apiInfo(KubevirtVersions.offlineVirtualMachine);
   }]);
 
 pluginLoader.addModule('openshiftConsole');

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1518,9 +1518,7 @@ tags: [ "mobile-service" ],
 icon: "fa fa-database"
 } ]
 }), Logger.info("AEROGEAR_MOBILE_ENABLED: " + e.AEROGEAR_MOBILE_ENABLED);
-} ]).run([ "$rootScope", "APIService", "KubevirtVersions", function(e, t, n) {
-e.KUBEVIRT_ENABLED = !!t.apiInfo(n.offlineVirtualMachine);
-} ]), pluginLoader.addModule("openshiftConsole"), angular.module("openshiftConsole").factory("HawtioExtension", [ "extensionRegistry", function(e) {
+} ]).run([ "$rootScope", "APIService", "KubevirtVersions", function(e, t, n) {} ]), pluginLoader.addModule("openshiftConsole"), angular.module("openshiftConsole").factory("HawtioExtension", [ "extensionRegistry", function(e) {
 return console.warn("HawtioExtension.add() has been deprecated.  Please migrate to angular-extension-registry https://github.com/openshift/angular-extension-registry"), {
 add: function(t, n) {
 e.add(t, function(e) {


### PR DESCRIPTION
Currently the UI can show list of Kubevirt OfflineVirtuaMachines in
Overview page. This patch disables such functionality since Kubevirt
entities are going to be renamed [1] and releasing current functionality
in Openshift 3.10 would cause future incompatibility.

Expected renaming:
* OfflineVirtualMachine -> VirtualMachine
* VirtualMachine -> VirtualMachineInstance

We expect to update the code once 3.10 will be branched and once new release of Kubevirt with renamed entities become available for testing.

[1]: https://groups.google.com/forum/#!topic/kubevirt-dev/CU_VskPIisg