### PR TITLE
Add base mobile client view

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -236,6 +236,7 @@
         <script src="scripts/controllers/pod.js"></script>
         <script src="scripts/controllers/overview.js"></script>
         <script src="scripts/controllers/quota.js"></script>
+        <script src="scripts/controllers/mobileClients.js"></script>
         <script src="scripts/controllers/monitoring.js"></script>
         <script src="scripts/controllers/membership.js"></script>
         <script src="scripts/controllers/builds.js"></script>
@@ -317,6 +318,7 @@
         <script src="scripts/directives/eventsSidebar.js"></script>
         <script src="scripts/directives/eventsBadge.js"></script>
         <script src="scripts/directives/fromFile.js"></script>
+        <script src="scripts/directives/inlineEdit.js"></script>
         <script src="scripts/directives/oscFileInput.js"></script>
         <script src="scripts/directives/oscFormSection.js"></script>
         <script src="scripts/directives/oscGitLink.js"></script>
@@ -346,6 +348,7 @@
         <script src="scripts/directives/catalog/categoryContent.js"></script>
         <script src="scripts/directives/catalog/catalogImage.js"></script>
         <script src="scripts/directives/catalog/catalogTemplate.js"></script>
+        <script src="scripts/directives/mobileServiceSdkDocs.js"></script>
         <script src="scripts/directives/podMetrics.js"></script>
         <script src="scripts/directives/deploymentMetrics.js"></script>
         <script src="scripts/directives/logViewer.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -64,7 +64,8 @@ angular
       })
       .when('/project/:project/catalog', {
         templateUrl: 'views/project-browse-catalog.html',
-        controller: 'ProjectBrowseCatalogController'
+        controller: 'ProjectBrowseCatalogController',
+        reloadOnSearch: false
       })
       .when('/project/:project', {
         redirectTo: function(params) {
@@ -118,6 +119,12 @@ angular
             $route.current.params.isPipeline = true;
           }
         },
+        reloadOnSearch: false
+      })
+      .when('/project/:project/browse/mobile-clients/:mobileclient', {
+        templateUrl: 'views/browse/mobile-clients.html',
+        controller: 'MobileClientsController',
+        controllerAs: 'ctrl',
         reloadOnSearch: false
       })
       .when('/project/:project/edit/yaml', {
@@ -470,6 +477,7 @@ angular
   //   (?!\.\.(\/|$))        do not match strings starting with `../` or exactly `..`
   //   (?!.*\/\.\.(\/|$))    do not match strings containing `/../` or ending in `/..`
   .constant('RELATIVE_PATH_PATTERN', /^(?!\/)(?!\.\.(\/|$))(?!.*\/\.\.(\/|$)).*$/)
+  .constant('VALID_URL_PATTERN', /^(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/)
   // http://stackoverflow.com/questions/5899783/detect-safari-using-jquery
   .constant('IS_SAFARI', /Version\/[\d\.]+.*Safari/.test(navigator.userAgent))
   .constant('amTimeAgoConfig', {

--- a/app/scripts/controllers/mobileClients.js
+++ b/app/scripts/controllers/mobileClients.js
@@ -1,0 +1,125 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .controller('MobileClientsController', function(
+    $filter,
+    $q,
+    $routeParams,
+    $scope,
+    APIService,
+    DataService,
+    Navigate,
+    ProjectsService,
+    NotificationsService,
+    VALID_URL_PATTERN
+  ) {
+      var ctrl = this;
+      var serviceInstanceVersion = APIService.getPreferredVersion('serviceinstances');
+      var clusterServiceClassesVersion = APIService.getPreferredVersion('clusterserviceclasses');
+      var mobileClientsVersion = APIService.getPreferredVersion('mobileclients');
+      var isServiceInstanceReady = $filter('isServiceInstanceReady');
+      var marServiceInstanceNameAnnotation = $filter('annotationName')('mobileServiceInstanceName');
+
+      var watches = [];
+      var projectContext;
+      ctrl.projectName = $routeParams.project;
+      ctrl.emptyMessage = 'Loading...';
+      ctrl.alerts = {};
+      $scope.breadcrumbs = [
+        {
+          title: 'Mobile Clients',
+          link: 'project/' + ctrl.projectName + '/browse/other?kind=MobileClient&group=' + mobileClientsVersion.group
+        },
+        {
+          title: $routeParams.mobileclient
+        }
+      ];
+      ctrl.validUrlPattern = VALID_URL_PATTERN;
+
+      ctrl.setDmzUrl = function(dmzUrl) {
+        var updatedMobileClient = angular.copy(ctrl.mobileClient);
+        updatedMobileClient.spec['dmzUrl'] = dmzUrl;
+
+        DataService.update(mobileClientsVersion, ctrl.mobileClient.metadata.name, updatedMobileClient, projectContext)
+        .then(function() {
+          NotificationsService.addNotification({
+            type: "success",
+            message: "Successfully updated the DMZ URL for " + ctrl.mobileClient.metadata.name
+          });
+        });
+      };
+
+      function setMobileCICDWatch(context) {
+        watches.push(DataService.watch(serviceInstanceVersion, context, function (serviceInstances) {
+          $scope.serviceInstances = serviceInstances.by("metadata.name");
+          ctrl.mobileCIService = _.find($scope.serviceInstances, function(serviceInstance) {
+            return /aerogear-digger/.test(serviceInstance.metadata.name);
+          });
+
+          ctrl.mobileCIProvisioning = _.get(ctrl, 'mobileCIService.status.currentOperation') === 'Provision';
+          ctrl.mobileCIDeprovisioning = _.get(ctrl, 'mobileCIService.status.currentOperation') === 'Deprovision';
+          ctrl.mobileCIEnabled = isServiceInstanceReady(ctrl.mobileCIService);
+        }));
+      }
+
+      function setCoreSdkSetup() {
+        var marServiceInstanceName = _.get(ctrl, ['mobileClient', 'metadata', 'annotations', marServiceInstanceNameAnnotation]);
+        var marClusterClassRef = _.get(ctrl, ['serviceInstances', marServiceInstanceName, 'spec', 'clusterServiceClassRef', 'name']);
+        ctrl.coreSdkSetup = _.get(ctrl, ['serviceClasses', marClusterClassRef, 'spec', 'externalMetadata', 'documentationUrl']);
+      }
+
+      function setMobileClientWatch(context) {
+        watches.push(DataService.watchObject(mobileClientsVersion, $routeParams.mobileclient, context, function(mobileClient, action) {
+          if (action === 'DELETED') {
+            ctrl.alerts['deleted'] = {
+              type: 'warning',
+              message: 'This mobile client has been deleted.'
+            };
+          }
+          ctrl.mobileClient = mobileClient;
+        }));
+      }
+
+
+      ProjectsService
+        .get(ctrl.projectName)
+        .then(_.spread(function(project, context) {
+          ctrl.project = project;
+          projectContext = context;
+
+          setMobileCICDWatch(projectContext);
+          setMobileClientWatch(projectContext);
+
+          return $q.all([
+            DataService.list(clusterServiceClassesVersion, projectContext),
+            DataService.list(serviceInstanceVersion, context),
+            DataService.get(mobileClientsVersion, $routeParams.mobileclient, context, { errorNotification: false })
+          ]).then(_.spread(function(serviceClasses, serviceInstances, mobileClient) {
+              ctrl.loaded = true;
+
+              ctrl.serviceClasses = serviceClasses.by('metadata.name');
+              ctrl.serviceInstances = serviceInstances.by('metadata.name');
+              ctrl.mobileClient = mobileClient;
+
+              setCoreSdkSetup();
+            }),
+            function(e) {
+              ctrl.loaded = true;
+              ctrl.alerts['load'] = {
+                type: 'error',
+                message: e.status === 404 ? 'This mobile client can not be found, it may have been deleted.' : 'The mobile client details could not be loaded.',
+                details: $filter('getErrorDetails')(e)
+              };
+            }
+          );
+        }));
+
+      ctrl.goToMobileServices = function () {
+        Navigate.toProjectCatalog(ctrl.projectName, {category: 'mobile', subcategory: 'services'});
+      };
+
+      $scope.$on('$destroy', function(){
+        DataService.unwatchAll(watches);
+      });
+
+    });

--- a/app/scripts/directives/inlineEdit.js
+++ b/app/scripts/directives/inlineEdit.js
@@ -1,0 +1,42 @@
+'use strict';
+
+angular.module('openshiftConsole').component('inlineEdit', {
+  controller: [
+    InlineEdit
+  ],
+  bindings: {
+    label: '<',
+    pattern: '<',
+    patternErrmsg: '<',
+    value: '<',
+    onEdited: '<'
+  },
+  templateUrl: 'views/directives/inline-edit.html'
+});
+
+function InlineEdit() {
+  var ctrl = this;
+  ctrl.onEdited = ctrl.onEdited || function(){};
+
+  ctrl.editEnabled = false;
+  
+  ctrl.enableEdit = function() {
+    ctrl.editEnabled = true;
+    ctrl.inputVal= ctrl.value;
+  };
+
+  ctrl.clearInput = function() {
+    ctrl.inputVal = "";
+  };
+
+  ctrl.cancelEdit = function() {
+    ctrl.editEnabled = false;
+  };
+
+  ctrl.save = function(val) {
+    if ((ctrl.value && ctrl.value !== ctrl.inputVal) || (!ctrl.value && ctrl.inputVal)) {
+      ctrl.onEdited(val);
+    }
+    ctrl.editEnabled = false;
+  };
+}

--- a/app/scripts/directives/mobileServiceSdkDocs.js
+++ b/app/scripts/directives/mobileServiceSdkDocs.js
@@ -1,0 +1,69 @@
+'use strict';
+
+(function() {
+  angular.module('openshiftConsole').component('mobileServiceSdkDocs', {
+    controller: [
+      "$filter",
+      "APIService",
+      "DataService",
+      MobileServiceSdkDocs
+    ],
+    controllerAs: 'ctrl',
+    bindings: {
+      context: '<',
+      mobileClient: '<',
+      serviceClasses: '<'
+    },
+    templateUrl: 'views/_mobile-service-sdk-docs.html'
+  });
+
+
+
+  function MobileServiceSdkDocs($filter, APIService, DataService) {
+    var serviceBindingsVersion = APIService.getPreferredVersion('servicebindings');
+    var serviceInstanceVersion = APIService.getPreferredVersion('serviceinstances');
+    var mobileBindingConsumerID = $filter('annotationName')('mobileBindingConsumerId');
+    var mobileBindingProviderID = $filter('annotationName')('mobileBindingProviderId');
+
+    var ctrl = this;
+    var watches = [];
+
+    ctrl.$onChanges = function(changes) {
+      var clientChanges = _.get(changes, 'mobileClient.currentValue');
+      var serviceClassChanges = _.get(changes, 'serviceClasses.currentValue');
+
+      if (clientChanges && serviceClassChanges && watches.length === 0) {
+        watches.push(DataService.watch(serviceBindingsVersion, {namespace: ctrl.context}, function(bindingsData) {
+          var mobileClientID = _.get(ctrl, 'mobileClient.metadata.name');
+          ctrl.bindings = _.filter(bindingsData.by('metadata.name'), function(binding) {
+            return _.get(binding, ['metadata', 'annotations', mobileBindingConsumerID]) === mobileClientID;
+          });
+          ctrl.addDetailsToBindings();
+        }));
+      }
+    };
+
+    ctrl.addDetailsToBindings = function () {
+      DataService.list(serviceInstanceVersion, {namespace: ctrl.context}, function (serviceInstances) {
+        var serviceInstancesData = serviceInstances.by('metadata.name');
+        ctrl.serviceSdkInfo = _.map(ctrl.bindings, function(binding) {
+          var bindingProviderInstance = serviceInstancesData[_.get(binding, ['metadata', 'annotations', mobileBindingProviderID], "")];
+          var serviceClass = ctrl.serviceClasses[_.get(bindingProviderInstance, 'spec.clusterServiceClassRef.name')];
+
+          return {
+            displayName: _.get(serviceClass, 'spec.externalMetadata.displayName'),
+            serviceInstanceName: _.get(bindingProviderInstance, 'metadata.name'),
+            description: _.get(serviceClass, 'spec.description'),
+            sdkDocs: _.get(serviceClass, 'spec.externalMetadata.sdk-docs-' + ctrl.mobileClient.spec.clientType),
+            logo: _.get(serviceClass, 'spec.externalMetadata.imageUrl'),
+            iconClass: _.get(serviceClass, ['spec', 'externalMetadata', 'console.openshift.io/iconClass'])
+          };
+        });
+      });
+    };
+
+    ctrl.$onDestroy = function() {
+      DataService.unwatchAll(watches);
+    };
+  }
+})();

--- a/app/scripts/directives/overview/mobileClientRow.js
+++ b/app/scripts/directives/overview/mobileClientRow.js
@@ -63,7 +63,7 @@
     };
     row.projectName = $routeParams.project;
     row.browseCatalog = function () {
-      Navigate.toProjectCatalog(row.projectName);
+      Navigate.toProjectCatalog(row.projectName, {category: 'mobile', subcategory: 'services'});
     };
   }
 })();

--- a/app/scripts/services/navigate.js
+++ b/app/scripts/services/navigate.js
@@ -245,6 +245,10 @@ angular.module("openshiftConsole")
               .segmentCoded(name.substring(0, ind))
               .segmentCoded(name.substring(ind + 1));
             break;
+          case "MobileClient":
+            url.segment("mobile-clients")
+              .segmentCoded(name);
+            break;
           case "ServiceInstance":
             url.segment("service-instances")
               .segmentCoded(name);

--- a/app/styles/_inline-edit.less
+++ b/app/styles/_inline-edit.less
@@ -1,0 +1,48 @@
+.inline-edit {
+  .form-control-pf-cancel, .form-control-pf-save {
+    margin-left: 3px;
+  }
+
+  .form-control-pf-empty {
+    background: none;
+    border: none;
+    color: #bbb;
+    height: 100%;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  .form-control-pf-textbox {
+    display: inline-block;
+    position: relative;
+    flex: 1;
+  }
+
+  .form-control-pf-textbox input {
+    padding-right: 26px;
+  }
+
+  .form-control-pf-value {
+    background-color: transparent;
+    border: 1px solid transparent;
+    padding-left: 0px;
+    padding-bottom: 2px;
+    padding-top: 2px;
+    padding-right: 2px;
+  }
+
+  .form-control-pf-value:hover {
+    background-color: transparent;
+    border: 1px solid lightgray;
+    padding-left: 0px;
+  }
+
+  .inline-edit-form {
+    display: flex;
+  }
+
+  .inline-edit-input-error {
+    color: pf-red-200;
+  }
+}

--- a/app/styles/_mobile-clients.less
+++ b/app/styles/_mobile-clients.less
@@ -1,0 +1,61 @@
+.mobile-clients-view {
+
+  .configuration {
+    .copy-to-clipboard {
+      margin-bottom: 25px;
+      pre {
+        max-height: 350px;
+      }
+    }
+
+    .service-configuration {
+      padding: 0;
+
+      h3 {
+        margin: 20px;
+      }
+
+      .service-instance-getting-started {
+        margin-bottom: 50px;
+        padding: 0;
+
+        .logo {
+          display: inline-block;
+          height: 30px;
+          width: 30px;
+        }
+
+        .logo-icon-class {
+          display: inline-block;
+          height: 30px;
+          width: 30px;
+          font-size: 22px;
+          text-align: center;
+        }
+
+        .service-details {
+          display: inline-block;
+          margin-left: 10px;
+          vertical-align: middle;
+
+          h4 {
+            margin: 0;
+          }
+        }
+
+        .sdk-docs {
+          left: 42px;
+          margin: 0;
+          position: relative;
+        }
+      }    
+    }
+
+  }
+
+  .builds {
+    .note {
+      text-align: center;
+    }
+  }
+}

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -31,9 +31,11 @@
 @import "_core.less";
 @import "_data-toolbar.less";
 @import "_ellipsis.less";
+@import "_inline-edit.less";
 @import "_layouts.less";
 @import "_list-pf.less";
 @import "_list-view.less";
+@import "_mobile-clients.less";
 @import "_monitoring.less";
 @import "_navbar-vertical.less";
 @import "_overlay-forms.less";

--- a/app/views/_mobile-service-sdk-docs.html
+++ b/app/views/_mobile-service-sdk-docs.html
@@ -1,0 +1,26 @@
+<div class="col-md-6 service-instance-getting-started" ng-repeat="sdkInfo in ctrl.serviceSdkInfo">
+  <div class="col-md-12">
+    <img ng-if="sdkInfo.logo" class="logo" ng-src="{{sdkInfo.logo}}">
+    <span ng-if="!sdkInfo.logo && sdkInfo.iconClass " class="logo-icon-class {{sdkInfo.iconClass}}"></span>
+    <div class="service-details">
+      <h4>
+        <div>
+          {{sdkInfo.displayName}}
+        </div>
+        <div>
+          <small class="meta">
+            {{sdkInfo.serviceInstanceName}}
+          </small>
+        </div>
+      </h4>
+    </div>
+  </div>
+  <div class="col-md-12">
+    <div class="sdk-docs">
+      <h5>{{sdkInfo.description}}</h5>
+      <h5>
+        <a href={{sdkInfo.sdkDocs}} target="_blank">{{sdkInfo.displayName}} SDK setup</a>
+      </h5>
+    </div>
+  </div>
+</div>

--- a/app/views/browse/mobile-clients.html
+++ b/app/views/browse/mobile-clients.html
@@ -1,0 +1,133 @@
+<div class="middle mobile-clients-view">
+  <div class="middle-header">
+    <div class="container-fluid">
+      <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
+      <alerts alerts="alerts"></alerts>
+      <div>
+        <h1 class="contains-actions">
+          <div class="pull-right dropdown" ng-if="ctrl.mobileClient">
+            <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
+              Actions
+              <span class="caret" aria-hidden="true"></span>
+            </button>
+            <a href=""
+               class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
+               data-toggle="dropdown"><i class="fa fa-ellipsis-v" aria-hidden="true"></i><span class="sr-only">Actions</span></a>
+            <ul class="dropdown-menu dropdown-menu-right actions action-button">
+              <li ng-if="ctrl.mobileCIEnabled && (ctrl.mobileClient.spec.clientType !== 'xamarin')">
+                <a ng-href="project/{{ctrl.project.metadata.name}}/create-client-build/{{ctrl.mobileClient.metadata.name}}" role="button">Create Build</a>
+              </li>
+              <li>
+                <a ng-href="{{ctrl.mobileClient | editYamlURL}}" role="button">Edit YAML</a>
+              </li>
+              <li>
+                <delete-link
+                  kind="MobileClient"
+                  group="mobile.k8s.io"
+                  resource-name="{{ctrl.mobileClient.metadata.name}}"
+                  project-name="{{ctrl.mobileClient.metadata.namespace}}"
+                  alerts="alerts"
+                  redirect-url={{ctrl.redirectUrl}}>
+                </delete-link>
+              </li>
+            </ul>
+          </div>
+          {{ctrl.mobileClient.spec.name}}
+          <small class="meta" ng-if="ctrl.mobileClient">created <span am-time-ago="ctrl.mobileClient.metadata.creationTimestamp"></span></small>
+        </h1>
+        <labels labels="ctrl.mobileClient.metadata.labels" clickable="true" kind="mobileClient" project-name="{{ctrl.mobileClient.metadata.namespace}}" limit="3"></labels>
+      </div>
+    </div>
+  </div>
+  <div class="middle-content" persist-tab-state>
+    <div class="container-fluid">
+      <div ng-if="!ctrl.loaded">{{ctrl.emptyMessage}}</div>
+      <div  ng-if="ctrl.loaded" class="row">
+        <div class="col-md-12" ng-class="{ 'hide-tabs' : !ctrl.mobileClient }">
+          <uib-tabset>
+            <uib-tab active="selectedTab.configuration">
+              <uib-tab-heading>Configuration</uib-tab-heading>
+              <div class="configuration">
+                <div class="row">
+                  <div class="resource-details col-md-6">
+                    <h3>Mobile Client Details</h3>
+                      <dl class="dl-horizontal left">
+                        <dt>Client Type:</dt>
+                        <dd>{{ctrl.mobileClient.spec.clientType}}</dd>
+                        <dt>Client ID:</dt>
+                        <dd>{{ctrl.mobileClient.spec.appIdentifier}}</dd>
+                        <dt>Client API Key:</dt>
+                        <dd>{{ctrl.mobileClient.spec.apiKey}}</dd>
+                        <dt>DMZ Url:</dt>
+                        <dd>
+                          <inline-edit
+                            pattern="ctrl.validUrlPattern"
+                            pattern-errmsg="'The value provided is not a valid url.'"
+                            label="'Set DMZ Url'"
+                            value="ctrl.mobileClient.spec.dmzUrl"
+                            on-edited="ctrl.setDmzUrl">
+                          </inline-edit>
+                        </dd>
+                      </dl>
+                  </div>
+
+                  <div class="col-md-6 resource-details client-config">
+                    <h3>Mobile Client Config</h3>
+                    <mobile-client-config mobile-client="ctrl.mobileClient"></mobile-client-config>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="resource-details col-md-12">
+                    <h3>SDK Configuration</h3>
+                    <h4>
+                      <a href="{{ctrl.coreSdkSetup}}" target="_blank">{{ctrl.mobileClient.spec.clientType | upperFirst}} SDK setup</a>
+                    </h4>
+                  </div>
+                  <div class="resource-details service-configuration col-md-12">
+                    <h3>Service Configuration</h3>
+                      <mobile-service-sdk-docs
+                        context="ctrl.projectName"
+                        mobile-client="ctrl.mobileClient"
+                        service-classes="ctrl.serviceClasses"></mobile-service-sdk-docs>
+                  </div>
+                </div>
+              </div>
+            </uib-tab>
+            <uib-tab ng-if="true" active="selectedTab.builds">
+              <uib-tab-heading>Builds</uib-tab-heading>
+                <div class="builds">
+                  <div class="note" ng-if="(ctrl.mobileCIProvisioning || ctrl.mobileCIDeprovisioning) && ctrl.mobileClient.spec.clientType !== 'xamarin'">
+                    <div class="col-md-offset-1 col-md-10">
+                      <div class="alert alert-info">
+                        <span class="pficon pficon-info"></span>
+                        <span ng-class="{'spinner spinner-xs spinner-inline': (ctrl.mobileCIProvisioning || ctrl.mobileCIDeprovisioning)}" aria-hidden="true"></span>
+                        <span ng-if="ctrl.mobileCIProvisioning" >Mobile CI | CD is provisioning</span>
+                        <span ng-if="ctrl.mobileCIDeprovisioning">Mobile CI | CD is deprovisioning</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="note" ng-if="!ctrl.mobileCIService && ctrl.mobileClient.spec.clientType !== 'xamarin'">
+                    <p>Provision a Mobile CI | CD service to create a mobile build.</p>
+                    <button class="btn btn-primary btn-lg" ng-click="ctrl.goToMobileServices()">Browse Mobile Services</button>
+                  </div>
+                  <div ng-if="ctrl.mobileClient.spec.clientType === 'xamarin'"  class="row">
+                    <div class="col-md-offset-1 col-md-10">
+                      <div class="alert alert-info">
+                        <span class="pficon pficon-info"></span>
+                        Mobile builds are not avaialble for Xamarin.
+                      </div>
+                    </div>
+                  </div>
+                  <mobile-client-builds-list ng-if="ctrl.mobileCIEnabled && ctrl.mobileClient.spec.clientType !== 'xamarin'" mobile-client="ctrl.mobileClient"></mobile-client-builds-list>
+                </div>
+            </uib-tab>
+            <uib-tab ng-if="true" active="selectedTab.mobileServices" class="mobile-services">
+              <uib-tab-heading>Mobile Services</uib-tab-heading>
+                  <mobile-service-instance-list></mobile-service-instance-list>
+            </uib-tab>
+          </uib-tabset>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/directives/inline-edit.html
+++ b/app/views/directives/inline-edit.html
@@ -1,0 +1,38 @@
+<div class="form-control-pf-editable inline-edit">
+    <ng-form name="$ctrl.inlineEditForm" class="inline-edit-form">
+    <button ng-if="!$ctrl.editEnabled" type="button" class="form-control-pf-value" ng-click="$ctrl.enableEdit()">
+        <span class="sr-only">{{$ctrl.label}}</span>
+        <span ng-if="$ctrl.value">{{$ctrl.value}}</span>
+        <span ng-if="!$ctrl.value">{{$ctrl.label}}</span>
+        <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
+    </button>
+    <div ng-if="$ctrl.editEnabled" class="form-control-pf-textbox">
+      <input
+        ng-model="$ctrl.inputVal"
+        name="input"
+        type="text"
+        ng-pattern="$ctrl.pattern"
+        class="form-control form-control-pf-editor"
+        autocorrect="off"
+        autocapitalize="none"
+        spellcheck="false"
+        aria-label="{{$ctrl.label}}"
+        autofocus/>
+      <button type="button" class="form-control-pf-empty" ng-click="$ctrl.clearInput()" aria-label="Clear Value">
+        <span class="fa fa-times-circle fa-lg"></span>
+      </button>
+    </div>
+    <button ng-if="$ctrl.editEnabled" 
+            type="button" 
+            class="btn btn-primary form-control-pf-save" 
+            aria-label="Save"
+            ng-click="$ctrl.save($ctrl.inputVal)" 
+            ng-disabled="$ctrl.inlineEditForm.input.$invalid">
+            <i class="glyphicon glyphicon-ok"></i>
+    </button>
+    <button ng-if="$ctrl.editEnabled" type="button" class="btn btn-default form-control-pf-cancel" aria-label="Cancel" ng-click="$ctrl.cancelEdit()"><i class="glyphicon glyphicon-remove"></i></button>
+    </ng-form>
+    <span ng-if="$ctrl.inlineEditForm.input.$error.pattern" class="help-block inline-edit-input-error">
+        {{$ctrl.patternErrmsg}}
+    </span>
+  </div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1,20 +1,20 @@
 "use strict";
 
 function OverviewController(e, t, n, r, a, o, i, s, c, l, u, d, m, p, f, g, v, h, y, b, S, C, w, P, j, k, I, R, E, T, N) {
-function A(e) {
+function D(e) {
 var t = e.metadata.ownerReferences;
 return t ? _(t).filter({
 kind: "OfflineVirtualMachine"
 }).map("uid").first() : null;
 }
-function D() {
+function A() {
 if (B.offlineVirtualMachines && B.virtualMachines && B.pods) {
 var e = _(B.pods).values().filter(function(e) {
 return !!_.get(e, 'metadata.labels["kubevirt.io/vmUID"]');
 }).keyBy('metadata.labels["kubevirt.io/vmUID"]').value(), t = _(B.virtualMachines).values().filter(function(e) {
-return !!A(e);
+return !!D(e);
 }).keyBy(function(e) {
-return A(e);
+return D(e);
 }).value(), n = [];
 _.each(B.offlineVirtualMachines, function(r) {
 var a = r.metadata.uid, o = t[a];
@@ -130,14 +130,14 @@ return _.isEmpty(be.pipelinesByDeploymentConfig[t]);
 B.deploymentConfigsNoPipeline = _.sortBy(e, "metadata.name"), B.pipelineViewHasOtherResources = !(_.isEmpty(B.deploymentConfigsNoPipeline) && _.isEmpty(B.vanillaReplicationControllers) && _.isEmpty(B.deployments) && _.isEmpty(B.vanillaReplicaSets) && _.isEmpty(B.statefulSets) && _.isEmpty(B.monopods));
 }, Ne = function() {
 B.disableFilter = "pipeline" === B.viewBy && _.isEmpty(B.pipelineBuildConfigs);
-}, Ae = function(e) {
+}, De = function(e) {
 return b.getLabelSelector().select(e);
-}, De = [ "metadata.name", "spec.clusterServiceClassExternalName" ], $e = function(e) {
-return y.filterForKeywords(e, De, be.filterKeywords);
+}, Ae = [ "metadata.name", "spec.clusterServiceClassExternalName" ], $e = function(e) {
+return y.filterForKeywords(e, Ae, be.filterKeywords);
 }, Be = function(e) {
 switch (B.filterBy) {
 case "label":
-return Ae(e);
+return De(e);
 
 case "name":
 return $e(e);
@@ -157,7 +157,7 @@ B.filteredDeploymentConfigs = Be(B.deploymentConfigs), B.filteredReplicationCont
 B.viewBy = localStorage.getItem(Oe) || "app", e.$watch(function() {
 return B.viewBy;
 }, function(e) {
-localStorage.setItem(Oe, e), Ne(), De = "app" === B.viewBy ? [ "metadata.name", "metadata.labels.app" ] : [ "metadata.name" ], Le(), "pipeline" === B.viewBy ? b.setLabelSuggestions(he) : b.setLabelSuggestions(ve);
+localStorage.setItem(Oe, e), Ne(), Ae = "app" === B.viewBy ? [ "metadata.name", "metadata.labels.app" ] : [ "metadata.name" ], Le(), "pipeline" === B.viewBy ? b.setLabelSuggestions(he) : b.setLabelSuggestions(ve);
 }), d.DISABLE_OVERVIEW_METRICS || (C.isAvailable(!0).then(function(e) {
 be.showMetrics = e;
 }), e.$on("metrics-connection-failed", function(e, t) {
@@ -240,7 +240,7 @@ _.isEmpty(e) || (b.addLabelSuggestionsFromResources(e, he), "pipeline" === B.vie
 }, nt = function(e) {
 return "Succeeded" !== e.status.phase && "Failed" !== e.status.phase && (!H(e, "openshift.io/deployer-pod-for.name") && (!O(e, "openshift.io/build.name") && "slave" !== H(e, "jenkins")));
 }, rt = function() {
-be.podsByOwnerUID = j.groupByOwnerUID(B.pods), B.monopods = _.filter(be.podsByOwnerUID[""], nt), D();
+be.podsByOwnerUID = j.groupByOwnerUID(B.pods), B.monopods = _.filter(be.podsByOwnerUID[""], nt), A();
 }, at = function(e) {
 return !!_.get(e, "status.replicas") || (!O(e, "deploymentConfig") || x(e));
 }, ot = function(e) {
@@ -495,13 +495,13 @@ poll: V,
 pollInterval: 6e4
 })), e.KUBEVIRT_ENABLED) {
 Rt.push(m.watch(N.offlineVirtualMachine, r, function(e) {
-B.offlineVirtualMachines = e.by("metadata.name"), D(), Le();
+B.offlineVirtualMachines = e.by("metadata.name"), A(), Le();
 }, {
 poll: V,
 pollInterval: 6e4
 }));
 Rt.push(m.watch(N.virtualMachine, r, function(e) {
-B.virtualMachines = e.by("metadata.name"), D(), Le();
+B.virtualMachines = e.by("metadata.name"), A(), Le();
 }, {
 poll: V,
 pollInterval: 6e4
@@ -559,6 +559,19 @@ m.unwatchAll(Rt), $(window).off(".overview");
 }), function(t) {
 L && _.get(t, "notFound") && (f.notifyInvalidProjectHomePage(e.projectName), w.toProjectList());
 });
+}
+
+function InlineEdit() {
+var e = this;
+e.onEdited = e.onEdited || function() {}, e.editEnabled = !1, e.enableEdit = function() {
+e.editEnabled = !0, e.inputVal = e.value;
+}, e.clearInput = function() {
+e.inputVal = "";
+}, e.cancelEdit = function() {
+e.editEnabled = !1;
+}, e.save = function(t) {
+(e.value && e.value !== e.inputVal || !e.value && e.inputVal) && e.onEdited(t), e.editEnabled = !1;
+};
 }
 
 function ResourceServiceBindings(e, t, n, r, a) {
@@ -1142,7 +1155,8 @@ templateUrl: "views/create-project.html",
 controller: "CreateProjectController"
 }).when("/project/:project/catalog", {
 templateUrl: "views/project-browse-catalog.html",
-controller: "ProjectBrowseCatalogController"
+controller: "ProjectBrowseCatalogController",
+reloadOnSearch: !1
 }).when("/project/:project", {
 redirectTo: function(e) {
 return "/project/" + encodeURIComponent(e.project) + "/overview";
@@ -1186,6 +1200,11 @@ isPipeline: [ "$route", function(e) {
 e.current.params.isPipeline = !0;
 } ]
 },
+reloadOnSearch: !1
+}).when("/project/:project/browse/mobile-clients/:mobileclient", {
+templateUrl: "views/browse/mobile-clients.html",
+controller: "MobileClientsController",
+controllerAs: "ctrl",
 reloadOnSearch: !1
 }).when("/project/:project/edit/yaml", {
 templateUrl: "views/edit/yaml.html",
@@ -1437,7 +1456,7 @@ redirectTo: "/"
 animation: !0,
 backdrop: "static"
 };
-} ]).constant("LOGGING_URL", _.get(window.OPENSHIFT_CONFIG, "loggingURL")).constant("METRICS_URL", _.get(window.OPENSHIFT_CONFIG, "metricsURL")).constant("SOURCE_URL_PATTERN", /^[a-z][a-z0-9+.-@]*:(\/\/)?[0-9a-z_-]+/i).constant("RELATIVE_PATH_PATTERN", /^(?!\/)(?!\.\.(\/|$))(?!.*\/\.\.(\/|$)).*$/).constant("IS_SAFARI", /Version\/[\d\.]+.*Safari/.test(navigator.userAgent)).constant("amTimeAgoConfig", {
+} ]).constant("LOGGING_URL", _.get(window.OPENSHIFT_CONFIG, "loggingURL")).constant("METRICS_URL", _.get(window.OPENSHIFT_CONFIG, "metricsURL")).constant("SOURCE_URL_PATTERN", /^[a-z][a-z0-9+.-@]*:(\/\/)?[0-9a-z_-]+/i).constant("RELATIVE_PATH_PATTERN", /^(?!\/)(?!\.\.(\/|$))(?!.*\/\.\.(\/|$)).*$/).constant("VALID_URL_PATTERN", /^(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/).constant("IS_SAFARI", /Version\/[\d\.]+.*Safari/.test(navigator.userAgent)).constant("amTimeAgoConfig", {
 titleFormat: "LLL"
 }).config([ "kubernetesContainerSocketProvider", function(e) {
 e.WebSocketFactory = "ContainerWebSocket";
@@ -1932,6 +1951,10 @@ break;
 case "ImageStreamTag":
 var m = s.indexOf(":");
 c.segment("images").segmentCoded(s.substring(0, m)).segmentCoded(s.substring(m + 1));
+break;
+
+case "MobileClient":
+c.segment("mobile-clients").segmentCoded(s);
 break;
 
 case "ServiceInstance":
@@ -4971,7 +4994,7 @@ name: e.containerName
 }), n = I(t);
 e.containerState = n;
 });
-}, N = e("annotation"), A = function(e, t) {
+}, N = e("annotation"), D = function(e, t) {
 if (r.loaded = !0, r.pod = e, r.dcName = N(e, "deploymentConfig"), r.rcName = N(e, "deployment"), r.deploymentVersion = N(e, "deploymentVersion"), r.logCanRun = !_.includes([ "New", "Pending", "Unknown" ], e.status.phase), S(), delete r.controllerRef, !r.dcName) {
 var n = m.getControllerReferences(e);
 r.controllerRef = _.find(n, function(e) {
@@ -4987,10 +5010,10 @@ f.get(n.project).then(_.spread(function(t, a) {
 b = a, r.project = t, r.projectContext = a, s.get(r.podsVersion, n.pod, a, {
 errorNotification: !1
 }).then(function(e) {
-A(e);
+D(e);
 var t = {};
 t[e.metadata.name] = e, r.logOptions.container = n.container || e.spec.containers[0].name, r.containerTerminals = R(), E(e), l.fetchReferencedImageStreamImages(t, r.imagesByDockerReference, r.imageStreamImageRefByDockerReference, b), h.push(s.watchObject(r.podsVersion, n.pod, a, function(e, t) {
-A(e, t), T(r.containerTerminals), E(e);
+D(e, t), T(r.containerTerminals), E(e);
 }));
 }, function(t) {
 r.loaded = !0, r.alerts.load = {
@@ -5124,6 +5147,60 @@ pollInterval: 6e4
 a.unwatchAll(u);
 });
 }));
+} ]), angular.module("openshiftConsole").controller("MobileClientsController", [ "$filter", "$q", "$routeParams", "$scope", "APIService", "DataService", "Navigate", "ProjectsService", "NotificationsService", "VALID_URL_PATTERN", function(e, t, n, r, a, o, i, s, c, l) {
+function u(e) {
+S.push(o.watch(g, e, function(e) {
+r.serviceInstances = e.by("metadata.name"), f.mobileCIService = _.find(r.serviceInstances, function(e) {
+return /aerogear-digger/.test(e.metadata.name);
+}), f.mobileCIProvisioning = "Provision" === _.get(f, "mobileCIService.status.currentOperation"), f.mobileCIDeprovisioning = "Deprovision" === _.get(f, "mobileCIService.status.currentOperation"), f.mobileCIEnabled = y(f.mobileCIService);
+}));
+}
+function d() {
+var e = _.get(f, [ "mobileClient", "metadata", "annotations", b ]), t = _.get(f, [ "serviceInstances", e, "spec", "clusterServiceClassRef", "name" ]);
+f.coreSdkSetup = _.get(f, [ "serviceClasses", t, "spec", "externalMetadata", "documentationUrl" ]);
+}
+function m(e) {
+S.push(o.watchObject(h, n.mobileclient, e, function(e, t) {
+"DELETED" === t && (f.alerts.deleted = {
+type: "warning",
+message: "This mobile client has been deleted."
+}), f.mobileClient = e;
+}));
+}
+var p, f = this, g = a.getPreferredVersion("serviceinstances"), v = a.getPreferredVersion("clusterserviceclasses"), h = a.getPreferredVersion("mobileclients"), y = e("isServiceInstanceReady"), b = e("annotationName")("mobileServiceInstanceName"), S = [];
+f.projectName = n.project, f.emptyMessage = "Loading...", f.alerts = {}, r.breadcrumbs = [ {
+title: "Mobile Clients",
+link: "project/" + f.projectName + "/browse/other?kind=MobileClient&group=" + h.group
+}, {
+title: n.mobileclient
+} ], f.validUrlPattern = l, f.setDmzUrl = function(e) {
+var t = angular.copy(f.mobileClient);
+t.spec.dmzUrl = e, o.update(h, f.mobileClient.metadata.name, t, p).then(function() {
+c.addNotification({
+type: "success",
+message: "Successfully updated the DMZ URL for " + f.mobileClient.metadata.name
+});
+});
+}, s.get(f.projectName).then(_.spread(function(r, a) {
+return f.project = r, p = a, u(p), m(p), t.all([ o.list(v, p), o.list(g, a), o.get(h, n.mobileclient, a, {
+errorNotification: !1
+}) ]).then(_.spread(function(e, t, n) {
+f.loaded = !0, f.serviceClasses = e.by("metadata.name"), f.serviceInstances = t.by("metadata.name"), f.mobileClient = n, d();
+}), function(t) {
+f.loaded = !0, f.alerts.load = {
+type: "error",
+message: 404 === t.status ? "This mobile client can not be found, it may have been deleted." : "The mobile client details could not be loaded.",
+details: e("getErrorDetails")(t)
+};
+});
+})), f.goToMobileServices = function() {
+i.toProjectCatalog(f.projectName, {
+category: "mobile",
+subcategory: "services"
+});
+}, r.$on("$destroy", function() {
+o.unwatchAll(S);
+});
 } ]), angular.module("openshiftConsole").controller("MonitoringController", [ "$routeParams", "$location", "$scope", "$filter", "APIService", "BuildsService", "DataService", "ImageStreamResolver", "KeywordService", "Logger", "MetricsService", "Navigate", "PodsService", "ProjectsService", "$rootScope", function(e, t, n, r, a, o, i, s, c, l, u, d, m, p, f) {
 n.projectName = e.project, n.alerts = n.alerts || {}, n.renderOptions = n.renderOptions || {}, n.renderOptions.showEventsSidebar = !0, n.renderOptions.collapseEventsSidebar = "true" === localStorage.getItem("monitoring.eventsidebar.collapsed"), n.buildsLogVersion = a.getPreferredVersion("builds/log"), n.podsLogVersion = a.getPreferredVersion("pods/log"), n.deploymentConfigsLogVersion = a.getPreferredVersion("deploymentconfigs/log");
 var g = r("isIE")(), v = [];
@@ -5191,12 +5268,12 @@ n.filteredStatefulSets = c.filterForKeywords(_.values(n.statefulSets), P, j);
 C = _.filter(n.pods, function(e) {
 return !n.filters.hideOlderResources || "Succeeded" !== e.status.phase && "Failed" !== e.status.phase;
 }), n.filteredPods = c.filterForKeywords(C, P, j);
-}, A = r("isIncompleteBuild"), D = r("buildConfigForBuild"), B = r("isRecentBuild"), V = function() {
+}, D = r("isIncompleteBuild"), A = r("buildConfigForBuild"), B = r("isRecentBuild"), V = function() {
 moment().subtract(5, "m");
 y = _.filter(n.builds, function(e) {
 if (!n.filters.hideOlderResources) return !0;
-if (A(e)) return !0;
-var t = D(e);
+if (D(e)) return !0;
+var t = A(e);
 return t ? n.latestBuildByConfig[t].metadata.name === e.metadata.name : B(e);
 }), n.filteredBuilds = c.filterForKeywords(y, P, j);
 }, L = r("deploymentStatus"), O = r("deploymentIsInProgress"), U = function() {
@@ -5408,7 +5485,7 @@ return e ? r + (y(e, "description") || "") : "";
 }
 }
 });
-var A = function(e, t, n, a) {
+var D = function(e, t, n, a) {
 var o = {
 title: "Confirm Removal",
 alerts: {},
@@ -5455,7 +5532,7 @@ project: n,
 subjectKinds: N,
 canUpdateRolebindings: b("rolebindings", "update", v),
 confirmRemove: function(n, a, i, s) {
-var l = null, u = A(n, a, i, r.user.metadata.name);
+var l = null, u = D(n, a, i, r.user.metadata.name);
 _.isEqual(n, r.user.metadata.name) && d.isLastRole(r.user.metadata.name, r.roleBindings) && (l = !0), o.open({
 templateUrl: "views/modals/confirm.html",
 controller: "ConfirmModalController",
@@ -6194,7 +6271,7 @@ o.unwatchAll(j);
 });
 }));
 } ]), angular.module("openshiftConsole").controller("ReplicaSetController", [ "$scope", "$filter", "$routeParams", "APIService", "AuthorizationService", "BreadcrumbsService", "DataService", "DeploymentsService", "HPAService", "ImageStreamResolver", "keyValueEditorUtils", "kind", "Logger", "MetricsService", "ModalsService", "Navigate", "OwnerReferencesService", "PodsService", "ProjectsService", "StorageService", function(e, t, n, r, a, o, i, s, c, l, u, d, m, p, f, g, v, h, y, b) {
-var S = !1, C = t("annotation"), w = t("humanizeKind")(d), P = t("hasDeployment"), j = r.getPreferredVersion("builds"), k = r.getPreferredVersion("imagestreams"), I = r.getPreferredVersion("horizontalpodautoscalers"), R = r.getPreferredVersion("limitranges"), E = r.getPreferredVersion("pods"), T = r.getPreferredVersion("replicasets"), N = r.getPreferredVersion("replicationcontrollers"), A = r.getPreferredVersion("resourcequotas"), D = r.getPreferredVersion("appliedclusterresourcequotas");
+var S = !1, C = t("annotation"), w = t("humanizeKind")(d), P = t("hasDeployment"), j = r.getPreferredVersion("builds"), k = r.getPreferredVersion("imagestreams"), I = r.getPreferredVersion("horizontalpodautoscalers"), R = r.getPreferredVersion("limitranges"), E = r.getPreferredVersion("pods"), T = r.getPreferredVersion("replicasets"), N = r.getPreferredVersion("replicationcontrollers"), D = r.getPreferredVersion("resourcequotas"), A = r.getPreferredVersion("appliedclusterresourcequotas");
 switch (d) {
 case "ReplicaSet":
 e.resource = T, e.healthCheckURL = g.healthCheckURL(n.project, "ReplicaSet", n.replicaSet, "extensions");
@@ -6342,12 +6419,12 @@ pollInterval: 6e4
 })), i.list(R, u).then(function(t) {
 e.limitRanges = t.by("metadata.name"), U();
 });
-B.push(i.watch(A, u, function(t) {
+B.push(i.watch(D, u, function(t) {
 e.quotas = t.by("metadata.name");
 }, {
 poll: !0,
 pollInterval: 6e4
-})), B.push(i.watch(D, u, function(t) {
+})), B.push(i.watch(A, u, function(t) {
 e.clusterQuotas = t.by("metadata.name");
 }, {
 poll: !0,
@@ -7251,7 +7328,7 @@ return _.map(e, "metadata.name");
 });
 e.webhookSecrets = m.groupSecretsByType(t).webhook, e.webhookSecrets.unshift(""), e.secrets.secretsByType = _.each(r, function(e) {
 e.unshift("");
-}), A(), P = S(t.by("metadata.name")), e.valueFromObjects = w.concat(P);
+}), D(), P = S(t.by("metadata.name")), e.valueFromObjects = w.concat(P);
 });
 var n = function(e, n) {
 e.type = n && n.kind ? n.kind : "None";
@@ -7398,7 +7475,7 @@ var t = [].concat(e.triggers.imageChangeTriggers, e.triggers.builderImageChangeT
 return t = _.filter(t, function(e) {
 return _.has(e, "disabled") && !e.disabled || e.present;
 }), t = t.concat(T(e.triggers.webhookTriggers)), t = _.map(t, "data");
-}, A = function() {
+}, D = function() {
 switch (e.secrets.picked = {
 gitSecret: e.buildConfig.spec.source.sourceSecret ? [ e.buildConfig.spec.source.sourceSecret ] : [ {
 name: ""
@@ -7428,7 +7505,7 @@ name: ""
 mountPath: ""
 } ];
 }
-}, D = function(e, t, n) {
+}, A = function(e, t, n) {
 t.name ? e[n] = t : delete e[n];
 }, $ = function(t, n) {
 var r = "Custom" === e.strategyType ? "secretSource" : "secret", a = _.filter(n, function(e) {
@@ -7449,7 +7526,7 @@ break;
 case "JenkinsPipeline":
 "path" === e.jenkinsfileOptions.type ? delete e.updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile : delete e.updatedBuildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath;
 }
-switch (e.sources.images && !_.isEmpty(e.sourceImages) && (e.updatedBuildConfig.spec.source.images[0].paths = R(e.imageSourcePaths), e.updatedBuildConfig.spec.source.images[0].from = E(e.imageOptions.fromSource)), "None" === e.imageOptions.from.type ? delete b(e.updatedBuildConfig).from : b(e.updatedBuildConfig).from = E(e.imageOptions.from), "None" === e.imageOptions.to.type ? delete e.updatedBuildConfig.spec.output.to : e.updatedBuildConfig.spec.output.to = E(e.imageOptions.to), b(e.updatedBuildConfig).env = p.compactEntries(e.envVars), D(e.updatedBuildConfig.spec.source, _.head(e.secrets.picked.gitSecret), "sourceSecret"), D(b(e.updatedBuildConfig), _.head(e.secrets.picked.pullSecret), "pullSecret"), D(e.updatedBuildConfig.spec.output, _.head(e.secrets.picked.pushSecret), "pushSecret"), e.strategyType) {
+switch (e.sources.images && !_.isEmpty(e.sourceImages) && (e.updatedBuildConfig.spec.source.images[0].paths = R(e.imageSourcePaths), e.updatedBuildConfig.spec.source.images[0].from = E(e.imageOptions.fromSource)), "None" === e.imageOptions.from.type ? delete b(e.updatedBuildConfig).from : b(e.updatedBuildConfig).from = E(e.imageOptions.from), "None" === e.imageOptions.to.type ? delete e.updatedBuildConfig.spec.output.to : e.updatedBuildConfig.spec.output.to = E(e.imageOptions.to), b(e.updatedBuildConfig).env = p.compactEntries(e.envVars), A(e.updatedBuildConfig.spec.source, _.head(e.secrets.picked.gitSecret), "sourceSecret"), A(b(e.updatedBuildConfig), _.head(e.secrets.picked.pullSecret), "pullSecret"), A(e.updatedBuildConfig.spec.output, _.head(e.secrets.picked.pushSecret), "pushSecret"), e.strategyType) {
 case "Source":
 case "Docker":
 $(e.updatedBuildConfig.spec.source, e.secrets.picked.sourceSecrets);
@@ -8115,13 +8192,13 @@ g.hideNotification("create-builder-list-config-maps-error"), g.hideNotification(
 });
 };
 e.$on("$destroy", N);
-var A = i.getPreferredVersion("configmaps"), D = i.getPreferredVersion("limitranges"), $ = i.getPreferredVersion("imagestreams"), B = i.getPreferredVersion("imagestreamtags"), V = i.getPreferredVersion("secrets"), L = i.getPreferredVersion("resourcequotas"), O = i.getPreferredVersion("appliedclusterresourcequotas");
+var D = i.getPreferredVersion("configmaps"), A = i.getPreferredVersion("limitranges"), $ = i.getPreferredVersion("imagestreams"), B = i.getPreferredVersion("imagestreamtags"), V = i.getPreferredVersion("secrets"), L = i.getPreferredVersion("resourcequotas"), O = i.getPreferredVersion("appliedclusterresourcequotas");
 v.get(a.project).then(_.spread(function(t, n) {
 e.project = t, a.sourceURI && (e.sourceURIinParams = !0), e.hasClusterResourceOverrides = d.hasClusterResourceOverrides(t);
 var i = function() {
 e.cpuProblems = d.validatePodLimits(e.limitRanges, "cpu", [ e.container ], t), e.memoryProblems = d.validatePodLimits(e.limitRanges, "memory", [ e.container ], t);
 };
-c.list(D, n).then(function(t) {
+c.list(A, n).then(function(t) {
 e.limitRanges = t.by("metadata.name"), _.isEmpty(e.limitRanges) || e.$watch("container", i, !0);
 });
 var v, y, C = function() {
@@ -8173,7 +8250,7 @@ return r.buildConfig.sourceUrl === _.get(r, "image.metadata.annotations.sampleRe
 e.metricsWarning = !t;
 });
 var o = [], i = [];
-e.valueFromObjects = [], c.list(A, n, null, {
+e.valueFromObjects = [], c.list(D, n, null, {
 errorNotification: !1
 }).then(function(t) {
 o = R(t.by("metadata.name")), e.valueFromObjects = o.concat(i);
@@ -9872,9 +9949,9 @@ details: e("getErrorDetails")(n)
 }
 function w() {
 var e = {
-started: "Creating resources in project " + D(p.input.selectedProject),
-success: "Creating resources in project " + D(p.input.selectedProject),
-failure: "Failed to create some resources in project " + D(p.input.selectedProject)
+started: "Creating resources in project " + A(p.input.selectedProject),
+success: "Creating resources in project " + A(p.input.selectedProject),
+failure: "Failed to create some resources in project " + A(p.input.selectedProject)
 }, t = {};
 d.add(e, t, p.input.selectedProject.metadata.name, function() {
 var e = n.defer();
@@ -9909,9 +9986,9 @@ hasErrors: r
 }
 function P() {
 var e = {
-started: "Updating resources in project " + D(p.input.selectedProject),
-success: "Updated resources in project " + D(p.input.selectedProject),
-failure: "Failed to update some resources in project " + D(p.input.selectedProject)
+started: "Updating resources in project " + A(p.input.selectedProject),
+success: "Updated resources in project " + A(p.input.selectedProject),
+failure: "Failed to update some resources in project " + A(p.input.selectedProject)
 }, t = {};
 d.add(e, t, p.input.selectedProject.metadata.name, function() {
 var e = n.defer();
@@ -9994,7 +10071,7 @@ type: "error"
 }).length ? (_.each(E, function(e) {
 e.id = _.uniqueId("from-file-alert-"), c.addNotification(e);
 }), p.disableInputs = !1) : E.length ? (R(E), p.disableInputs = !1) : y();
-}, A = function() {
+}, D = function() {
 if (_.has(p.input.selectedProject, "metadata.uid")) return n.when(p.input.selectedProject);
 var t = p.input.selectedProject.metadata.name, r = p.input.selectedProject.metadata.annotations["new-display-name"], a = e("description")(p.input.selectedProject);
 return m.create(t, r, a);
@@ -10009,7 +10086,7 @@ var e = [];
 p.errorOccurred = !1, _.forEach(p.resourceList, function(t) {
 if (!g(t)) return p.errorOccurred = !0, !1;
 e.push(S(t));
-}), A().then(function(t) {
+}), D().then(function(t) {
 p.input.selectedProject = t, n.all(e).then(function() {
 p.errorOccurred || (1 === p.createResources.length && "Template" === p.resourceList[0].kind ? v() : _.isEmpty(p.updateResources) ? l.getLatestQuotaAlerts(p.createResources, {
 namespace: p.input.selectedProject.metadata.name
@@ -10027,11 +10104,21 @@ details: I(e)
 }, p.cancel = function() {
 T(), s.toProjectOverview(p.input.selectedProject.metadata.name);
 };
-var D = e("displayName");
+var A = e("displayName");
 p.$on("importFileFromYAMLOrJSON", p.create), p.$on("$destroy", T);
 } ]
 };
-} ]), angular.module("openshiftConsole").directive("oscFileInput", [ "$filter", "Logger", "NotificationsService", function(e, t, n) {
+} ]), angular.module("openshiftConsole").component("inlineEdit", {
+controller: [ InlineEdit ],
+bindings: {
+label: "<",
+pattern: "<",
+patternErrmsg: "<",
+value: "<",
+onEdited: "<"
+},
+templateUrl: "views/directives/inline-edit.html"
+}), angular.module("openshiftConsole").directive("oscFileInput", [ "$filter", "Logger", "NotificationsService", function(e, t, n) {
 return {
 restrict: "E",
 scope: {
@@ -10906,11 +10993,11 @@ _.size(h) <= 100 ? (y = e("orderByDisplayName")(h), T = _.map(y, function(e) {
 return n(e, !1);
 })) : T = [ n(h[t], !0) ], E.empty(), E.append(T), E.append($('<option data-divider="true"></option>')), E.append($('<option value="">View All Projects</option>')), E.selectpicker("refresh");
 }
-}, A = function() {
+}, D = function() {
 return f.list().then(function(e) {
 h = e.by("metadata.name");
 });
-}, D = function() {
+}, A = function() {
 k(R);
 var e = a.project;
 if (i.currentProjectName !== e) {
@@ -10927,7 +11014,7 @@ n.all([ r, a ]).then(function() {
 i.catalogItems = c.sortCatalogItems(_.concat(t, o));
 });
 }
-}), A().then(function() {
+}), D().then(function() {
 i.currentProjectName && h && (h[i.currentProjectName] || (h[i.currentProjectName] = {
 metadata: {
 name: i.currentProjectName
@@ -10967,7 +11054,7 @@ m.toProjectCatalog(i.currentProjectName, n);
 });
 i.closeOrderingPanel = function() {
 v.addItem(_.get(i.selectedItem, "resource.metadata.uid")), i.orderingPanelVisible = !1;
-}, D(), i.$on("$routeChangeSuccess", D), E.change(function() {
+}, A(), i.$on("$routeChangeSuccess", A), E.change(function() {
 var e = $(this).val(), t = "" === e ? "projects" : g(e);
 I(t);
 }), i.$on("$destroy", function() {
@@ -11925,7 +12012,50 @@ keywords: "="
 },
 templateUrl: "views/catalog/_template.html"
 };
-}), angular.module("openshiftConsole").directive("podMetrics", [ "$filter", "$interval", "$parse", "$timeout", "$q", "$rootScope", "ChartsService", "ConversionService", "MetricsCharts", "MetricsService", "ModalsService", "usageValueFilter", function(e, t, n, r, a, o, i, s, c, l, u, d) {
+}), function() {
+angular.module("openshiftConsole").component("mobileServiceSdkDocs", {
+controller: [ "$filter", "APIService", "DataService", function(e, t, n) {
+var r = t.getPreferredVersion("servicebindings"), a = t.getPreferredVersion("serviceinstances"), o = e("annotationName")("mobileBindingConsumerId"), i = e("annotationName")("mobileBindingProviderId"), s = this, c = [];
+s.$onChanges = function(e) {
+var t = _.get(e, "mobileClient.currentValue"), a = _.get(e, "serviceClasses.currentValue");
+t && a && 0 === c.length && c.push(n.watch(r, {
+namespace: s.context
+}, function(e) {
+var t = _.get(s, "mobileClient.metadata.name");
+s.bindings = _.filter(e.by("metadata.name"), function(e) {
+return _.get(e, [ "metadata", "annotations", o ]) === t;
+}), s.addDetailsToBindings();
+}));
+}, s.addDetailsToBindings = function() {
+n.list(a, {
+namespace: s.context
+}, function(e) {
+var t = e.by("metadata.name");
+s.serviceSdkInfo = _.map(s.bindings, function(e) {
+var n = t[_.get(e, [ "metadata", "annotations", i ], "")], r = s.serviceClasses[_.get(n, "spec.clusterServiceClassRef.name")];
+return {
+displayName: _.get(r, "spec.externalMetadata.displayName"),
+serviceInstanceName: _.get(n, "metadata.name"),
+description: _.get(r, "spec.description"),
+sdkDocs: _.get(r, "spec.externalMetadata.sdk-docs-" + s.mobileClient.spec.clientType),
+logo: _.get(r, "spec.externalMetadata.imageUrl"),
+iconClass: _.get(r, [ "spec", "externalMetadata", "console.openshift.io/iconClass" ])
+};
+});
+});
+}, s.$onDestroy = function() {
+n.unwatchAll(c);
+};
+} ],
+controllerAs: "ctrl",
+bindings: {
+context: "<",
+mobileClient: "<",
+serviceClasses: "<"
+},
+templateUrl: "views/_mobile-service-sdk-docs.html"
+});
+}(), angular.module("openshiftConsole").directive("podMetrics", [ "$filter", "$interval", "$parse", "$timeout", "$q", "$rootScope", "ChartsService", "ConversionService", "MetricsCharts", "MetricsService", "ModalsService", "usageValueFilter", function(e, t, n, r, a, o, i, s, c, l, u, d) {
 return {
 restrict: "E",
 scope: {
@@ -11963,7 +12093,7 @@ Available: "#d1d1d1"
 }
 };
 R[t.id] ? R[t.id].load(a) : ((n = B(e)).data = a, r(function() {
-D || (R[t.id] = c3.generate(n));
+A || (R[t.id] = c3.generate(n));
 }));
 }
 }
@@ -11979,7 +12109,7 @@ var n, a = c.getSparklineData(t), o = e.chartPrefix + "sparkline";
 E[o] ? E[o].load(a) : ((n = V(e)).data = a, e.chartDataColors && (n.color = {
 pattern: e.chartDataColors
 }), r(function() {
-D || (E[o] = c3.generate(n));
+A || (E[o] = c3.generate(n));
 }));
 }
 }
@@ -11990,7 +12120,7 @@ function h() {
 return 60 * m.options.timeRange.value * 1e3;
 }
 function y() {
-return Math.floor(h() / A) + "ms";
+return Math.floor(h() / D) + "ms";
 }
 function b(e, t, n) {
 var r, a = {
@@ -12005,12 +12135,12 @@ containerName: e.containerMetric ? m.options.selectedContainer.name : "pod"
 }) : null;
 }
 function S() {
-D || (L = 0, _.each(m.metrics, function(e) {
+A || (L = 0, _.each(m.metrics, function(e) {
 g(e), f(e);
 }));
 }
 function C(e) {
-if (!D) if (L++, m.noData) m.metricsError = {
+if (!A) if (L++, m.noData) m.metricsError = {
 status: _.get(e, "status", 0),
 details: _.get(e, "data.errorMsg") || _.get(e, "statusText") || "Status code " + _.get(e, "status", 0)
 }; else if (!(L < 2)) {
@@ -12039,7 +12169,7 @@ isNaN(r) && (r = 0), e.convert && (r = e.convert(r)), t.used = d3.round(r, e.usa
 function j(e, t) {
 m.noData = !1;
 var n = _.initial(t.data);
-e.data ? e.data = _.chain(e.data).takeRight(A).concat(n).value() : e.data = n;
+e.data ? e.data = _.chain(e.data).takeRight(D).concat(n).value() : e.data = n;
 }
 function k() {
 if (w()) {
@@ -12055,7 +12185,7 @@ P(n, a, e);
 }));
 }
 }), t = t.concat(r), a.all(r).then(function(e) {
-D || angular.forEach(e, function(e) {
+A || angular.forEach(e, function(e) {
 e && j(_.find(n.datasets, {
 id: e.metricID
 }), e);
@@ -12067,7 +12197,7 @@ m.loaded = !0;
 }
 }
 m.includedMetrics = m.includedMetrics || [ "cpu", "memory", "network" ];
-var I, R = {}, E = {}, T = n("resources.limits.memory"), N = n("resources.limits.cpu"), A = 30, D = !1;
+var I, R = {}, E = {}, T = n("resources.limits.memory"), N = n("resources.limits.cpu"), D = 30, A = !1;
 m.uniqueID = c.uniqueID(), m.metrics = [], _.includes(m.includedMetrics, "memory") && m.metrics.push({
 label: "Memory",
 units: "MiB",
@@ -12171,7 +12301,7 @@ I && (t.cancel(I), I = null), O && (O(), O = null), angular.forEach(R, function(
 e.destroy();
 }), R = null, angular.forEach(E, function(e) {
 e.destroy();
-}), E = null, D = !0;
+}), E = null, A = !0;
 });
 }
 };
@@ -12233,7 +12363,7 @@ return e[0];
 function u(e) {
 P || (N = 0, t.showAverage = _.size(t.pods) > 5 || w, _.each(t.metrics, function(n) {
 var r, a = o(e, n), i = n.descriptor;
-w && n.compactCombineWith && (i = n.compactCombineWith, n.lastValue && (T[i].lastValue = (T[i].lastValue || 0) + n.lastValue)), S[i] ? (S[i].load(a), t.showAverage ? S[i].legend.hide() : S[i].legend.show()) : ((r = A(n)).data = a, S[i] = c3.generate(r));
+w && n.compactCombineWith && (i = n.compactCombineWith, n.lastValue && (T[i].lastValue = (T[i].lastValue || 0) + n.lastValue)), S[i] ? (S[i].load(a), t.showAverage ? S[i].legend.hide() : S[i].legend.show()) : ((r = D(n)).data = a, S[i] = c3.generate(r));
 }));
 }
 function d() {
@@ -12363,7 +12493,7 @@ t.metricsURL = e;
 }), t.options = {
 rangeOptions: s.getTimeRangeOptions()
 }, t.options.timeRange = _.head(t.options.rangeOptions), t.options.selectedContainer = _.head(t.containers);
-var A = function(e) {
+var D = function(e) {
 var n = s.getDefaultSparklineConfig(e.chartID, e.units, w);
 return _.set(n, "legend.show", !w && !t.showAverage), n;
 };
@@ -12372,11 +12502,11 @@ I = {}, j = null, delete t.metricsError, y();
 }, !0), b = e(y, s.getDefaultUpdateInterval(), !1), t.updateInView = function(e) {
 R = !e, e && (!k || Date.now() > k + s.getDefaultUpdateInterval()) && y();
 };
-var D = a.$on("metrics.charts.resize", function() {
+var A = a.$on("metrics.charts.resize", function() {
 s.redraw(S);
 });
 t.$on("$destroy", function() {
-b && (e.cancel(b), b = null), D && (D(), D = null), angular.forEach(S, function(e) {
+b && (e.cancel(b), b = null), A && (A(), A = null), angular.forEach(S, function(e) {
 e.destroy();
 }), S = null, P = !0;
 });
@@ -12455,17 +12585,17 @@ k(!0), b(), C();
 m.on("resize", R);
 var E, T = function() {
 S = !0, d.scrollBottom(u);
-}, N = document.createDocumentFragment(), A = _.debounce(function() {
+}, N = document.createDocumentFragment(), D = _.debounce(function() {
 l.appendChild(N), N = document.createDocumentFragment(), t.autoScrollActive && T(), t.showScrollLinks || b();
 }, 100, {
 maxWait: 300
-}), D = function(e) {
+}), A = function(e) {
 var t = a.defer();
 return E ? (E.onClose(function() {
 t.resolve();
-}), E.stop()) : t.resolve(), e || (A.cancel(), l && (l.innerHTML = ""), N = document.createDocumentFragment()), t.promise;
+}), E.stop()) : t.resolve(), e || (D.cancel(), l && (l.innerHTML = ""), N = document.createDocumentFragment()), t.promise;
 }, B = function() {
-D().then(function() {
+A().then(function() {
 t.$evalAsync(function() {
 if (t.run) {
 angular.extend(t, {
@@ -12481,14 +12611,14 @@ follow: !0,
 tailLines: 5e3,
 limitBytes: 10485760
 }, t.options), n = 0, r = function(e) {
-n++, N.appendChild(f(n, e)), A();
+n++, N.appendChild(f(n, e)), D();
 };
 (E = c.createStream(v, h, t.context, e)).onMessage(function(a, o, i) {
 t.$evalAsync(function() {
 t.empty = !1, "logs" !== t.state && (t.state = "logs", I());
 }), a && (e.limitBytes && i >= e.limitBytes && (t.$evalAsync(function() {
 t.limitReached = !0, t.loading = !1;
-}), D(!0)), r(a), !t.largeLog && n >= e.tailLines && t.$evalAsync(function() {
+}), A(!0)), r(a), !t.largeLog && n >= e.tailLines && t.$evalAsync(function() {
 t.largeLog = !0;
 }));
 }), E.onClose(function() {
@@ -12548,7 +12678,7 @@ t.autoScrollActive = !t.autoScrollActive, t.autoScrollActive && T();
 goChromeless: d.chromelessLink,
 restartLogs: B
 }), t.$on("$destroy", function() {
-D(), m.off("resize", R), m.off("scroll", C), u && $(u).off("scroll", C);
+A(), m.off("resize", R), m.off("scroll", C), u && $(u).off("scroll", C);
 }), "deploymentconfigs/logs" === v && !h) return t.state = "empty", void (t.emptyStateMessage = "Logs are not available for this replication controller because it was not generated from a deployment configuration.");
 t.$watchGroup([ "name", "options.container", "run" ], B);
 } ],
@@ -14087,7 +14217,10 @@ resource: "mobileclients"
 }, l.actionsDropdownVisible = function() {
 return !_.get(l.apiObject, "metadata.deletionTimestamp") && a.canI(l.mobileclientVersion, "delete");
 }, l.projectName = n.project, l.browseCatalog = function() {
-s.toProjectCatalog(l.projectName);
+s.toProjectCatalog(l.projectName, {
+category: "mobile",
+subcategory: "services"
+});
 };
 } ],
 controllerAs: "row",
@@ -14748,7 +14881,7 @@ cancelButtonText: "Cancel"
 }
 }
 }).result.then(T);
-}, A = function(e) {
+}, D = function(e) {
 b = e.quotaAlerts || [];
 var t = _.filter(b, {
 type: "error"
@@ -14765,7 +14898,7 @@ namespace: n.input.selectedProject.metadata.name
 }), i = function(e) {
 return n.nameTaken = e.nameTaken, r;
 };
-t.then(i, i).then(A, A);
+t.then(i, i).then(D, D);
 }, function(e) {
 n.disableInputs = !1, "AlreadyExists" === e.data.reason ? n.projectNameTaken = !0 : l.addNotification({
 id: "deploy-image-create-project-error",
@@ -15237,7 +15370,7 @@ namespace: e.namespace
 S[a.project] && delete S[a.project][e.uid], b[a.project] && delete b[a.project][e.uid], E(e);
 }, N = function() {
 b[a.project] = {}, S[a.project] = {};
-}, A = function(e) {
+}, D = function(e) {
 return _.reduce(e, function(e, t) {
 return e[t.metadata.uid] = {
 actions: null,
@@ -15250,7 +15383,7 @@ firstTimestamp: t.firstTimestamp,
 event: t
 }, e;
 }, {});
-}, D = function(e) {
+}, A = function(e) {
 return _.reduce(e, function(e, t) {
 return u.isImportantAPIEvent(t) && !u.isCleared(t.metadata.uid) && (e[t.metadata.uid] = t), e;
 }, {});
@@ -15272,7 +15405,7 @@ m && (l.unwatch(m), m = null);
 }, U = function() {
 d && d(), d = null;
 }, F = function(e) {
-b[a.project] = A(D(e.by("metadata.name"))), V();
+b[a.project] = D(A(e.by("metadata.name"))), V();
 }, x = function(e, t) {
 var n = t.namespace || a.project, r = t.id ? n + "/" + t.id : _.uniqueId("notification_") + Date.now();
 t.showInDrawer && !u.isCleared(r) && (S[n] = S[n] || {}, S[n][r] = {

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -224,6 +224,36 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
   );
 
 
+  $templateCache.put('views/_mobile-service-sdk-docs.html',
+    "<div class=\"col-md-6 service-instance-getting-started\" ng-repeat=\"sdkInfo in ctrl.serviceSdkInfo\">\n" +
+    "<div class=\"col-md-12\">\n" +
+    "<img ng-if=\"sdkInfo.logo\" class=\"logo\" ng-src=\"{{sdkInfo.logo}}\">\n" +
+    "<span ng-if=\"!sdkInfo.logo && sdkInfo.iconClass \" class=\"logo-icon-class {{sdkInfo.iconClass}}\"></span>\n" +
+    "<div class=\"service-details\">\n" +
+    "<h4>\n" +
+    "<div>\n" +
+    "{{sdkInfo.displayName}}\n" +
+    "</div>\n" +
+    "<div>\n" +
+    "<small class=\"meta\">\n" +
+    "{{sdkInfo.serviceInstanceName}}\n" +
+    "</small>\n" +
+    "</div>\n" +
+    "</h4>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"col-md-12\">\n" +
+    "<div class=\"sdk-docs\">\n" +
+    "<h5>{{sdkInfo.description}}</h5>\n" +
+    "<h5>\n" +
+    "<a href=\"{{sdkInfo.sdkDocs}}\" target=\"_blank\">{{sdkInfo.displayName}} SDK setup</a>\n" +
+    "</h5>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>"
+  );
+
+
   $templateCache.put('views/_parse-error.html',
     "<div ng-show=\"error && !hidden\" class=\"alert alert-danger animate-show\">\n" +
     "<button ng-click=\"hidden = true\" type=\"button\" class=\"close\" aria-hidden=\"true\">\n" +
@@ -2894,6 +2924,126 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</registry-image-listing>\n" +
     "<registry-imagestream-push settings=\"settings\" imagestream=\"imageStream\">\n" +
     "</registry-imagestream-push>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>"
+  );
+
+
+  $templateCache.put('views/browse/mobile-clients.html',
+    "<div class=\"middle mobile-clients-view\">\n" +
+    "<div class=\"middle-header\">\n" +
+    "<div class=\"container-fluid\">\n" +
+    "<breadcrumbs breadcrumbs=\"breadcrumbs\"></breadcrumbs>\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
+    "<div>\n" +
+    "<h1 class=\"contains-actions\">\n" +
+    "<div class=\"pull-right dropdown\" ng-if=\"ctrl.mobileClient\">\n" +
+    "<button type=\"button\" class=\"dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs\" data-toggle=\"dropdown\">\n" +
+    "Actions\n" +
+    "<span class=\"caret\" aria-hidden=\"true\"></span>\n" +
+    "</button>\n" +
+    "<a href=\"\" class=\"dropdown-toggle actions-dropdown-kebab visible-xs-inline\" data-toggle=\"dropdown\"><i class=\"fa fa-ellipsis-v\" aria-hidden=\"true\"></i><span class=\"sr-only\">Actions</span></a>\n" +
+    "<ul class=\"dropdown-menu dropdown-menu-right actions action-button\">\n" +
+    "<li ng-if=\"ctrl.mobileCIEnabled && (ctrl.mobileClient.spec.clientType !== 'xamarin')\">\n" +
+    "<a ng-href=\"project/{{ctrl.project.metadata.name}}/create-client-build/{{ctrl.mobileClient.metadata.name}}\" role=\"button\">Create Build</a>\n" +
+    "</li>\n" +
+    "<li>\n" +
+    "<a ng-href=\"{{ctrl.mobileClient | editYamlURL}}\" role=\"button\">Edit YAML</a>\n" +
+    "</li>\n" +
+    "<li>\n" +
+    "<delete-link kind=\"MobileClient\" group=\"mobile.k8s.io\" resource-name=\"{{ctrl.mobileClient.metadata.name}}\" project-name=\"{{ctrl.mobileClient.metadata.namespace}}\" alerts=\"alerts\" redirect-url=\"{{ctrl.redirectUrl}}\">\n" +
+    "</delete-link>\n" +
+    "</li>\n" +
+    "</ul>\n" +
+    "</div>\n" +
+    "{{ctrl.mobileClient.spec.name}}\n" +
+    "<small class=\"meta\" ng-if=\"ctrl.mobileClient\">created <span am-time-ago=\"ctrl.mobileClient.metadata.creationTimestamp\"></span></small>\n" +
+    "</h1>\n" +
+    "<labels labels=\"ctrl.mobileClient.metadata.labels\" clickable=\"true\" kind=\"mobileClient\" project-name=\"{{ctrl.mobileClient.metadata.namespace}}\" limit=\"3\"></labels>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"middle-content\" persist-tab-state>\n" +
+    "<div class=\"container-fluid\">\n" +
+    "<div ng-if=\"!ctrl.loaded\">{{ctrl.emptyMessage}}</div>\n" +
+    "<div ng-if=\"ctrl.loaded\" class=\"row\">\n" +
+    "<div class=\"col-md-12\" ng-class=\"{ 'hide-tabs' : !ctrl.mobileClient }\">\n" +
+    "<uib-tabset>\n" +
+    "<uib-tab active=\"selectedTab.configuration\">\n" +
+    "<uib-tab-heading>Configuration</uib-tab-heading>\n" +
+    "<div class=\"configuration\">\n" +
+    "<div class=\"row\">\n" +
+    "<div class=\"resource-details col-md-6\">\n" +
+    "<h3>Mobile Client Details</h3>\n" +
+    "<dl class=\"dl-horizontal left\">\n" +
+    "<dt>Client Type:</dt>\n" +
+    "<dd>{{ctrl.mobileClient.spec.clientType}}</dd>\n" +
+    "<dt>Client ID:</dt>\n" +
+    "<dd>{{ctrl.mobileClient.spec.appIdentifier}}</dd>\n" +
+    "<dt>Client API Key:</dt>\n" +
+    "<dd>{{ctrl.mobileClient.spec.apiKey}}</dd>\n" +
+    "<dt>DMZ Url:</dt>\n" +
+    "<dd>\n" +
+    "<inline-edit pattern=\"ctrl.validUrlPattern\" pattern-errmsg=\"'The value provided is not a valid url.'\" label=\"'Set DMZ Url'\" value=\"ctrl.mobileClient.spec.dmzUrl\" on-edited=\"ctrl.setDmzUrl\">\n" +
+    "</inline-edit>\n" +
+    "</dd>\n" +
+    "</dl>\n" +
+    "</div>\n" +
+    "<div class=\"col-md-6 resource-details client-config\">\n" +
+    "<h3>Mobile Client Config</h3>\n" +
+    "<mobile-client-config mobile-client=\"ctrl.mobileClient\"></mobile-client-config>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"row\">\n" +
+    "<div class=\"resource-details col-md-12\">\n" +
+    "<h3>SDK Configuration</h3>\n" +
+    "<h4>\n" +
+    "<a href=\"{{ctrl.coreSdkSetup}}\" target=\"_blank\">{{ctrl.mobileClient.spec.clientType | upperFirst}} SDK setup</a>\n" +
+    "</h4>\n" +
+    "</div>\n" +
+    "<div class=\"resource-details service-configuration col-md-12\">\n" +
+    "<h3>Service Configuration</h3>\n" +
+    "<mobile-service-sdk-docs context=\"ctrl.projectName\" mobile-client=\"ctrl.mobileClient\" service-classes=\"ctrl.serviceClasses\"></mobile-service-sdk-docs>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</uib-tab>\n" +
+    "<uib-tab ng-if=\"true\" active=\"selectedTab.builds\">\n" +
+    "<uib-tab-heading>Builds</uib-tab-heading>\n" +
+    "<div class=\"builds\">\n" +
+    "<div class=\"note\" ng-if=\"(ctrl.mobileCIProvisioning || ctrl.mobileCIDeprovisioning) && ctrl.mobileClient.spec.clientType !== 'xamarin'\">\n" +
+    "<div class=\"col-md-offset-1 col-md-10\">\n" +
+    "<div class=\"alert alert-info\">\n" +
+    "<span class=\"pficon pficon-info\"></span>\n" +
+    "<span ng-class=\"{'spinner spinner-xs spinner-inline': (ctrl.mobileCIProvisioning || ctrl.mobileCIDeprovisioning)}\" aria-hidden=\"true\"></span>\n" +
+    "<span ng-if=\"ctrl.mobileCIProvisioning\">Mobile CI | CD is provisioning</span>\n" +
+    "<span ng-if=\"ctrl.mobileCIDeprovisioning\">Mobile CI | CD is deprovisioning</span>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<div class=\"note\" ng-if=\"!ctrl.mobileCIService && ctrl.mobileClient.spec.clientType !== 'xamarin'\">\n" +
+    "<p>Provision a Mobile CI | CD service to create a mobile build.</p>\n" +
+    "<button class=\"btn btn-primary btn-lg\" ng-click=\"ctrl.goToMobileServices()\">Browse Mobile Services</button>\n" +
+    "</div>\n" +
+    "<div ng-if=\"ctrl.mobileClient.spec.clientType === 'xamarin'\" class=\"row\">\n" +
+    "<div class=\"col-md-offset-1 col-md-10\">\n" +
+    "<div class=\"alert alert-info\">\n" +
+    "<span class=\"pficon pficon-info\"></span>\n" +
+    "Mobile builds are not avaialble for Xamarin.\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "<mobile-client-builds-list ng-if=\"ctrl.mobileCIEnabled && ctrl.mobileClient.spec.clientType !== 'xamarin'\" mobile-client=\"ctrl.mobileClient\"></mobile-client-builds-list>\n" +
+    "</div>\n" +
+    "</uib-tab>\n" +
+    "<uib-tab ng-if=\"true\" active=\"selectedTab.mobileServices\" class=\"mobile-services\">\n" +
+    "<uib-tab-heading>Mobile Services</uib-tab-heading>\n" +
+    "<mobile-service-instance-list></mobile-service-instance-list>\n" +
+    "</uib-tab>\n" +
+    "</uib-tabset>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
@@ -7452,6 +7602,33 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt ng-if-start=\"hpa.status.lastScaleTime\">Last Scaled:</dt>\n" +
     "<dd ng-if-end><span am-time-ago=\"hpa.status.lastScaleTime\"></span></dd>\n" +
     "</dl>"
+  );
+
+
+  $templateCache.put('views/directives/inline-edit.html',
+    "<div class=\"form-control-pf-editable inline-edit\">\n" +
+    "<ng-form name=\"$ctrl.inlineEditForm\" class=\"inline-edit-form\">\n" +
+    "<button ng-if=\"!$ctrl.editEnabled\" type=\"button\" class=\"form-control-pf-value\" ng-click=\"$ctrl.enableEdit()\">\n" +
+    "<span class=\"sr-only\">{{$ctrl.label}}</span>\n" +
+    "<span ng-if=\"$ctrl.value\">{{$ctrl.value}}</span>\n" +
+    "<span ng-if=\"!$ctrl.value\">{{$ctrl.label}}</span>\n" +
+    "<i class=\"glyphicon glyphicon-pencil\" aria-hidden=\"true\"></i>\n" +
+    "</button>\n" +
+    "<div ng-if=\"$ctrl.editEnabled\" class=\"form-control-pf-textbox\">\n" +
+    "<input ng-model=\"$ctrl.inputVal\" name=\"input\" type=\"text\" ng-pattern=\"$ctrl.pattern\" class=\"form-control form-control-pf-editor\" autocorrect=\"off\" autocapitalize=\"none\" spellcheck=\"false\" aria-label=\"{{$ctrl.label}}\" autofocus/>\n" +
+    "<button type=\"button\" class=\"form-control-pf-empty\" ng-click=\"$ctrl.clearInput()\" aria-label=\"Clear Value\">\n" +
+    "<span class=\"fa fa-times-circle fa-lg\"></span>\n" +
+    "</button>\n" +
+    "</div>\n" +
+    "<button ng-if=\"$ctrl.editEnabled\" type=\"button\" class=\"btn btn-primary form-control-pf-save\" aria-label=\"Save\" ng-click=\"$ctrl.save($ctrl.inputVal)\" ng-disabled=\"$ctrl.inlineEditForm.input.$invalid\">\n" +
+    "<i class=\"glyphicon glyphicon-ok\"></i>\n" +
+    "</button>\n" +
+    "<button ng-if=\"$ctrl.editEnabled\" type=\"button\" class=\"btn btn-default form-control-pf-cancel\" aria-label=\"Cancel\" ng-click=\"$ctrl.cancelEdit()\"><i class=\"glyphicon glyphicon-remove\"></i></button>\n" +
+    "</ng-form>\n" +
+    "<span ng-if=\"$ctrl.inlineEditForm.input.$error.pattern\" class=\"help-block inline-edit-input-error\">\n" +
+    "{{$ctrl.patternErrmsg}}\n" +
+    "</span>\n" +
+    "</div>"
   );
 
 

--- a/dist/scripts/vendor.js
+++ b/dist/scripts/vendor.js
@@ -22786,10 +22786,13 @@ e.each(n, function(r, l) {
 });
 }
 function a(e) {
-var t = qe.defaults.oLanguage, n = e.sZeroRecords;
-!e.sEmptyTable && n && "No data available in table" === t.sEmptyTable && Fe(e, e, "sZeroRecords", "sEmptyTable"), !e.sLoadingRecords && n && "Loading..." === t.sLoadingRecords && Fe(e, e, "sZeroRecords", "sLoadingRecords"), e.sInfoThousands && (e.sThousands = e.sInfoThousands);
-var i = e.sDecimal;
-i && je(i);
+var t = qe.defaults.oLanguage, n = t.sDecimal;
+if (n && je(n), e) {
+var i = e.sZeroRecords;
+!e.sEmptyTable && i && "No data available in table" === t.sEmptyTable && Fe(e, e, "sZeroRecords", "sEmptyTable"), !e.sLoadingRecords && i && "Loading..." === t.sLoadingRecords && Fe(e, e, "sZeroRecords", "sLoadingRecords"), e.sInfoThousands && (e.sThousands = e.sInfoThousands);
+var r = e.sDecimal;
+r && n !== r && je(r);
+}
 }
 function s(e) {
 ht(e, "ordering", "bSort"), ht(e, "orderMulti", "bSortMulti"), ht(e, "orderClasses", "bSortClasses"), ht(e, "orderCellsTop", "bSortCellsTop"), ht(e, "order", "aaSorting"), ht(e, "orderFixed", "aaSortingFixed"), ht(e, "paging", "bPaginate"), ht(e, "pagingType", "sPaginationType"), ht(e, "pageLength", "iDisplayLength"), ht(e, "searching", "bFilter"), "boolean" == typeof e.sScrollX && (e.sScrollX = e.sScrollX ? "100%" : ""), "boolean" == typeof e.scrollX && (e.scrollX = e.scrollX ? "100%" : "");
@@ -23078,7 +23081,7 @@ for (a = r || n.createElement("tr"), d.nTr = a, d.anCells = f, a._DT_RowIndex = 
 row: i,
 column: c
 }, f.push(s), r && !l.mRender && l.mData === c || e.isPlainObject(l.mData) && l.mData._ === c + ".display" || (s.innerHTML = x(t, i, c, "display")), l.sClass && (s.className += " " + l.sClass), l.bVisible && !r ? a.appendChild(s) : !l.bVisible && r && s.parentNode.removeChild(s), l.fnCreatedCell && l.fnCreatedCell.call(t.oInstance, s, x(t, i, c), h, i, c);
-Le(t, "aoRowCreatedCallback", null, [ a, h, i ]);
+Le(t, "aoRowCreatedCallback", null, [ a, h, i, f ]);
 }
 d.nTr.setAttribute("role", "row");
 }
@@ -23138,7 +23141,7 @@ if (0 !== s) {
 var _ = a[o % s];
 y._sRowStripe != _ && (e(w).removeClass(y._sRowStripe).addClass(_), y._sRowStripe = _);
 }
-Le(t, "aoRowCallback", null, [ w, y._aData, o, v ]), r.push(w), o++;
+Le(t, "aoRowCallback", null, [ w, y._aData, o, v, b ]), r.push(w), o++;
 } else {
 var x = l.sZeroRecords;
 1 == t.iDraw && "ajax" == Ne(t) ? x = l.sLoadingRecords : l.sEmptyTable && 0 === t.fnRecordsTotal() && (x = l.sEmptyTable), r[0] = e("<tr/>", {
@@ -23221,9 +23224,8 @@ var a, s = t.ajax, l = t.oInstance, c = function(e) {
 Le(t, null, "xhr", [ t, e, t.jqXHR ]), i(e);
 };
 if (e.isPlainObject(s) && s.data) {
-a = s.data;
-var u = e.isFunction(a) ? a(n, t) : a;
-n = e.isFunction(a) && u ? u : e.extend(!0, n, u), delete s.data;
+var u = "function" == typeof (a = s.data) ? a(n, t) : a;
+n = "function" == typeof a && u ? u : e.extend(!0, n, u), delete s.data;
 }
 var d = {
 data: n,
@@ -23246,7 +23248,7 @@ value: e
 };
 }), c, t) : t.sAjaxSource || "string" == typeof s ? t.jqXHR = e.ajax(e.extend(d, {
 url: s || t.sAjaxSource
-})) : e.isFunction(s) ? t.jqXHR = s.call(l, n, c, t) : (t.jqXHR = e.ajax(e.extend(d, s)), s.data = a);
+})) : "function" == typeof s ? t.jqXHR = s.call(l, n, c, t) : (t.jqXHR = e.ajax(e.extend(d, s)), s.data = a);
 }
 function V(e) {
 return !e.bAjaxDataGet || (e.iDraw++, de(e, !0), H(e, U(e), function(t) {
@@ -23550,9 +23552,9 @@ H.push(t.innerHTML), N.push(ye(e(t).css("width")));
 }, a), pe(function(e, t) {
 e.style.width = N[t];
 }, r), e(a).height(0)), pe(function(e, t) {
-e.innerHTML = '<div class="dataTables_sizing" style="height:0;overflow:hidden;">' + B[t] + "</div>", e.style.width = R[t];
+e.innerHTML = '<div class="dataTables_sizing">' + B[t] + "</div>", e.childNodes[0].style.height = "0", e.childNodes[0].style.overflow = "hidden", e.style.width = R[t];
 }, o), I && pe(function(e, t) {
-e.innerHTML = '<div class="dataTables_sizing" style="height:0;overflow:hidden;">' + H[t] + "</div>", e.style.width = N[t];
+e.innerHTML = '<div class="dataTables_sizing">' + H[t] + "</div>", e.childNodes[0].style.height = "0", e.childNodes[0].style.overflow = "hidden", e.style.width = N[t];
 }, a), E.outerWidth() < d ? (u = S.scrollHeight > S.offsetHeight || "scroll" == $.css("overflow-y") ? d + b : d, L && (S.scrollHeight > S.offsetHeight || "scroll" == $.css("overflow-y")) && (M.width = ye(u - b)), "" !== g && "" === m || Ee(t, 1, "Possible column misalignment", 6)) : u = "100%", A.width = ye(u), w.width = ye(u), I && (t.nScrollFoot.style.width = ye(u)), v || L && (A.height = ye(F.offsetHeight + b));
 var z = E.outerWidth();
 C[0].style.width = ye(z), x.width = ye(z);
@@ -23761,8 +23763,8 @@ for (var o in n) n.hasOwnProperty(o) && (r = n[o], e.isPlainObject(r) ? (e.isPla
 return t;
 }
 function Ie(t, n, i) {
-e(t).on("click.DT", n, function(e) {
-t.blur(), i(e);
+e(t).on("click.DT", n, function(n) {
+e(t).blur(), i(n);
 }).on("keypress.DT", n, function(e) {
 13 === e.which && (e.preventDefault(), i(e));
 }).on("selectstart.DT", function() {
@@ -23900,7 +23902,7 @@ s(x), l(x.column), o(x, x, !0), o(x.column, x.column, !0), o(x, e.extend(g, C.da
 var S = qe.settings;
 for (m = 0, f = S.length; m < f; m++) {
 var A = S[m];
-if (A.nTable == this || A.nTHead.parentNode == this || A.nTFoot && A.nTFoot.parentNode == this) {
+if (A.nTable == this || A.nTHead && A.nTHead.parentNode == this || A.nTFoot && A.nTFoot.parentNode == this) {
 var k = g.bRetrieve !== i ? g.bRetrieve : x.bRetrieve, T = g.bDestroy !== i ? g.bDestroy : x.bDestroy;
 if (r || k) return A.oInstance;
 if (T) {
@@ -23920,7 +23922,7 @@ sDestroyWidth: C[0].style.width,
 sInstance: v,
 sTableId: v
 });
-D.nTable = this, D.oApi = n.internal, D.oInit = g, S.push(D), D.oInstance = 1 === n.length ? n : C.dataTable(), s(g), g.oLanguage && a(g.oLanguage), g.aLengthMenu && !g.iDisplayLength && (g.iDisplayLength = e.isArray(g.aLengthMenu[0]) ? g.aLengthMenu[0][0] : g.aLengthMenu[0]), g = Me(e.extend(!0, {}, x), g), Fe(D.oFeatures, g, [ "bPaginate", "bLengthChange", "bFilter", "bSort", "bSortMulti", "bInfo", "bProcessing", "bAutoWidth", "bSortClasses", "bServerSide", "bDeferRender" ]), Fe(D, g, [ "asStripeClasses", "ajax", "fnServerData", "fnFormatNumber", "sServerMethod", "aaSorting", "aaSortingFixed", "aLengthMenu", "sPaginationType", "sAjaxSource", "sAjaxDataProp", "iStateDuration", "sDom", "bSortCellsTop", "iTabIndex", "fnStateLoadCallback", "fnStateSaveCallback", "renderer", "searchDelay", "rowId", [ "iCookieDuration", "iStateDuration" ], [ "oSearch", "oPreviousSearch" ], [ "aoSearchCols", "aoPreSearchCols" ], [ "iDisplayLength", "_iDisplayLength" ] ]), Fe(D.oScroll, g, [ [ "sScrollX", "sX" ], [ "sScrollXInner", "sXInner" ], [ "sScrollY", "sY" ], [ "bScrollCollapse", "bCollapse" ] ]), 
+D.nTable = this, D.oApi = n.internal, D.oInit = g, S.push(D), D.oInstance = 1 === n.length ? n : C.dataTable(), s(g), a(g.oLanguage), g.aLengthMenu && !g.iDisplayLength && (g.iDisplayLength = e.isArray(g.aLengthMenu[0]) ? g.aLengthMenu[0][0] : g.aLengthMenu[0]), g = Me(e.extend(!0, {}, x), g), Fe(D.oFeatures, g, [ "bPaginate", "bLengthChange", "bFilter", "bSort", "bSortMulti", "bInfo", "bProcessing", "bAutoWidth", "bSortClasses", "bServerSide", "bDeferRender" ]), Fe(D, g, [ "asStripeClasses", "ajax", "fnServerData", "fnFormatNumber", "sServerMethod", "aaSorting", "aaSortingFixed", "aLengthMenu", "sPaginationType", "sAjaxSource", "sAjaxDataProp", "iStateDuration", "sDom", "bSortCellsTop", "iTabIndex", "fnStateLoadCallback", "fnStateSaveCallback", "renderer", "searchDelay", "rowId", [ "iCookieDuration", "iStateDuration" ], [ "oSearch", "oPreviousSearch" ], [ "aoSearchCols", "aoPreSearchCols" ], [ "iDisplayLength", "_iDisplayLength" ] ]), Fe(D.oScroll, g, [ [ "sScrollX", "sX" ], [ "sScrollXInner", "sXInner" ], [ "sScrollY", "sY" ], [ "bScrollCollapse", "bCollapse" ] ]), 
 Fe(D.oLanguage, g, "fnInfoCallback"), Pe(D, "aoDrawCallback", g.fnDrawCallback, "user"), Pe(D, "aoServerParams", g.fnServerParams, "user"), Pe(D, "aoStateSaveParams", g.fnStateSaveParams, "user"), Pe(D, "aoStateLoadParams", g.fnStateLoadParams, "user"), Pe(D, "aoStateLoaded", g.fnStateLoaded, "user"), Pe(D, "aoRowCallback", g.fnRowCallback, "user"), Pe(D, "aoRowCreatedCallback", g.fnCreatedRow, "user"), Pe(D, "aoHeaderCallback", g.fnHeaderCallback, "user"), Pe(D, "aoFooterCallback", g.fnFooterCallback, "user"), Pe(D, "aoInitComplete", g.fnInitComplete, "user"), Pe(D, "aoPreDrawCallback", g.fnPreDrawCallback, "user"), D.rowIdFn = $(g.rowId), c(D);
 var E = D.oClasses;
 if (e.extend(E, qe.ext.classes, g.oClasses), C.addClass(E.sTable), D.iInitDisplayStart === i && (D.iInitDisplayStart = g.iDisplayStart, D._iDisplayStart = g.iDisplayStart), null !== g.iDeferLoading) {
@@ -23993,7 +23995,7 @@ D.aiDisplay = D.aiDisplayMaster.slice(), D.bInitialised = !0, !1 === b && re(D);
 g.bStateSave ? (H.bStateSave = !0, Pe(D, "aoDrawCallback", ke, "state_save"), Te(D, 0, V)) : V();
 } else Ee(null, 0, "Non-table node initialisation (" + this.nodeName + ")", 2);
 }), n = null, this;
-}, Ge = {}, Ye = /[\r\n]/g, Ke = /<.*?>/g, Xe = /^\d{2,4}[\.\/\-]\d{1,2}[\.\/\-]\d{1,2}([T ]{1}\d{1,2}[:\.]\d{2}([\.:]\d{2})?)?$/, Qe = new RegExp("(\\" + [ "/", ".", "*", "+", "?", "|", "(", ")", "[", "]", "{", "}", "\\", "$", "^", "-" ].join("|\\") + ")", "g"), Ze = /[',$£€¥%\u2009\u202F\u20BD\u20a9\u20BArfk]/gi, Je = function(e) {
+}, Ge = {}, Ye = /[\r\n]/g, Ke = /<.*?>/g, Xe = /^\d{2,4}[\.\/\-]\d{1,2}[\.\/\-]\d{1,2}([T ]{1}\d{1,2}[:\.]\d{2}([\.:]\d{2})?)?$/, Qe = new RegExp("(\\" + [ "/", ".", "*", "+", "?", "|", "(", ")", "[", "]", "{", "}", "\\", "$", "^", "-" ].join("|\\") + ")", "g"), Ze = /[',$£€¥%\u2009\u202F\u20BD\u20a9\u20BArfkɃΞ]/gi, Je = function(e) {
 return !e || !0 === e || "-" === e;
 }, et = function(e) {
 var t = parseInt(e, 10);
@@ -24309,35 +24311,41 @@ page: "all"
 for (var t = 0, n = e.length; t < n; t++) if (e[t].length > 0) return e[0] = e[t], e[0].length = 1, e.length = 1, e.context = [ e.context[t] ], e;
 return e.length = 0, e;
 }, Tt = function(t, n) {
-var i, r, o, a = [], s = t.aiDisplay, l = t.aiDisplayMaster, c = n.search, u = n.order, d = n.page;
-if ("ssp" == Ne(t)) return "removed" === c ? [] : st(0, l.length);
-if ("current" == d) for (i = t._iDisplayStart, r = t.fnDisplayEnd(); i < r; i++) a.push(s[i]); else if ("current" == u || "applied" == u) a = "none" == c ? l.slice() : "applied" == c ? s.slice() : e.map(l, function(t, n) {
-return -1 === e.inArray(t, s) ? t : null;
-}); else if ("index" == u || "original" == u) for (i = 0, r = t.aoData.length; i < r; i++) "none" == c ? a.push(i) : (-1 === (o = e.inArray(i, s)) && "removed" == c || o >= 0 && "applied" == c) && a.push(i);
-return a;
+var i, r = [], o = t.aiDisplay, a = t.aiDisplayMaster, s = n.search, l = n.order, c = n.page;
+if ("ssp" == Ne(t)) return "removed" === s ? [] : st(0, a.length);
+if ("current" == c) for (d = t._iDisplayStart, h = t.fnDisplayEnd(); d < h; d++) r.push(o[d]); else if ("current" == l || "applied" == l) {
+if ("none" == s) r = a.slice(); else if ("applied" == s) r = o.slice(); else if ("removed" == s) {
+for (var u = {}, d = 0, h = o.length; d < h; d++) u[o[d]] = null;
+r = e.map(a, function(e) {
+return u.hasOwnProperty(e) ? null : e;
+});
+}
+} else if ("index" == l || "original" == l) for (d = 0, h = t.aoData.length; d < h; d++) "none" == s ? r.push(d) : (-1 === (i = e.inArray(d, o)) && "removed" == s || i >= 0 && "applied" == s) && r.push(d);
+return r;
 }, Dt = function(t, n, r) {
 var o;
 return $t("row", n, function(n) {
-var a = et(n);
+var a = et(n), s = t.aoData;
 if (null !== a && !r) return [ a ];
 if (o || (o = Tt(t, r)), null !== a && -1 !== e.inArray(a, o)) return [ a ];
 if (null === n || n === i || "" === n) return o;
 if ("function" == typeof n) return e.map(o, function(e) {
-var i = t.aoData[e];
-return n(e, i._aData, i.nTr) ? e : null;
+var t = s[e];
+return n(e, t._aData, t.nTr) ? e : null;
 });
-var s = lt(at(t.aoData, o, "nTr"));
 if (n.nodeName) {
-if (n._DT_RowIndex !== i) return [ n._DT_RowIndex ];
-if (n._DT_CellIndex) return [ n._DT_CellIndex.row ];
-var l = e(n).closest("*[data-dt-row]");
-return l.length ? [ l.data("dt-row") ] : [];
+var l = n._DT_RowIndex, c = n._DT_CellIndex;
+if (l !== i) return s[l] && s[l].nTr === n ? [ l ] : [];
+if (c) return s[c.row] && s[c.row].nTr === n ? [ c.row ] : [];
+var u = e(n).closest("*[data-dt-row]");
+return u.length ? [ u.data("dt-row") ] : [];
 }
 if ("string" == typeof n && "#" === n.charAt(0)) {
-var c = t.aIds[n.replace(/^#/, "")];
-if (c !== i) return [ c.idx ];
+var d = t.aIds[n.replace(/^#/, "")];
+if (d !== i) return [ d.idx ];
 }
-return e(s).filter(n).map(function() {
+var h = lt(at(t.aoData, o, "nTr"));
+return e(h).filter(n).map(function() {
 return this._DT_RowIndex;
 }).toArray();
 }, t, r);
@@ -24395,9 +24403,11 @@ return o;
 return i.pop(), e.merge(i, n), i;
 }), ze("row()", function(e, t) {
 return kt(this.rows(e, t));
-}), ze("row().data()", function(e) {
-var t = this.context;
-return e === i ? t.length && this.length ? t[0].aoData[this[0]]._aData : i : (t[0].aoData[this[0]]._aData = e, E(t[0], this[0], "data"), this);
+}), ze("row().data()", function(t) {
+var n = this.context;
+if (t === i) return n.length && this.length ? n[0].aoData[this[0]]._aData : i;
+var r = n[0].aoData[this[0]];
+return r._aData = t, e.isArray(t) && r.nTr.id && A(n[0].rowId)(t, r.nTr.id), E(n[0], this[0], "data"), this;
 }), ze("row().node()", function() {
 var e = this.context;
 return e.length && this.length ? e[0].aoData[this[0]].nTr || null : null;
@@ -24508,7 +24518,7 @@ if (r) {
 var h = e.inArray(!0, ot(c, "bVisible"), n + 1);
 for (a = 0, s = d.length; a < s; a++) l = d[a].nTr, o = d[a].anCells, l && l.insertBefore(o[n], o[h] || null);
 } else e(ot(t.aoData, "anCells", n)).detach();
-u.bVisible = r, L(t, t.aoHeader), L(t, t.aoFooter), ke(t);
+u.bVisible = r, L(t, t.aoHeader), L(t, t.aoFooter), t.aiDisplay.length || e(t.nTBody).find("td[colspan]").attr("colspan", m(t)), ke(t);
 }
 };
 ze("columns()", function(t, n) {
@@ -24575,7 +24585,7 @@ column: c
 }, r ? (d = h[o], n(u, x(t, o, c), d.anCells ? d.anCells[c] : null) && a.push(u)) : a.push(u);
 return a;
 }
-if (e.isPlainObject(n)) return [ n ];
+if (e.isPlainObject(n)) return n.column !== i && n.row !== i && -1 !== e.inArray(n.row, f) ? [ n ] : [];
 var p = g.filter(n).map(function(e, t) {
 return {
 row: t._DT_CellIndex.row,
@@ -24592,13 +24602,14 @@ ze("cells()", function(t, n, r) {
 if (e.isPlainObject(t) && (t.row === i ? (r = t, t = null) : (r = n, n = null)), e.isPlainObject(n) && (r = n, n = null), null === n || n === i) return this.iterator("table", function(e) {
 return Nt(e, t, At(r));
 });
-var o, a, s, l, c, u = this.columns(n, r), d = this.rows(t, r), h = this.iterator("table", function(e, t) {
+var o, a, s, l, c, u = this.columns(n), d = this.rows(t);
+this.iterator("table", function(e, t) {
 for (o = [], a = 0, s = d[t].length; a < s; a++) for (l = 0, c = u[t].length; l < c; l++) o.push({
 row: d[t][a],
 column: u[t][l]
 });
-return o;
 }, 1);
+var h = this.cells(o, r);
 return e.extend(h.selector, {
 cols: n,
 rows: t,
@@ -24762,7 +24773,7 @@ e.call(r[t](a, "cell" === t ? s : n, "cell" === t ? n : i), a, s, l, c);
 }), ze("i18n()", function(t, n, r) {
 var o = this.context[0], a = $(t)(o.oLanguage);
 return a === i && (a = n), r !== i && e.isPlainObject(a) && (a = a[r] !== i ? a[r] : a._), a.replace("%d", r);
-}), qe.version = "1.10.16", qe.settings = [], qe.models = {}, qe.models.oSearch = {
+}), qe.version = "1.10.18", qe.settings = [], qe.models = {}, qe.models.oSearch = {
 bCaseInsensitive: !0,
 sSearch: "",
 bRegex: !1,
@@ -25226,7 +25237,8 @@ return 0 === e || e && "-" !== e ? (t && (e = tt(e, t)), e.replace && (n && (e =
 };
 e.extend(Ve.type.order, {
 "date-pre": function(e) {
-return Date.parse(e) || -1 / 0;
+var t = Date.parse(e);
+return isNaN(t) ? -1 / 0 : t;
 },
 "html-pre": function(e) {
 return Je(e) ? "" : e.replace ? e.replace(/<.*?>/g, "").toLowerCase() : e + "";
@@ -25374,6 +25386,7 @@ _fnLengthOverflow: Oe,
 _fnRenderer: Re,
 _fnDataSource: Ne,
 _fnRowAttributes: I,
+_fnExtend: Me,
 _fnCalculateEnd: function() {}
 }), e.fn.dataTable = qe, qe.$ = e, e.fn.dataTableSettings = qe.settings, e.fn.dataTableExt = qe.ext, e.fn.DataTable = function(t) {
 return e(this).dataTable(t).api();
@@ -26579,34 +26592,36 @@ var n = t.settings()[0]._select.selector;
 e(t.table().container()).off("mousedown.dtSelect", n).off("mouseup.dtSelect", n).off("click.dtSelect", n), e("body").off("click.dtSelect" + t.table().node().id);
 }
 function a(n) {
-var i = e(n.table().container()), r = n.settings()[0], o = r._select.selector;
-i.on("mousedown.dtSelect", o, function(e) {
-(e.shiftKey || e.metaKey || e.ctrlKey) && i.css("-moz-user-select", "none").one("selectstart.dtSelect", o, function() {
+var i, r = e(n.table().container()), o = n.settings()[0], a = o._select.selector;
+r.on("mousedown.dtSelect", a, function(e) {
+(e.shiftKey || e.metaKey || e.ctrlKey) && r.css("-moz-user-select", "none").one("selectstart.dtSelect", a, function() {
 return !1;
-});
-}).on("mouseup.dtSelect", o, function() {
-i.css("-moz-user-select", "");
-}).on("click.dtSelect", o, function(i) {
-var r, o = n.select.items();
-if (!t.getSelection || !e.trim(t.getSelection().toString())) {
-var a = n.settings()[0];
-if (e(i.target).closest("div.dataTables_wrapper")[0] == n.table().container()) {
-var l = n.cell(e(i.target).closest("td, th"));
-if (l.any()) {
-var c = e.Event("user-select.dt");
-if (s(n, c, [ o, l, i ]), !c.isDefaultPrevented()) {
-var u = l.index();
-"row" === o ? (r = u.row, h(i, n, a, "row", r)) : "column" === o ? (r = l.index().column, h(i, n, a, "column", r)) : "cell" === o && (r = l.index(), h(i, n, a, "cell", r)), a._select_lastCell = u;
+}), t.getSelection && (i = t.getSelection());
+}).on("mouseup.dtSelect", a, function() {
+r.css("-moz-user-select", "");
+}).on("click.dtSelect", a, function(r) {
+var o, a = n.select.items();
+if (t.getSelection) {
+var l = t.getSelection();
+if ((!l.anchorNode || e(l.anchorNode).closest("table")[0] === n.table().node()) && l !== i) return;
 }
+var c = n.settings()[0], u = n.settings()[0].oClasses.sWrapper.replace(/ /g, ".");
+if (e(r.target).closest("div." + u)[0] == n.table().container()) {
+var d = n.cell(e(r.target).closest("td, th"));
+if (d.any()) {
+var f = e.Event("user-select.dt");
+if (s(n, f, [ a, d, r ]), !f.isDefaultPrevented()) {
+var p = d.index();
+"row" === a ? (o = p.row, h(r, n, c, "row", o)) : "column" === a ? (o = d.index().column, h(r, n, c, "column", o)) : "cell" === a && (o = d.index(), h(r, n, c, "cell", o)), c._select_lastCell = p;
 }
 }
 }
 }), e("body").on("click.dtSelect" + n.table().node().id, function(t) {
-if (r._select.blurable) {
+if (o._select.blurable) {
 if (e(t.target).parents().filter(n.table().container()).length) return;
 if (0 === e(t.target).parents("html").length) return;
 if (e(t.target).parents("div.DTE").length) return;
-d(r, !0);
+d(o, !0);
 }
 });
 }
@@ -26639,7 +26654,7 @@ l.length && l.remove(), "" !== s.text() && n.append(s);
 }
 }
 function c(t) {
-var n = new g.Api(t);
+var n = new m.Api(t);
 t.aoRowCreatedCallback.push({
 fn: function(n, i, r) {
 var o, a, s = t.aoData[r];
@@ -26692,7 +26707,7 @@ selected: !0
 }
 function d(e, t) {
 if (t || "single" === e._select.style) {
-var n = new g.Api(e);
+var n = new m.Api(e);
 n.rows({
 selected: !0
 }).deselect(), n.columns({
@@ -26722,9 +26737,18 @@ function p(e) {
 var t = e._eventNamespace;
 return "draw.dt.DT" + t + " select.dt.DT" + t + " deselect.dt.DT" + t;
 }
-var g = e.fn.dataTable;
-g.select = {}, g.select.version = "1.2.3", g.select.init = function(t) {
-var n = t.settings()[0], r = n.oInit.select, o = g.defaults.select, a = r === i ? o : r, s = "row", l = "api", c = !1, u = !0, d = "td, th", h = "selected", f = !1;
+function g(t, n) {
+return !(-1 === e.inArray("rows", n.limitTo) || !t.rows({
+selected: !0
+}).any()) || (!(-1 === e.inArray("columns", n.limitTo) || !t.columns({
+selected: !0
+}).any()) || !(-1 === e.inArray("cells", n.limitTo) || !t.cells({
+selected: !0
+}).any()));
+}
+var m = e.fn.dataTable;
+m.select = {}, m.select.version = "1.2.6", m.select.init = function(t) {
+var n = t.settings()[0], r = n.oInit.select, o = m.defaults.select, a = r === i ? o : r, s = "row", l = "api", c = !1, u = !0, d = "td, th", h = "selected", f = !1;
 n._select = {}, !0 === a ? (l = "os", f = !0) : "string" == typeof a ? (l = a, f = !0) : e.isPlainObject(a) && (a.blurable !== i && (c = a.blurable), a.info !== i && (u = a.info), a.items !== i && (s = a.items), a.style !== i && (l = a.style, f = !0), a.selector !== i && (d = a.selector), a.className !== i && (h = a.className)), t.select.selector(d), t.select.items(s), t.select.style(l), t.select.blurable(c), t.select.info(u), n._select.className = h, e.fn.dataTable.ext.order["select-checkbox"] = function(t, n) {
 return this.api().column(n, {
 order: "index"
@@ -26739,62 +26763,62 @@ prop: "aoData"
 type: "column",
 prop: "aoColumns"
 } ], function(e, t) {
-g.ext.selector[t.type].push(function(e, n, r) {
-var o, a = n.selected, s = [];
-if (a === i) return r;
-for (var l = 0, c = r.length; l < c; l++) o = e[t.prop][r[l]], (!0 === a && !0 === o._select_selected || !1 === a && !o._select_selected) && s.push(r[l]);
-return s;
+m.ext.selector[t.type].push(function(e, n, i) {
+var r, o = n.selected, a = [];
+if (!0 !== o && !1 !== o) return i;
+for (var s = 0, l = i.length; s < l; s++) r = e[t.prop][i[s]], (!0 === o && !0 === r._select_selected || !1 === o && !r._select_selected) && a.push(i[s]);
+return a;
 });
-}), g.ext.selector.cell.push(function(e, t, n) {
+}), m.ext.selector.cell.push(function(e, t, n) {
 var r, o = t.selected, a = [];
 if (o === i) return n;
 for (var s = 0, l = n.length; s < l; s++) r = e.aoData[n[s].row], (!0 === o && r._selected_cells && !0 === r._selected_cells[n[s].column] || !1 === o && (!r._selected_cells || !r._selected_cells[n[s].column])) && a.push(n[s]);
 return a;
 });
-var m = g.Api.register, v = g.Api.registerPlural;
-m("select()", function() {
+var v = m.Api.register, b = m.Api.registerPlural;
+v("select()", function() {
 return this.iterator("table", function(e) {
-g.select.init(new g.Api(e));
+m.select.init(new m.Api(e));
 });
-}), m("select.blurable()", function(e) {
+}), v("select.blurable()", function(e) {
 return e === i ? this.context[0]._select.blurable : this.iterator("table", function(t) {
 t._select.blurable = e;
 });
-}), m("select.info()", function(e) {
+}), v("select.info()", function(e) {
 return l === i ? this.context[0]._select.info : this.iterator("table", function(t) {
 t._select.info = e;
 });
-}), m("select.items()", function(e) {
+}), v("select.items()", function(e) {
 return e === i ? this.context[0]._select.items : this.iterator("table", function(t) {
-t._select.items = e, s(new g.Api(t), "selectItems", [ e ]);
+t._select.items = e, s(new m.Api(t), "selectItems", [ e ]);
 });
-}), m("select.style()", function(e) {
+}), v("select.style()", function(e) {
 return e === i ? this.context[0]._select.style : this.iterator("table", function(t) {
 t._select.style = e, t._select_init || c(t);
-var n = new g.Api(t);
-o(n), "api" !== e && a(n), s(new g.Api(t), "selectStyle", [ e ]);
+var n = new m.Api(t);
+o(n), "api" !== e && a(n), s(new m.Api(t), "selectStyle", [ e ]);
 });
-}), m("select.selector()", function(e) {
+}), v("select.selector()", function(e) {
 return e === i ? this.context[0]._select.selector : this.iterator("table", function(t) {
-o(new g.Api(t)), t._select.selector = e, "api" !== t._select.style && a(new g.Api(t));
+o(new m.Api(t)), t._select.selector = e, "api" !== t._select.style && a(new m.Api(t));
 });
-}), v("rows().select()", "row().select()", function(t) {
+}), b("rows().select()", "row().select()", function(t) {
 var n = this;
 return !1 === t ? this.deselect() : (this.iterator("row", function(t, n) {
 d(t), t.aoData[n]._select_selected = !0, e(t.aoData[n].nTr).addClass(t._select.className);
 }), this.iterator("table", function(e, t) {
 s(n, "select", [ "row", n[t] ], !0);
 }), this);
-}), v("columns().select()", "column().select()", function(t) {
+}), b("columns().select()", "column().select()", function(t) {
 var n = this;
 return !1 === t ? this.deselect() : (this.iterator("column", function(t, n) {
 d(t), t.aoColumns[n]._select_selected = !0;
-var i = new g.Api(t).column(n);
+var i = new m.Api(t).column(n);
 e(i.header()).addClass(t._select.className), e(i.footer()).addClass(t._select.className), i.nodes().to$().addClass(t._select.className);
 }), this.iterator("table", function(e, t) {
 s(n, "select", [ "column", n[t] ], !0);
 }), this);
-}), v("cells().select()", "cell().select()", function(t) {
+}), b("cells().select()", "cell().select()", function(t) {
 var n = this;
 return !1 === t ? this.deselect() : (this.iterator("cell", function(t, n, r) {
 d(t);
@@ -26803,18 +26827,18 @@ o._selected_cells === i && (o._selected_cells = []), o._selected_cells[r] = !0, 
 }), this.iterator("table", function(e, t) {
 s(n, "select", [ "cell", n[t] ], !0);
 }), this);
-}), v("rows().deselect()", "row().deselect()", function() {
+}), b("rows().deselect()", "row().deselect()", function() {
 var t = this;
 return this.iterator("row", function(t, n) {
 t.aoData[n]._select_selected = !1, e(t.aoData[n].nTr).removeClass(t._select.className);
 }), this.iterator("table", function(e, n) {
 s(t, "deselect", [ "row", t[n] ], !0);
 }), this;
-}), v("columns().deselect()", "column().deselect()", function() {
+}), b("columns().deselect()", "column().deselect()", function() {
 var t = this;
 return this.iterator("column", function(t, n) {
 t.aoColumns[n]._select_selected = !1;
-var i = new g.Api(t), r = i.column(n);
+var i = new m.Api(t), r = i.column(n);
 e(r.header()).removeClass(t._select.className), e(r.footer()).removeClass(t._select.className), i.cells(null, n).indexes().each(function(n) {
 var i = t.aoData[n.row], r = i._selected_cells;
 !i.anCells || r && r[n.column] || e(i.anCells[n.column]).removeClass(t._select.className);
@@ -26822,7 +26846,7 @@ var i = t.aoData[n.row], r = i._selected_cells;
 }), this.iterator("table", function(e, n) {
 s(t, "deselect", [ "column", t[n] ], !0);
 }), this;
-}), v("cells().deselect()", "cell().deselect()", function() {
+}), b("cells().deselect()", "cell().deselect()", function() {
 var t = this;
 return this.iterator("cell", function(t, n, i) {
 var r = t.aoData[n];
@@ -26831,22 +26855,16 @@ r._selected_cells[i] = !1, r.anCells && !t.aoColumns[i]._select_selected && e(r.
 s(t, "deselect", [ "cell", t[n] ], !0);
 }), this;
 });
-var b = 0;
-return e.extend(g.ext.buttons, {
+var y = 0;
+return e.extend(m.ext.buttons, {
 selected: {
 text: f("selected", "Selected"),
 className: "buttons-selected",
+limitTo: [ "rows", "columns", "cells" ],
 init: function(e, t, n) {
 var i = this;
-n._eventNamespace = ".select" + b++, e.on(p(n), function() {
-var e = i.rows({
-selected: !0
-}).any() || i.columns({
-selected: !0
-}).any() || i.cells({
-selected: !0
-}).any();
-i.enable(e);
+n._eventNamespace = ".select" + y++, e.on(p(n), function() {
+i.enable(g(e, n));
 }), this.disable();
 },
 destroy: function(e, t, n) {
@@ -26858,7 +26876,7 @@ text: f("selectedSingle", "Selected single"),
 className: "buttons-selected-single",
 init: function(e, t, n) {
 var i = this;
-n._eventNamespace = ".select" + b++, e.on(p(n), function() {
+n._eventNamespace = ".select" + y++, e.on(p(n), function() {
 var t = e.rows({
 selected: !0
 }).flatten().length + e.columns({
@@ -26888,7 +26906,7 @@ d(this.settings()[0], !0);
 },
 init: function(e, t, n) {
 var i = this;
-n._eventNamespace = ".select" + b++, e.on(p(n), function() {
+n._eventNamespace = ".select" + y++, e.on(p(n), function() {
 var t = e.rows({
 selected: !0
 }).flatten().length + e.columns({
@@ -26905,7 +26923,7 @@ e.off(n._eventNamespace);
 }
 }), e.each([ "Row", "Column", "Cell" ], function(e, t) {
 var n = t.toLowerCase();
-g.ext.buttons["select" + t + "s"] = {
+m.ext.buttons["select" + t + "s"] = {
 text: f("select" + t + "s", "Select " + n + "s"),
 className: "buttons-select-" + n + "s",
 action: function() {
@@ -26919,8 +26937,8 @@ t.active(r === n);
 }
 };
 }), e(n).on("preInit.dt.dtSelect", function(e, t) {
-"dt" === e.namespace && g.select.init(new g.Api(t));
-}), g.select;
+"dt" === e.namespace && m.select.init(new m.Api(t));
+}), m.select;
 }), function() {
 function e(e, t) {
 return e.set(t[0], t[1]), e;
@@ -43439,10 +43457,13 @@ e.each(n, function(r, l) {
 });
 }
 function a(e) {
-var t = qe.defaults.oLanguage, n = e.sZeroRecords;
-!e.sEmptyTable && n && "No data available in table" === t.sEmptyTable && Fe(e, e, "sZeroRecords", "sEmptyTable"), !e.sLoadingRecords && n && "Loading..." === t.sLoadingRecords && Fe(e, e, "sZeroRecords", "sLoadingRecords"), e.sInfoThousands && (e.sThousands = e.sInfoThousands);
-var i = e.sDecimal;
-i && je(i);
+var t = qe.defaults.oLanguage, n = t.sDecimal;
+if (n && je(n), e) {
+var i = e.sZeroRecords;
+!e.sEmptyTable && i && "No data available in table" === t.sEmptyTable && Fe(e, e, "sZeroRecords", "sEmptyTable"), !e.sLoadingRecords && i && "Loading..." === t.sLoadingRecords && Fe(e, e, "sZeroRecords", "sLoadingRecords"), e.sInfoThousands && (e.sThousands = e.sInfoThousands);
+var r = e.sDecimal;
+r && n !== r && je(r);
+}
 }
 function s(e) {
 ht(e, "ordering", "bSort"), ht(e, "orderMulti", "bSortMulti"), ht(e, "orderClasses", "bSortClasses"), ht(e, "orderCellsTop", "bSortCellsTop"), ht(e, "order", "aaSorting"), ht(e, "orderFixed", "aaSortingFixed"), ht(e, "paging", "bPaginate"), ht(e, "pagingType", "sPaginationType"), ht(e, "pageLength", "iDisplayLength"), ht(e, "searching", "bFilter"), "boolean" == typeof e.sScrollX && (e.sScrollX = e.sScrollX ? "100%" : ""), "boolean" == typeof e.scrollX && (e.scrollX = e.scrollX ? "100%" : "");
@@ -43731,7 +43752,7 @@ for (a = r || n.createElement("tr"), d.nTr = a, d.anCells = f, a._DT_RowIndex = 
 row: i,
 column: c
 }, f.push(s), r && !l.mRender && l.mData === c || e.isPlainObject(l.mData) && l.mData._ === c + ".display" || (s.innerHTML = x(t, i, c, "display")), l.sClass && (s.className += " " + l.sClass), l.bVisible && !r ? a.appendChild(s) : !l.bVisible && r && s.parentNode.removeChild(s), l.fnCreatedCell && l.fnCreatedCell.call(t.oInstance, s, x(t, i, c), h, i, c);
-Le(t, "aoRowCreatedCallback", null, [ a, h, i ]);
+Le(t, "aoRowCreatedCallback", null, [ a, h, i, f ]);
 }
 d.nTr.setAttribute("role", "row");
 }
@@ -43791,7 +43812,7 @@ if (0 !== s) {
 var _ = a[o % s];
 y._sRowStripe != _ && (e(w).removeClass(y._sRowStripe).addClass(_), y._sRowStripe = _);
 }
-Le(t, "aoRowCallback", null, [ w, y._aData, o, v ]), r.push(w), o++;
+Le(t, "aoRowCallback", null, [ w, y._aData, o, v, b ]), r.push(w), o++;
 } else {
 var x = l.sZeroRecords;
 1 == t.iDraw && "ajax" == Ne(t) ? x = l.sLoadingRecords : l.sEmptyTable && 0 === t.fnRecordsTotal() && (x = l.sEmptyTable), r[0] = e("<tr/>", {
@@ -43874,9 +43895,8 @@ var a, s = t.ajax, l = t.oInstance, c = function(e) {
 Le(t, null, "xhr", [ t, e, t.jqXHR ]), i(e);
 };
 if (e.isPlainObject(s) && s.data) {
-a = s.data;
-var u = e.isFunction(a) ? a(n, t) : a;
-n = e.isFunction(a) && u ? u : e.extend(!0, n, u), delete s.data;
+var u = "function" == typeof (a = s.data) ? a(n, t) : a;
+n = "function" == typeof a && u ? u : e.extend(!0, n, u), delete s.data;
 }
 var d = {
 data: n,
@@ -43899,7 +43919,7 @@ value: e
 };
 }), c, t) : t.sAjaxSource || "string" == typeof s ? t.jqXHR = e.ajax(e.extend(d, {
 url: s || t.sAjaxSource
-})) : e.isFunction(s) ? t.jqXHR = s.call(l, n, c, t) : (t.jqXHR = e.ajax(e.extend(d, s)), s.data = a);
+})) : "function" == typeof s ? t.jqXHR = s.call(l, n, c, t) : (t.jqXHR = e.ajax(e.extend(d, s)), s.data = a);
 }
 function V(e) {
 return !e.bAjaxDataGet || (e.iDraw++, de(e, !0), H(e, U(e), function(t) {
@@ -44203,9 +44223,9 @@ H.push(t.innerHTML), N.push(ye(e(t).css("width")));
 }, a), pe(function(e, t) {
 e.style.width = N[t];
 }, r), e(a).height(0)), pe(function(e, t) {
-e.innerHTML = '<div class="dataTables_sizing" style="height:0;overflow:hidden;">' + B[t] + "</div>", e.style.width = R[t];
+e.innerHTML = '<div class="dataTables_sizing">' + B[t] + "</div>", e.childNodes[0].style.height = "0", e.childNodes[0].style.overflow = "hidden", e.style.width = R[t];
 }, o), I && pe(function(e, t) {
-e.innerHTML = '<div class="dataTables_sizing" style="height:0;overflow:hidden;">' + H[t] + "</div>", e.style.width = N[t];
+e.innerHTML = '<div class="dataTables_sizing">' + H[t] + "</div>", e.childNodes[0].style.height = "0", e.childNodes[0].style.overflow = "hidden", e.style.width = N[t];
 }, a), E.outerWidth() < d ? (u = S.scrollHeight > S.offsetHeight || "scroll" == $.css("overflow-y") ? d + b : d, L && (S.scrollHeight > S.offsetHeight || "scroll" == $.css("overflow-y")) && (M.width = ye(u - b)), "" !== g && "" === m || Ee(t, 1, "Possible column misalignment", 6)) : u = "100%", A.width = ye(u), w.width = ye(u), I && (t.nScrollFoot.style.width = ye(u)), v || L && (A.height = ye(F.offsetHeight + b));
 var z = E.outerWidth();
 C[0].style.width = ye(z), x.width = ye(z);
@@ -44414,8 +44434,8 @@ for (var o in n) n.hasOwnProperty(o) && (r = n[o], e.isPlainObject(r) ? (e.isPla
 return t;
 }
 function Ie(t, n, i) {
-e(t).on("click.DT", n, function(e) {
-t.blur(), i(e);
+e(t).on("click.DT", n, function(n) {
+e(t).blur(), i(n);
 }).on("keypress.DT", n, function(e) {
 13 === e.which && (e.preventDefault(), i(e));
 }).on("selectstart.DT", function() {
@@ -44553,7 +44573,7 @@ s(x), l(x.column), o(x, x, !0), o(x.column, x.column, !0), o(x, e.extend(g, C.da
 var S = qe.settings;
 for (m = 0, f = S.length; m < f; m++) {
 var A = S[m];
-if (A.nTable == this || A.nTHead.parentNode == this || A.nTFoot && A.nTFoot.parentNode == this) {
+if (A.nTable == this || A.nTHead && A.nTHead.parentNode == this || A.nTFoot && A.nTFoot.parentNode == this) {
 var k = g.bRetrieve !== i ? g.bRetrieve : x.bRetrieve, T = g.bDestroy !== i ? g.bDestroy : x.bDestroy;
 if (r || k) return A.oInstance;
 if (T) {
@@ -44573,7 +44593,7 @@ sDestroyWidth: C[0].style.width,
 sInstance: v,
 sTableId: v
 });
-D.nTable = this, D.oApi = n.internal, D.oInit = g, S.push(D), D.oInstance = 1 === n.length ? n : C.dataTable(), s(g), g.oLanguage && a(g.oLanguage), g.aLengthMenu && !g.iDisplayLength && (g.iDisplayLength = e.isArray(g.aLengthMenu[0]) ? g.aLengthMenu[0][0] : g.aLengthMenu[0]), g = Me(e.extend(!0, {}, x), g), Fe(D.oFeatures, g, [ "bPaginate", "bLengthChange", "bFilter", "bSort", "bSortMulti", "bInfo", "bProcessing", "bAutoWidth", "bSortClasses", "bServerSide", "bDeferRender" ]), Fe(D, g, [ "asStripeClasses", "ajax", "fnServerData", "fnFormatNumber", "sServerMethod", "aaSorting", "aaSortingFixed", "aLengthMenu", "sPaginationType", "sAjaxSource", "sAjaxDataProp", "iStateDuration", "sDom", "bSortCellsTop", "iTabIndex", "fnStateLoadCallback", "fnStateSaveCallback", "renderer", "searchDelay", "rowId", [ "iCookieDuration", "iStateDuration" ], [ "oSearch", "oPreviousSearch" ], [ "aoSearchCols", "aoPreSearchCols" ], [ "iDisplayLength", "_iDisplayLength" ] ]), Fe(D.oScroll, g, [ [ "sScrollX", "sX" ], [ "sScrollXInner", "sXInner" ], [ "sScrollY", "sY" ], [ "bScrollCollapse", "bCollapse" ] ]), 
+D.nTable = this, D.oApi = n.internal, D.oInit = g, S.push(D), D.oInstance = 1 === n.length ? n : C.dataTable(), s(g), a(g.oLanguage), g.aLengthMenu && !g.iDisplayLength && (g.iDisplayLength = e.isArray(g.aLengthMenu[0]) ? g.aLengthMenu[0][0] : g.aLengthMenu[0]), g = Me(e.extend(!0, {}, x), g), Fe(D.oFeatures, g, [ "bPaginate", "bLengthChange", "bFilter", "bSort", "bSortMulti", "bInfo", "bProcessing", "bAutoWidth", "bSortClasses", "bServerSide", "bDeferRender" ]), Fe(D, g, [ "asStripeClasses", "ajax", "fnServerData", "fnFormatNumber", "sServerMethod", "aaSorting", "aaSortingFixed", "aLengthMenu", "sPaginationType", "sAjaxSource", "sAjaxDataProp", "iStateDuration", "sDom", "bSortCellsTop", "iTabIndex", "fnStateLoadCallback", "fnStateSaveCallback", "renderer", "searchDelay", "rowId", [ "iCookieDuration", "iStateDuration" ], [ "oSearch", "oPreviousSearch" ], [ "aoSearchCols", "aoPreSearchCols" ], [ "iDisplayLength", "_iDisplayLength" ] ]), Fe(D.oScroll, g, [ [ "sScrollX", "sX" ], [ "sScrollXInner", "sXInner" ], [ "sScrollY", "sY" ], [ "bScrollCollapse", "bCollapse" ] ]), 
 Fe(D.oLanguage, g, "fnInfoCallback"), Pe(D, "aoDrawCallback", g.fnDrawCallback, "user"), Pe(D, "aoServerParams", g.fnServerParams, "user"), Pe(D, "aoStateSaveParams", g.fnStateSaveParams, "user"), Pe(D, "aoStateLoadParams", g.fnStateLoadParams, "user"), Pe(D, "aoStateLoaded", g.fnStateLoaded, "user"), Pe(D, "aoRowCallback", g.fnRowCallback, "user"), Pe(D, "aoRowCreatedCallback", g.fnCreatedRow, "user"), Pe(D, "aoHeaderCallback", g.fnHeaderCallback, "user"), Pe(D, "aoFooterCallback", g.fnFooterCallback, "user"), Pe(D, "aoInitComplete", g.fnInitComplete, "user"), Pe(D, "aoPreDrawCallback", g.fnPreDrawCallback, "user"), D.rowIdFn = $(g.rowId), c(D);
 var E = D.oClasses;
 if (e.extend(E, qe.ext.classes, g.oClasses), C.addClass(E.sTable), D.iInitDisplayStart === i && (D.iInitDisplayStart = g.iDisplayStart, D._iDisplayStart = g.iDisplayStart), null !== g.iDeferLoading) {
@@ -44646,7 +44666,7 @@ D.aiDisplay = D.aiDisplayMaster.slice(), D.bInitialised = !0, !1 === b && re(D);
 g.bStateSave ? (H.bStateSave = !0, Pe(D, "aoDrawCallback", ke, "state_save"), Te(D, 0, V)) : V();
 } else Ee(null, 0, "Non-table node initialisation (" + this.nodeName + ")", 2);
 }), n = null, this;
-}, Ge = {}, Ye = /[\r\n]/g, Ke = /<.*?>/g, Xe = /^\d{2,4}[\.\/\-]\d{1,2}[\.\/\-]\d{1,2}([T ]{1}\d{1,2}[:\.]\d{2}([\.:]\d{2})?)?$/, Qe = new RegExp("(\\" + [ "/", ".", "*", "+", "?", "|", "(", ")", "[", "]", "{", "}", "\\", "$", "^", "-" ].join("|\\") + ")", "g"), Ze = /[',$£€¥%\u2009\u202F\u20BD\u20a9\u20BArfk]/gi, Je = function(e) {
+}, Ge = {}, Ye = /[\r\n]/g, Ke = /<.*?>/g, Xe = /^\d{2,4}[\.\/\-]\d{1,2}[\.\/\-]\d{1,2}([T ]{1}\d{1,2}[:\.]\d{2}([\.:]\d{2})?)?$/, Qe = new RegExp("(\\" + [ "/", ".", "*", "+", "?", "|", "(", ")", "[", "]", "{", "}", "\\", "$", "^", "-" ].join("|\\") + ")", "g"), Ze = /[',$£€¥%\u2009\u202F\u20BD\u20a9\u20BArfkɃΞ]/gi, Je = function(e) {
 return !e || !0 === e || "-" === e;
 }, et = function(e) {
 var t = parseInt(e, 10);
@@ -44962,35 +44982,41 @@ page: "all"
 for (var t = 0, n = e.length; t < n; t++) if (e[t].length > 0) return e[0] = e[t], e[0].length = 1, e.length = 1, e.context = [ e.context[t] ], e;
 return e.length = 0, e;
 }, Tt = function(t, n) {
-var i, r, o, a = [], s = t.aiDisplay, l = t.aiDisplayMaster, c = n.search, u = n.order, d = n.page;
-if ("ssp" == Ne(t)) return "removed" === c ? [] : st(0, l.length);
-if ("current" == d) for (i = t._iDisplayStart, r = t.fnDisplayEnd(); i < r; i++) a.push(s[i]); else if ("current" == u || "applied" == u) a = "none" == c ? l.slice() : "applied" == c ? s.slice() : e.map(l, function(t, n) {
-return -1 === e.inArray(t, s) ? t : null;
-}); else if ("index" == u || "original" == u) for (i = 0, r = t.aoData.length; i < r; i++) "none" == c ? a.push(i) : (-1 === (o = e.inArray(i, s)) && "removed" == c || o >= 0 && "applied" == c) && a.push(i);
-return a;
+var i, r = [], o = t.aiDisplay, a = t.aiDisplayMaster, s = n.search, l = n.order, c = n.page;
+if ("ssp" == Ne(t)) return "removed" === s ? [] : st(0, a.length);
+if ("current" == c) for (d = t._iDisplayStart, h = t.fnDisplayEnd(); d < h; d++) r.push(o[d]); else if ("current" == l || "applied" == l) {
+if ("none" == s) r = a.slice(); else if ("applied" == s) r = o.slice(); else if ("removed" == s) {
+for (var u = {}, d = 0, h = o.length; d < h; d++) u[o[d]] = null;
+r = e.map(a, function(e) {
+return u.hasOwnProperty(e) ? null : e;
+});
+}
+} else if ("index" == l || "original" == l) for (d = 0, h = t.aoData.length; d < h; d++) "none" == s ? r.push(d) : (-1 === (i = e.inArray(d, o)) && "removed" == s || i >= 0 && "applied" == s) && r.push(d);
+return r;
 }, Dt = function(t, n, r) {
 var o;
 return $t("row", n, function(n) {
-var a = et(n);
+var a = et(n), s = t.aoData;
 if (null !== a && !r) return [ a ];
 if (o || (o = Tt(t, r)), null !== a && -1 !== e.inArray(a, o)) return [ a ];
 if (null === n || n === i || "" === n) return o;
 if ("function" == typeof n) return e.map(o, function(e) {
-var i = t.aoData[e];
-return n(e, i._aData, i.nTr) ? e : null;
+var t = s[e];
+return n(e, t._aData, t.nTr) ? e : null;
 });
-var s = lt(at(t.aoData, o, "nTr"));
 if (n.nodeName) {
-if (n._DT_RowIndex !== i) return [ n._DT_RowIndex ];
-if (n._DT_CellIndex) return [ n._DT_CellIndex.row ];
-var l = e(n).closest("*[data-dt-row]");
-return l.length ? [ l.data("dt-row") ] : [];
+var l = n._DT_RowIndex, c = n._DT_CellIndex;
+if (l !== i) return s[l] && s[l].nTr === n ? [ l ] : [];
+if (c) return s[c.row] && s[c.row].nTr === n ? [ c.row ] : [];
+var u = e(n).closest("*[data-dt-row]");
+return u.length ? [ u.data("dt-row") ] : [];
 }
 if ("string" == typeof n && "#" === n.charAt(0)) {
-var c = t.aIds[n.replace(/^#/, "")];
-if (c !== i) return [ c.idx ];
+var d = t.aIds[n.replace(/^#/, "")];
+if (d !== i) return [ d.idx ];
 }
-return e(s).filter(n).map(function() {
+var h = lt(at(t.aoData, o, "nTr"));
+return e(h).filter(n).map(function() {
 return this._DT_RowIndex;
 }).toArray();
 }, t, r);
@@ -45048,9 +45074,11 @@ return o;
 return i.pop(), e.merge(i, n), i;
 }), ze("row()", function(e, t) {
 return kt(this.rows(e, t));
-}), ze("row().data()", function(e) {
-var t = this.context;
-return e === i ? t.length && this.length ? t[0].aoData[this[0]]._aData : i : (t[0].aoData[this[0]]._aData = e, E(t[0], this[0], "data"), this);
+}), ze("row().data()", function(t) {
+var n = this.context;
+if (t === i) return n.length && this.length ? n[0].aoData[this[0]]._aData : i;
+var r = n[0].aoData[this[0]];
+return r._aData = t, e.isArray(t) && r.nTr.id && A(n[0].rowId)(t, r.nTr.id), E(n[0], this[0], "data"), this;
 }), ze("row().node()", function() {
 var e = this.context;
 return e.length && this.length ? e[0].aoData[this[0]].nTr || null : null;
@@ -45161,7 +45189,7 @@ if (r) {
 var h = e.inArray(!0, ot(c, "bVisible"), n + 1);
 for (a = 0, s = d.length; a < s; a++) l = d[a].nTr, o = d[a].anCells, l && l.insertBefore(o[n], o[h] || null);
 } else e(ot(t.aoData, "anCells", n)).detach();
-u.bVisible = r, L(t, t.aoHeader), L(t, t.aoFooter), ke(t);
+u.bVisible = r, L(t, t.aoHeader), L(t, t.aoFooter), t.aiDisplay.length || e(t.nTBody).find("td[colspan]").attr("colspan", m(t)), ke(t);
 }
 };
 ze("columns()", function(t, n) {
@@ -45228,7 +45256,7 @@ column: c
 }, r ? (d = h[o], n(u, x(t, o, c), d.anCells ? d.anCells[c] : null) && a.push(u)) : a.push(u);
 return a;
 }
-if (e.isPlainObject(n)) return [ n ];
+if (e.isPlainObject(n)) return n.column !== i && n.row !== i && -1 !== e.inArray(n.row, f) ? [ n ] : [];
 var p = g.filter(n).map(function(e, t) {
 return {
 row: t._DT_CellIndex.row,
@@ -45245,13 +45273,14 @@ ze("cells()", function(t, n, r) {
 if (e.isPlainObject(t) && (t.row === i ? (r = t, t = null) : (r = n, n = null)), e.isPlainObject(n) && (r = n, n = null), null === n || n === i) return this.iterator("table", function(e) {
 return Nt(e, t, At(r));
 });
-var o, a, s, l, c, u = this.columns(n, r), d = this.rows(t, r), h = this.iterator("table", function(e, t) {
+var o, a, s, l, c, u = this.columns(n), d = this.rows(t);
+this.iterator("table", function(e, t) {
 for (o = [], a = 0, s = d[t].length; a < s; a++) for (l = 0, c = u[t].length; l < c; l++) o.push({
 row: d[t][a],
 column: u[t][l]
 });
-return o;
 }, 1);
+var h = this.cells(o, r);
 return e.extend(h.selector, {
 cols: n,
 rows: t,
@@ -45415,7 +45444,7 @@ e.call(r[t](a, "cell" === t ? s : n, "cell" === t ? n : i), a, s, l, c);
 }), ze("i18n()", function(t, n, r) {
 var o = this.context[0], a = $(t)(o.oLanguage);
 return a === i && (a = n), r !== i && e.isPlainObject(a) && (a = a[r] !== i ? a[r] : a._), a.replace("%d", r);
-}), qe.version = "1.10.16", qe.settings = [], qe.models = {}, qe.models.oSearch = {
+}), qe.version = "1.10.18", qe.settings = [], qe.models = {}, qe.models.oSearch = {
 bCaseInsensitive: !0,
 sSearch: "",
 bRegex: !1,
@@ -45879,7 +45908,8 @@ return 0 === e || e && "-" !== e ? (t && (e = tt(e, t)), e.replace && (n && (e =
 };
 e.extend(Ve.type.order, {
 "date-pre": function(e) {
-return Date.parse(e) || -1 / 0;
+var t = Date.parse(e);
+return isNaN(t) ? -1 / 0 : t;
 },
 "html-pre": function(e) {
 return Je(e) ? "" : e.replace ? e.replace(/<.*?>/g, "").toLowerCase() : e + "";
@@ -46027,6 +46057,7 @@ _fnLengthOverflow: Oe,
 _fnRenderer: Re,
 _fnDataSource: Ne,
 _fnRowAttributes: I,
+_fnExtend: Me,
 _fnCalculateEnd: function() {}
 }), e.fn.dataTable = qe, qe.$ = e, e.fn.dataTableSettings = qe.settings, e.fn.dataTableExt = qe.ext, e.fn.DataTable = function(t) {
 return e(this).dataTable(t).api();
@@ -46091,7 +46122,7 @@ if (S) for (o(S, n, s), h = 0, p = S.length; h < p; h++) S[h] && S[h]._DT_CellIn
 }
 for (u = 0, d = t.aoHeader.length; u < d; u++) o(t.aoHeader[u], n, s);
 if (null !== t.aoFooter) for (u = 0, d = t.aoFooter.length; u < d; u++) o(t.aoFooter[u], n, s);
-for ((c || c === i) && e.fn.dataTable.Api(t).rows().invalidate(), u = 0, d = v; u < d; u++) e(t.aoColumns[u].nTh).off("click.DT"), this.oApi._fnSortAttachListener(t, t.aoColumns[u].nTh, u);
+for ((c || c === i) && e.fn.dataTable.Api(t).rows().invalidate(), u = 0, d = v; u < d; u++) e(t.aoColumns[u].nTh).off(".DT"), this.oApi._fnSortAttachListener(t, t.aoColumns[u].nTh, u);
 e(t.oInstance).trigger("column-reorder.dt", [ t, {
 from: n,
 to: s,
@@ -46110,6 +46141,7 @@ if (i._colReorder) return i._colReorder;
 var r = e.fn.dataTable.camelToHungarian;
 return r && (r(l.defaults, l.defaults, !0), r(l.defaults, n || {})), this.s = {
 dt: null,
+enable: null,
 init: e.extend(!0, {}, l.defaults, n),
 fixed: 0,
 fixedRight: 0,
@@ -46127,9 +46159,16 @@ aoTargets: []
 }, this.dom = {
 drag: null,
 pointer: null
-}, this.s.dt = i, this.s.dt._colReorder = this, this._fnConstruct(), this;
+}, this.s.enable = this.s.init.bEnable, this.s.dt = i, this.s.dt._colReorder = this, this._fnConstruct(), this;
 };
 return e.extend(l.prototype, {
+fnEnable: function(e) {
+if (!1 === e) return fnDisable();
+this.s.enable = !0;
+},
+fnDisable: function() {
+this.s.enable = !1;
+},
 fnReset: function() {
 return this._fnOrderColumns(this.fnOrder()), this;
 },
@@ -46179,8 +46218,8 @@ n._fnOrderColumns.call(n, e);
 });
 } else this._fnSetColumnIndexes();
 e(o).on("destroy.dt.colReorder", function() {
-e(o).off("destroy.dt.colReorder draw.dt.colReorder"), e(n.s.dt.nTHead).find("*").off(".ColReorder"), e.each(n.s.dt.aoColumns, function(t, n) {
-e(n.nTh).removeAttr("data-column-index");
+e(o).off("destroy.dt.colReorder draw.dt.colReorder"), e.each(n.s.dt.aoColumns, function(t, n) {
+e(n.nTh).off(".ColReorder"), e(n.nTh).removeAttr("data-column-index");
 }), n.s.dt._colReorder = null, n.s = null;
 });
 },
@@ -46191,7 +46230,7 @@ for (var i = 0, r = t.length; i < r; i++) {
 var a = e.inArray(i, t);
 i != a && (o(t, a, i), this.s.dt.oInstance.fnColReorder(a, i, !0, !1), n = !0);
 }
-e.fn.dataTable.Api(this.s.dt).rows().invalidate(), this._fnSetColumnIndexes(), n && ("" === this.s.dt.oScroll.sX && "" === this.s.dt.oScroll.sY || this.s.dt.oInstance.fnAdjustColumnSizing(!1), this.s.dt.oInstance.oApi._fnSaveState(this.s.dt), null !== this.s.reorderCallback && this.s.reorderCallback.call(this));
+this._fnSetColumnIndexes(), n && (e.fn.dataTable.Api(this.s.dt).rows().invalidate(), "" === this.s.dt.oScroll.sX && "" === this.s.dt.oScroll.sY || this.s.dt.oInstance.fnAdjustColumnSizing(!1), this.s.dt.oInstance.oApi._fnSaveState(this.s.dt), null !== this.s.reorderCallback && this.s.reorderCallback.call(this));
 } else this.s.dt.oInstance.oApi._fnLog(this.s.dt, 1, "ColReorder - array reorder does not match known number of columns. Skipping.");
 },
 _fnStateSave: function(t) {
@@ -46209,9 +46248,9 @@ for (n = 0, i = o.length; n < i; n++) r = o[n]._ColReorder_iOrigCol, t.columns[r
 _fnMouseListener: function(t, n) {
 var i = this;
 e(n).on("mousedown.ColReorder", function(e) {
-i._fnMouseDown.call(i, e, n);
+i.s.enable && i._fnMouseDown.call(i, e, n);
 }).on("touchstart.ColReorder", function(e) {
-i._fnMouseDown.call(i, e, n);
+i.s.enable && i._fnMouseDown.call(i, e, n);
 });
 },
 _fnMouseDown: function(t, r) {
@@ -46235,7 +46274,7 @@ for (var t = !1, n = this.s.mouse.toIndex, i = 1, r = this.s.aoTargets.length; i
 this.dom.pointer.css("left", this.s.aoTargets[i - 1].x), this.s.mouse.toIndex = this.s.aoTargets[i - 1].to, t = !0;
 break;
 }
-t || (this.dom.pointer.css("left", this.s.aoTargets[this.s.aoTargets.length - 1].x), this.s.mouse.toIndex = this.s.aoTargets[this.s.aoTargets.length - 1].to), this.s.init.bRealtime && n !== this.s.mouse.toIndex && (this.s.dt.oInstance.fnColReorder(this.s.mouse.fromIndex, this.s.mouse.toIndex, !1), this.s.mouse.fromIndex = this.s.mouse.toIndex, this._fnRegions());
+t || (this.dom.pointer.css("left", this.s.aoTargets[this.s.aoTargets.length - 1].x), this.s.mouse.toIndex = this.s.aoTargets[this.s.aoTargets.length - 1].to), this.s.init.bRealtime && n !== this.s.mouse.toIndex && (this.s.dt.oInstance.fnColReorder(this.s.mouse.fromIndex, this.s.mouse.toIndex), this.s.mouse.fromIndex = this.s.mouse.toIndex, "" === this.s.dt.oScroll.sX && "" === this.s.dt.oScroll.sY || this.s.dt.oInstance.fnAdjustColumnSizing(!1), this._fnRegions());
 },
 _fnMouseUp: function(t) {
 e(n).off(".ColReorder"), null !== this.dom.drag && (this.dom.drag.remove(), this.dom.pointer.remove(), this.dom.drag = null, this.dom.pointer = null, this.s.dt.oInstance.fnColReorder(this.s.mouse.fromIndex, this.s.mouse.toIndex, !0), this._fnSetColumnIndexes(), "" === this.s.dt.oScroll.sX && "" === this.s.dt.oScroll.sY || this.s.dt.oInstance.fnAdjustColumnSizing(!1), this.s.dt.oInstance.oApi._fnSaveState(this.s.dt), null !== this.s.reorderCallback && this.s.reorderCallback.call(this));
@@ -46276,11 +46315,12 @@ return -1 !== e.type.indexOf("touch") ? e.originalEvent.touches[0][t] : e[t];
 }
 }), l.defaults = {
 aiOrder: null,
+bEnable: !0,
 bRealtime: !0,
 iFixedColumnsLeft: 0,
 iFixedColumnsRight: 0,
 fnReorderCallback: null
-}, l.version = "1.4.1", e.fn.dataTable.ColReorder = l, e.fn.DataTable.ColReorder = l, "function" == typeof e.fn.dataTable && "function" == typeof e.fn.dataTableExt.fnVersionCheck && e.fn.dataTableExt.fnVersionCheck("1.10.8") ? e.fn.dataTableExt.aoFeatures.push({
+}, l.version = "1.5.0", e.fn.dataTable.ColReorder = l, e.fn.DataTable.ColReorder = l, "function" == typeof e.fn.dataTable && "function" == typeof e.fn.dataTableExt.fnVersionCheck && e.fn.dataTableExt.fnVersionCheck("1.10.8") ? e.fn.dataTableExt.aoFeatures.push({
 fnInit: function(e) {
 var t = e.oInstance;
 if (e._colReorder) t.oApi._fnLog(e, 1, "ColReorder attempted to initialise twice. Ignoring second"); else {
@@ -46311,6 +46351,14 @@ n._colReorder.fnOrder(e, t);
 return this.context.length && this.context[0]._colReorder ? this.context[0]._colReorder.fnTranspose(e, t) : e;
 }), e.fn.dataTable.Api.register("colReorder.move()", function(e, t, n, i) {
 return this.context.length && this.context[0]._colReorder.s.dt.oInstance.fnColReorder(e, t, n, i), this;
+}), e.fn.dataTable.Api.register("colReorder.enable()", function(e) {
+return this.iterator("table", function(t) {
+t._colReorder && t._colReorder.fnEnable(e);
+});
+}), e.fn.dataTable.Api.register("colReorder.disable()", function() {
+return this.iterator("table", function(e) {
+e._colReorder && e._colReorder.fnDisable();
+});
 }), l;
 }), function(e, t, n) {
 var i = function(e, n) {
@@ -74682,9 +74730,6 @@ kind: "HorizontalPodAutoscaler"
 }, {
 group: "extensions",
 kind: "NetworkPolicy"
-}, {
-group: "extensions",
-kind: "ReplicationControllerDummy"
 } ]
 }), angular.module("openshiftCommonServices").constant("API_PREFERRED_VERSIONS", {
 appliedclusterresourcequotas: {
@@ -74802,6 +74847,11 @@ resource: "imagestreamimports"
 limitranges: {
 version: "v1",
 resource: "limitranges"
+},
+mobileclients: {
+group: "mobile.k8s.io",
+version: "v1alpha1",
+resource: "mobileclients"
 },
 oauthaccesstokens: {
 group: "oauth.openshift.io",
@@ -74968,7 +75018,12 @@ loggingUIHostname: [ "openshift.io/logging.ui.hostname" ],
 loggingDataPrefix: [ "openshift.io/logging.data.prefix" ],
 idledAt: [ "idling.alpha.openshift.io/idled-at" ],
 idledPreviousScale: [ "idling.alpha.openshift.io/previous-scale" ],
-systemOnly: [ "authorization.openshift.io/system-only" ]
+systemOnly: [ "authorization.openshift.io/system-only" ],
+mobileSetBuildDownload: [ "aerogear.org/download-mobile-artifact" ],
+mobileGetBuildDownload: [ "aerogear.org/download-mobile-artifact-url" ],
+mobileServiceInstanceName: [ "aerogear.org/service-instance-name" ],
+mobileBindingConsumerId: [ "binding.aerogear.org/consumer" ],
+mobileBindingProviderId: [ "binding.aerogear.org/provider" ]
 };
 return function(t) {
 return e[t] || null;
@@ -75687,33 +75742,35 @@ type: "Opaque",
 stringData: {}
 };
 return i.stringData.parameters = JSON.stringify(t), i;
-}, d = function(e, t, n) {
-var i = e.metadata.name, r = c(e.metadata.name + "-credentials-"), o = {
+}, d = function(e, t, n, i) {
+var r = e.metadata.name;
+i = _.assign({
+generateName: r + "-"
+}, i);
+var o = c(e.metadata.name + "-credentials-"), a = {
 kind: "ServiceBinding",
 apiVersion: "servicecatalog.k8s.io/v1beta1",
-metadata: {
-generateName: i + "-"
-},
+metadata: i,
 spec: {
 instanceRef: {
-name: i
+name: r
 },
-secretName: r
+secretName: o
 }
 };
-n && (o.spec.parametersFrom = [ {
+n && (a.spec.parametersFrom = [ {
 secretKeyRef: {
 name: n,
 key: "parameters"
 }
 } ]);
-var a = _.get(t, "spec.selector");
-return a && (a.matchLabels || a.matchExpressions || (a = {
-matchLabels: a
-}), o.spec.alphaPodPresetTemplate = {
-name: r,
-selector: a
-}), o;
+var s = _.get(t, "spec.selector");
+return s && (s.matchLabels || s.matchExpressions || (s = {
+matchLabels: s
+}), a.spec.alphaPodPresetTemplate = {
+name: o,
+selector: s
+}), a;
 }, h = function(t, n, i) {
 if (!t || !n || !i) return !1;
 if (_.get(t, "metadata.deletionTimestamp")) return !1;
@@ -75736,18 +75793,18 @@ return n ? t[n] : null;
 },
 makeParametersSecret: u,
 generateSecretName: c,
-bindService: function(e, t, n, i) {
-var o;
-_.isEmpty(i) || (o = c(e.metadata.name + "-bind-parameters-"));
-var l = d(e, t, o), h = {
+bindService: function(e, t, n, i, o) {
+var l;
+_.isEmpty(i) || (l = c(e.metadata.name + "-bind-parameters-"));
+var h = d(e, t, l, o), f = {
 namespace: e.metadata.namespace
-}, f = r.create(a, null, l, h);
-return o ? f.then(function(e) {
-var t = u(o, i, e);
-return r.create(s, null, t, h).then(function() {
+}, p = r.create(a, null, h, f);
+return l ? p.then(function(e) {
+var t = u(l, i, e);
+return r.create(s, null, t, f).then(function() {
 return e;
 });
-}) : f;
+}) : p;
 },
 isServiceBindable: h,
 getPodPresetSelectorsForBindings: f,
@@ -79383,7 +79440,7 @@ e.exports = '<div class="order-service-config">\n  <div class="config-top">\n   
 }, function(e, t) {
 e.exports = '<div class="order-service-config">\n  <bind-service-form service-class="$ctrl.serviceClass.resource"\n                     show-pod-presets="$ctrl.showPodPresets"\n                     applications="$ctrl.applications"\n                     form-name="$ctrl.forms.bindForm"\n                     allow-no-binding="true"\n                     project-name="$ctrl.projectDisplayName"\n                     bind-type="$ctrl.bindType"\n                     app-to-bind="$ctrl.appToBind">\n  </bind-service-form>\n</div>\n';
 }, function(e, t) {
-e.exports = '<div class="order-service-config">\n  <div class="config-top">\n    <form name="$ctrl.forms.orderConfigureForm" class="config-form">\n      <select-project ng-if="!$ctrl.addToProject" selected-project="$ctrl.selectedProject" name-taken="$ctrl.projectNameTaken" show-divider="$ctrl.parameterSchema.properties.length > 0"></select-project>\n      <catalog-parameters\n        ng-if="$ctrl.parameterSchema.properties && !$ctrl.noProjectsCantCreate"\n        model="$ctrl.parameterData"\n        parameter-schema="$ctrl.parameterSchema"\n        parameter-form-definition="$ctrl.parameterFormDefinition">\n      </catalog-parameters>\n    </form>\n    <div ng-if="$ctrl.error" class="has-error">\n      <span class="help-block">{{$ctrl.error}}</span>\n    </div>\n  </div>\n</div>\n';
+e.exports = '<div class="order-service-config">\n  <div class="config-top">\n    <form name="$ctrl.forms.orderConfigureForm" class="config-form">\n      <select-project ng-if="!$ctrl.addToProject"\n                      selected-project="$ctrl.selectedProject"\n                      name-taken="$ctrl.projectNameTaken"\n                      show-divider="$ctrl.parameterSchema.properties | size"></select-project>\n      <catalog-parameters\n        ng-if="$ctrl.parameterSchema.properties && !$ctrl.noProjectsCantCreate"\n        model="$ctrl.parameterData"\n        parameter-schema="$ctrl.parameterSchema"\n        parameter-form-definition="$ctrl.parameterFormDefinition">\n      </catalog-parameters>\n    </form>\n    <div ng-if="$ctrl.error" class="has-error">\n      <span class="help-block">{{$ctrl.error}}</span>\n    </div>\n  </div>\n</div>\n';
 }, function(e, t) {
 e.exports = '<div class="order-service-details">\n  <div class="order-service-details-top" ng-class="{\'order-service-details-top-icon-top\': $ctrl.serviceClass.vendor || $ctrl.docUrl || $ctrl.supportUrl}">\n    <div class="service-icon">\n      <span ng-if="!$ctrl.imageUrl" class="icon {{$ctrl.iconClass}}" aria-hidden="true"></span>\n      <span ng-if="$ctrl.imageUrl" class="image"><img ng-src="{{$ctrl.imageUrl}}" alt=""></span>\n    </div>\n    <div class="service-title-area">\n      <div class="service-title">\n        {{$ctrl.serviceName}}\n      </div>\n      <div ng-if="$ctrl.serviceClass.vendor" class="service-vendor">\n        {{$ctrl.serviceClass.vendor}}\n      </div>\n      <div ng-if="$ctrl.serviceClass.tags" class="order-service-tags">\n        <span ng-repeat="tag in $ctrl.serviceClass.tags" class="tag">\n          {{tag}}\n        </span>\n      </div>\n      <ul ng-if="$ctrl.docUrl || $ctrl.supportUrl" class="list-inline order-service-documentation-url">\n        <li ng-if="$ctrl.docUrl" >\n          <a ng-href="{{$ctrl.docUrl}}" target="_blank" class="learn-more-link">View Documentation <i class="fa fa-external-link" aria-hidden="true"></i></a>\n        </li>\n        <li ng-if="$ctrl.supportUrl" >\n          <a ng-href="{{$ctrl.supportUrl}}" target="_blank" class="learn-more-link">Get Support <i class="fa fa-external-link" aria-hidden="true"></i></a>\n        </li>\n      </ul>\n    </div>\n  </div>\n  <div class="order-service-description-block">\n    <p ng-if="!$ctrl.multipleServicePlans && ($ctrl.selectedPlan.spec.externalMetadata.displayName || $ctrl.selectedPlan.spec.description)">\n      <span ng-if="$ctrl.selectedPlan.spec.externalMetadata.displayName">\n        Plan {{$ctrl.selectedPlan.spec.externalMetadata.displayName}}\n        <span ng-if="$ctrl.selectedPlan.spec.description">&ndash;</span>\n      </span>\n      <span ng-if="$ctrl.selectedPlan.spec.description">{{$ctrl.selectedPlan.spec.description}}</span>\n    </p>\n    <p ng-if="!$ctrl.description && !$ctrl.longDescription" class="description">No description provided.</p>\n    <p ng-if="$ctrl.description" ng-bind-html="($ctrl.description | linky : \'_blank\')" class="description"></p>\n    <p ng-if="$ctrl.longDescription" ng-bind-html="$ctrl.longDescription | linky : \'_blank\'" class="description"></p>\n    <div ng-if="$ctrl.imageDependencies.length">\n      <div class="order-service-subheading">Image Dependencies</div>\n      <div ng-repeat="imageName in $ctrl.imageDependencies" class="order-service-dependent-image">\n        <span class="pficon pficon-image" aria-hidden="true"></span>\n        <span class="sr-only">Image</span>\n        {{imageName}}\n      </div>\n    </div>\n  </div>\n</div>\n';
 }, function(e, t) {
@@ -81324,27 +81381,27 @@ o.$inject = [ "$filter", "$scope", "AuthService", "AuthorizationService", "Keywo
 "use strict";
 t.__esModule = !0;
 var i = n(0), r = n(2), o = function() {
-function e(e, t, n, r, o, a, s, l, c, u) {
-var d = this;
+function e(e, t, n, r, o, a, s, l, c, u, d) {
+var h = this;
 this.ctrl = this, this.previousSubCategoryHeight = 0, this.resizeRetries = 0, this.serviceViewItemClicked = function(e, t) {
-d.$scope.$emit("open-overlay-panel", e);
+h.$scope.$emit("open-overlay-panel", e);
 }, this.filterChange = function(e) {
-d.filterByCategory(d.ctrl.currentFilter, d.ctrl.currentSubFilter, !1), i.isEmpty(e) || i.each(e, function(e) {
+h.filterByCategory(h.ctrl.currentFilter, h.ctrl.currentSubFilter, !1), i.isEmpty(e) || i.each(e, function(e) {
 switch (e.id) {
 case "keyword":
-d.ctrl.filteredItems = d.filterForKeywords(e.values[0], d.ctrl.filteredItems);
+h.ctrl.filteredItems = h.filterForKeywords(e.values[0], h.ctrl.filteredItems);
 break;
 
 case "vendors":
-d.ctrl.filteredItems = d.filterForVendors(e.values, d.ctrl.filteredItems);
+h.ctrl.filteredItems = h.filterForVendors(e.values, h.ctrl.filteredItems);
 }
-}), d.ctrl.filterConfig.resultsCount = d.ctrl.filteredItems.length, d.ctrl.keywordFilterValue = null;
+}), h.ctrl.filterConfig.resultsCount = h.ctrl.filteredItems.length, h.ctrl.keywordFilterValue = null;
 }, this.clearAppliedFilters = function() {
-d.$scope.$broadcast("clear-filters");
-}, this.constants = e, this.catalog = t, this.keywordService = n, this.logger = r, this.htmlService = o, this.element = a[0], this.$filter = s, this.$rootScope = l, this.$scope = c, this.$timeout = u, this.ctrl.loaded = !1, this.ctrl.isEmpty = !1, this.ctrl.mobileView = "categories", this.ctrl.filterConfig = {
+h.$scope.$broadcast("clear-filters");
+}, this.constants = e, this.catalog = t, this.keywordService = n, this.logger = r, this.htmlService = o, this.element = a[0], this.$filter = s, this.$rootScope = c, this.$location = l, this.$scope = u, this.$timeout = d, this.ctrl.loaded = !1, this.ctrl.isEmpty = !1, this.ctrl.mobileView = "categories", this.ctrl.filterConfig = {
 resultsLabel: "Items",
 appliedFilters: []
-}, this.ctrl.keywordFilterValue = null;
+}, this.ctrl.keywordFilterValue = null, this.ctrl.currentFilter = this.$location.search().category || "all", this.ctrl.currentSubFilter = this.$location.search().category && this.$location.search().subcategory;
 }
 return e.prototype.$onInit = function() {
 var e = this;
@@ -81352,7 +81409,7 @@ this.debounceResize = i.debounce(function() {
 return e.resizeExpansion(!1);
 }, 50, {
 maxWait: 250
-}), r(window).on("resize.services", this.debounceResize), this.ctrl.currentFilter = this.ctrl.currentSubFilter = "all", this.ctrl.sectionTitle = this.ctrl.sectionTitle || "Browse Catalog", this.removeFilterListener = this.$rootScope.$on("filter-catalog-items", function(t, n) {
+}), r(window).on("resize.services", this.debounceResize), this.ctrl.sectionTitle = this.ctrl.sectionTitle || "Browse Catalog", this.removeFilterListener = this.$rootScope.$on("filter-catalog-items", function(t, n) {
 e.setKeywordFilter(n.searchText);
 }), this.ctrl.emptyFilterConfig = {
 title: "No results match.",
@@ -81370,7 +81427,7 @@ url: "https://docs.openshift.org/latest/install_config/imagestreams_templates.ht
 }
 }, this.ctrl.keywordFilter && this.setKeywordFilter(this.ctrl.keywordFilter);
 }, e.prototype.$onChanges = function(e) {
-e.catalogItems && e.catalogItems.currentValue && (this.ctrl.isEmpty = i.isEmpty(this.ctrl.catalogItems), this.ctrl.isEmpty || (this.ctrl.categories = this.catalog.categorizeItems(this.ctrl.catalogItems), this.ctrl.vendors = this.catalog.getVendors(this.ctrl.catalogItems), this.filterByCategory("all", "all", !0)), this.ctrl.loaded = !0), e.keywordFilter && !e.keywordFilter.isFirstChange() && this.setKeywordFilter(this.ctrl.keywordFilter);
+e.catalogItems && e.catalogItems.currentValue && (this.ctrl.isEmpty = i.isEmpty(this.ctrl.catalogItems), this.ctrl.isEmpty || (this.ctrl.categories = this.catalog.categorizeItems(this.ctrl.catalogItems), this.ctrl.vendors = this.catalog.getVendors(this.ctrl.catalogItems), this.filterByCategory(this.ctrl.currentFilter, this.ctrl.currentSubFilter, !0)), this.ctrl.loaded = !0), e.keywordFilter && !e.keywordFilter.isFirstChange() && this.setKeywordFilter(this.ctrl.keywordFilter);
 }, e.prototype.$postLink = function() {
 this.scrollParent = this.getScrollParent(this.element), this.scrollParent && this.htmlService.isWindowAboveBreakpoint(this.htmlService.WINDOW_SIZE_SM) && (this.ctrl.viewStyle = {
 "min-height": "calc(100vh - " + this.scrollParent.getBoundingClientRect().top + "px)"
@@ -81390,18 +81447,27 @@ this.ctrl.mobileView = "items", this.ctrl.currentSubFilter === e && "xxs" !== th
 var t = [];
 return this.ctrl.categories.map(function(n) {
 e === n.id && (t = t.concat(n.subCategories));
-}), "all" === (t = i.filter(t, {
+}), (t = i.filter(t, {
 hasItems: !0
-}))[0].id && 2 === t.length && (t = i.drop(t, 1)), t;
+}))[0] && "all" === t[0].id && 2 === t.length && (t = i.drop(t, 1)), t;
 }, e.prototype.applyFilters = function(e) {
 this.filterChange(e.appliedFilters);
 }, e.prototype.filterByCategory = function(e, t, n) {
 var r, o;
-"all" === e || "other" === e ? t = "all" : (n && (this.ctrl.subCategories = this.getSubCategories(e)), t = 1 === this.ctrl.subCategories.length ? this.ctrl.subCategories[0].id : t || null), (r = i.find(this.ctrl.categories, {
+if ("all" === e || "other" === e) t = "all"; else if (n && (this.ctrl.subCategories = this.getSubCategories(e)), t) {
+var a = i.some(this.ctrl.subCategories, function(e) {
+return e.id === t;
+});
+t = a ? t : null;
+} else t = 1 === this.ctrl.subCategories.length ? this.ctrl.subCategories[0].id : null;
+(r = i.find(this.ctrl.categories, {
 id: e
 })) ? t && ((o = i.find(r.subCategories, {
 id: t
-})) ? (this.ctrl.filteredItems = o.items, this.ctrl.filterConfig.totalCount = this.ctrl.filteredItems.length, this.ctrl.filterConfig.resultsCount = this.ctrl.filterConfig.totalCount) : this.logger.error("Could not find subcategory '" + t + "' for category '" + e + "'")) : this.logger.error("Could not find category '" + e + "'"), this.ctrl.currentFilter = e, this.ctrl.currentSubFilter = t, this.updateActiveCardStyles();
+})) ? (this.ctrl.filteredItems = o.items, this.ctrl.filterConfig.totalCount = this.ctrl.filteredItems.length, this.ctrl.filterConfig.resultsCount = this.ctrl.filterConfig.totalCount) : this.logger.error("Could not find subcategory '" + t + "' for category '" + e + "'")) : this.logger.error("Could not find category '" + e + "'"), this.ctrl.currentFilter = e, this.ctrl.currentSubFilter = t, t = "all" === e ? null : t, this.$location.path(this.$location.path()).search({
+category: this.ctrl.currentFilter,
+subcategory: t
+}), this.updateActiveCardStyles();
 }, e.prototype.setKeywordFilter = function(e) {
 this.ctrl.keywordFilterValue = e, this.ctrl.currentFilter = this.ctrl.currentSubFilter = "all", this.ctrl.mobileView = "subcategories";
 }, e.prototype.filterForKeywords = function(e, t) {
@@ -81440,7 +81506,7 @@ return e.resizeExpansion(!0);
 });
 }, e;
 }();
-o.$inject = [ "Constants", "Catalog", "KeywordService", "Logger", "HTMLService", "$element", "$filter", "$rootScope", "$scope", "$timeout" ], o.MAX_RESIZE_RETRIES = 20, t.ServicesViewController = o;
+o.$inject = [ "Constants", "Catalog", "KeywordService", "Logger", "HTMLService", "$element", "$filter", "$location", "$rootScope", "$scope", "$timeout" ], o.MAX_RESIZE_RETRIES = 20, t.ServicesViewController = o;
 }, function(e, t, n) {
 "use strict";
 t.__esModule = !0;

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -5179,6 +5179,9 @@ pre.clipped.scroll{max-height:150px;overflow:auto;width:100%}
 .data-toolbar .data-toolbar-filter .form-group{margin-bottom:0}
 .header-toolbar .data-toolbar{background-color:#fff;border-bottom:1px solid #e4e4e4;margin:0 -20px;padding-left:20px;padding-right:20px}
 .data-toolbar .vertical-divider+.data-toolbar-filter{margin-top:10px}
+@media (min-width:768px){.data-toolbar .data-toolbar-filter{flex:1 1 0%}
+.data-toolbar .vertical-divider+.data-toolbar-filter{margin-top:0}
+}
 .selectize-dropdown{font-size:12px}
 .ellipsis-pulser{padding:10px;text-align:center}
 .ellipsis-pulser .dot{display:inline-block;height:4px;position:relative;width:4px}
@@ -5203,12 +5206,18 @@ pre.clipped.scroll{max-height:150px;overflow:auto;width:100%}
 70%{transform:scale(.66)}
 100%{opacity:.33;z-index:1}
 }
+.inline-edit .form-control-pf-cancel,.inline-edit .form-control-pf-save{margin-left:3px}
+.inline-edit .form-control-pf-empty{background:0 0;border:none;color:#bbb;height:100%;position:absolute;right:0;top:0}
+.inline-edit .form-control-pf-textbox{display:inline-block;position:relative;flex:1}
+.inline-edit .form-control-pf-textbox input{padding-right:26px}
+.inline-edit .form-control-pf-value{background-color:transparent;border:1px solid transparent;padding:2px 2px 2px 0px}
+.inline-edit .form-control-pf-value:hover{background-color:transparent;border:1px solid #d3d3d3;padding-left:0px}
+.inline-edit .inline-edit-form{display:flex}
+.inline-edit .inline-edit-input-error{color:pf-red-200}
 .layout-pf.layout-pf-fixed{height:1px}
 .layout-pf.layout-pf-fixed body{height:1px;padding-top:41px}
 .layout-pf.layout-pf-fixed .container-pf-nav-pf-vertical,.layout-pf.layout-pf-fixed .container-pf-nav-pf-vertical .view{height:100%}
-@media (min-width:768px){.data-toolbar .data-toolbar-filter{flex:1 1 0%}
-.data-toolbar .vertical-divider+.data-toolbar-filter{margin-top:0}
-.layout-pf.layout-pf-fixed body{padding-top:61px}
+@media (min-width:768px){.layout-pf.layout-pf-fixed body{padding-top:61px}
 }
 .layout-pf.layout-pf-fixed body.has-project-bar{padding-top:69px}
 .layout-pf.layout-pf-fixed body.has-project-bar.has-project-search{padding-top:116px}
@@ -5261,7 +5270,7 @@ h2+.list-view-pf{margin-top:20px}
 .list-view-pf .list-group-item-heading small{overflow:hidden;text-overflow:ellipsis;color:#757575}
 .list-view-pf .list-group-item-text{margin-bottom:5px}
 .list-view-pf-additional-info-item{display:inline-block;text-align:left;width:100%}
-.list-view-pf-additional-info-item image-names,.monitoring-page .list-pf-expansion .list-pf-container{display:block}
+.list-view-pf-additional-info-item image-names{display:block}
 .list-view-pf-description{flex:1 0 55%}
 .list-view-pf-main-info{padding-bottom:10px;padding-top:10px}
 @media (max-width:991px){.list-view-pf-main-info .list-view-pf-body{display:block}
@@ -5271,7 +5280,19 @@ h2+.list-view-pf{margin-top:20px}
 .list-view-pf-description{width:60%}
 .monitoring-page .list-pf-main-content{flex-basis:30%}
 }
+.mobile-clients-view .configuration .copy-to-clipboard{margin-bottom:25px}
+.mobile-clients-view .configuration .copy-to-clipboard pre{max-height:350px}
+.mobile-clients-view .configuration .service-configuration{padding:0}
+.mobile-clients-view .configuration .service-configuration h3{margin:20px}
+.mobile-clients-view .configuration .service-configuration .service-instance-getting-started{margin-bottom:50px;padding:0}
+.mobile-clients-view .configuration .service-configuration .service-instance-getting-started .logo{display:inline-block;height:30px;width:30px}
+.mobile-clients-view .configuration .service-configuration .service-instance-getting-started .logo-icon-class{display:inline-block;height:30px;width:30px;font-size:22px;text-align:center}
+.mobile-clients-view .configuration .service-configuration .service-instance-getting-started .service-details{display:inline-block;margin-left:10px;vertical-align:middle}
+.mobile-clients-view .configuration .service-configuration .service-instance-getting-started .service-details h4{margin:0}
+.mobile-clients-view .configuration .service-configuration .service-instance-getting-started .sdk-docs{left:42px;margin:0;position:relative}
+.mobile-clients-view .builds .note{text-align:center}
 .monitoring-page .list-pf-content{min-height:45px}
+.monitoring-page .list-pf-expansion .list-pf-container{display:block}
 .monitoring-page .list-pf-expansion .log-fixed-height.empty-state-message,.monitoring-page .list-pf-expansion .metrics .empty-state-message{margin:10px 0 0;padding:0;text-align:left}
 .monitoring-page .list-pf-expansion .log-fixed-height.empty-state-message h2,.monitoring-page .list-pf-expansion .metrics .empty-state-message h2{margin-top:0}
 .monitoring-page .list-pf-expansion .metrics .empty-state-message .pficon-error-circle-o{display:none}


### PR DESCRIPTION
Adding a new view to present more detailed information for mobile clients.

![client-view-baseconfig](https://user-images.githubusercontent.com/22113654/41246017-a65445bc-6da1-11e8-9b2b-1297930d15c4.png)

This is the base view which contains a configuration tab with:
- Mobile Client details
- Copy to clipboard component containg sdk info to connect to services
- inline edit component
     
![dmz-edit](https://user-images.githubusercontent.com/22113654/41246154-15dd23c2-6da2-11e8-8374-e15157d60c8f.png)


- SDK setup links for client and services

There are tabs for builds and mobile services which will contain the components in https://github.com/openshift/origin-web-console/pull/3020 and https://github.com/openshift/origin-web-console/pull/3021


**NOTE:** This PR makes use of https://github.com/openshift/origin-web-common/pull/320 and https://github.com/openshift/origin-web-catalog/pull/669