### PR TITLE
[enterprise-3.11] Bug 1672904 - Build Config's are not editable on WebConsole

### DIFF
--- a/app/components/istag-select/istag-select.component.js
+++ b/app/components/istag-select/istag-select.component.js
@@ -86,7 +86,7 @@
           ctrl.isNamesByNamespace[ns] = ctrl.isNamesByNamespace[ns].concat(ctrl.istag.imageStream);
           ctrl.isByNamespace[ns][ctrl.istag.imageStream] = {
             status: {
-              tags: {}
+              tags: []
             }
           };
         }

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -11258,7 +11258,7 @@ namespace: e
 var n = angular.copy(t.by("metadata.name"));
 s(n), a.isByNamespace[e] = n, a.isNamesByNamespace[e] = _.keys(n).sort(), _.includes(a.isNamesByNamespace[e], a.istag.imageStream) || (a.isNamesByNamespace[e] = a.isNamesByNamespace[e].concat(a.istag.imageStream), a.isByNamespace[e][a.istag.imageStream] = {
 status: {
-tags: {}
+tags: []
 }
 }), _.find(a.isByNamespace[e][a.istag.imageStream].status.tags, {
 tag: a.istag.tagObject.tag


### PR DESCRIPTION
When the ImageStream that is used in the BuildConfig is missing we need to create one in the scope of the istag component, so the BC editor won't error out. There was an issue that we have been initializing the `tags` by an object , instead of `array`.
Just for additional info the issue was introduced before the [directive](https://github.com/openshift/origin-web-console/pull/1424/files) was rewritten into [component](https://github.com/openshift/origin-web-console/pull/2768/files).

@benjaminapetersen PTAL
@spadgett FYI