### PR TITLE
Bug 1607305 - Adjust log viewer to handle multiline and non-newline terminated responses

### DIFF
--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -12602,15 +12602,23 @@ var e = angular.extend({
 follow: !0,
 tailLines: 5e3,
 limitBytes: 10485760
-}, t.options), n = 0, r = function(e) {
-n++, N.appendChild(f(n, e)), A();
+}, t.options), n = 0, r = "", a = function(e) {
+return /\n$/.test(e);
+}, o = function(e) {
+return e.match(/^.*(\n|$)/gm);
+}, i = function(e) {
+var t = r + e;
+a(e) ? (r = "", n++, N.appendChild(f(n, t)), A()) : r = t;
+}, s = function(e) {
+var t = o(e);
+_.each(t, i);
 };
-(E = c.createStream(v, h, t.context, e)).onMessage(function(a, o, i) {
+(E = c.createStream(v, h, t.context, e)).onMessage(function(r, a, o) {
 t.$evalAsync(function() {
 t.empty = !1, "logs" !== t.state && (t.state = "logs", I());
-}), a && (e.limitBytes && i >= e.limitBytes && (t.$evalAsync(function() {
+}), r && (e.limitBytes && o >= e.limitBytes && (t.$evalAsync(function() {
 t.limitReached = !0, t.loading = !1;
-}), D(!0)), r(a), !t.largeLog && n >= e.tailLines && t.$evalAsync(function() {
+}), D(!0)), s(r), !t.largeLog && n >= e.tailLines && t.$evalAsync(function() {
 t.largeLog = !0;
 }));
 }), E.onClose(function() {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1607305
Fixes #472

**Multiline Responses**
Sometimes, WebSocket response will contain multiple log lines. Added logic to break each response down into individual lines before appending them to the DOM.

**Partial Responses** 
Sometimes when a log line is very long, it will be broken down over multiple WebSocket messages, and each will include only part of that line (non-newline terminated string). Added logic which concatenates partial lines until new line is reached and the full line is appended to the DOM.