### PR TITLE
Bug 1652645 - Webhook urls in configuration page are invalid with undefined included

### DIFF
--- a/app/scripts/directives/util.js
+++ b/app/scripts/directives/util.js
@@ -57,6 +57,16 @@ angular.module('openshiftConsole')
       }
     };
   })
+  .directive('copyWebhookTrigger', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        webhookUrl: "=",
+        secretRef: "=?"
+      },
+      templateUrl: 'views/directives/_copy-webhook-trigger.html',
+    };
+  })
   .directive('copyToClipboard', function() {
     return {
       restrict: 'E',

--- a/app/scripts/filters/resources.js
+++ b/app/scripts/filters/resources.js
@@ -182,6 +182,9 @@ angular.module('openshiftConsole')
       var secretsVersion = APIService.getPreferredVersion('secrets');
       if (canIFilter(secretsVersion, 'list')) {
         secret = SecretsService.getWebhookSecretValue(secret, webhookSecrets);
+        if (!secret) {
+          return '';
+        }
         return DataService.url({
           // arbitrarily many subresources can be included
           // url encoding of the segments is handled by the url() function

--- a/app/scripts/services/secrets.js
+++ b/app/scripts/services/secrets.js
@@ -152,7 +152,7 @@ angular.module("openshiftConsole")
       // to list Secrets
       if (_.get(secret, 'secretReference.name') && webhookSecrets) {
         var matchingSecret = _.find(webhookSecrets, {metadata:{name: secret.secretReference.name}});
-        return decodeSecretData(matchingSecret.data).WebHookSecretKey;
+        return _.has(matchingSecret, 'data') ? decodeSecretData(matchingSecret.data).WebHookSecretKey : '';
       } else {
         return _.get(secret, 'secret');
       }

--- a/app/views/browse/build-config.html
+++ b/app/views/browse/build-config.html
@@ -386,29 +386,28 @@
                               <dt>Bitbucket Webhook URL:
                               </dt>
                               <dd>
-                                <copy-to-clipboard clipboard-text="buildConfig.metadata.name | webhookURL : trigger.type : trigger.bitbucket : project.metadata.name : webhookSecrets"></copy-to-clipboard>
-
+                                <copy-webhook-trigger webhook-url="buildConfig.metadata.name | webhookURL : trigger.type : trigger.bitbucket : project.metadata.name : webhookSecrets" secret-ref="trigger.bitbucket.secretReference.name"></copy-webhook-trigger>
                               </dd>
                           </div>
                           <div ng-switch-when="GitHub">
                               <dt>GitHub Webhook URL:
                               </dt>
                               <dd>
-                                <copy-to-clipboard clipboard-text="buildConfig.metadata.name | webhookURL : trigger.type : trigger.github : project.metadata.name : webhookSecrets"></copy-to-clipboard>
+                                <copy-webhook-trigger webhook-url="buildConfig.metadata.name | webhookURL : trigger.type : trigger.github : project.metadata.name : webhookSecrets" secret-ref="trigger.github.secretReference.name"></copy-webhook-trigger>
                               </dd>
                           </div>
                           <div ng-switch-when="GitLab">
                               <dt>GitLab Webhook URL:
                               </dt>
                               <dd>
-                                <copy-to-clipboard clipboard-text="buildConfig.metadata.name | webhookURL : trigger.type : trigger.gitlab : project.metadata.name : webhookSecrets"></copy-to-clipboard>
+                                <copy-webhook-trigger webhook-url="buildConfig.metadata.name | webhookURL : trigger.type : trigger.gitlab : project.metadata.name : webhookSecrets" secret-ref="trigger.gitlab.secretReference.name"></copy-webhook-trigger>
                               </dd>
                           </div>
                           <div ng-switch-when="Generic">
                               <dt>Generic Webhook URL:
                               </dt>
                               <dd>
-                                <copy-to-clipboard clipboard-text="buildConfig.metadata.name | webhookURL : trigger.type : trigger.generic : project.metadata.name : webhookSecrets"></copy-to-clipboard>
+                                <copy-webhook-trigger webhook-url="buildConfig.metadata.name | webhookURL : trigger.type : trigger.generic : project.metadata.name : webhookSecrets" secret-ref="trigger.generic.secretReference.name"></copy-webhook-trigger>
                               </dd>
                           </div>
                           <div ng-switch-when="ImageChange">

--- a/app/views/directives/_copy-webhook-trigger.html
+++ b/app/views/directives/_copy-webhook-trigger.html
@@ -1,0 +1,12 @@
+<div ng-if="webhookUrl">
+	<copy-to-clipboard clipboard-text="webhookUrl"></copy-to-clipboard>
+</div>
+<div ng-if="!webhookUrl">
+  <span ng-show="secretRef"
+  		class="pficon pficon-warning-triangle-o"
+      aria-hidden="true"
+      data-toggle="tooltip"
+      data-original-title="Webhook secret {{secretRef}} referenced by this webhook trigger is not yet available, or was deleted.">
+  </span>
+  <em>Not available</em>
+</div>

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -3371,7 +3371,7 @@ metadata: {
 name: e.secretReference.name
 }
 });
-return i(n.data).WebHookSecretKey;
+return _.has(n, "data") ? i(n.data).WebHookSecretKey : "";
 }
 return _.get(e, "secret");
 }
@@ -11128,6 +11128,15 @@ $(this).hide(), $(".reveal-contents", t).show();
 });
 }
 };
+}).directive("copyWebhookTrigger", function() {
+return {
+restrict: "E",
+scope: {
+webhookUrl: "=",
+secretRef: "=?"
+},
+templateUrl: "views/directives/_copy-webhook-trigger.html"
+};
 }).directive("copyToClipboard", function() {
 return {
 restrict: "E",
@@ -15232,11 +15241,11 @@ return null;
 }).filter("webhookURL", [ "canIFilter", "APIService", "DataService", "SecretsService", function(e, t, n, r) {
 return function(a, o, i, s, c) {
 var l = t.getPreferredVersion("secrets");
-return e(l, "list") ? (i = r.getWebhookSecretValue(i, c), n.url({
+return e(l, "list") ? (i = r.getWebhookSecretValue(i, c)) ? n.url({
 resource: "buildconfigs/webhooks/" + encodeURIComponent(i) + "/" + encodeURIComponent(o.toLowerCase()),
 name: a,
 namespace: s
-})) : n.url({
+}) : "" : n.url({
 resource: "buildconfigs/webhooks/",
 name: a,
 namespace: s

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -1897,28 +1897,28 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<dt>Bitbucket Webhook URL:\n" +
     "</dt>\n" +
     "<dd>\n" +
-    "<copy-to-clipboard clipboard-text=\"buildConfig.metadata.name | webhookURL : trigger.type : trigger.bitbucket : project.metadata.name : webhookSecrets\"></copy-to-clipboard>\n" +
+    "<copy-webhook-trigger webhook-url=\"buildConfig.metadata.name | webhookURL : trigger.type : trigger.bitbucket : project.metadata.name : webhookSecrets\" secret-ref=\"trigger.bitbucket.secretReference.name\"></copy-webhook-trigger>\n" +
     "</dd>\n" +
     "</div>\n" +
     "<div ng-switch-when=\"GitHub\">\n" +
     "<dt>GitHub Webhook URL:\n" +
     "</dt>\n" +
     "<dd>\n" +
-    "<copy-to-clipboard clipboard-text=\"buildConfig.metadata.name | webhookURL : trigger.type : trigger.github : project.metadata.name : webhookSecrets\"></copy-to-clipboard>\n" +
+    "<copy-webhook-trigger webhook-url=\"buildConfig.metadata.name | webhookURL : trigger.type : trigger.github : project.metadata.name : webhookSecrets\" secret-ref=\"trigger.github.secretReference.name\"></copy-webhook-trigger>\n" +
     "</dd>\n" +
     "</div>\n" +
     "<div ng-switch-when=\"GitLab\">\n" +
     "<dt>GitLab Webhook URL:\n" +
     "</dt>\n" +
     "<dd>\n" +
-    "<copy-to-clipboard clipboard-text=\"buildConfig.metadata.name | webhookURL : trigger.type : trigger.gitlab : project.metadata.name : webhookSecrets\"></copy-to-clipboard>\n" +
+    "<copy-webhook-trigger webhook-url=\"buildConfig.metadata.name | webhookURL : trigger.type : trigger.gitlab : project.metadata.name : webhookSecrets\" secret-ref=\"trigger.gitlab.secretReference.name\"></copy-webhook-trigger>\n" +
     "</dd>\n" +
     "</div>\n" +
     "<div ng-switch-when=\"Generic\">\n" +
     "<dt>Generic Webhook URL:\n" +
     "</dt>\n" +
     "<dd>\n" +
-    "<copy-to-clipboard clipboard-text=\"buildConfig.metadata.name | webhookURL : trigger.type : trigger.generic : project.metadata.name : webhookSecrets\"></copy-to-clipboard>\n" +
+    "<copy-webhook-trigger webhook-url=\"buildConfig.metadata.name | webhookURL : trigger.type : trigger.generic : project.metadata.name : webhookSecrets\" secret-ref=\"trigger.generic.secretReference.name\"></copy-webhook-trigger>\n" +
     "</dd>\n" +
     "</div>\n" +
     "<div ng-switch-when=\"ImageChange\">\n" +
@@ -5418,6 +5418,18 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<span class=\"sr-only\">Copy to Clipboard</span>\n" +
     "</a>\n" +
     "</span>\n" +
+    "</div>"
+  );
+
+
+  $templateCache.put('views/directives/_copy-webhook-trigger.html',
+    "<div ng-if=\"webhookUrl\">\n" +
+    "<copy-to-clipboard clipboard-text=\"webhookUrl\"></copy-to-clipboard>\n" +
+    "</div>\n" +
+    "<div ng-if=\"!webhookUrl\">\n" +
+    "<span ng-show=\"secretRef\" class=\"pficon pficon-warning-triangle-o\" aria-hidden=\"true\" data-toggle=\"tooltip\" data-original-title=\"Webhook secret {{secretRef}} referenced by this webhook trigger is not yet available, or was deleted.\">\n" +
+    "</span>\n" +
+    "<em>Not available</em>\n" +
     "</div>"
   );
 


### PR DESCRIPTION
From the bug description there are two issues:
1. When a freshly created webhook secret is not available right away so the secret value of the trigger URL is undefined: *.../buildconfigs/webhooks/**undefined**/generic*  
2. When the referenced secrets is deleted, but still used in the buildConfig trigger
Just met the issue one time after trying at least ten times. This requests the copy action taking place right after the secret is created and added as webhook.

Haven't found any reasonable precedence for showing warnings in the description list terms in the codebase(hopefully I haven't overlooked anything), so created a proposal that would cover both issues:
![1](https://user-images.githubusercontent.com/1668218/49082567-602f1480-f24a-11e8-811f-54b38b5001ec.png)

 Marked the PR as WIP to open the design discussion, code is not ready for review...

cc'ing @openshift/team-ux-review 

@spadgett PTAL  
 