### PR TITLE
Bug 1782695: Supply the navigateResourceURL filter with kind and name space in the ConfigMap list page [enterprise-3.11]

### DIFF
--- a/app/views/browse/config-maps.html
+++ b/app/views/browse/config-maps.html
@@ -56,7 +56,7 @@
             <tbody>
               <tr ng-repeat="configMap in configMaps">
                 <td data-title="Name">
-                  <a href="{{configMap | navigateResourceURL}}">{{configMap.metadata.name}}</a>
+                  <a href="{{configMap.metadata.name | navigateResourceURL : 'ConfigMap' : configMap.metadata.namespace}}">{{configMap.metadata.name}}</a>
                 </td>
                 <td data-title="Created">
                   <span am-time-ago="configMap.metadata.creationTimestamp"></span>

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -2230,7 +2230,7 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<tbody>\n" +
     "<tr ng-repeat=\"configMap in configMaps\">\n" +
     "<td data-title=\"Name\">\n" +
-    "<a href=\"{{configMap | navigateResourceURL}}\">{{configMap.metadata.name}}</a>\n" +
+    "<a href=\"{{configMap.metadata.name | navigateResourceURL : 'ConfigMap' : configMap.metadata.namespace}}\">{{configMap.metadata.name}}</a>\n" +
     "</td>\n" +
     "<td data-title=\"Created\">\n" +
     "<span am-time-ago=\"configMap.metadata.creationTimestamp\"></span>\n" +


### PR DESCRIPTION
Since we started to retrieving the `PartialObjectMetadateList` for ConfigMap list page in https://github.com/openshift/origin-web-console/pull/3152 we need to tell to the `navigateResourceURL` filter explicitly that we need URL for configmap resource, since the `resourceURL` service function is aware about [first-class resource](https://github.com/openshift/origin-web-console/blob/enterprise-3.11/app/scripts/services/navigate.js#L201-L260), not the `PartialObjectMetadate` that is used. 
Due to the fact that are are supplying the filter with `PartialObjectMetadata` object, `null` return value is [returned](https://github.com/openshift/origin-web-console/blob/enterprise-3.11/app/scripts/services/navigate.js#L282) from the `navigateResourceURL` filter.

/assign @spadgett 