### PR TITLE
Bug 1607150 - UI Timeout causing IE 11 to automatically log out

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -585,7 +585,7 @@ angular
     $(window).on('storage', function (event) {
       if (event.originalEvent.key === lastInteractionKey) {
         restartCheckInteractionInterval();
-      } else if (event.originalEvent.key === inactivityLogoutKey) {
+      } else if (event.originalEvent.key === inactivityLogoutKey && localStorage.getItem(inactivityLogoutKey) === 'true') {
         logout();
       }
     });

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -1482,7 +1482,7 @@ cause: "timeout"
 e.url(t.toString());
 };
 $(window).on("storage", function(e) {
-e.originalEvent.key === s ? u() : "origin-web-console-inactivity-logout" === e.originalEvent.key && p();
+e.originalEvent.key === s ? u() : "origin-web-console-inactivity-logout" === e.originalEvent.key && "true" === localStorage.getItem("origin-web-console-inactivity-logout") && p();
 }), n.onUserChanged(function() {
 m(!1);
 }), d(), $(document).bind("click keydown", _.throttle(d, 500));


### PR DESCRIPTION
The bug was cause by the fact that events on the `storage`:
```js
$(window).on('storage', function (event) {
...
}
```
are in IE11 also triggered in the same tab, whereas in other browsers the event is triggered only by duplicate tabs.
For that case we need to check if the `inactivityLogoutKey` was set to `true` before logging out.
The event itself is triggered by [onUserChanged call](https://github.com/openshift/origin-web-console/blob/master/app/scripts/app.js#L595)

@spadgett PTAL