### PR TITLE
Bug 1777758: Checking for wrong default storageclass annotation

### DIFF
--- a/app/scripts/directives/oscPersistentVolumeClaim.js
+++ b/app/scripts/directives/oscPersistentVolumeClaim.js
@@ -135,7 +135,7 @@ angular.module("openshiftConsole")
            scope.storageClasses = _.sortBy(storageClasses, 'metadata.name');
            var annotation = $filter('annotation');
            scope.defaultStorageClass = _.find(scope.storageClasses, function(storageClass) {
-             return annotation(storageClass, 'storageclass.beta.kubernetes.io/is-default-class') === 'true';
+             return annotation(storageClass, 'storageclass.kubernetes.io/is-default-class') === 'true';
            });
            if (!scope.defaultStorageClass)  { //if there is no default, set a no storage class option
              var noclass = {

--- a/dist/scripts/scripts.js
+++ b/dist/scripts/scripts.js
@@ -10543,7 +10543,7 @@ if (!_.isEmpty(r)) {
 t.storageClasses = _.sortBy(r, "metadata.name");
 var a = e("annotation");
 if (t.defaultStorageClass = _.find(t.storageClasses, function(e) {
-return "true" === a(e, "storageclass.beta.kubernetes.io/is-default-class");
+return "true" === a(e, "storageclass.kubernetes.io/is-default-class");
 }), t.defaultStorageClass) t.claim.storageClass = t.defaultStorageClass; else {
 var o = {
 metadata: {


### PR DESCRIPTION
Annotation for default storageclass is now `storageclass.kubernetes.io/is-default-class`.

As of https://github.com/openshift/openshift-ansible/commit/18b42ee