### PR TITLE
Bug 1721428: Remove misleading "Metrics might not be available" warning

### DIFF
--- a/app/scripts/controllers/create/createFromImage.js
+++ b/app/scripts/controllers/create/createFromImage.js
@@ -148,11 +148,6 @@ angular.module("openshiftConsole")
             return scope.buildConfig.sourceUrl === _.get(scope, 'image.metadata.annotations.sampleRepo');
           };
 
-          // Warn if metrics aren't configured when setting autoscaling options.
-          MetricsService.isAvailable().then(function(available) {
-            $scope.metricsWarning = !available;
-          });
-
            var configMapDataOrdered = [];
            var secretDataOrdered = [];
            $scope.valueFromObjects = [];

--- a/app/scripts/controllers/edit/autoscaler.js
+++ b/app/scripts/controllers/edit/autoscaler.js
@@ -58,11 +58,6 @@ angular.module('openshiftConsole')
 
     $scope.labels = [];
 
-    // Warn if metrics aren't configured when setting autoscaling options.
-    MetricsService.isAvailable().then(function(available) {
-      $scope.metricsWarning = !available;
-    });
-
     var getErrorDetails = $filter('getErrorDetails');
 
     var navigateBack = function() {

--- a/app/views/create/fromimage.html
+++ b/app/views/create/fromimage.html
@@ -313,12 +313,6 @@
                             <div class="learn-more-block">
                               <a href="{{'pod_autoscaling' | helpLink}}" target="_blank">Learn More&nbsp;<i class="fa fa-external-link" aria-hidden="true"></i></a>
                             </div>
-                            <div class="has-warning" ng-if="metricsWarning && scaling.autoscale">
-                              <span class="help-block">
-                                CPU metrics might not be available. In order to use horizontal pod autoscalers,
-                                your cluster administrator must have properly configured cluster metrics.
-                              </span>
-                            </div>
                           </div>
                           <div ng-if="!scaling.autoscale"
                                class="form-group"

--- a/app/views/edit/autoscaler.html
+++ b/app/views/edit/autoscaler.html
@@ -14,16 +14,8 @@
             <div class="help-block">
               Scale replicas automatically based on CPU usage.
             </div>
-            <div class="learn-more-block" ng-class="{ 'gutter-bottom': metricsWarning || showCPURequestWarning }">
+            <div class="learn-more-block" ng-class="{ 'gutter-bottom': showCPURequestWarning }">
               <a href="{{'pod_autoscaling' | helpLink}}" target="_blank">Learn More&nbsp;<i class="fa fa-external-link" aria-hidden> </i></a>
-            </div>
-
-            <!-- Warning: metrics not configured -->
-            <div ng-if="metricsWarning" class="alert alert-warning">
-              <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
-              <span class="sr-only">Warning:</span>
-              Metrics might not be configured by your cluster administrator. Metrics are
-              required for autoscaling.
             </div>
 
             <!-- Warning: CPU request not set -->

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -5024,11 +5024,6 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"learn-more-block\">\n" +
     "<a href=\"{{'pod_autoscaling' | helpLink}}\" target=\"_blank\">Learn More&nbsp;<i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></a>\n" +
     "</div>\n" +
-    "<div class=\"has-warning\" ng-if=\"metricsWarning && scaling.autoscale\">\n" +
-    "<span class=\"help-block\">\n" +
-    "CPU metrics might not be available. In order to use horizontal pod autoscalers, your cluster administrator must have properly configured cluster metrics.\n" +
-    "</span>\n" +
-    "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"!scaling.autoscale\" class=\"form-group\" ng-class=\"{ 'has-error': form.replicas.$dirty && form.replicas.$invalid }\">\n" +
     "<label class=\"number\">Replicas</label>\n" +
@@ -9502,14 +9497,8 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"help-block\">\n" +
     "Scale replicas automatically based on CPU usage.\n" +
     "</div>\n" +
-    "<div class=\"learn-more-block\" ng-class=\"{ 'gutter-bottom': metricsWarning || showCPURequestWarning }\">\n" +
+    "<div class=\"learn-more-block\" ng-class=\"{ 'gutter-bottom': showCPURequestWarning }\">\n" +
     "<a href=\"{{'pod_autoscaling' | helpLink}}\" target=\"_blank\">Learn More&nbsp;<i class=\"fa fa-external-link\" aria-hidden> </i></a>\n" +
-    "</div>\n" +
-    "\n" +
-    "<div ng-if=\"metricsWarning\" class=\"alert alert-warning\">\n" +
-    "<span class=\"pficon pficon-warning-triangle-o\" aria-hidden=\"true\"></span>\n" +
-    "<span class=\"sr-only\">Warning:</span>\n" +
-    "Metrics might not be configured by your cluster administrator. Metrics are required for autoscaling.\n" +
     "</div>\n" +
     "\n" +
     "<div ng-if=\"showCPURequestWarning\" class=\"alert alert-warning\">\n" +

--- a/test/spec/services/hpaServiceSpec.js
+++ b/test/spec/services/hpaServiceSpec.js
@@ -93,43 +93,6 @@ describe('HPAService', function() {
       });
     });
 
-    describe('When metrics are not configured', function() {
-      it('should return a warning with reason MetricsNotAvailable', function() {
-        // flip the bool that controls the MetricsService mock
-        metricsAreAvailable = false;
-        HPAService
-          .getHPAWarnings(defaultScaleTarget, defaultHpaResources, defaultLimitRanges, defaultProject)
-          .then(function(warnings) {
-            expect(_.head(warnings).reason).toEqual('MetricsNotAvailable');
-          });
-        $rootScope.$digest();
-      });
-    });
-
-
-    // TODO: we should be testing more than just the happy paths
-    // describe('When there is a CPU request', function() {
-    //   // this is the first check in the hasCPURequest fn
-    //   // it should use $window && set OPENSHIFT_CONFIG.clusterResourceOverridesEnabled
-    //   // to trigger the LimitRangesService.hasClusterResourceOverrides function
-    //   // it('should not return a warning when cluster resource overrides are enabled', function() {
-    //   //
-    //   // });
-    //
-    //   // 2nd check in the hasCPURequest fn
-    //   // need to test this with some mock limit ranges passed to the fn
-    //   // it('should not return a warning when containers or limit ranges have a cpu request', function() {
-    //   //
-    //   // });
-    //
-    //   // 3rd check in the hasCPURequest fn
-    //   // more tests with mock limit ranges
-    //   // it('should not return a warning when the containers or limit ranges have a cpu limit', function() {
-    //   //
-    //   // });
-    //
-    // });
-
     describe('When the scale target does not have a CPU request set', function() {
       var scaleTargetWithoutLimit = {
         kind: '',


### PR DESCRIPTION
A metrics URL is not required to use HPAs. Since we can't reliably
detect whether metrics server is configured, remove the misleading
warning that might show up when HPAs will otherwise work.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1721428

/assign @rhamilto 